### PR TITLE
GUI: Handle open file requests.

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -16,7 +16,7 @@ add_subdirectory(shellwidget)
 
 include(GNUInstallDirs)
 set(RUNTIME_PATH )
-add_library(neovim-qt-gui shell.cpp input.cpp errorwidget.cpp mainwindow.cpp
+add_library(neovim-qt-gui shell.cpp input.cpp errorwidget.cpp mainwindow.cpp app.cpp
 	${CMAKE_SOURCE_DIR}/third-party/konsole_wcwidth.cpp
 	${NEOVIM_RCC_SOURCES})
 target_link_libraries(neovim-qt-gui qshellwidget neovim-qt)

--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -1,7 +1,6 @@
 #include "app.h"
 
 #include <QFileOpenEvent>
-#include <QMessageBox>
 
 namespace NeovimQt {
 
@@ -12,18 +11,13 @@ App::App(int &argc, char ** argv)
 
 bool App::event(QEvent *event)
 {
-  if( event->type()  == QEvent::FileOpen) {
-    //QFileOpenEvent is triggered for each file|URL seperately. Kepping
-    //the QList<QUrl> here does not cause any file|URL to be ignored.
-    QList<QUrl> urls;
-    QFileOpenEvent * fileOpenEvent = static_cast<QFileOpenEvent *>(event);
-    if(fileOpenEvent) {
-      QString file = fileOpenEvent->file();
-      urls.append(fileOpenEvent->url());
-      emit openFilesTriggered(urls);
-    }
-  }
-  return QApplication::event(event);
+	if( event->type()  == QEvent::FileOpen) {
+		QFileOpenEvent * fileOpenEvent = static_cast<QFileOpenEvent *>(event);
+		if(fileOpenEvent) {
+			emit openFilesTriggered({fileOpenEvent->url()});
+		}
+	}
+	return QApplication::event(event);
 }
 
 } // Namespace

--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -1,6 +1,7 @@
 #include "app.h"
 
 #include <QFileOpenEvent>
+#include <QMessageBox>
 
 namespace NeovimQt {
 
@@ -12,13 +13,14 @@ App::App(int &argc, char ** argv)
 bool App::event(QEvent *event)
 {
   if( event->type()  == QEvent::FileOpen) {
+    //QFileOpenEvent is triggered for each file|URL seperately. Kepping
+    //the QList<QUrl> here does not cause any file|URL to be ignored.
+    QList<QUrl> urls;
     QFileOpenEvent * fileOpenEvent = static_cast<QFileOpenEvent *>(event);
     if(fileOpenEvent) {
       QString file = fileOpenEvent->file();
-      if(!file.isEmpty()) {
-        emit neovimOpenFileTriggered(file);
-        return true;
-      }
+      urls.append(fileOpenEvent->url());
+      emit openFilesTriggered(urls);
     }
   }
   return QApplication::event(event);

--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -1,0 +1,27 @@
+#include "app.h"
+
+#include <QFileOpenEvent>
+
+namespace NeovimQt {
+
+App::App(int &argc, char ** argv)
+:QApplication(argc, argv)
+{
+}
+
+bool App::event(QEvent *event)
+{
+  if( event->type()  == QEvent::FileOpen) {
+    QFileOpenEvent * fileOpenEvent = static_cast<QFileOpenEvent *>(event);
+    if(fileOpenEvent) {
+      QString file = fileOpenEvent->file();
+      if(!file.isEmpty()) {
+        emit neovimOpenFileTriggered(file);
+        return true;
+      }
+    }
+  }
+  return QApplication::event(event);
+}
+
+} // Namespace

--- a/src/gui/app.h
+++ b/src/gui/app.h
@@ -1,0 +1,21 @@
+#ifndef NEOVIM_QT_APP
+#define NEOVIM_QT_APP
+
+#include <QApplication>
+#include <QEvent>
+
+namespace NeovimQt {
+
+class App: public QApplication
+{
+	Q_OBJECT
+public:
+  App(int &argc, char ** argv);
+  bool event(QEvent *event);
+signals:
+  void neovimOpenFileTriggered(const QString &file);
+};
+
+} // Namespace
+
+#endif

--- a/src/gui/app.h
+++ b/src/gui/app.h
@@ -12,10 +12,10 @@ class App: public QApplication
 {
 	Q_OBJECT
 public:
-  App(int &argc, char ** argv);
-  bool event(QEvent *event);
+	App(int &argc, char ** argv);
+	bool event(QEvent *event);
 signals:
-  void openFilesTriggered(const QList<QUrl>);
+	void openFilesTriggered(const QList<QUrl>);
 };
 
 } // Namespace

--- a/src/gui/app.h
+++ b/src/gui/app.h
@@ -3,6 +3,8 @@
 
 #include <QApplication>
 #include <QEvent>
+#include <QUrl>
+#include <QList>
 
 namespace NeovimQt {
 
@@ -13,7 +15,7 @@ public:
   App(int &argc, char ** argv);
   bool event(QEvent *event);
 signals:
-  void neovimOpenFileTriggered(const QString &file);
+  void openFilesTriggered(const QList<QUrl>);
 };
 
 } // Namespace

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -165,8 +165,8 @@ int main(int argc, char **argv)
 #else
 	NeovimQt::MainWindow *win = new NeovimQt::MainWindow(c);
 
-	QObject::connect(&app, SIGNAL(neovimOpenFileTriggered(const QString &)),
-      win->shell(), SLOT(neovimOpenFile(const QString &)));
+	QObject::connect(&app, SIGNAL(openFilesTriggered(const QList<QUrl>)),
+      win->shell(), SLOT(openFiles(const QList<QUrl>)));
 
 	if (parser.isSet("fullscreen")) {
 		win->delayedShow(NeovimQt::MainWindow::DelayedShow::FullScreen);

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -166,7 +166,7 @@ int main(int argc, char **argv)
 	NeovimQt::MainWindow *win = new NeovimQt::MainWindow(c);
 
 	QObject::connect(&app, SIGNAL(openFilesTriggered(const QList<QUrl>)),
-      win->shell(), SLOT(openFiles(const QList<QUrl>)));
+		win->shell(), SLOT(openFiles(const QList<QUrl>)));
 
 	if (parser.isSet("fullscreen")) {
 		win->delayedShow(NeovimQt::MainWindow::DelayedShow::FullScreen);

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -7,6 +7,7 @@
 #include <QDir>
 #include "neovimconnector.h"
 #include "mainwindow.h"
+#include "app.h"
 
 
 /// A log handler for Qt messages, all messages are dumped into the file
@@ -56,7 +57,7 @@ void loadLoginEnvironmen()
 
 int main(int argc, char **argv)
 {
-	QApplication app(argc, argv);
+	NeovimQt::App app(argc, argv);
 	app.setApplicationDisplayName("Neovim");
 	app.setWindowIcon(QIcon(":/neovim.png"));
 
@@ -163,6 +164,10 @@ int main(int argc, char **argv)
 	}
 #else
 	NeovimQt::MainWindow *win = new NeovimQt::MainWindow(c);
+
+	QObject::connect(&app, SIGNAL(neovimOpenFileTriggered(const QString &)),
+      win->shell(), SLOT(neovimOpenFile(const QString &)));
+
 	if (parser.isSet("fullscreen")) {
 		win->delayedShow(NeovimQt::MainWindow::DelayedShow::FullScreen);
 	} else if (parser.isSet("maximized")) {

--- a/src/gui/runtime/plugin/nvim_gui_shim.vim
+++ b/src/gui/runtime/plugin/nvim_gui_shim.vim
@@ -64,4 +64,5 @@ function GuiDrop(...)
 	let l:fnames = deepcopy(a:000)
 	let l:args = map(l:fnames, 'fnameescape(v:val)')
 	exec 'drop '.join(l:args, ' ')
+	doautocmd BufEnter
 endfunction

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -138,11 +138,11 @@ void Shell::setAttached(bool attached)
 		m_nvim->neovimObject()->vim_command("runtime plugin/nvim_gui_shim.vim");
 		m_nvim->neovimObject()->vim_command("runtime! ginit.vim");
 
-    // Noevim was not able to open urls till now. Check if we have any to open.
-    if(!m_urls.isEmpty()){
-      openFiles(m_urls);
-      m_urls.clear();    //Neovim may change state. Clear to prevent reopening.
-    }
+		// Noevim was not able to open urls till now. Check if we have any to open.
+		if(!m_urls.isEmpty()){
+			openFiles(m_urls);
+			m_urls.clear();    //Neovim may change state. Clear to prevent reopening.
+		}
 
 	}
 	emit neovimAttached(attached);
@@ -979,11 +979,11 @@ void Shell::openFiles(QList<QUrl> urls)
 		}
 		m_nvim->neovimObject()->vim_call_function("GuiDrop", args);
 	} else {
-    // Neovim cannot open urls now. Store them to open later.
+		// Neovim cannot open urls now. Store them to open later.
 		foreach(QUrl u, urls) {
-      m_urls.append(u);
-    }
-  }
+			m_urls.append(u);
+		}
+	}
 }
 
 } // Namespace

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -139,9 +139,9 @@ void Shell::setAttached(bool attached)
 		m_nvim->neovimObject()->vim_command("runtime! ginit.vim");
 
 		// Noevim was not able to open urls till now. Check if we have any to open.
