### PR TITLE
GUI: Handle event Gui Linespace

### DIFF
--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -72,8 +72,14 @@ int main(int argc, char **argv)
 			QString server = parser.value("server");
 			c = NeovimQt::NeovimConnector::connectToNeovim(server);
 		} else {
+			auto path = qgetenv("NVIM_QT_RUNTIME_PATH");
+			if (QFileInfo(path).isDir()) {
+				neovimArgs.insert(0, "--cmd");
+				neovimArgs.insert(1, QString("set rtp+=%1")
+						.arg(QString::fromLocal8Bit(path)));
+			}
 #ifdef NVIM_QT_RUNTIME_PATH
-			if (QFileInfo(NVIM_QT_RUNTIME_PATH).isDir()) {
+			else if (QFileInfo(NVIM_QT_RUNTIME_PATH).isDir()) {
 				neovimArgs.insert(0, "--cmd");
 				neovimArgs.insert(1, QString("set rtp+=%1")
 						.arg(NVIM_QT_RUNTIME_PATH));

--- a/src/gui/runtime/doc/neovim_gui_shim.txt
+++ b/src/gui/runtime/doc/neovim_gui_shim.txt
@@ -63,7 +63,7 @@ override the window behaviour.
 g:GuiWindowId holds the window id (X11) or the window handle (Windows).
 
 							*g:GuiFont*
-g:GuiWindowId holds the current GUI font name, the same value used by
+g:GuiFont holds the current GUI font name, the same value used by
 |GuiFont|.
 
 ==============================================================================

--- a/src/gui/runtime/doc/neovim_gui_shim.txt
+++ b/src/gui/runtime/doc/neovim_gui_shim.txt
@@ -33,6 +33,11 @@ GuiFont		When called with no arguments this command display the
 			b   - bold
 			i   - italic
 
+								*GuiLinespace*
+GuiLinespace	When called with no arguments this command displays the
+		linespace, the number of extra pixels each line will have.
+                A single argument is accepted as the new linespace height.
+
 ==============================================================================
 2. GUI variables
 
@@ -66,6 +71,10 @@ g:GuiWindowId holds the window id (X11) or the window handle (Windows).
 g:GuiFont holds the current GUI font name, the same value used by
 |GuiFont|.
 
+							*g:GuiLinespace*
+g:GuiLinespace holds the extra vertical space (in pixels) added to
+each line.
+
 ==============================================================================
 3. Functions
 
@@ -86,6 +95,10 @@ enabled and 0 disabled.
 							*GuiFont()* 
 GuiFont(fname) Sets the GUI font, see |GuiFont| for details on the font name
 format. Replaces |'guifont'|.
+
+							*GuiLinespace()*
+GuiLinespace(height) sets the number of vertical pixels added to each line.
+Replaces |'linespace'|.
 
 ==============================================================================
 4. Internals

--- a/src/gui/runtime/plugin/nvim_gui_shim.vim
+++ b/src/gui/runtime/plugin/nvim_gui_shim.vim
@@ -24,6 +24,11 @@ function! GuiFont(fname)
 	call rpcnotify(0, 'Gui', 'Font', a:fname)
 endfunction
 
+" Set additional linespace
+function! GuiLinespace(height)
+	call rpcnotify(0, 'Gui', 'Linespace', a:height)
+endfunction
+
 " The GuiFont command. For compatibility there is also Guifont
 function s:GuiFontCommand(fname)
 	if a:fname == ""
@@ -38,3 +43,16 @@ function s:GuiFontCommand(fname)
 endfunction
 command! -nargs=? Guifont call s:GuiFontCommand("<args>")
 command! -nargs=? GuiFont call s:GuiFontCommand("<args>")
+
+function s:GuiLinespaceCommand(height)
+	if a:height == ""
+		if exists('g:GuiLinespace')
+			echo g:GuiLinespace
+		else
+			echo 'No GuiLinespace is set'
+		endif
+	else
+		call GuiLinespace(a:height)
+	endif
+endfunction
+command! -nargs=? GuiLinespace call s:GuiLinespaceCommand("<args>")

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -132,6 +132,7 @@ void Shell::setAttached(bool attached)
 		if (isWindow()) {
 			updateGuiWindowState(windowState());
 		}
+		m_nvim->neovimObject()->vim_command("runtime plugin/nvim_gui_shim.vim");
 		m_nvim->neovimObject()->vim_command("runtime! ginit.vim");
 	}
 	update();

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -477,6 +477,11 @@ void Shell::handleNeovimNotification(const QByteArray &name, const QVariantList&
 			} else {
 				emit neovimFullScreen(variant_not_zero(args.at(1)));
 			}
+		} else if (guiEvName == "Linespace" && args.size() == 2) {
+			auto val = args.at(1).toUInt();
+			setLineSpace(val);
+			m_nvim->neovimObject()->vim_set_var("GuiLinespace", val);
+			resizeNeovim(size());
 		}
 		return;
 	} else if (name != "redraw") {

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -125,7 +125,6 @@ Shell::~Shell()
 void Shell::setAttached(bool attached)
 {
 	m_attached = attached;
-	emit neovimAttached(attached);
 	if (attached) {
 		updateWindowId();
 		m_nvim->neovimObject()->vim_set_var("GuiFont", fontDesc());
@@ -135,6 +134,7 @@ void Shell::setAttached(bool attached)
 		m_nvim->neovimObject()->vim_command("runtime plugin/nvim_gui_shim.vim");
 		m_nvim->neovimObject()->vim_command("runtime! ginit.vim");
 	}
+	emit neovimAttached(attached);
 	update();
 }
 

--- a/src/gui/shellwidget/shellwidget.cpp
+++ b/src/gui/shellwidget/shellwidget.cpp
@@ -68,7 +68,7 @@ void ShellWidget::setFont(const QFont& f)
 	QWidget::setFont(f);
 }
 
