### PR TITLE
Use new Neovim mode change API events

### DIFF
--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -401,10 +401,13 @@ void Shell::handleRedraw(const QByteArray& name, const QVariantList& opargs, QPa
 		this->unsetCursor();
 	} else if (name == "mouse_off"){
 		this->setCursor(Qt::BlankCursor);
-	} else if (name == "normal_mode"){
-		handleNormalMode(painter);
-	} else if (name == "insert_mode"){
-		handleInsertMode(painter);
+	} else if (name == "mode_change"){
+		if (opargs.size() != 1) {
+			qWarning() << "Unexpected argument for change_mode:" << opargs;
+			return;
+		}
+		QString mode = m_nvim->decode(opargs.at(0).toByteArray());
+		handleModeChange(mode);
 	} else if (name == "cursor_on"){
 	} else if (name == "set_title"){
 		handleSetTitle(opargs);
@@ -426,14 +429,14 @@ void Shell::setNeovimCursor(quint64 row, quint64 col)
 	update(QRect(neovimCursorTopLeft(), neovimCharSize()));
 }
 
-void Shell::handleNormalMode(QPainter& painter)
+void Shell::handleModeChange(const QString& mode)
 {
-	m_insertMode = false;
-}
-
-void Shell::handleInsertMode(QPainter& painter)
-{
-	m_insertMode = true;
+	// TODO: Implement visual aids for other modes
+	if (mode == "insert") {
+		m_insertMode = true;
+	} else {
+		m_insertMode = false;
+	}
 }
 
 void Shell::handleSetTitle(const QVariantList& opargs)

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -64,8 +64,7 @@ protected:
 	virtual void handleHighlightSet(const QVariantMap& args, QPainter& painter);
 	virtual void handleRedraw(const QByteArray& name, const QVariantList& args, QPainter& painter);
 	virtual void handleScroll(const QVariantList& args, QPainter& painter);
-	virtual void handleNormalMode(QPainter& painter);
-	virtual void handleInsertMode(QPainter& painter);
+	virtual void handleModeChange(const QString& mode);
 	virtual void handleSetTitle(const QVariantList& opargs);
 	virtual void handleSetScrollRegion(const QVariantList& opargs);
 	virtual void handleBusy(bool);


### PR DESCRIPTION
The Neovim API changed, now uses a single event for mode change
notifications. Remove the old functions and replace them with the
new one.