### PR TITLE
Remove -Werror from build flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR
 		"${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wall -Wextra -Wno-unused-parameter -std=c++11 -Wfatal-errors")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-unused-parameter -std=c++11 -Wfatal-errors")
 endif()
 
 option(USE_GCOV "Enable gcov support" OFF)


### PR DESCRIPTION
Issue #32 (gcc 4.8.4, Qt 5.2.1 in Mint) -Werror may cause the build
to fail due to -Winconsistent-missing-override.