-		if(!m_urls.isEmpty()){
-			openFiles(m_urls);
-			m_urls.clear();    //Neovim may change state. Clear to prevent reopening.
+		if(!m_deferredOpen.isEmpty()){
+			openFiles(m_deferredOpen);
+			m_deferredOpen.clear();    //Neovim may change state. Clear to prevent reopening.
 		}
 
 	}
@@ -980,9 +980,7 @@ void Shell::openFiles(QList<QUrl> urls)
 		m_nvim->neovimObject()->vim_call_function("GuiDrop", args);
 	} else {
 		// Neovim cannot open urls now. Store them to open later.
-		foreach(QUrl u, urls) {
-			m_urls.append(u);
-		}
+		m_deferredOpen.append(urls);
 	}
 }
 

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -119,6 +119,11 @@ bool Shell::setGuiFont(const QString& fdesc, bool force)
 	return ok;
 }
 
+void Shell::neovimOpenFile(const QString &file)
+{
+  m_nvim->neovimObject()->vim_command(QByteArray::fromStdString("e " + file.toStdString()));
+}
+
 
 Shell::~Shell()
 {
@@ -688,6 +693,7 @@ bool Shell::event(QEvent *event)
 	if (event->type() == QEvent::WinIdChange){
 		updateWindowId();
 	}
+
 	return QWidget::event(event);
 }
 

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -121,6 +121,9 @@ bool Shell::setGuiFont(const QString& fdesc, bool force)
 
 void Shell::neovimOpenFile(const QString &file)
 {
+  if (!m_nvim || !m_nvim->neovimObject()) {
+    return;
+  }
   m_nvim->neovimObject()->vim_command(QByteArray::fromStdString("e " + file.toStdString()));
 }
 

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -107,7 +107,7 @@ private:
 
 	NeovimConnector *m_nvim;
 
