### PR TITLE
In Unix map Windows key as D-

### DIFF
--- a/src/gui/input.cpp
+++ b/src/gui/input.cpp
@@ -58,7 +58,7 @@ InputConv::InputConv() {
 QString InputConv::modPrefix(Qt::KeyboardModifiers mod)
 {
 	QString modprefix;
-#ifdef Q_OS_MAC
+#if defined(Q_OS_MAC) || defined(Q_OS_UNIX)
 	if ( mod & CmdModifier ) {
 		modprefix += "D-"; // like MacVim does
 	}

--- a/src/gui/input.h
+++ b/src/gui/input.h
@@ -28,14 +28,17 @@ protected:
 	const Qt::KeyboardModifiers MetaModifier  = Qt::AltModifier;
 	const Qt::Key Key_Control = Qt::Key_Meta;
 	const Qt::Key Key_Cmd = Qt::Key_Control;
-	const Qt::Key Key_Meta = Qt::Key_Alt;
 #else
 	const Qt::KeyboardModifiers ControlModifier = Qt::ControlModifier;
+# ifdef Q_OS_UNIX
+	const Qt::KeyboardModifiers CmdModifier = Qt::MetaModifier;
+	const Qt::Key Key_Cmd = Qt::Key_Meta;;
+# else
 	const Qt::KeyboardModifiers CmdModifier = (Qt::KeyboardModifiers)0;
+	const Qt::Key Key_Cmd = (Qt::Key)0;
+# endif
 	const Qt::KeyboardModifiers MetaModifier  = Qt::MetaModifier;
 	const Qt::Key Key_Control = Qt::Key_Control;
-	const Qt::Key Key_Cmd = (Qt::Key)0;
-	const Qt::Key Key_Meta = Qt::Key_Meta;
 #endif
 	const Qt::KeyboardModifiers ShiftModifier = Qt::ShiftModifier;
 	const Qt::KeyboardModifiers AltModifier   = Qt::AltModifier;

--- a/test/tst_input.cpp
+++ b/test/tst_input.cpp
@@ -7,9 +7,20 @@ class TestInput: public QObject
 	Q_OBJECT
 private slots:
 	void specialKeys();
+	void modifiersAreNotKeys();
 private:
 	NeovimQt::InputConv input;
 };
+
+void TestInput::modifiersAreNotKeys()
+{
+	QCOMPARE(input.convertKey("", Qt::Key_Meta, Qt::MetaModifier),
+			QString());
+	QCOMPARE(input.convertKey("", Qt::Key_Control, Qt::ControlModifier),
+			QString());
+	QCOMPARE(input.convertKey("", Qt::Key_Alt, Qt::AltModifier),
+			QString());
+}
 
 void TestInput::specialKeys()
 {
@@ -18,8 +29,7 @@ void TestInput::specialKeys()
 			QString("<%1>").arg(input.specialKeys.value(k)));
 
 #ifdef Q_OS_MAC
-		// On Mac Control is actually the Cmd key, which we
-		// don't support yet
+		// On Mac Control is actually the Cmd key
 		QCOMPARE(input.convertKey("", k, Qt::ControlModifier),
 			QString("<D-%1>").arg(input.specialKeys.value(k)));
 #else
@@ -30,10 +40,14 @@ void TestInput::specialKeys()
 		QCOMPARE(input.convertKey("", k, Qt::AltModifier),
 			QString("<A-%1>").arg(input.specialKeys.value(k)));
 
-#ifdef Q_OS_MAC
+#if defined(Q_OS_MAC)
 		QCOMPARE(input.convertKey("", k, Qt::MetaModifier),
 			// On Mac Meta is actually the Control key
 			QString("<C-%1>").arg(input.specialKeys.value(k)));
+#elif defined(Q_OS_UNIX)
+		QCOMPARE(input.convertKey("", k, Qt::MetaModifier),
+			// On UNIX Meta is the Windows key, treated as D-
+			QString("<D-%1>").arg(input.specialKeys.value(k)));
 #else
 		QCOMPARE(input.convertKey("", k, Qt::MetaModifier),
 			// Meta is not handled right now


### PR DESCRIPTION
Neovim now supports the D- modifer, which we already in Mac OS X
for the Command key. This commit enables a similar behaviour for the
Windows key. Qt represents the Windows key as being the Meta key.