### PR TITLE
GUI: Don't call :qa on close for UNIX/TCP sockets

### DIFF
--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -632,7 +632,10 @@ void Shell::changeEvent( QEvent *ev)
 
 void Shell::closeEvent(QCloseEvent *ev)
 {
-	if (m_attached) {
+	if (m_attached &&
+		m_nvim->connectionType() == NeovimConnector::SpawnedConnection) {
+		// If attached to a spawned Neovim process, ignore the event
+		// and try to close Neovim as :qa
 		ev->ignore();
 		m_nvim->neovimObject()->vim_command("qa");
 	} else {

--- a/src/neovimconnector.cpp
+++ b/src/neovimconnector.cpp
@@ -253,6 +253,11 @@ bool NeovimConnector::canReconnect()
 	return m_ctype != OtherConnection;
 }
 
+NeovimConnector::NeovimConnectionType NeovimConnector::connectionType()
+{
+	return m_ctype;
+}
+
 /**
  * Create a new connection using the same parameters as the current one.
  *

--- a/src/neovimconnector.h
+++ b/src/neovimconnector.h
@@ -62,6 +62,7 @@ public:
 	uint64_t channel();
 	QString decode(const QByteArray&);
 	QByteArray encode(const QString&);
+	NeovimConnectionType connectionType();
 
 signals:
 	void ready();

--- a/test/tst_neovimconnector.cpp
+++ b/test/tst_neovimconnector.cpp
@@ -20,6 +20,7 @@ private slots:
 		QCOMPARE(c.canReconnect(), false);
 
 		NeovimConnector *spawned = NeovimConnector::spawn();
+		QCOMPARE(spawned->connectionType(), NeovimConnector::SpawnedConnection);
 		QCOMPARE(spawned->canReconnect(), true);
 
 		spawned->reconnect();
@@ -55,6 +56,7 @@ private slots:
 	void connectToNeovimTCP() {
 		// These 2 cases WILL FAIL because there is no Neovim instance running
 		NeovimConnector *c = NeovimConnector::connectToNeovim("127.0.0.1:64999");
+		QCOMPARE(c->connectionType(), NeovimConnector::HostConnection);
 		QSignalSpy onError(c, SIGNAL(error(NeovimError)));
 		QVERIFY(onError.isValid());
 		QVERIFY(SPYWAIT(onError));
@@ -65,6 +67,7 @@ private slots:
 
 	void connectToNeovimSocket() {
 		NeovimConnector *c = NeovimConnector::connectToNeovim("NoSuchFile");
+		QCOMPARE(c->connectionType(), NeovimConnector::SocketConnection);
 		QSignalSpy onError(c, SIGNAL(error(NeovimError)));
 		QVERIFY(onError.isValid());
 		// The signal might be emited before we get to connect


### PR DESCRIPTION
When the Neovim shell is closed (e.g. user closes window) the GUI would ignore
the event and call :qa, triggering the Neovim process to exit. This makes sense
when Neovim was launched by the GUI, since we need to cleanup the process.
However when connecting to an external Neovim process (TCP/UNIX socket) this
might not be what the user intends.

For TCP/UNIX sockets the "qa" command is no longer sent. This means that if the
user closes the GUI window the GUI will terminate the connection and close, but
the Neovim process will remain runnning. In cases where the user wants to exit
the Neovim process he would need to call :q himself.

This breaks the previous behaviour, but there was no way to override it. From a
user perspective the situation might improve later for UNIX sockets if the GUI
can discover available sockets.

Issue #36