### PR TITLE
GUI: set termguicolors on spawn

### DIFF
--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -85,6 +85,8 @@ int main(int argc, char **argv)
 
 	int sep = app.arguments().indexOf("--");
 	QStringList neovimArgs;
+	neovimArgs << "--cmd";
+	neovimArgs << "set termguicolors";
 	if (sep != -1) {
 		QStringList args = app.arguments().mid(0, sep);
 		neovimArgs += app.arguments().mid(sep+1);


### PR DESCRIPTION
When spawning Neovim, set termguicolors at startup to enable
true color support.

- Should have the same effect as https://github.com/equalsraf/neovim-qt/pull/101 but for upcoming Neovim 0.1.5.
- Partially fixes #124 