### PR TITLE
GUI: Accept filenames as positional arguments

### DIFF
--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -47,6 +47,8 @@ int main(int argc, char **argv)
 		QCoreApplication::translate("main", "Maximize the window on startup")));
 	parser.addOption(QCommandLineOption("fullscreen",
 		QCoreApplication::translate("main", "Open the window in fullscreen on startup")));
+	parser.addPositionalArgument("file",
+		QCoreApplication::translate("main", "Edit specified file(s)"), "[file...]");
 	parser.addPositionalArgument("...", "Additional arguments are fowarded to Neovim", "[-- ...]");
 	parser.addHelpOption();
 
@@ -97,6 +99,9 @@ int main(int argc, char **argv)
 							.arg(d.path()));
 				}
 			}
+
+			// Pass positional file arguments to Neovim
+			neovimArgs.append(parser.positionalArguments());
 			c = NeovimQt::NeovimConnector::spawn(neovimArgs);
 		}
 	}


### PR DESCRIPTION
Previously when spawning Neovim only arguments after "--" were forwarded
to Neovim. nvim-qt now takes filenames as positional parameters that are
appended to the Neovim arguments.

The following are equivalent and open three files

    nvim-qt -- file0 file1 file2
    nvim-qt file0 file1 file2

The following is also equivalent, but notice the order,
because positional arguments are appended at the end of
neovim arguments

    nvim-qt file1 file2 -- file0

For #148 https://github.com/equalsraf/neovim-qt/issues/125