### PR TITLE
Improvements to CLI options

### DIFF
--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -68,6 +68,10 @@ int main(int argc, char **argv)
 	QCommandLineParser parser;
 	parser.addOption(QCommandLineOption("embed",
 		QCoreApplication::translate("main", "Communicate with Neovim over stdin/out")));
+	parser.addOption(QCommandLineOption("nvim",
+		QCoreApplication::translate("main", "nvim executable path"),
+		QCoreApplication::translate("main", "nvim_path"),
+		"nvim"));
 	parser.addOption(QCommandLineOption("server",
 		QCoreApplication::translate("main", "Connect to existing Neovim instance"),
 		QCoreApplication::translate("main", "addr")));
@@ -150,7 +154,7 @@ int main(int argc, char **argv)
 
 			// Pass positional file arguments to Neovim
 			neovimArgs.append(parser.positionalArguments());
-			c = NeovimQt::NeovimConnector::spawn(neovimArgs);
+			c = NeovimQt::NeovimConnector::spawn(neovimArgs, parser.value("nvim"));
 		}
 	}
 

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -66,15 +66,10 @@ int main(int argc, char **argv)
 	}
 
 	QCommandLineParser parser;
-	parser.addOption(QCommandLineOption("embed",
-		QCoreApplication::translate("main", "Communicate with Neovim over stdin/out")));
 	parser.addOption(QCommandLineOption("nvim",
 		QCoreApplication::translate("main", "nvim executable path"),
 		QCoreApplication::translate("main", "nvim_path"),
 		"nvim"));
-	parser.addOption(QCommandLineOption("server",
-		QCoreApplication::translate("main", "Connect to existing Neovim instance"),
-		QCoreApplication::translate("main", "addr")));
 	parser.addOption(QCommandLineOption("geometry",
 		QCoreApplication::translate("main", "Initial window geometry"),
 		QCoreApplication::translate("main", "geometry")));
@@ -82,24 +77,35 @@ int main(int argc, char **argv)
 		QCoreApplication::translate("main", "Maximize the window on startup")));
 	parser.addOption(QCommandLineOption("fullscreen",
 		QCoreApplication::translate("main", "Open the window in fullscreen on startup")));
+	parser.addHelpOption();
+	parser.addOption(QCommandLineOption("embed",
+		QCoreApplication::translate("main", "Communicate with Neovim over stdin/out")));
+	parser.addOption(QCommandLineOption("server",
+		QCoreApplication::translate("main", "Connect to existing Neovim instance"),
+		QCoreApplication::translate("main", "addr")));
+
 	parser.addPositionalArgument("file",
 		QCoreApplication::translate("main", "Edit specified file(s)"), "[file...]");
 	parser.addPositionalArgument("...", "Additional arguments are fowarded to Neovim", "[-- ...]");
-	parser.addHelpOption();
 
-	int sep = app.arguments().indexOf("--");
+	int positionalMarker = app.arguments().indexOf("--");
 	QStringList neovimArgs;
 	neovimArgs << "--cmd";
 	neovimArgs << "set termguicolors";
