### PR TITLE
Fix cropped and double width chars.

### DIFF
--- a/src/gui/shellwidget/shellwidget.cpp
+++ b/src/gui/shellwidget/shellwidget.cpp
@@ -124,6 +124,10 @@ void ShellWidget::paintEvent(QPaintEvent *ev)
 				QRect r = absoluteShellRect(i, j, 1, chars);
 
 				if (j <= 0 || !contents().constValue(i, j-1).doubleWidth) {
+
+					// If parts of previous character were drawn in our rect, keep it.
+					p.setCompositionMode(QPainter::CompositionMode_DestinationOver);
+
 					// Only paint bg/fg if this is not the second cell
 					// of a wide char
 					if (cell.backgroundColor.isValid()) {
@@ -131,6 +135,9 @@ void ShellWidget::paintEvent(QPaintEvent *ev)
 					} else {
 						p.fillRect(r, m_bgColor);
 					}
+
+					// Put new char over the bg ( possible previous chars parts )
+					p.setCompositionMode(QPainter::CompositionMode_SourceOver);
 
 					if (cell.c == ' ') {
 						continue;


### PR DESCRIPTION
This PR solves two issues I had with neovim-qt.
----
1- Fixes cropped chars.
2- Fixes an issue where only first cell of double width chars were drawn.

Compare the Before and after photos.
Before:
----------------
![cropped](https://cloud.githubusercontent.com/assets/1681606/17808533/24e4eb6c-6619-11e6-9adf-0490e422c2e6.png)


After:
---------
![fixed](https://cloud.githubusercontent.com/assets/1681606/17808545/3b10410c-6619-11e6-90a0-953c1e283a4d.png)




Now I have two issues.
------------
1- When the cursor moves over the chars, the update call forces the chars to be drawn as they were before this PR.
2- I see a little `x` in the second cell of double width chars. How can I remove it.