### PR TITLE
Enable Guifont force assignment

### DIFF
--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -39,7 +39,7 @@ signals:
 public slots:
 	void handleNeovimNotification(const QByteArray &name, const QVariantList& args);
 	void resizeNeovim(const QSize&);
-	bool setGuiFont(const QString& fdesc);
+	bool setGuiFont(const QString& fdesc, bool force=false);
 
 protected slots:
 	void neovimIsReady();


### PR DESCRIPTION
Multibyte users sometime require to use "Invalid font" so allow to specify that kind of font by option
With this change, the following will be available

    command -nargs=? -bang Guifont
        \ call rpcnotify(0, 'Gui', 'SetFont', <q-args>, <q-bang> ==# '!') |
        \ let g:Guifont = "<args>"

    " The following will show exception
    Guifont An invalid font:h10
    " The following won't
    Guifont! An invalid font:h10