-	if (sep != -1) {
-		QStringList args = app.arguments().mid(0, sep);
-		neovimArgs += app.arguments().mid(sep+1);
+	if (positionalMarker != -1) {
+		QStringList args = app.arguments().mid(0, positionalMarker);
+		neovimArgs += app.arguments().mid(positionalMarker+1);
 		parser.process(args);
 	} else {
 		parser.process(app.arguments());
 	}
 
 	if (parser.isSet("help")) {
+		parser.showHelp();
+	}
+
+	if (parser.isSet("server") && parser.isSet("embed")) {
+		qWarning() << "Options --server and --embed are mutually exclusive\n";
 		parser.showHelp();
 	}
 
@@ -112,50 +118,58 @@ int main(int argc, char **argv)
 
 	NeovimQt::NeovimConnector *c;
 	if (parser.isSet("embed")) {
-		c = NeovimQt::NeovimConnector::fromStdinOut();
-	} else {
-		if (parser.isSet("server")) {
-			QString server = parser.value("server");
-			c = NeovimQt::NeovimConnector::connectToNeovim(server);
-		} else {
-			auto path = qgetenv("NVIM_QT_RUNTIME_PATH");
-			if (QFileInfo(path).isDir()) {
-				neovimArgs.insert(0, "--cmd");
-				neovimArgs.insert(1, QString("set rtp+=%1")
-						.arg(QString::fromLocal8Bit(path)));
-			}
-#ifdef NVIM_QT_RUNTIME_PATH
-			else if (QFileInfo(NVIM_QT_RUNTIME_PATH).isDir()) {
-				neovimArgs.insert(0, "--cmd");
-				neovimArgs.insert(1, QString("set rtp+=%1")
-						.arg(NVIM_QT_RUNTIME_PATH));
-			} else
-#endif
-			{
-				// Look for the runtime relative to the nvim-qt binary
-				QDir d = QFileInfo(QCoreApplication::applicationDirPath()).dir();
-#ifdef Q_OS_MAC
-				// within the bundle at ../Resources/runtime
-				d.cd("Resources");
-				d.cd("runtime");
-#else
-				// ../share/nvim-qt/runtime
-				d.cd("share");
-				d.cd("nvim-qt");
-				d.cd("runtime");
-#endif
-
-				if (d.exists()) {
-					neovimArgs.insert(0, "--cmd");
-					neovimArgs.insert(1, QString("set rtp+=%1")
-							.arg(d.path()));
-				}
-			}
-
-			// Pass positional file arguments to Neovim
-			neovimArgs.append(parser.positionalArguments());
-			c = NeovimQt::NeovimConnector::spawn(neovimArgs, parser.value("nvim"));
+		if (!parser.positionalArguments().isEmpty()
+				|| positionalMarker != -1) {
+			qWarning() << "--embed does not accept positional arguments\n";
+			parser.showHelp();
 		}
+		c = NeovimQt::NeovimConnector::fromStdinOut();
+	} else if (parser.isSet("server")) {
+		if (!parser.positionalArguments().isEmpty()
+				|| positionalMarker != -1) {
+			qWarning() << "--server does not accept positional arguments\n";
+			parser.showHelp();
+		}
+		QString server = parser.value("server");
+		c = NeovimQt::NeovimConnector::connectToNeovim(server);
+	} else {
+		auto path = qgetenv("NVIM_QT_RUNTIME_PATH");
+		if (QFileInfo(path).isDir()) {
+			neovimArgs.insert(0, "--cmd");
+			neovimArgs.insert(1, QString("set rtp+=%1")
+					.arg(QString::fromLocal8Bit(path)));
+		}
+#ifdef NVIM_QT_RUNTIME_PATH
+		else if (QFileInfo(NVIM_QT_RUNTIME_PATH).isDir()) {
+			neovimArgs.insert(0, "--cmd");
+			neovimArgs.insert(1, QString("set rtp+=%1")
+					.arg(NVIM_QT_RUNTIME_PATH));
+		} else
+#endif
+		{
+			// Look for the runtime relative to the nvim-qt binary
+			QDir d = QFileInfo(QCoreApplication::applicationDirPath()).dir();
+#ifdef Q_OS_MAC
+			// within the bundle at ../Resources/runtime
+			d.cd("Resources");
+			d.cd("runtime");
+#else
+			// ../share/nvim-qt/runtime
+			d.cd("share");
+			d.cd("nvim-qt");
+			d.cd("runtime");
+#endif
+
+			if (d.exists()) {
+				neovimArgs.insert(0, "--cmd");
+				neovimArgs.insert(1, QString("set rtp+=%1")
+						.arg(d.path()));
+			}
+		}
+
+		// Pass positional file arguments to Neovim
+		neovimArgs.append(parser.positionalArguments());
+		c = NeovimQt::NeovimConnector::spawn(neovimArgs, parser.value("nvim"));
 	}
 
 #ifdef NEOVIMQT_GUI_WIDGET

--- a/src/neovimconnector.cpp
+++ b/src/neovimconnector.cpp
@@ -194,7 +194,8 @@ NeovimConnector* NeovimConnector::spawn(const QStringList& params, const QString
 
 	NeovimConnector *c = new NeovimConnector(p);
 	c->m_ctype = SpawnedConnection;
-	c->m_connParams = params;
+	c->m_spawnArgs = params;
+	c->m_spawnExe = exe;
 
 	connect(p, SIGNAL(error(QProcess::ProcessError)),
 			c, SLOT(processError(QProcess::ProcessError)));
@@ -359,7 +360,7 @@ NeovimConnector* NeovimConnector::reconnect()
 {
 	switch(m_ctype) {
 	case SpawnedConnection:
-		return NeovimConnector::spawn(m_connParams);
+		return NeovimConnector::spawn(m_spawnArgs, m_spawnExe);
 	case HostConnection:
 		return NeovimConnector::connectToHost(m_connHost, m_connPort);
 	case SocketConnection:

--- a/src/neovimconnector.cpp
+++ b/src/neovimconnector.cpp
@@ -176,7 +176,7 @@ Neovim* NeovimConnector::neovimObject()
  * Launch an embedded Neovim process
  * @see processExited
  */
-NeovimConnector* NeovimConnector::spawn(const QStringList& params)
+NeovimConnector* NeovimConnector::spawn(const QStringList& params, const QString& exe)
 {
 	QProcess *p = new QProcess();
 	QStringList args;
@@ -202,7 +202,7 @@ NeovimConnector* NeovimConnector::spawn(const QStringList& params)
 			c, SIGNAL(processExited(int)));
 	connect(p, &QProcess::started,
 			c, &NeovimConnector::discoverMetadata);
-	p->start("nvim", args);
+	p->start(exe, args);
 	return c;
 }
 

--- a/src/neovimconnector.h
+++ b/src/neovimconnector.h
@@ -102,7 +102,8 @@ private:
 
 	// Store connection arguments for reconnect()
 	NeovimConnectionType m_ctype;
-	QStringList m_connParams;
+	QStringList m_spawnArgs;
+	QString m_spawnExe;
 	QString m_connSocket, m_connHost;
 	int m_connPort;
 	bool m_ready;

--- a/src/neovimconnector.h
+++ b/src/neovimconnector.h
@@ -48,7 +48,8 @@ public:
 
 	NeovimConnector(QIODevice* s);
 	NeovimConnector(MsgpackIODevice* s);
-	static NeovimConnector* spawn(const QStringList& params=QStringList());
+	static NeovimConnector* spawn(const QStringList& params=QStringList(),
+									const QString& exe="nvim");
 	static NeovimConnector* connectToSocket(const QString&);
 	static NeovimConnector* connectToHost(const QString& host, int port);
 	static NeovimConnector* connectToNeovim(const QString& server=QString());


### PR DESCRIPTION
- override nvim path or command used to start neovim
- fix some unclear command line conditions

The primary motivation here is

```
nvim-qt --spawn ssh HOST nvim --embed
```