### PR TITLE
Cleanup after Neovim API change

### DIFF
--- a/bindings/neovim.h
+++ b/bindings/neovim.h
@@ -23,6 +23,9 @@ private:
 	NeovimConnector *m_c;
 public slots:
 {% for f in functions %}
+{% if f.deprecated() %}
+	// DEPRECATED
+{% endif %}
 	// {{f.signature()}}
 	MsgpackRequest* {{f.name}}({{f.argstring}});
 {% endfor %}

--- a/src/function.cpp
+++ b/src/function.cpp
@@ -134,8 +134,15 @@ Function Function::fromVariant(const QVariant& fun)
 			// Deprecated
 		} else if ( it.key() == "receives_channel_id" ) {
 			// Internal
+		} else if ( it.key() == "impl_name" ) {
+			// Internal
+		} else if ( it.key() == "method" ) {
+			// Internal
+		} else if ( it.key() == "noeval" ) {
 		} else if ( it.key() == "deferred" || it.key() == "async" ) {
 			// Internal, "deferred" renamed "async" in neovim/ccdeb91
+		} else if ( it.key() == "deprecated_since" ) {
+			// This function is deprecated
 		} else {
 			qWarning() << "Unsupported function attribute"<< it.key() << it.value();
 		}

--- a/src/function.cpp
+++ b/src/function.cpp
@@ -144,7 +144,7 @@ Function Function::fromVariant(const QVariant& fun)
 		} else if ( it.key() == "deprecated_since" ) {
 			// This function is deprecated
 		} else {
-			qWarning() << "Unsupported function attribute"<< it.key() << it.value();
+			qDebug() << "Unsupported function attribute"<< it.key() << it.value();
 		}
 	}
 


### PR DESCRIPTION
Recent changes in the Neovim API cause nvim-qt to print a lot of warning messages due to the new attributes

- don't print attribute warnings in non debug builds
- add support for the new attributes in the binding generator and in function.cpp

To retain backwards compatibility this PR DOES NOT update the bindings.

ref https://github.com/equalsraf/neovim-qt/issues/184