### PR TITLE
Add GUI helper plugin

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -11,13 +11,17 @@ add_subdirectory(shellwidget)
 
 include(GNUInstallDirs)
 set(RUNTIME_PATH )
+add_library(neovim-qt-gui shell.cpp input.cpp errorwidget.cpp mainwindow.cpp
+	${CMAKE_SOURCE_DIR}/third-party/konsole_wcwidth.cpp
+	${NEOVIM_RCC_SOURCES})
+target_link_libraries(neovim-qt-gui qshellwidget neovim-qt)
+
 set_property(SOURCE main.cpp PROPERTY COMPILE_DEFINITIONS
 	NVIM_QT_RUNTIME="${CMAKE_INSTALL_FULL_DATADIR}/nvim-qt/runtime")
-add_executable(nvim-qt WIN32 main.cpp shell.cpp input.cpp errorwidget.cpp mainwindow.cpp
+add_executable(nvim-qt WIN32 main.cpp
 	${NEOVIM_RCC_SOURCES}
-	${CMAKE_SOURCE_DIR}/third-party/konsole_wcwidth.cpp
 	${RES_FILE})
-target_link_libraries(nvim-qt ${QTLIBS} ${MSGPACK_LIBRARIES} neovim-qt qshellwidget)
+target_link_libraries(nvim-qt ${QTLIBS} ${MSGPACK_LIBRARIES} neovim-qt-gui)
 
 if(WIN32 AND NOT CMAKE_CROSSCOMPILING)
 	include(WinDeployQt)

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -9,6 +9,10 @@ endif()
 
 add_subdirectory(shellwidget)
 
+include(GNUInstallDirs)
+set(RUNTIME_PATH )
+set_property(SOURCE main.cpp PROPERTY COMPILE_DEFINITIONS
+	NVIM_QT_RUNTIME="${CMAKE_INSTALL_FULL_DATADIR}/nvim-qt/runtime")
 add_executable(nvim-qt WIN32 main.cpp shell.cpp input.cpp errorwidget.cpp mainwindow.cpp
 	${NEOVIM_RCC_SOURCES}
 	${CMAKE_SOURCE_DIR}/third-party/konsole_wcwidth.cpp
@@ -20,9 +24,10 @@ if(WIN32 AND NOT CMAKE_CROSSCOMPILING)
 	WinDeployQt(TARGET nvim-qt COMPILER_RUNTIME INCLUDE_MODULES ${QTLIBS} EXCLUDE_MODULES webkit webkit2)
 endif()
 
-include(GNUInstallDirs)
 install(TARGETS nvim-qt DESTINATION ${CMAKE_INSTALL_BINDIR})
 install(FILES nvim-qt.desktop DESTINATION ${CMAKE_INSTALL_DATADIR}/applications)
 install(FILES ${CMAKE_SOURCE_DIR}/third-party/neovim.png
         RENAME nvim-qt.png
         DESTINATION ${CMAKE_INSTALL_DATADIR}/pixmaps/)
+install(DIRECTORY runtime
+        DESTINATION ${CMAKE_INSTALL_DATADIR}/nvim-qt/)

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -3,6 +3,7 @@
 #include <QtGlobal>
 #include <QFile>
 #include <QCommandLineParser>
+#include <QFileInfo>
 #include "neovimconnector.h"
 #include "mainwindow.h"
 
@@ -70,6 +71,13 @@ int main(int argc, char **argv)
 			QString server = parser.value("server");
 			c = NeovimQt::NeovimConnector::connectToNeovim(server);
 		} else {
+#ifdef NVIM_QT_RUNTIME
+			if (QFileInfo(NVIM_QT_RUNTIME).isDir()) {
+				neovimArgs.insert(0, "--cmd");
+				neovimArgs.insert(1, QString("set rtp+=%1")
+						.arg(NVIM_QT_RUNTIME));
+			}
+#endif
 			c = NeovimQt::NeovimConnector::spawn(neovimArgs);
 		}
 	}

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -29,6 +29,8 @@ void MainWindow::init(NeovimConnector *c)
 	m_shell = new Shell(c);
 	m_stack.insertWidget(1, m_shell);
 	m_stack.setCurrentIndex(1);
