### PR TITLE
Use Travis CI for OSX builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+sudo: false
+language: cpp
+os:
+  - osx
+compiler:
+  - gcc
+  - clang
+before_install:
+  - brew update
+  # Install Neovim for the unit tests
+  - brew install neovim/neovim/neovim
+  - brew ls | grep -wq cmake || brew install cmake
+  - brew ls | grep -wq qt5 || brew install qt5
+  - brew ls | grep -wq msgpack || brew install msgpack
+script:
+  - mkdir build
+  - cd build
+  - cmake -DUSE_SYSTEM_MSGPACK=OFF ..
+  - make
+  - nvim --version
+  - ctest --output-on-failure

--- a/test/tst_input.cpp
+++ b/test/tst_input.cpp
@@ -21,7 +21,7 @@ void TestInput::specialKeys()
 #ifdef Q_OS_MAC
 			// On Mac Control is actually the Cmd key, which we
 			// don't support yet
-			QString("<%1>").arg(input.specialKeys.value(k)));
+			QString("<D-%1>").arg(input.specialKeys.value(k)));
 #else
 			QString("<C-%1>").arg(input.specialKeys.value(k)));
 #endif


### PR DESCRIPTION
Following #86, enable Travis CI builds. Currently failing because we are missing https://github.com/equalsraf/neovim-qt/commit/5f7a552e125a29486563136099a7699daa52e33a