### PR TITLE
Communicate with Neovim using stdin/stdout

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,11 @@ foreach(CFGNAME ${CMAKE_CONFIGURATION_TYPES})
   set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_${CFGNAME} ${CMAKE_BINARY_DIR}/lib)
 endforeach()
 
+if(MSVC)
+  # Allow use of deprecated function names in MSVC (read/write)
+  add_definitions(-D_CRT_NONSTDC_NO_DEPRECATE)
+endif()
+
 add_subdirectory(src)
 add_subdirectory(doc)
 enable_testing()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,9 @@
 
 set(NEOVIM_QT_SOURCES util.cpp neovimconnector.cpp neovimconnectorhelper.cpp function.cpp msgpackrequest.cpp auto/neovim.cpp msgpackiodevice.cpp)
+if(WIN32)
+  list(APPEND NEOVIM_QT_SOURCES stdinreader.cpp)
+endif()
+
 add_library(neovim-qt STATIC ${NEOVIM_QT_SOURCES})
 target_link_libraries(neovim-qt Qt5::Network ${MSGPACK_LIBRARIES})
 

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -42,20 +42,24 @@ int main(int argc, char **argv)
 		qInstallMessageHandler(logger);
 	}
 
-	QString server;
 	QStringList args = app.arguments().mid(1);
-	int serverIdx = args.indexOf("--server");
-	if (serverIdx != -1 && args.size() > serverIdx+1) {
-		server = args.at(serverIdx+1);
-		args.removeAt(serverIdx);
-		args.removeAt(serverIdx);
-	}
-
 	NeovimQt::NeovimConnector *c;
-	if (!server.isEmpty()) {
-		c = NeovimQt::NeovimConnector::connectToNeovim(server);
+	if (args.indexOf("--embed") != -1) {
+		c = NeovimQt::NeovimConnector::fromStdinOut();
 	} else {
-		c = NeovimQt::NeovimConnector::spawn(args);
+		QString server;
+		int serverIdx = args.indexOf("--server");
+		if (serverIdx != -1 && args.size() > serverIdx+1) {
+			server = args.at(serverIdx+1);
+			args.removeAt(serverIdx);
+			args.removeAt(serverIdx);
+		}
+
+		if (!server.isEmpty()) {
+			c = NeovimQt::NeovimConnector::connectToNeovim(server);
+		} else {
+			c = NeovimQt::NeovimConnector::spawn(args);
+		}
 	}
 
 #ifdef NEOVIMQT_GUI_WIDGET

--- a/src/msgpackiodevice.h
+++ b/src/msgpackiodevice.h
@@ -24,9 +24,9 @@ public:
 	};
 	MsgpackIODevice(QIODevice *, QObject *parent=0);
 	~MsgpackIODevice();
+        static MsgpackIODevice* fromStdinOut(QObject *parent=0);
 
-	/** True if the underlying IO device is open @see QIODevice::isOpen */
-	bool isOpen() {return m_dev->isOpen();}
+	bool isOpen();
 	QString errorString() const;
 	MsgpackError errorCause() const {return m_error;};
 
@@ -86,11 +86,16 @@ protected:
 
 protected slots:
 	void setError(MsgpackError err, const QString& msg);
+
 	void dataAvailable();
+	void dataAvailableStdin(const QByteArray&);
+	void dataAvailableFd(int fd);
+
 	void requestTimeout(quint32 id);
 
 private:
-	static int msgpack_write_cb(void* data, const char* buf, unsigned long int len);
+	static int msgpack_write_to_stdout(void* data, const char* buf, unsigned long int len);
+	static int msgpack_write_to_dev(void* data, const char* buf, unsigned long int len);
 
 	quint32 m_reqid;
 	QIODevice *m_dev;

