### PR TITLE
GUI: Add support for underline/curl colors

### DIFF
--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -107,7 +107,7 @@ private:
 
 	// highlight fg/bg - from redraw:highlightset - by default we
 	// use the values from above
-	QColor m_hg_foreground, m_hg_background;
+	QColor m_hg_foreground, m_hg_background, m_hg_special;
 	QColor m_cursor_color;
 
 	/// Cursor position in shell coordinates

--- a/src/gui/shellwidget/cell.h
+++ b/src/gui/shellwidget/cell.h
@@ -8,9 +8,10 @@
 struct Cell {
 public:
 
-	inline Cell(QChar c, QColor fgColor, QColor bgColor, bool bold,
+
+	inline Cell(QChar c, QColor fgColor, QColor bgColor, QColor spColor, bool bold,
 			bool italic, bool underline, bool undercurl)
-	:foregroundColor(fgColor), backgroundColor(bgColor),
+	:foregroundColor(fgColor), backgroundColor(bgColor), specialColor(spColor),
 	bold(bold), italic(italic), underline(underline), undercurl(undercurl),
 	valid(true), doubleWidth(false) {
 		setChar(c);
@@ -18,7 +19,7 @@ public:
 
 	/// Default cells are space characters using invalid colors
 	inline Cell()
-	:c(' '), foregroundColor(QColor()), backgroundColor(QColor()),
+	:c(' '), foregroundColor(QColor()), backgroundColor(QColor()), specialColor(QColor()),
 	bold(false), italic(false), underline(false), undercurl(false),
 	valid(true), doubleWidth(false) {}
 
@@ -26,6 +27,7 @@ public:
 		c = ' ';
 		foregroundColor = QColor();
 		backgroundColor = foregroundColor;
+		specialColor = foregroundColor;
 		bold = italic = underline = undercurl = doubleWidth = false;
 		valid = true;
 	}
@@ -44,13 +46,13 @@ public:
 	}
 
 	static inline Cell invalid() {
-		Cell c = Cell('X', Qt::white, Qt::red, false, false, false, false);
+		Cell c = Cell('X', Qt::white, Qt::red, QColor(), false, false, false, false);
 		c.valid = false;
 		return c;
 	}
 
 	QChar c;
-	QColor foregroundColor, backgroundColor;
+	QColor foregroundColor, backgroundColor, specialColor;
 	bool bold, italic, underline, undercurl;
 	bool valid;
 	bool doubleWidth;
@@ -67,6 +69,7 @@ inline bool operator==(const Cell& c1, const Cell& c2)
 	return (c1.c == c2.c
 			&& c1.foregroundColor == c2.foregroundColor
 			&& c1.backgroundColor == c2.backgroundColor
+			&& c1.specialColor == c2.specialColor
 			&& c1.bold == c2.bold
 			&& c1.italic == c2.italic
 			&& c1.underline == c2.underline

--- a/src/gui/shellwidget/shellcontents.cpp
+++ b/src/gui/shellwidget/shellcontents.cpp
@@ -222,7 +222,7 @@ const Cell& ShellContents::constValue(int row, int column) const
 
 /// Writes content to the shell, returns the number of columns written
 int ShellContents::put(const QString& str, int row, int column,
-		QColor fg, QColor bg, bool bold, bool italic,
+		QColor fg, QColor bg, QColor sp, bool bold, bool italic,
 		bool underline, bool undercurl)
 {
 	if (row < 0 || row >= _rows || column < 0 || column >= _columns) {
@@ -232,7 +232,7 @@ int ShellContents::put(const QString& str, int row, int column,
 	int pos = column;
 	foreach(const QChar chr, str) {
 		Cell& c = value(row, pos);
-		c = Cell(chr, fg, bg, bold, italic, underline, undercurl);
+		c = Cell(chr, fg, bg, sp, bold, italic, underline, undercurl);
 		if (c.doubleWidth) {
 			value(row, pos+1) = Cell();
 			pos += 2;

--- a/src/gui/shellwidget/shellcontents.h
+++ b/src/gui/shellwidget/shellcontents.h
@@ -26,7 +26,7 @@ public:
 	Cell& value(int row, int column);
 	const Cell& constValue(int row, int column) const;
 	int put(const QString&, int row, int column,
-			QColor fg=Qt::black, QColor bg=Qt::white,
+			QColor fg=Qt::black, QColor bg=Qt::white, QColor sp=QColor(),
 			bool bold=false, bool italic=false,
 			bool underline=false, bool undercurl=false);
 

--- a/src/gui/shellwidget/shellwidget.h
+++ b/src/gui/shellwidget/shellwidget.h
@@ -21,6 +21,7 @@ public:
 
 	QColor background() const;
 	QColor foreground() const;
+	QColor special() const;
 	QString fontFamily() const;
 	int fontSize() const;
 	static ShellWidget* fromFile(const QString& path);
@@ -35,11 +36,12 @@ signals:
 	void fontError(const QString& msg);
 public slots:
 	void resizeShell(int rows, int columns);
+	void setSpecial(const QColor& color);
 	void setBackground(const QColor& color);
 	void setForeground(const QColor& color);
 	void setDefaultFont();
 	int put(const QString&, int row, int column,
-			QColor fg=QColor(), QColor bg=QColor(),
+			QColor fg=QColor(), QColor bg=QColor(), QColor sp=QColor(),
 			bool bold=false, bool italic=false,
 			bool underline=false, bool undercurl=false);
 	void clearRow(int row);
@@ -61,7 +63,7 @@ private:
 	ShellContents m_contents;
 	QSize m_cellSize;
 	int m_ascent;
-	QColor m_bgColor, m_fgColor;
+	QColor m_bgColor, m_fgColor, m_spColor;
 };
 
 #endif

--- a/src/gui/shellwidget/test/bench_cell.cpp
+++ b/src/gui/shellwidget/test/bench_cell.cpp
@@ -7,7 +7,7 @@ class Test: public QObject
 private slots:
 	void benchCell() {
 		QBENCHMARK {
-			Cell c('1', Qt::red, Qt::blue, false, false, false, false);
+			Cell c('1', Qt::red, Qt::blue, QColor(), false, false, false, false);
 		}
 	}
 };

--- a/src/gui/shellwidget/test/test_cell.cpp
+++ b/src/gui/shellwidget/test/test_cell.cpp
@@ -11,8 +11,10 @@ private slots:
 		// Default colors are invalid
 		QCOMPARE(c.foregroundColor, QColor());
 		QCOMPARE(c.backgroundColor, QColor());
+		QCOMPARE(c.specialColor, QColor());
 		QVERIFY(!c.foregroundColor.isValid());
 		QVERIFY(!c.backgroundColor.isValid());
+		QVERIFY(!c.specialColor.isValid());
 
 		QBENCHMARK {
 			Cell c;
@@ -21,13 +23,13 @@ private slots:
 
 	void cellValue() {
 		QBENCHMARK {
-			Cell c('z', Qt::black, Qt::white,
+			Cell c('z', Qt::black, Qt::white, QColor(),
 					false, false, false, false);
 		}
 	}
 	void cellValueRgb() {
 		QBENCHMARK {
-			Cell c('z', QRgb(33), QRgb(66),
+			Cell c('z', QRgb(33), QRgb(66), QColor(),
 					false, false, false, false);
 		}
 	}


### PR DESCRIPTION
Added support for the 'special' color field used for underlines/undercurl.
When the 'special' color isn't set, uses foreground color for underline.

The use of foreground color when special isn't set is consistent with MacVim's behavior.

There is a pull request (https://github.com/neovim/neovim/pull/4633) for neovim to add special colors back in.