### PR TITLE
GUI: Allow font style customization with :Guifont

### DIFF
--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -81,6 +81,8 @@ bool Shell::setGuiFont(const QString& fdesc)
 	}
 
 	int pointSize = font().pointSize();
+	int weight = -1;
+	bool italic = false;
 	foreach(QString attr, attrs) {
 		if (attr.size() >= 2 && attr[0] == 'h') {
 			bool ok = false;
@@ -90,9 +92,13 @@ bool Shell::setGuiFont(const QString& fdesc)
 				return false;
 			}
 			pointSize = height;
+		} else if (attr == "b") {
+			weight = QFont::Bold;
+		} else if (attr == "i") {
+			italic = true;
 		}
 	}
-	setShellFont(attrs.at(0), pointSize);
+	setShellFont(attrs.at(0), pointSize, weight, italic);
 
 	if (m_attached) {
 		resizeNeovim(size());

--- a/src/gui/shellwidget/shellwidget.cpp
+++ b/src/gui/shellwidget/shellwidget.cpp
@@ -34,14 +34,12 @@ void ShellWidget::setDefaultFont()
 #endif
 }
 
-bool ShellWidget::setShellFont(const QString& family, int ptSize)
+bool ShellWidget::setShellFont(const QString& family, int ptSize, int weight, bool italic)
 {
-	QFont f;
+	QFont f(family, ptSize, weight, italic);
 	f.setStyleHint(QFont::TypeWriter, QFont::StyleStrategy(QFont::PreferDefault | QFont::ForceIntegerMetrics));
-	f.setFamily(family);
 	f.setFixedPitch(true);
 	f.setKerning(false);
-	f.setPointSize(ptSize);
 
 	QFontInfo fi(f);
 	if (fi.family().compare(f.family(), Qt::CaseInsensitive) != 0 &&

--- a/src/gui/shellwidget/shellwidget.h
+++ b/src/gui/shellwidget/shellwidget.h
@@ -17,7 +17,7 @@ class ShellWidget: public QWidget
 	Q_PROPERTY(QSize cellSize READ cellSize)
 public:
 	ShellWidget(QWidget *parent=0);
-	bool setShellFont(const QString& family, int ptSize);
+	bool setShellFont(const QString& family, int ptSize, int weight = -1, bool italic = false);
 
 	QColor background() const;
 	QColor foreground() const;


### PR DESCRIPTION
I personally work with Monaco Bold, this change makes neovim-qt look exactly like my gvim setup. I added the extra styles in case anyone would like those. 

You can use them like in gvim with Guifont, for example to get Monospace with Bold+Italic:

`:Guifont Monospace:h12:b:i`