### PR TITLE
Enforce timeouts for critical RPC requests

### DIFF
--- a/src/neovimconnector.cpp
+++ b/src/neovimconnector.cpp
@@ -88,7 +88,11 @@ QString NeovimConnector::errorString()
 void NeovimConnector::attachUi(int64_t width, int64_t height)
 {
 	// FIXME: this should be in class Neovim
-	m_dev->startRequestUnchecked("ui_attach", 3);
+	MsgpackRequest *r = m_dev->startRequestUnchecked("ui_attach", 3);
+	connect(r, &MsgpackRequest::timeout,
+			this, &NeovimConnector::fatalTimeout);
+	r->setTimeout(10000);
+
 	m_dev->send(width);
 	m_dev->send(height);
 	m_dev->send(true);

--- a/src/neovimconnector.cpp
+++ b/src/neovimconnector.cpp
@@ -122,6 +122,9 @@ void NeovimConnector::discoverMetadata()
 			m_helper, &NeovimConnectorHelper::handleMetadata);
 	connect(r, &MsgpackRequest::error,
 			m_helper, &NeovimConnectorHelper::handleMetadataError);
+	connect(r, &MsgpackRequest::timeout,
+			this, &NeovimConnector::fatalTimeout);
+	r->setTimeout(10000);
 }
 
 /**
@@ -299,6 +302,18 @@ void NeovimConnector::socketError()
 void NeovimConnector::msgpackError()
 {
 	setError(MsgpackError, m_dev->errorString());
+}
+
+/**
+ * Raise a fatal error for a Neovim timeout
+ *
+ * Sometimes Neovim takes too long to respond to some requests, or maybe
+ * the channel is stuck. In such cases it is preferable to raise and error,
+ * internally this is what discoverMetadata does if Neovim does not reply.
+ */
+void NeovimConnector::fatalTimeout()
+{
+	setError(RuntimeMsgpackError, "Neovim is taking too long to respond");
 }
 
 /**

--- a/src/neovimconnector.h
+++ b/src/neovimconnector.h
@@ -77,6 +77,9 @@ signals:
 	void error(NeovimError);
 	void processExited(int exitCode);
 
+public slots:
+	void fatalTimeout();
+
 protected:
 	void setError(NeovimError err, const QString& msg);
 	void clearError();

--- a/src/neovimconnectorhelper.cpp
+++ b/src/neovimconnectorhelper.cpp
@@ -3,6 +3,7 @@
 #include "neovimconnectorhelper.h"
 #include "neovimconnector.h"
 #include "msgpackiodevice.h"
+#include "msgpackrequest.h"
 #include "util.h"
 
 namespace NeovimQt {
@@ -65,7 +66,10 @@ void NeovimConnectorHelper::handleMetadata(quint32 msgid, Function::FunctionId, 
 		// Get &encoding before we signal readyness
 		connect(m_c->neovimObject(), &Neovim::on_vim_get_option,
 				this, &NeovimConnectorHelper::encodingChanged);
-		m_c->neovimObject()->vim_get_option("encoding");
+		MsgpackRequest *r = m_c->neovimObject()->vim_get_option("encoding");
+		connect(r, &MsgpackRequest::timeout,
+				m_c, &NeovimConnector::fatalTimeout);
+		r->setTimeout(10000);
 	} else {
 		qWarning() << "Error retrieving metadata" << m_c->errorString();
 	}

--- a/test/common.h
+++ b/test/common.h
@@ -4,5 +4,6 @@
 // This is just a fix for QSignalSpy::wait
 // http://stackoverflow.com/questions/22390208/google-test-mock-with-qt-signals
 #define SPYWAIT(spy) (spy.count()>0||spy.wait())
+#define SPYWAIT2(spy, time) (spy.count()>0||spy.wait(time))
 
 #endif


### PR DESCRIPTION
With 03236e2a9a88477bc6f9fae6115e8aa9c5dd86a1 we now have the means to enforce arbitrary timeouts for each RPC request, this is important for some critical RPC calls, otherwise the connector or GUI appear to be stuck when in fact Neovim is blocked, or the communication channel is stuck.

This PR should cover

- [x] discoverMetadata/vim_get_api_info
- [x] ui_attach
- [x] &encoding and vim_get_option during initialization

Maybe:

- [ ] vim_input in the GUI