+	connect(m_shell, SIGNAL(neovimAttached(bool)),
+			this, SLOT(neovimAttachmentChanged(bool)));
 	connect(m_shell, SIGNAL(neovimTitleChanged(const QString &)),
 			this, SLOT(neovimSetTitle(const QString &)));
 	connect(m_shell, &Shell::neovimResized,
@@ -48,6 +50,11 @@ void MainWindow::init(NeovimConnector *c)
 	if (m_nvim->errorCause()) {
 		neovimError(m_nvim->errorCause());
 	}
+}
+
+bool MainWindow::neovimAttached() const
+{
+	return (m_shell != NULL && m_shell->neovimAttached());
 }
 
 /** The Neovim process has exited */
@@ -171,6 +178,14 @@ void MainWindow::showIfDelayed()
 		}
 	}
 	m_delayedShow = DelayedShow::Disabled;
+}
+
+void MainWindow::neovimAttachmentChanged(bool attached)
+{
+	emit neovimAttached(attached);
+	if (isWindow() && m_shell != NULL) {
+		m_shell->updateGuiWindowState(windowState());
+	}
 }
 
 } // Namespace

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -33,6 +33,10 @@ void MainWindow::init(NeovimConnector *c)
 			this, SLOT(neovimSetTitle(const QString &)));
 	connect(m_shell, &Shell::neovimResized,
 			this, &MainWindow::neovimWidgetResized);
+	connect(m_shell, &Shell::neovimMaximized,
+			this, &MainWindow::neovimMaximized);
+	connect(m_shell, &Shell::neovimFullScreen,
+			this, &MainWindow::neovimFullScreen);
 	connect(m_nvim, &NeovimConnector::processExited,
 			this, &MainWindow::neovimExited);
 	connect(m_nvim, &NeovimConnector::error,
@@ -92,6 +96,24 @@ void MainWindow::neovimWidgetResized()
 	}
 }
 
+void MainWindow::neovimMaximized(bool set)
+{
+	if (set) {
+		setWindowState(windowState() | Qt::WindowMaximized);
+	} else {
+		setWindowState(windowState() & ~Qt::WindowMaximized);
+	}
+}
+
+void MainWindow::neovimFullScreen(bool set)
+{
+	if (set) {
+		setWindowState(windowState() | Qt::WindowFullScreen);
+	} else {
+		setWindowState(windowState() & ~Qt::WindowFullScreen);
+	}
+}
+
 void MainWindow::reconnectNeovim()
 {
 	if (m_nvim->canReconnect()) {
@@ -108,6 +130,13 @@ void MainWindow::closeEvent(QCloseEvent *ev)
 	} else {
 		ev->ignore();
 	}
+}
+void MainWindow::changeEvent( QEvent *ev)
+{
+	if (ev->type() == QEvent::WindowStateChange && isWindow()) {
+		m_shell->updateGuiWindowState(windowState());
+	}
+	QWidget::changeEvent(ev);
 }
 
 /// Call show() after a 1s delay or when Neovim attachment

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -21,8 +21,11 @@ public:
 	};
 
 	MainWindow(NeovimConnector *, QWidget *parent=0);
+	bool neovimAttached() const;
 public slots:
 	void delayedShow(DelayedShow type=DelayedShow::Normal);
+signals:
+	void neovimAttached(bool);
 protected:
 	virtual void closeEvent(QCloseEvent *ev) Q_DECL_OVERRIDE;
 	virtual void changeEvent(QEvent *ev) Q_DECL_OVERRIDE;
@@ -35,6 +38,7 @@ private slots:
 	void neovimError(NeovimConnector::NeovimError);
 	void reconnectNeovim();
 	void showIfDelayed();