-void ShellWidget::setLineSpace(int height)
+void ShellWidget::setLineSpace(unsigned int height)
 {
 	if (height != m_lineSpace) {
 		m_lineSpace = height;

--- a/src/gui/shellwidget/shellwidget.cpp
+++ b/src/gui/shellwidget/shellwidget.cpp
@@ -6,7 +6,7 @@
 
 ShellWidget::ShellWidget(QWidget *parent)
 :QWidget(parent), m_contents(0,0), m_bgColor(Qt::white),
-	m_fgColor(Qt::black), m_spColor(QColor())
+	m_fgColor(Qt::black), m_spColor(QColor()), m_lineSpace(0)
 {
 	setAttribute(Qt::WA_OpaquePaintEvent);
 	setAttribute(Qt::WA_KeyCompression, false);
@@ -56,8 +56,8 @@ bool ShellWidget::setShellFont(const QString& family, int ptSize, int weight, bo
 		emit fontError(QString("Warning: Font \"%1\" reports bad fixed pitch metrics").arg(f.family()));
 	}
 
-	setCellSize(f);
 	setFont(f);
+	setCellSize();
 	emit shellFontChanged();
 	return true;
 }
@@ -68,17 +68,26 @@ void ShellWidget::setFont(const QFont& f)
 	QWidget::setFont(f);
 }
 
+void ShellWidget::setLineSpace(int height)
+{
+	if (height != m_lineSpace) {
+		m_lineSpace = height;
+		setCellSize();
+		emit shellFontChanged();
+	}
+}
+
 /// Changed the cell size based on font metrics:
 /// - Height is either the line spacing or the font
 ///   height, the leading may be negative and we want the
 ///   larger value
 /// - Width is the width of the "W" character
-void ShellWidget::setCellSize(const QFont& f)
+void ShellWidget::setCellSize()
 {
-	QFontMetrics fm(f);
+	QFontMetrics fm(font());
 	m_ascent = fm.ascent();
 	m_cellSize = QSize(fm.width('W'),
-			qMax(fm.lineSpacing(), fm.height()));
+			qMax(fm.lineSpacing(), fm.height()) + m_lineSpace);
 	setSizeIncrement(m_cellSize);
 }
 QSize ShellWidget::cellSize() const

