### PR TITLE
GUI: Use Forbidden mouse cursor on mouse_off notification

### DIFF
--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -417,7 +417,7 @@ void Shell::handleRedraw(const QByteArray& name, const QVariantList& opargs, QPa
 	} else if (name == "mouse_on"){
 		this->unsetCursor();
 	} else if (name == "mouse_off"){
-		this->setCursor(Qt::BlankCursor);
+		this->setCursor(Qt::ForbiddenCursor);
 	} else if (name == "mode_change"){
 		if (opargs.size() != 1) {
 			qWarning() << "Unexpected argument for change_mode:" << opargs;


### PR DESCRIPTION
Previously the "mouse_off" event caused the cursor to become invisible. Instead
use the Forbidden stock cursor, for consistency with GVim.

For #54.