+	void neovimAttachmentChanged(bool);
 private:
 	void init(NeovimConnector *);
         NeovimConnector *m_nvim;

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -25,9 +25,12 @@ public slots:
 	void delayedShow(DelayedShow type=DelayedShow::Normal);
 protected:
 	virtual void closeEvent(QCloseEvent *ev) Q_DECL_OVERRIDE;
+	virtual void changeEvent(QEvent *ev) Q_DECL_OVERRIDE;
 private slots:
 	void neovimSetTitle(const QString &title);
 	void neovimWidgetResized();
+	void neovimMaximized(bool);
+	void neovimFullScreen(bool);
 	void neovimExited(int status);
 	void neovimError(NeovimConnector::NeovimError);
 	void reconnectNeovim();

--- a/src/gui/runtime/README.md
+++ b/src/gui/runtime/README.md
@@ -1,0 +1,3 @@
+
+A VimL plugin that provides functions and commands for Neovim GUIs. By itself this plugin doesn't do much, it just provides a shim Neovim GUIs can use to implement features. See `:h nvim_gui_shim`.
+

--- a/src/gui/runtime/doc/neovim_gui_shim.txt
+++ b/src/gui/runtime/doc/neovim_gui_shim.txt
@@ -1,5 +1,5 @@
-*nvim_gui_shim.txt* A helper plugin for Neovim GUIs
-*nvim_gui_shim*
+*neovim_gui_shim.txt* A helper plugin for Neovim GUIs
+*neovim-gui-shim*
 
 In Neovim the GUI is an external process that communicates with the Neovim
 process using the |msgpack-rpc-api|. This separation means the GUI is just a
@@ -46,7 +46,7 @@ the shim has loaded. For example to set the GUI font on startup >
 
 The GUI is expected to set certain variables about its current state, however
 you are encouraged to be defensive about using the following variables.
