### PR TITLE
Accept msgpack STR type instead of BIN

### DIFF
--- a/src/neovimconnectorhelper.cpp
+++ b/src/neovimconnectorhelper.cpp
@@ -66,6 +66,8 @@ void NeovimConnectorHelper::handleMetadata(quint32 msgid, Function::FunctionId, 
 		connect(m_c->neovimObject(), &Neovim::on_vim_get_option,
 				this, &NeovimConnectorHelper::encodingChanged);
 		m_c->neovimObject()->vim_get_option("encoding");
+	} else {
+		qWarning() << "Error retrieving metadata" << m_c->errorString();
 	}
 }
 
@@ -81,6 +83,8 @@ void NeovimConnectorHelper::encodingChanged(const QVariant&  obj)
 	if (m_c->m_dev->setEncoding(enc_name)) {
 		m_c->m_ready = true;
 		emit m_c->ready();
+	} else {
+		qWarning() << "Unable to set encoding" << obj;
 	}
 }
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -32,6 +32,9 @@ QDebug operator<<(QDebug dbg, const msgpack_object& obj)
 	case MSGPACK_OBJECT_FLOAT:
 		dbg.space() <<  obj.via.f64;
 		break;
+	case MSGPACK_OBJECT_STR:
+		dbg.space() << QByteArray(obj.via.str.ptr, obj.via.str.size);
+		break;
 	case MSGPACK_OBJECT_BIN:
 		dbg.space() << QByteArray(obj.via.bin.ptr, obj.via.bin.size);
 		break;

--- a/test/tst_encoding.cpp
+++ b/test/tst_encoding.cpp
@@ -11,6 +11,7 @@ private slots:
 	void initTestCase();
 	void encodeString();
 	void map();
+	void stringsAreBinaryNotUtf8();
 protected:
 	NeovimQt::NeovimConnector *m_c;
 };
@@ -51,6 +52,22 @@ void TestEncoding::map()
 	conn = connect(m_c->neovimObject(), &NeovimQt::Neovim::on_vim_get_var,
 			[map](const QVariant& v) {
 				QVERIFY(v == map);
+			});
+	QTest::qWait(500);
+	disconnect(conn);
+}
+
+// A reminder that Strings in the Neovim API are binary data
+// that may or may not conform to encoding
+void TestEncoding::stringsAreBinaryNotUtf8()
+{
+	QByteArray data = "\xc3\x28";
+	m_c->neovimObject()->vim_set_current_line(data);
+	m_c->neovimObject()->vim_get_current_line();
+	QMetaObject::Connection conn;
+	conn = connect(m_c->neovimObject(), &NeovimQt::Neovim::on_vim_get_current_line,
+			[data](const QVariant& v) {
+				QCOMPARE(v.toByteArray(), data);
 			});
 	QTest::qWait(500);
 	disconnect(conn);


### PR DESCRIPTION
For neovim/neovim#3431 - neovim-qt did not accept the msgpack STR
type (used BIN instead):

- Neovim API signatures with type String
- Msgpack request method names

Now both types are treated the exact same way by the decode functions.

This does not change the current API, we still treat strings as binary
arrays (QByteArray), and we are still sending outgoing strings with type
BIN.