### PR TITLE
Account for Modifier Keys

### DIFF
--- a/src/gui/input.cpp
+++ b/src/gui/input.cpp
@@ -101,6 +101,12 @@ QString InputConv::convertKey(const QString& text, int k, Qt::KeyboardModifiers 
 		mod &= ~Qt::ControlModifier;
 	}
 
+	// Format with prefix if necessary
+	QString prefix = modPrefix(mod);
+	if (!prefix.isEmpty()) {
+		return QString("<%1%2>").arg(prefix).arg(text);
+	}
+
 	return text;
 }
 

--- a/src/gui/input.cpp
+++ b/src/gui/input.cpp
@@ -96,7 +96,7 @@ QString InputConv::convertKey(const QString& text, int k, Qt::KeyboardModifiers 
 		mod &= ~Qt::ShiftModifier;
 	}
 
-	// Remove CTRL
+	// Remove CTRL empty characters at the start of the ASCII range
 	if (c.unicode() < 0x20) {
 		mod &= ~Qt::ControlModifier;
 	}


### PR DESCRIPTION
Hi,

As noted in #6, the `<C-[>` sequence wasn't getting interpreted correctly. I tend to use that instead of `<ESC>`.

This is my attempt at supporting that. I'm super new to the code base and it has been a while since I did C++ so this might be a confused and foolish change but I hope its ok :)

Cheers,
Michael 