-Settings the values of these variables has no effect on the GUI (i.e. only the
+Setting the values of these variables has no effect on the GUI (i.e. only the
 GUI should set them).
 
 							*g:GuiWindowMaximized*

--- a/src/gui/runtime/doc/nvim_gui_shim.txt
+++ b/src/gui/runtime/doc/nvim_gui_shim.txt
@@ -1,0 +1,110 @@
+*nvim_gui_shim.txt* A helper plugin for Neovim GUIs
+*nvim_gui_shim*
+
+In Neovim the GUI is an external process that communicates with the Neovim
+process using the |msgpack-rpc-api|. This separation means the GUI is just a
+particular type of plugin, as a consequence some functionality that was
+available in Vim is a NOOP in Neovim, or is still in the process of being
+specified.
+
+This plugin provides replacements for some missing GUI bits in Neovim. These
+can be used in |ginit.vim| provided that
+
+1. The user's GUI loaded the |ginit.vim| file
+2. The user's GUI supports the rpc events used by this plugin
+
+==============================================================================
+1. Commands
+
+								*Guifont* *GuiFont*
+GuiFont		When called with no arguments this command display the
+		current font used by the GUI. 
+
+		If an argument is provided it is treated as the font
+		description. The format for the font is a subset of the font
+		name used by Vim's 'guifont' in OS X. For example to set the
+		GUI font family to Monaco with height 13: >
+
+		    :GuiFont Monaco:h13
+<
+		The following attributes are available
+
+			hXX - height is XX in points
+			b   - bold
+			i   - italic
+
+==============================================================================
+2. GUI variables
+
+							*g:GuiLoaded*
+g:GuiLoaded is set when this plugin loads. Use it in |ginit.vim| to make sure
+the shim has loaded. For example to set the GUI font on startup >
+
+    if !exists('g:GuiLoaded')
+	Guifont DejaVu Sans Mono:h15
+    endif
+
+The GUI is expected to set certain variables about its current state, however
+you are encouraged to be defensive about using the following variables.
+Settings the values of these variables has no effect on the GUI (i.e. only the
+GUI should set them).
+
+							*g:GuiWindowMaximized*
+g:GuiWindowMaximized indicates whether the GUI window is maximized. In some system
+(X11) this not a reliable indicator, since the window manager can override the
+window behaviour.
+
+							*g:GuiWindowFullScreen*
+g:GuiWindowFullScreen indicates whether the GUI window is maximized. In some
+system (X11) this not a reliable indicator, since the window manager can
+override the window behaviour.
+
+							*g:GuiWindowId*
+g:GuiWindowId holds the window id (X11) or the window handle (Windows).
+
+							*g:GuiFont*
+g:GuiWindowId holds the current GUI font name, the same value used by
+|GuiFont|.
+
+==============================================================================
+3. Functions
+
+							*GuiForeground()*
+GuiForeground()	moves the GUI window to the foreground. In some systems this
+might not work due to window manager policy (X11) or focus stealing prevention
+(Windows). Replaces |foreground()|.
+
+							*GuiWindowMaximized()* 
+GuiWindowMaximized(enabled) sets the window maximized state, 1 means
+enabled and 0 disabled. In some systems (X11) this function is not guaranteed
+to work.
+
+							*GuiWindowFullScreen()* 
+GuiWindowFullScreen(enabled) sets the window fullscreen state, 1 means
+enabled and 0 disabled.
+
+							*GuiFont()* 
+GuiFont(fname) Sets the GUI font, see |GuiFont| for details on the font name
+format. Replaces |'guifont'|.
+
+==============================================================================
+4. Internals
+
+This section is not very interesting unless you are implementing a GUI and
+want to reuse this. Internally the plugin uses the |msgpack-rpc-api| to
+broadcast notifications to attached GUIs, for example: >
+
+	call rpcnotify(0, 'Gui', 'Foreground')
+
+All notifications use the 'Gui' event name followed by a name and optionally
+more parameters. Use the Neovim API (vim_subscribe) to subscribe to these
+events. By convention all the functions listed in the previous section are
+named as GuiEventName, and mapped as
+ >
+	call rpcnotify(0, 'Gui', 'EventName', ...)
+
+The GUI is expected to load the user's |ginit.vim|, it should also make sure
+this plugin is loaded before loading |ginit.vim|, for example setting
+the runtimepath.
+
+ vim:tw=78:ts=8:ft=help:norl:

--- a/src/gui/runtime/plugin/nvim_gui_shim.vim
+++ b/src/gui/runtime/plugin/nvim_gui_shim.vim
@@ -1,0 +1,40 @@
+" A Neovim plugin that implements GUI helper commands
+if !has("nvim") || exists('g:GuiLoaded')
+	finish
+endif
+let g:GuiLoaded = 1
+
+" A replacement for foreground()
+function! GuiForeground()
+	call rpcnotify(0, 'Gui', 'Foreground')
+endfunction
+
+" Set maximized state for GUI window (1 is enabled, 0 disabled)
+function! GuiWindowMaximized(enabled)
+	call rpcnotify(0, 'Gui', 'WindowMaximized', a:enabled)
+endfunction
+
+" Set fullscreen state for GUI window (1 is enabled, 0 disabled)
+function! GuiWindowFullScreen(enabled)
+	call rpcnotify(0, 'Gui', 'WindowFullScreen', a:enabled)
+endfunction
+
+" Set GUI font
+function! GuiFont(fname)
+	call rpcnotify(0, 'Gui', 'Font', a:fname)
+endfunction
+
+" The GuiFont command. For compatibility there is also Guifont
+function s:GuiFontCommand(fname)
+	if a:fname == ""
+		if exists('g:GuiFont')
+			echo g:GuiFont
+		else
+			echo 'No GuiFont is set'
+		endif
+	else
+		call GuiFont(a:fname)
+	endif
+endfunction
+command! -nargs=? Guifont call s:GuiFontCommand("<args>")
+command! -nargs=? GuiFont call s:GuiFontCommand("<args>")

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -129,6 +129,7 @@ void Shell::setAttached(bool attached)
 	m_attached = attached;
 	emit neovimAttached(attached);
 	if (attached) {
+		updateWindowId();
 		m_nvim->neovimObject()->vim_command("runtime! ginit.vim");
 	}
 	update();
@@ -633,6 +634,24 @@ void Shell::wheelEvent(QWheelEvent *ev)
 			.arg(pos.x()).arg(pos.y());
 	}
 	m_nvim->neovimObject()->vim_input(inp.toLatin1());