--- a/src/neovimconnector.cpp
+++ b/src/neovimconnector.cpp
@@ -20,11 +20,15 @@ namespace NeovimQt {
  * Create a new Neovim API connection from an open IO device
  */
 NeovimConnector::NeovimConnector(QIODevice *dev)
-:QObject(), m_dev(0), m_helper(0), m_error(NoError), m_neovimobj(NULL), 
+:NeovimConnector(new MsgpackIODevice(dev))
+{
+}
+
+NeovimConnector::NeovimConnector(MsgpackIODevice *dev)
+:QObject(), m_dev(dev), m_helper(0), m_error(NoError), m_neovimobj(NULL),
 	m_channel(0), m_ctype(OtherConnection), m_ready(false)
 {
 	m_helper = new NeovimConnectorHelper(this);
-	m_dev = new MsgpackIODevice(dev, this);
 	qRegisterMetaType<NeovimError>("NeovimError");
 
 	connect(m_dev, &MsgpackIODevice::error,
@@ -258,6 +262,11 @@ NeovimConnector* NeovimConnector::connectToNeovim(const QString& server)
 		}
 	}
 	return connectToSocket(addr);
+}
+
+NeovimConnector* NeovimConnector::fromStdinOut()
+{
+	return new NeovimConnector(MsgpackIODevice::fromStdinOut());
 }
 
 /**

--- a/src/neovimconnector.h
+++ b/src/neovimconnector.h
@@ -47,10 +47,12 @@ public:
         };
 
 	NeovimConnector(QIODevice* s);
+	NeovimConnector(MsgpackIODevice* s);
 	static NeovimConnector* spawn(const QStringList& params=QStringList());
 	static NeovimConnector* connectToSocket(const QString&);
 	static NeovimConnector* connectToHost(const QString& host, int port);
 	static NeovimConnector* connectToNeovim(const QString& server=QString());
+	static NeovimConnector* fromStdinOut();
 
 	bool canReconnect();
 	NeovimConnector* reconnect();

--- a/src/stdinreader.cpp
+++ b/src/stdinreader.cpp
@@ -1,0 +1,59 @@
+#include "stdinreader.h"
+
+#include <QDebug>
+#ifdef _WIN32
+# include <io.h>
+# include <fcntl.h>
+#else
+# include <unistd.h>
+#endif
+
+namespace NeovimQt {
+
+/**
+ * \class NeovimQt::StdinReader
+ *
+ * A background thread to read data from Stdin
+ *
+ * For Unix systems a better alternative to this is to use QSocketNotifier, with
+ * a little work it produces the same effect with none of the overhead.
+ */
+
+/**
+ * Read from stdin in a background thread with
+ * @arg maxSize is the read buffer size
+ */
+StdinReader::StdinReader(qint64 maxSize, QObject *parent)
+:QThread(parent), m_maxSize(maxSize)
+{
+#ifdef _WIN32
+	setmode(0, _O_BINARY);
+#endif
+	if (!m_in.open(0, QIODevice::ReadOnly | QIODevice::Unbuffered)) {
+		qWarning("Unable to open stdin for reading");
+	}
+}
+
+void StdinReader::run()
+{
+	char *buf = new char[m_maxSize];
+	while (true) {
+		qint64 bytes = read(0, buf, m_maxSize);
+		if (bytes > 0 ) {
+			qDebug() << "Reading data from Stdin" << bytes;
+			emit dataAvailable(QByteArray(buf, bytes));
+		}
+	}
+	delete buf;
+}
+
+/**
+ * \fn NeovimQt::StdinReader::dataAvailable()
+ *
+ * Emitted when data is read from stdin
+ *
+ * @arg data is no larger than maxSize
+ * @see StdinReader::StdinReader
+ */
+
+} // Namespace

--- a/src/stdinreader.h
+++ b/src/stdinreader.h
@@ -1,0 +1,24 @@
+#ifndef NEOVIM_QT_STDINNOTIFIER
+#define NEOVIM_QT_STDINNOTIFIER
+
+#include <QThread>
+#include <QFile>
+
+namespace NeovimQt {
+class StdinReader: public QThread
+{
+        Q_OBJECT
+public:
+        StdinReader(qint64 maxSize, QObject *parent=0);
+        virtual void run();
+signals:
+        void dataAvailable(const QByteArray& data);
+
+private:
+        QFile m_in;
+        qint64 m_maxSize;
+};
+
+} // Namespace
+
+#endif


### PR DESCRIPTION
For #50. Right now you can

    :call rpcstart('nvim-qt', ['--embed'])

I have not decided on the internals yet, but this seems to be a working start - there are probably lots of pitfalls I'm missing about reading from stdin.