### PR TITLE
Fix two regressions

### DIFF
--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -44,6 +44,7 @@ protected slots:
 	void mouseClickReset();
 	void mouseClickIncrement(Qt::MouseButton bt);
         void init();
+	void attach();
 
 protected:
 	void tooltip(const QString& text);

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -43,7 +43,7 @@ protected slots:
 	void neovimResizeFinished();
 	void mouseClickReset();
 	void mouseClickIncrement(Qt::MouseButton bt);
-        void init();
+	void init();
 	void attach();
 
 protected:


### PR DESCRIPTION
I bisected this bug down to commit https://github.com/equalsraf/neovim-qt/commit/38644b9

Here is a .gif demonstrating the problem. It is a bit multisided. The gif demonstrate the following things in order: 

* Without mouse/keyboard input you just see white. It only renders something once it gets input.
* Moving the window back and forth is fine until it gets to the big screen, then it freezes
* But giving it a lot of input also causes it to freeze (last part)

*Edit: I removed the embedded gif and only post a link as it seems to crash some browsers / create huge memory usage*
https://cloud.githubusercontent.com/assets/424752/11551006/5787c8ee-9975-11e5-8137-e58a932d1bd2.gif