### PR TITLE
set NVIM_TUI_ENABLE_TRUE_COLOR to 1

### DIFF
--- a/src/neovimconnector.cpp
+++ b/src/neovimconnector.cpp
@@ -191,6 +191,11 @@ NeovimConnector* NeovimConnector::spawn(const QStringList& params)
 			c, SIGNAL(processExited(int)));
 	connect(p, &QProcess::started,
 			c, &NeovimConnector::discoverMetadata);
+
+	QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
+	env.insert("NVIM_TUI_ENABLE_TRUE_COLOR", "1");
+	p->setProcessEnvironment(env);
+
 	p->start("nvim", args);
 	return c;
 }


### PR DESCRIPTION
I noticed vim-airline neovim-qt had [the same issues as Neovim.app](https://github.com/rogual/neovim-dot-app/issues/215), and the fix is the same.