### PR TITLE
GUI: Support FocusGained and FocusLost

### DIFF
--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -859,6 +859,18 @@ void Shell::closeEvent(QCloseEvent *ev)
 	}
 }
 
+void Shell::focusInEvent(QFocusEvent *ev)
+{
+	m_nvim->neovimObject()->vim_input("<FocusGained>");
+	QWidget::focusInEvent(ev);
+}
+
+void Shell::focusOutEvent(QFocusEvent *ev)
+{
+	m_nvim->neovimObject()->vim_input("<FocusLost>");
+	QWidget::focusOutEvent(ev);
+}
+
 QColor Shell::color(qint64 color, const QColor& fallback)
 {
 	if (color == -1) {

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -72,6 +72,8 @@ protected:
 	virtual void paintEvent(QPaintEvent *ev) Q_DECL_OVERRIDE;
 	virtual void changeEvent(QEvent *ev) Q_DECL_OVERRIDE;
 	virtual void closeEvent(QCloseEvent *ev) Q_DECL_OVERRIDE;
+	virtual void focusInEvent(QFocusEvent *ev) Q_DECL_OVERRIDE;
+	virtual void focusOutEvent(QFocusEvent *ev) Q_DECL_OVERRIDE;
 
 	virtual void handleResize(uint64_t cols, uint64_t rows);
 	virtual void handlePut(const QVariantList& args, QPainter&);


### PR DESCRIPTION
Forward widget focus events as <FocusGained> and <FocusLost>. For #96. Should work with `:au FocusGained ...`