### PR TITLE
Fix unicode surrogate chars in shellwidget

### DIFF
--- a/src/gui/shellwidget/cell.h
+++ b/src/gui/shellwidget/cell.h
@@ -45,6 +45,19 @@ public:
 		doubleWidth = (konsole_wcwidth(c.unicode()) > 1);
 	}
 
+	inline void setLowSurrogate(const QChar& chr) {
+		lowSurrogate = chr;
+		doubleWidth = (string_width(text()));
+	}
+
+	inline QString text() const {
+		if (c.isHighSurrogate() && lowSurrogate.isLowSurrogate()) {
+			return QString(c) + lowSurrogate;
+		} else {
+			return c;
+		}
+	}
+
 	static inline Cell invalid() {
 		Cell c = Cell('X', Qt::white, Qt::red, QColor(), false, false, false, false);
 		c.valid = false;
@@ -52,6 +65,7 @@ public:
 	}
 
 	QChar c;
+	QChar lowSurrogate;
 	QColor foregroundColor, backgroundColor, specialColor;
 	bool bold, italic, underline, undercurl;
 	bool valid;

--- a/src/gui/shellwidget/shellcontents.cpp
+++ b/src/gui/shellwidget/shellcontents.cpp
@@ -230,9 +230,18 @@ int ShellContents::put(const QString& str, int row, int column,
 	}
 	
 	int pos = column;
-	foreach(const QChar chr, str) {
+	for (int i=0; i<str.size(); i++) {
 		Cell& c = value(row, pos);
-		c = Cell(chr, fg, bg, sp, bold, italic, underline, undercurl);
+		QChar cell_chr = str.at(i);
+		c = Cell(cell_chr, fg, bg, sp, bold, italic, underline, undercurl);
+
+		if (cell_chr.isHighSurrogate()) {
+			if (i<str.size()-1 && str.at(i+1).isLowSurrogate()) {
+				c.setLowSurrogate(str.at(i+1));
+			}
+			i++;
+		}
+
 		if (c.doubleWidth) {
 			value(row, pos+1) = Cell();
 			pos += 2;

--- a/src/gui/shellwidget/shellwidget.cpp
+++ b/src/gui/shellwidget/shellwidget.cpp
@@ -156,7 +156,7 @@ void ShellWidget::paintEvent(QPaintEvent *ev)
 
 					// Draw chars at the baseline
 					QPoint pos(r.left(), r.top()+m_ascent+m_lineSpace);
-					p.drawText(pos, QString(cell.c));
+					p.drawText(pos, cell.text());
 				}
 
 				// Draw "undercurl" at the bottom of the cell

--- a/src/gui/shellwidget/test/test_cell.cpp
+++ b/src/gui/shellwidget/test/test_cell.cpp
@@ -49,6 +49,18 @@ private slots:
 		Cell c2 = Cell::bg(Qt::red);
 		QCOMPARE(c2.backgroundColor, QColor(Qt::red));
 	}
+
+	void cellSurrogate() {
+		Cell c0;
+		QCOMPARE(c0.lowSurrogate, QChar());
+		QCOMPARE(c0.lowSurrogate.isLowSurrogate(), false);
+
+		Cell c1;
+		c1.c = QChar(55356);
+		c1.setLowSurrogate(QChar(57232));
+		QCOMPARE(c1.text(), QString("🎐"));
+		QCOMPARE(c1.doubleWidth, true);
+	}
 };
 
 QTEST_MAIN(Test)

--- a/src/gui/shellwidget/test/test_shellcontents.cpp
+++ b/src/gui/shellwidget/test/test_shellcontents.cpp
@@ -333,6 +333,18 @@ private slots:
 		QCOMPARE(s0.value(5, 9).c, QChar('o'));
 	}
 
+	void putSurrogate() {
+		int rows = 10;
+		int cols = 10;
+
+		ShellContents s0(rows, cols);
+		s0.put("🎐", 0, 0);
+		QCOMPARE(s0.value(0, 0).text(), QString("🎐"));
+
+		s0.put("🎐", 0, 9);
+		QCOMPARE(s0.value(0, 9).text(), QString("🎐"));
+	}
+
 	// Grab test cases from ../test/shellcontents
 	void cases() {
 		QDir dir("../test/shellcontents/");


### PR DESCRIPTION
The shell widget is backed up by QChar, a 16bit char. For surrogate
chars this is problematic because we are painting char by char, but
painting a surrogate requires painting it as a whole.

To address this we allow storing the low surrogate inside the cell and
add Cell::text() that returns accordingly.
