### PR TITLE
Fix #134

### DIFF
--- a/src/gui/input.cpp
+++ b/src/gui/input.cpp
@@ -150,15 +150,24 @@ QString InputConv::convertMouse(Qt::MouseButton bt, QEvent::Type type, Qt::Keybo
  */
 QString InputConv::convertKey(const QString& text, int k, Qt::KeyboardModifiers mod)
 {
+	QChar c;
 	if (specialKeys.contains(k)) {
-		return QString("<%1%2>").arg(modPrefix(mod)).arg(specialKeys.value(k));
+		c = text.at(0);
+		if (text.isEmpty() || c.isSpace() || !c.isPrint()) {
+			return QString("<%1%2>").arg(modPrefix(mod)).arg(specialKeys.value(k));
+		} else {
+			// 'k' include the information about SHIFT so do not check 'mod'
+			// See #134
+			return QString("<%1>").arg(specialKeys.value(k));
+		}
 	}
 
-	QChar c;
 	// Escape < and backslash
 	if (text == "<") {
+		// XXX: Never be called
 		return QString("<%1%2>").arg(modPrefix(mod)).arg("lt");
 	} else if (text == "\\") {
+		// XXX: Never be called?
 		return QString("<%1%2>").arg(modPrefix(mod)).arg("Bslash");
 	} else if (text.isEmpty()) {
 		// on macs, text is empty for ctrl+key and cmd+key combos (with or without alt)

--- a/src/gui/input.cpp
+++ b/src/gui/input.cpp
@@ -162,14 +162,7 @@ QString InputConv::convertKey(const QString& text, int k, Qt::KeyboardModifiers 
 		}
 	}
 
-	// Escape < and backslash
-	if (text == "<") {
-		// XXX: Never be called
-		return QString("<%1%2>").arg(modPrefix(mod)).arg("lt");
-	} else if (text == "\\") {
-		// XXX: Never be called?
-		return QString("<%1%2>").arg(modPrefix(mod)).arg("Bslash");
-	} else if (text.isEmpty()) {
+	if (text.isEmpty()) {
 		// on macs, text is empty for ctrl+key and cmd+key combos (with or without alt)
 		if (mod & ControlModifier || mod & CmdModifier) {
 			// ignore ctrl, alt and cmd key combos by themselves

--- a/src/gui/input.cpp
+++ b/src/gui/input.cpp
@@ -152,7 +152,7 @@ QString InputConv::convertKey(const QString& text, int k, Qt::KeyboardModifiers 
 {
 	QChar c;
 	if (specialKeys.contains(k)) {
-		c = text.at(0);
+		c = text.isEmpty() ? QChar() : text.at(0);
 		if (text.isEmpty() || c.isSpace() || !c.isPrint()) {
 			return QString("<%1%2>").arg(modPrefix(mod)).arg(specialKeys.value(k));
 		} else {


### PR DESCRIPTION
Fix #134. Could you check it?

In my environment, `text` of the following keys are empty.
- Up/Down/Left/Right
- F1-F12
- Home/End/PageUp/PageDown
- Insert

And the following keys are control characters (such as `\r`)
- Backspace/Delete/Enter/Tab/Escape

And the following keys are actual text
- <
- \

And I think Vim does not support `<S-lt>` or `<S-Bslash>` anyway (not confirmed).