-	QList<QUrl> m_urls;
+	QList<QUrl> m_deferredOpen;
 
 	QRect m_scroll_region;
 	bool m_font_bold, m_font_italic, m_font_underline, m_font_undercurl;

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -107,7 +107,7 @@ private:
 
 	NeovimConnector *m_nvim;
 
-  QList<QUrl> m_urls;
+	QList<QUrl> m_urls;
 
 	QRect m_scroll_region;
 	bool m_font_bold, m_font_italic, m_font_underline, m_font_undercurl;

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -49,7 +49,6 @@ public slots:
 	void resizeNeovim(const QSize&);
 	void resizeNeovim(int n_cols, int n_rows);
 	bool setGuiFont(const QString& fdesc, bool force = false);
-	void neovimOpenFile(const QString &file);
 	void updateGuiWindowState(Qt::WindowStates state);
 	void openFiles(const QList<QUrl> url);
 
@@ -107,6 +106,8 @@ private:
 	bool m_attached;
 
 	NeovimConnector *m_nvim;
+
+  QList<QUrl> m_urls;
 
 	QRect m_scroll_region;
 	bool m_font_bold, m_font_italic, m_font_underline, m_font_undercurl;

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -49,6 +49,7 @@ public slots:
 	void resizeNeovim(const QSize&);
 	void resizeNeovim(int n_cols, int n_rows);
 	bool setGuiFont(const QString& fdesc, bool force = false);
+	void neovimOpenFile(const QString &file);
 	void updateGuiWindowState(Qt::WindowStates state);
 	void openFiles(const QList<QUrl> url);
 


### PR DESCRIPTION
In Mac OS X, this enables the application to handle
requests to open files. This can be through double
clicking a file in the finder, dropping a file on the
application icon (bundle), or dropping a file on the
application's icon in the dock.

This does not handle dropping directories on the app.
icon in the finder or the Dock. Since, I did not know
what should happen then.

I am a noob. I definitely have made many mistakes in this pr 😉 