--- a/src/gui/shellwidget/shellwidget.cpp
+++ b/src/gui/shellwidget/shellwidget.cpp
@@ -150,7 +150,7 @@ void ShellWidget::paintEvent(QPaintEvent *ev)
 					}
 
 					// Draw chars at the baseline
-					QPoint pos(r.left(), r.top()+m_ascent);
+					QPoint pos(r.left(), r.top()+m_ascent+m_lineSpace);
 					p.drawText(pos, QString(cell.c));
 				}
 

--- a/src/gui/shellwidget/shellwidget.h
+++ b/src/gui/shellwidget/shellwidget.h
@@ -50,7 +50,7 @@ public slots:
 	void scrollShell(int rows);
 	void scrollShellRegion(int row0, int row1, int col0,
 			int col1, int rows);
-        void setLineSpace(int height);
+        void setLineSpace(unsigned int height);
 protected:
 	virtual void paintEvent(QPaintEvent *ev) Q_DECL_OVERRIDE;
 	virtual void resizeEvent(QResizeEvent *ev) Q_DECL_OVERRIDE;

--- a/src/gui/shellwidget/shellwidget.h
+++ b/src/gui/shellwidget/shellwidget.h
@@ -50,11 +50,12 @@ public slots:
 	void scrollShell(int rows);
 	void scrollShellRegion(int row0, int row1, int col0,
 			int col1, int rows);
+        void setLineSpace(int height);
 protected:
 	virtual void paintEvent(QPaintEvent *ev) Q_DECL_OVERRIDE;
 	virtual void resizeEvent(QResizeEvent *ev) Q_DECL_OVERRIDE;
 
-	void setCellSize(const QFont& f);
+	void setCellSize();
 	QRect absoluteShellRect(int row0, int col0, int rowcount, int colcount);
 
 private:
@@ -64,6 +65,7 @@ private:
 	QSize m_cellSize;
 	int m_ascent;
 	QColor m_bgColor, m_fgColor, m_spColor;
+        unsigned int m_lineSpace;
 };
 
 #endif

--- a/src/msgpackiodevice.cpp
+++ b/src/msgpackiodevice.cpp
@@ -48,6 +48,7 @@ MsgpackIODevice::MsgpackIODevice(QIODevice *dev, QObject *parent)
 :QObject(parent), m_reqid(0), m_dev(dev), m_encoding(0), m_reqHandler(0), m_error(NoError)
 {
 	qRegisterMetaType<MsgpackError>("MsgpackError");
+	qRegisterMetaType<Function::FunctionId>("Function::FunctionId");
 	msgpack_unpacker_init(&m_uk, MSGPACK_UNPACKER_INIT_BUFFER_SIZE);
 
 	if (m_dev) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,7 +12,9 @@ endfunction()
 function(add_xtest_gui SOURCE_NAME)
 	add_executable(${SOURCE_NAME} ${SOURCE_NAME}.cpp)
 	target_link_libraries(${SOURCE_NAME} Qt5::Network Qt5::Test ${MSGPACK_LIBRARIES} neovim-qt Qt5::Widgets neovim-qt-gui)
-	add_test(NAME ${SOURCE_NAME} COMMAND ${SOURCE_NAME})
+	add_test(NAME ${SOURCE_NAME} COMMAND ${SOURCE_NAME}
+		# Run GUI tests from source dir, they depend on src files
+		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 	add_dependencies(check ${SOURCE_NAME})
 endfunction()
 


### PR DESCRIPTION
gVim and MacVim support the linespace option that sets a margin space below
each line (in pixels).

The GUI now handles a notification ['Gui', 'Linespace', 4] that sets this space
to a positive integer. This is achieved by adding the extra space as part of the
cell metrics.

For #126, this first commit only adds the event handling, we are still missing a command in the shim. For testing try
```vim
    :call rpcnotify(0, 'Gui', 'Linespace', 4)
```