### PR TITLE
Improve shim loading and attach notification

### DIFF
--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -97,6 +97,8 @@ int main(int argc, char **argv)
 							.arg(d.path()));
 				}
 			}
+			neovimArgs.insert(2, QStringLiteral("--cmd"));
+			neovimArgs.insert(3, QStringLiteral("runtime plugin/nvim_gui_shim.vim"));
 			c = NeovimQt::NeovimConnector::spawn(neovimArgs);
 		}
 	}

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -134,8 +134,8 @@ void Shell::setAttached(bool attached)
 		if (isWindow()) {
 			updateGuiWindowState(windowState());
 		}
-		m_nvim->neovimObject()->vim_command("runtime plugin/nvim_gui_shim.vim");
 		m_nvim->neovimObject()->vim_command("runtime! ginit.vim");
+		m_nvim->neovimObject()->vim_command(QByteArrayLiteral("doautocmd User NeovimGuiAttached"));
 	}
 	emit neovimAttached(attached);
 	update();


### PR DESCRIPTION
- Instead of calling `runtime plugin/nvim_gui_shim.vim` at the moment
  the GUI attaches to Neovim, do it as a "pre-seeded" command that runs
  before init.vim is loaded, but just after the runtimepath sees added
  the path to the shim. That way the user can check for the presence of
  g:GuiLoaded.
- Since g:GuiLoaded is not sufficient for all cases, trigger a User
  NeovimGuiAttached auto command at the moment the GUI attaches. That is
  appropriate for calling GuiFont and friends from an auto command
  handler in init.vim.

Fixes #156.
