### PR TITLE
WIP: Support undercurl attribute

### DIFF
--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -13,7 +13,7 @@ namespace NeovimQt {
 
 Shell::Shell(NeovimConnector *nvim, QWidget *parent)
 :QWidget(parent), m_attached(false), m_nvim(nvim), m_rows(1), m_cols(1),
-	m_font_bold(false), m_font_italic(false), m_font_underline(false), m_fm(NULL),
+	m_font_bold(false), m_font_italic(false), m_font_underline(false), m_font_undercurl(false), m_fm(NULL),
 	m_foreground(Qt::black), m_background(Qt::white),
 	m_hg_foreground(Qt::black), m_hg_background(Qt::white),
 	m_cursor_color(Qt::white), m_cursor_pos(0,0), m_insertMode(false),
@@ -219,7 +219,9 @@ void Shell::handleHighlightSet(const QVariantMap& attrs, QPainter& painter)
 	// TODO: undercurl
 	m_font_bold = attrs.value("bold").toBool();
 	m_font_italic = attrs.value("italic").toBool();
-	m_font_underline = attrs.value("undercurl").toBool();
+	m_font_undercurl = attrs.value("undercurl").toBool();
+	// enable underline ONLY if undercurl is already not on
+	m_font_underline = attrs.value("underline").toBool() && !m_font_undercurl;
 	setupPainter(painter);
 }
 
@@ -251,6 +253,16 @@ void Shell::handlePut(const QVariantList& args, QPainter& painter)
 		QPoint pos(m_cursor_pos.x()*neovimCellWidth(), m_cursor_pos.y()*neovimRowHeight()+m_fm->ascent());
 		painter.drawText(pos, text.at(0));
 
+		if (m_font_undercurl) {
+			// Draw "undercurl" at the bottom of the cell
+			// FIXME: use correct highlight color instead of red
+			// TODO: draw a proper undercurl
+			painter.setPen(QPen(Qt::red, 1, Qt::DashDotDotLine));
+			QPoint start = clipRect.bottomLeft();
+			QPoint end = clipRect.bottomRight();
+			start.ry()--; end.ry()--;
+			painter.drawLine(start, end);
+		}
 		painter.restore();
 	}
 

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -77,7 +77,7 @@ private:
 	QRect m_scroll_region;
 
 	QFont m_font;
-	bool m_font_bold, m_font_italic, m_font_underline;
+	bool m_font_bold, m_font_italic, m_font_underline, m_font_undercurl;
 	QFontMetrics *m_fm;
 
 	QImage m_image;


### PR DESCRIPTION
When drawing text the undercurl attribute was being represented as an
underline, and the underline attribute was ignored - this commit
corrects the use of underline and adds initial support for undercurl.

The undercurl is drawn over the text as a red dotted line, at the
bottom of the text cell.

 For #43.

Caveats:
- currently the color is hardcoded
- its not actually an undercurl :D
- Quick reference to [old issues](https://bitbucket.org/equalsraf/vim-qt/issues/59/undercurl-underline-or-even-underscore-not) we want to avoid.