### PR TITLE
Windows: Set $WINDOWID in Neovim process

### DIFF
--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -247,6 +247,23 @@ void Shell::init()
 
 	// Subscribe to GUI events
 	m_nvim->neovimObject()->vim_subscribe("Gui");
+
+	updateWindowId();
+}
+
+// In Win32, set $WINDOWID environment variable
+// in other systems this does nothing
+void Shell::updateWindowId()
+{
+#ifdef _WIN32
+	if (m_attached &&
+		m_nvim->connectionType() == NeovimConnector::SpawnedConnection) {
+		WId window_id = effectiveWinId();
+		m_nvim->neovimObject()->vim_command(
+				m_nvim->encode(QString("let $WINDOWID=\"%1\"").arg(window_id))
+				);
+	}
+#endif
 }
 
 void Shell::neovimError(NeovimConnector::NeovimError err)
@@ -800,6 +817,17 @@ void Shell::wheelEvent(QWheelEvent *ev)
 			.arg(pos.x()).arg(pos.y());
 	}
 	m_nvim->neovimObject()->vim_input(inp.toLatin1());
+}
+
+bool Shell::event(QEvent *event)
+{
+#ifdef _WIN32
+	if (event->type() == QEvent::WinIdChange){
+		updateWindowId();
+		return true;
+	}
+#endif
+	return QWidget::event(event);
 }
 
 void Shell::resizeNeovim(const QSize& newSize)

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -824,7 +824,6 @@ bool Shell::event(QEvent *event)
 #ifdef _WIN32
 	if (event->type() == QEvent::WinIdChange){
 		updateWindowId();
-		return true;
 	}
 #endif
 	return QWidget::event(event);

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -50,11 +50,13 @@ protected slots:
 	void mouseClickReset();
 	void mouseClickIncrement(Qt::MouseButton bt);
         void init();
+        void updateWindowId();
 
 protected:
 	void tooltip(const QString& text);
 	virtual void inputMethodEvent(QInputMethodEvent *event) Q_DECL_OVERRIDE;
 	virtual void wheelEvent(QWheelEvent *event) Q_DECL_OVERRIDE;
+        bool event(QEvent *event) Q_DECL_OVERRIDE;
 
 	int neovimWidth() const;
 	int neovimHeight() const;


### PR DESCRIPTION
From issue #64 - in Neovim the v:windowid var is not available, while in Unix
systems a workaround the issue is to use the $WINDOWID variable, in Windows
there is no alternative. This commit sets the $WINDOWID environment var inside
the attached Neovim process using a call to vim_command(let $WINDOWID="...").

Still need to clarify some bits:

- [ ] unset the variable on detach
- [ ] This has not been tested for correctness, the Qt docs warn about corner cases such as the winId changing - and there were some recent bugs over the Qt API, maybe we need to use the native Win32 API. Also casts might be needed.
- [ ] Should this be set when connecting to remote instances?
