### PR TITLE
Use custom layout instead of dock widgets

### DIFF
--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -2,10 +2,11 @@
 #define NEOVIM_QT_MAINWINDOW
 
 #include <QMainWindow>
-#include <QDockWidget>
 #include "neovimconnector.h"
 #include "errorwidget.h"
 #include "shell.h"
+
+class QVBoxLayout;
 
 namespace NeovimQt {
 
@@ -15,7 +16,6 @@ class MainWindow: public QMainWindow
 public:
 	MainWindow(NeovimConnector *, QWidget *parent=0);
 protected:
-        QDockWidget* newDockWidgetFor(QWidget *);
 	virtual void closeEvent(QCloseEvent *ev) Q_DECL_OVERRIDE;
 private slots:
 	void neovimSetTitle(const QString &title);
@@ -28,6 +28,7 @@ private:
         NeovimConnector *m_nvim;
 	ErrorWidget *m_errorWidget;
 	Shell *m_shell;
+	QVBoxLayout *m_layout;
 };
 
 } // Namespace

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -196,6 +196,11 @@ QSize Shell::sizeHint() const
 	}
 }
 
+QSize Shell::minimumSizeHint() const
+{
+	return 5 * neovimCharSize();
+}
+
 /** Pixel size of the Neovim shell */
 QSize Shell::neovimSize() const
 {

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -6,6 +6,7 @@
 #include <QDesktopWidget>
 #include <QApplication>
 #include <QKeyEvent>
+#include <QLayout>
 #include "msgpackrequest.h"
 #include "input.h"
 #include "konsole_wcwidth.h"
@@ -292,6 +293,12 @@ void Shell::handleResize(uint64_t cols, uint64_t rows)
 		}
 		m_image.swap(new_image);
 		updateGeometry();
+		// Layout recalculation is done in next even cycle, but we start
+		// rendering right after emitting the neovimResized() signal.
+		if (parentWidget() && parentWidget()->layout()) {
+			parentWidget()->layout()->invalidate();
+			parentWidget()->layout()->activate();
+		}
 		emit neovimResized(neovimSize());
 	}
 }

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -20,6 +20,7 @@ public:
 	~Shell();
 	QSize sizeIncrement() const;
 	QSize sizeHint() const Q_DECL_OVERRIDE;
+	QSize minimumSizeHint() const Q_DECL_OVERRIDE;
 	static QColor color(qint64 color, const QColor& fallback=QColor());
 	static bool isBadMonospace(const QFont& f);
 	virtual QVariant inputMethodQuery(Qt::InputMethodQuery) const Q_DECL_OVERRIDE;


### PR DESCRIPTION
Adding dock widget to main window will add a separator between the
dock widget and the central widget.
This resulted in an extra spacing at the top of main window.

No more spacing at the top, error widget still works and looks the same.