+}
+
+void Shell::updateWindowId()
+{
+	if (m_attached &&
+		m_nvim->connectionType() == NeovimConnector::SpawnedConnection) {
+		WId window_id = effectiveWinId();
+		QString cmd = QString("let g:GuiWindowId=%1").arg(window_id);
+		m_nvim->neovimObject()->vim_command(m_nvim->encode(cmd));
+	}
+}
+
+bool Shell::event(QEvent *event)
+{
+	if (event->type() == QEvent::WinIdChange){
+		updateWindowId();
+	}
+	return QWidget::event(event);
 }
 
 /// Resize remote Neovim (pixel coordinates)

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -65,9 +65,15 @@ void Shell::fontError(const QString& msg)
 
 void Shell::showGuiFont()
 {
-	QByteArray desc = m_nvim->encode(QString("%1:h%2\n")
-			.arg(fontFamily())
-			.arg(fontSize()));
+	QString fdesc = QString("%1:h%2").arg(fontFamily()).arg(fontSize());
+	if (font().bold()) {
+		fdesc += ":b";
+	}
+	if (font().italic()) {
+		fdesc += ":b";
+	}
+	fdesc += "\n";
+	QByteArray desc = m_nvim->encode(fdesc);
 	m_nvim->neovimObject()->vim_out_write(desc);
 }
 

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -109,8 +109,7 @@ bool Shell::setGuiFont(const QString& fdesc)
 	bool ok = setShellFont(attrs.at(0), pointSize, weight, italic);
 	if (ok && m_attached) {
 		resizeNeovim(size());
-		QString cmd = QString("let g:GuiFont=\"%1\"").arg(fdesc);
-		m_nvim->neovimObject()->vim_command(m_nvim->encode(cmd));
+		m_nvim->neovimObject()->vim_set_var("GuiFont", fdesc);
 	}
 
 	return ok;
@@ -644,8 +643,7 @@ void Shell::updateWindowId()
 	if (m_attached &&
 		m_nvim->connectionType() == NeovimConnector::SpawnedConnection) {
 		WId window_id = effectiveWinId();
-		QString cmd = QString("let g:GuiWindowId=%1").arg(window_id);
-		m_nvim->neovimObject()->vim_command(m_nvim->encode(cmd));
+		m_nvim->neovimObject()->vim_set_var("GuiWindowId", QVariant(window_id));
 	}
 }
 
@@ -726,14 +724,14 @@ void Shell::updateGuiWindowState(Qt::WindowStates state)
 		return;
 	}
 	if (state & Qt::WindowMaximized) {
-		m_nvim->neovimObject()->vim_command("let g:GuiWindowMaximized=1");
+		m_nvim->neovimObject()->vim_set_var("GuiWindowMaximized", 1);
 	} else {
-		m_nvim->neovimObject()->vim_command("let g:GuiWindowMaximized=0");
+		m_nvim->neovimObject()->vim_set_var("GuiWindowMaximized", 0);
 	}
 	if (state & Qt::WindowFullScreen) {
-		m_nvim->neovimObject()->vim_command("let g:GuiWindowFullScreen=1");
+		m_nvim->neovimObject()->vim_set_var("GuiWindowFullScreen", 1);
 	} else {
-		m_nvim->neovimObject()->vim_command("let g:GuiWindowFullScreen=0");
+		m_nvim->neovimObject()->vim_set_var("GuiWindowFullScreen", 0);
 	}
 }
 

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -425,6 +425,9 @@ void Shell::handleNeovimNotification(const QByteArray &name, const QVariantList&
 		if (guiEvName == "SetFont" && args.size() == 2) {
 			QString fdesc = m_nvim->decode(args.at(1).toByteArray());
 			setGuiFont(fdesc);
+		} else if (guiEvName == "Foreground" && args.size() == 1) {
+			activateWindow();
+			raise();
 		}
 		return;
 	} else if (name != "redraw") {

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -63,7 +63,7 @@ void Shell::fontError(const QString& msg)
 	}
 }
 
