### PR TITLE
Show the window only after nvim is initted with correct geometry

### DIFF
--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -2,6 +2,7 @@
 #include <QFontDatabase>
 #include <QtGlobal>
 #include <QFile>
+#include <QTimer>
 #include "neovimconnector.h"
 #include "mainwindow.h"
 
@@ -67,7 +68,10 @@ int main(int argc, char **argv)
 #else
 	NeovimQt::MainWindow *win = new NeovimQt::MainWindow(c);
 #endif
-	win->show();
+	// Window is shown on first resize, however if the nvim is taking too
+	// long to start, open the window manually to display possible errors
+	// to user.
+	QTimer::singleShot(1000, win, [&]() { win->show(); });
 	return app.exec();
 }
 

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -107,6 +107,10 @@ void MainWindow::closeEvent(QCloseEvent *ev)
 
 void MainWindow::neovimWidgetResized(const QSize& newSize)
 {
+	if (!isVisible()) {
+		show();
+	}
+
 	if ((windowState() & Qt::WindowMaximized)) {
 		if (newSize.width() > width() || newSize.height() > height()) {
 			// If the Neovim shell is larger than the main window, resize it

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -293,6 +293,9 @@ void Shell::handleResize(uint64_t cols, uint64_t rows)
 		m_image.swap(new_image);
 		updateGeometry();
 		emit neovimResized(neovimSize());
+		if (!isVisible()) {
+			show();
+		}
 	}
 }
 


### PR DESCRIPTION
This is kind of hacky, but I think it is better if the window is displayed only after nvim is loaded, otherwise there is a small white window at the start only to be resized a moment later.