### PR TITLE
Appveyor: Cleanup settings, use Qt 5.5/Mingw

### DIFF
--- a/contrib/appveyor-mingw.bat
+++ b/contrib/appveyor-mingw.bat
@@ -1,0 +1,9 @@
+rem CMake/MinGW workaround - remove sh.exe from PATH
+where sh
+set PATH=%PATH:C:\Program Files\Git\usr\bin;=%
+set CMAKE_PREFIX_PATH=%QTDIR%
+set PATH=%MINGW%\bin;%PATH%;%QTDIR%\bin
+mkdir build
+cd build
+cmake -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=%configuration% -DCMAKE_INSTALL_PREFIX=../INSTALL ..
+cmake --build . --target windeployqt

--- a/contrib/appveyor-msvc.bat
+++ b/contrib/appveyor-msvc.bat
@@ -1,0 +1,7 @@
+set CMAKE_PREFIX_PATH=%QTDIR%
+set PATH=%PATH%;%QTDIR%\bin
+mkdir build
+cd build
+rem FYI CMAKE_BUILD_TYPE does not work with VS generators, use --config
+cmake -G "Visual Studio 12" -DCMAKE_BUILD_TYPE=%configuration% -DCMAKE_INSTALL_PREFIX=../INSTALL ..
+cmake --build . --config %configuration% --target windeployqt

--- a/contrib/appveyor.yml
+++ b/contrib/appveyor.yml
@@ -8,6 +8,7 @@ environment:
     QTDIR: C:\Qt\5.5\mingw492_32
     MINGW: C:\Qt\Tools\mingw492_32
     SCRIPT: contrib\appveyor-mingw.bat
+    RELEASE_ARTIFACT: true
   - VCINSTALLDIR: C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\
     QTDIR: C:\Qt\5.5\msvc2013
     SCRIPT: contrib\appveyor-msvc.bat
@@ -23,10 +24,12 @@ artifacts:
 deploy:
   - provider: GitHub
     description: Automated builds (Appveyor)
+    release: $(appveyor_repo_tag_name)
     auth_token:
       secure: Hx2tU6GZPZNB6qGjHcIqa1tEm8fVGXZUVfXyjboVrPcmA9OWMTXhLxayDzMMl3kD
     artifact: build\neovim-qt.zip
-    prerelease: true
+    prerelease: false
     on:
       appveyor_repo_tag: true
       configuration: RelWithDebInfo
+      release_artifact: true

--- a/contrib/appveyor.yml
+++ b/contrib/appveyor.yml
@@ -3,41 +3,23 @@ skip_tags: false
 os: MinGW
 shallow_clone: true
 environment:
-  VCINSTALLDIR: C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\
   matrix:
-  - CMAKE_GENERATOR: Visual Studio 12
-    QTDIR: C:/Qt/5.4/msvc2013_opengl
+  - CMAKE_GENERATOR: MinGW Makefiles
+    QTDIR: C:\Qt\5.5\mingw492_32
+    MINGW: C:\Qt\Tools\mingw492_32
+    SCRIPT: contrib\appveyor-mingw.bat
+  - VCINSTALLDIR: C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\
+    QTDIR: C:\Qt\5.5\msvc2013
+    SCRIPT: contrib\appveyor-msvc.bat
 configuration:
 - RelWithDebInfo
 matrix:
   fast_finish: true
 build_script:
-- set SEMVER=0.0.0
-# Build packages as 0.1.2-ci{build}
-- set PKG_VERSION=%SEMVER%-ci%APPVEYOR_BUILD_NUMBER%
-# Build packages for tags as 0.1.2-TAGNAME
-- if DEFINED APPVEYOR_REPO_TAG_NAME set PKG_VERSION=%SEMVER%-%APPVEYOR_REPO_TAG_NAME%
-- echo %PKG_VERSION%
-- set CMAKE_PREFIX_PATH=%QTDIR%
-- set PATH=%PATH%;%QTDIR%/bin
-# Build Msgpack
-- mkdir build-third-party
-- cd build-third-party
-  # FYI CMAKE_BUILD_TYPE does not work with VS generators, use --config
-- cmake -G "%CMAKE_GENERATOR%" -DCMAKE_BUILD_TYPE=%configuration% -DCMAKE_INSTALL_PREFIX=../INSTALL ../third-party
-- cmake --build . --config %configuration% --target install
-- cd ..
-# Build nvim-qt
-- mkdir build
-- cd build
-- cmake -G "%CMAKE_GENERATOR%" -DCMAKE_BUILD_TYPE=%configuration% -DCMAKE_INSTALL_PREFIX=../INSTALL ..
-# FYI CMAKE_BUILD_TYPE does not work with VS generators, use --config
-- cmake --build . --config %configuration% --target windeployqt
+- cmd: '%SCRIPT%'
 artifacts:
 - path: build/bin
   name: neovim-qt
-- path: 'build/*.nupkg'
-  name: nupkgs
 deploy:
   - provider: GitHub
     description: Automated builds (Appveyor)


### PR DESCRIPTION
- Cleanup old settings in Appveyor that are no longer used since the
Nuget packages were removed.
- Bump Qt version to 5.5.
- Build using MinGW instead of MSVC.

This also seems to help with #98 (the reason is unclear).