-void Shell::showGuiFont()
+QString Shell::fontDesc()
 {
 	QString fdesc = QString("%1:h%2").arg(fontFamily()).arg(fontSize());
 	if (font().bold()) {
@@ -73,8 +73,7 @@ void Shell::showGuiFont()
 		fdesc += ":b";
 	}
 	fdesc += "\n";
-	QByteArray desc = m_nvim->encode(fdesc);
-	m_nvim->neovimObject()->vim_out_write(desc);
+	return fdesc;
 }
 
 /**
@@ -129,6 +128,7 @@ void Shell::setAttached(bool attached)
 	emit neovimAttached(attached);
 	if (attached) {
 		updateWindowId();
+		m_nvim->neovimObject()->vim_set_var("GuiFont", fontDesc());
 		if (isWindow()) {
 			updateGuiWindowState(windowState());
 		}

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -130,6 +130,9 @@ void Shell::setAttached(bool attached)
 	emit neovimAttached(attached);
 	if (attached) {
 		updateWindowId();
+		if (isWindow()) {
+			updateGuiWindowState(windowState());
+		}
 		m_nvim->neovimObject()->vim_command("runtime! ginit.vim");
 	}
 	update();

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -38,12 +38,15 @@ signals:
 	void neovimBusy(bool);
 	void neovimResized(int rows, int cols);
 	void neovimAttached(bool);
+	void neovimMaximized(bool);
+	void neovimFullScreen(bool);
 
 public slots:
 	void handleNeovimNotification(const QByteArray &name, const QVariantList& args);
 	void resizeNeovim(const QSize&);
 	void resizeNeovim(int n_cols, int n_rows);
 	bool setGuiFont(const QString& fdesc);
+	void updateGuiWindowState(Qt::WindowStates state);
 
 protected slots:
 	void neovimError(NeovimConnector::NeovimError);

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -47,6 +47,7 @@ public slots:
 	void resizeNeovim(int n_cols, int n_rows);
 	bool setGuiFont(const QString& fdesc);
 	void updateGuiWindowState(Qt::WindowStates state);
+	void showGuiFont();
 
 protected slots:
 	void neovimError(NeovimConnector::NeovimError);

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -46,8 +46,6 @@ public slots:
 	bool setGuiFont(const QString& fdesc);
 
 protected slots:
-	void neovimIsReady();
-        void neovimFontVarOk(quint32, Function::FunctionId, const QVariant&);
 	void neovimError(NeovimConnector::NeovimError);
 	void neovimExited(int);
 	void neovimResizeFinished();

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -32,6 +32,7 @@ public:
 	virtual QVariant inputMethodQuery(Qt::InputMethodQuery) const Q_DECL_OVERRIDE;
 	bool neovimBusy() const;
 	bool neovimAttached() const;
+	QString fontDesc();
 
 signals:
 	void neovimTitleChanged(const QString &title);
@@ -47,7 +48,6 @@ public slots:
 	void resizeNeovim(int n_cols, int n_rows);
 	bool setGuiFont(const QString& fdesc);
 	void updateGuiWindowState(Qt::WindowStates state);
-	void showGuiFont();
 
 protected slots:
 	void neovimError(NeovimConnector::NeovimError);

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -57,11 +57,13 @@ protected slots:
 	void mouseClickIncrement(Qt::MouseButton bt);
         void init();
 	void fontError(const QString& msg);
+	void updateWindowId();
 
 protected:
 	void tooltip(const QString& text);
 	virtual void inputMethodEvent(QInputMethodEvent *event) Q_DECL_OVERRIDE;
 	virtual void wheelEvent(QWheelEvent *event) Q_DECL_OVERRIDE;
+	virtual bool event(QEvent *event) Q_DECL_OVERRIDE;
 
 	QPoint neovimCursorTopLeft() const;
 	QRect neovimCursorRect() const;

--- a/src/msgpackiodevice.cpp
+++ b/src/msgpackiodevice.cpp
@@ -735,6 +735,18 @@ void MsgpackIODevice::send(const QVariant& var)
 	case QMetaType::UInt:
 		msgpack_pack_unsigned_int(&m_pk, var.toUInt());
 		break;
+	case QMetaType::Long:
+		msgpack_pack_long_long(&m_pk, var.toLongLong());
+		break;
+	case QMetaType::LongLong:
+		msgpack_pack_long_long(&m_pk, var.toLongLong());
+		break;
+	case QMetaType::ULong:
+		msgpack_pack_unsigned_long_long(&m_pk, var.toULongLong());
+		break;
+	case QMetaType::ULongLong:
+		msgpack_pack_unsigned_long_long(&m_pk, var.toULongLong());
+		break;
 	case QMetaType::Float:
 		msgpack_pack_float(&m_pk, var.toFloat());
 		break;
@@ -846,6 +858,14 @@ bool MsgpackIODevice::checkVariant(const QVariant& var)
 	case QMetaType::Int:
 		break;
 	case QMetaType::UInt:
+		break;
+	case QMetaType::Long:
+		break;
+	case QMetaType::LongLong:
+		break;
+	case QMetaType::ULong:
+		break;
+	case QMetaType::ULongLong:
 		break;
 	case QMetaType::Float:
 		break;

--- a/src/util.h
+++ b/src/util.h
@@ -40,6 +40,15 @@ bool decode(const QVariant& in, T& out) {
 	return false;
 }
 
+/// Return false if the variant is an integer with
+/// value (0), all other values return true
+inline bool variant_not_zero(const QVariant& v)
+{
+	bool ok=false;
+	int int_val = v.toInt(&ok);
+	return !ok || int_val != 0;
+}
+
 }
 
 #endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,8 +10,8 @@ function(add_xtest SOURCE_NAME)
 endfunction()
 
 function(add_xtest_gui SOURCE_NAME)
-	add_executable(${SOURCE_NAME} ${SOURCE_NAME}.cpp ${ARGV1} ${ARGV2})
-	target_link_libraries(${SOURCE_NAME} Qt5::Network Qt5::Test ${MSGPACK_LIBRARIES} neovim-qt Qt5::Widgets qshellwidget)
+	add_executable(${SOURCE_NAME} ${SOURCE_NAME}.cpp)
+	target_link_libraries(${SOURCE_NAME} Qt5::Network Qt5::Test ${MSGPACK_LIBRARIES} neovim-qt Qt5::Widgets neovim-qt-gui)
 	add_test(NAME ${SOURCE_NAME} COMMAND ${SOURCE_NAME})
 	add_dependencies(check ${SOURCE_NAME})
 endfunction()
@@ -22,6 +22,4 @@ add_xtest(tst_callallmethods)
 add_xtest(tst_encoding)
 add_xtest(tst_msgpackiodevice)
 add_xtest(tst_input ${CMAKE_SOURCE_DIR}/src/gui/input.cpp)
-add_xtest_gui(tst_shell
-	${CMAKE_SOURCE_DIR}/src/gui/input.cpp
-	${CMAKE_SOURCE_DIR}/src/gui/shell.cpp)
+add_xtest_gui(tst_shell)

--- a/test/tst_shell.cpp
+++ b/test/tst_shell.cpp
@@ -61,7 +61,7 @@ protected:
 			});
 
 		QStringList vars = {"GuiWindowId", "GuiWindowMaximized",
-			"GuiWindowFullScreen"};
+			"GuiWindowFullScreen", "GuiFont"};
 		foreach(const QString& var, vars) {
 			qDebug() << "Checking Neovim for Gui var" << var;
 			QSignalSpy onVar(nvim, &NeovimQt::Neovim::on_vim_get_var);

--- a/test/tst_shell.cpp
+++ b/test/tst_shell.cpp
@@ -39,8 +39,37 @@ private slots:
 		p.save("tst_shell_start.jpg");
 
 	}
+
+	void startVarsShellWidget() {
+		QStringList args = {"-u", "NONE"};
+		NeovimConnector *c = NeovimConnector::spawn(args);
+		Shell *s = new Shell(c);
+		QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
+		QVERIFY(onAttached.isValid());
+		QVERIFY(SPYWAIT(onAttached));
+		QVERIFY(s->neovimAttached());
+		checkStartVars(c);
+	}
+
 protected:
-	NeovimQt::NeovimConnector *m_c;
+	/// Check for the presence of the GUI variables in Neovim
+	void checkStartVars(NeovimQt::NeovimConnector *conn) {
+		NeovimQt::Neovim *nvim = conn->neovimObject();
+		connect(nvim, &NeovimQt::Neovim::err_vim_get_var,
+			[](const QString& err, const QVariant& v) {
+				qDebug() << err<< v;
+			});
+
+		QStringList vars = {"GuiWindowId", "GuiWindowMaximized",
+			"GuiWindowFullScreen"};
+		foreach(const QString& var, vars) {
+			qDebug() << "Checking Neovim for Gui var" << var;
+			QSignalSpy onVar(nvim, &NeovimQt::Neovim::on_vim_get_var);
+			QVERIFY(onVar.isValid());
+			nvim->vim_get_var(conn->encode(var));
+			QVERIFY(SPYWAIT(onVar));
+		}
+	}
 };
 
 } // Namespace NeovimQt

--- a/test/tst_shell.cpp
+++ b/test/tst_shell.cpp
@@ -1,6 +1,6 @@
 #include <QtTest/QtTest>
 #include <QLocalSocket>
-#include <gui/shell.h>
+#include <gui/mainwindow.h>
 #include "common.h"
 
 namespace NeovimQt {
@@ -44,6 +44,17 @@ private slots:
 		QStringList args = {"-u", "NONE"};
 		NeovimConnector *c = NeovimConnector::spawn(args);
 		Shell *s = new Shell(c);
+		QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
+		QVERIFY(onAttached.isValid());
+		QVERIFY(SPYWAIT(onAttached));
+		QVERIFY(s->neovimAttached());
+		checkStartVars(c);
+	}
+
+	void startVarsMainWindow() {
+		QStringList args = {"-u", "NONE"};
+		NeovimConnector *c = NeovimConnector::spawn(args);
+		MainWindow *s = new MainWindow(c);
 		QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
 		QVERIFY(onAttached.isValid());
 		QVERIFY(SPYWAIT(onAttached));


### PR DESCRIPTION
Basically load a VimL helper plugin to help simplify some issues, avoid writing more C++, and make it easier to add new commands or global variables.

This partially helps with things like #94, ~~`exists('g:Gui')`~~ does not guarantee the GUI is attached but it guarantees that whatever commands the helper plugin provides are available,  So far the only thing they do is setting global variables and calling `rpcnotify(0, ...)` which should be harmless if the GUI is not attached.

This is also required for #64/#65, but we still need to define an API for that, likewise for #83

- [x] Partially fix #83 
- [x] Fixes #64
- [x] Move helper plugin to a separate repo, easier to setup when using a remote GUI
- [x] Check scope for option function in the script
- [x] Unit tests
- [x] Load ginit.vim on attachment