### PR TITLE
Multiple improvements to binding generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,8 +79,9 @@ endif()
 # Bindings
 find_package(PythonInterp)
 if (PYTHONINTERP_FOUND)
+	set(NVIM "nvim" CACHE STRING "Path to nvim executable")
 	add_custom_target(bindings
-		COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/bindings/generate_bindings.py nvim ${CMAKE_SOURCE_DIR}/src/auto
+		COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/bindings/generate_bindings.py ${NVIM} ${CMAKE_SOURCE_DIR}/src/auto
 		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
 		COMMENT "Generating bindings"
 		)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,10 @@ if (PYTHONINTERP_FOUND)
 		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
 		COMMENT "Generating bindings"
 		)
+
+	add_custom_target(bindings-preview
+		COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/bindings/generate_bindings.py ${NVIM}
+		)
 endif()
 
 

--- a/bindings/function_static.cpp
+++ b/bindings/function_static.cpp
@@ -6,6 +6,6 @@ const QList<Function> Function::knownFunctions = QList<Function>()
 	{% for param in f.parameters %}
 		<< QString("{{param.neovim_type}}")
 	{% endfor %}
-	, {% if f.can_fail%}true{%else%}false{%endif%})
+	, false)
 {% endfor %}
 	;

--- a/bindings/generate_bindings.py
+++ b/bindings/generate_bindings.py
@@ -54,6 +54,7 @@ class NeovimTypeVal:
             'String': 'QByteArray',
             'Object': 'QVariant',
             'Array': 'QVariantList',
+            'Dictionary': 'QVariantMap',
         }
     # msgpack extension types
     EXTTYPES = {

--- a/bindings/generate_bindings.py
+++ b/bindings/generate_bindings.py
@@ -131,7 +131,6 @@ class Function:
             print('Found unknown attributes for function %s: %s' % (self.name, u_attrs))
 
         self.argcount = len(self.parameters)
-        self.can_fail = self.fun.get('can_fail', False)
 
         # Build the argument string - makes it easier for the templates
         self.argstring = ', '.join(['%s %s' % (tv.native_type, tv.name) for tv in self.parameters])
@@ -154,8 +153,6 @@ class Function:
             params += '%s %s' % (p.native_type, p.name)
             params += ', '
         notes = ''
-        if self.can_fail:
-            notes += '!fails'
         return '%s %s(%s) %s' % (self.return_type.native_type,self.name,params, notes)
     def signature(self):
         params = ''
@@ -163,8 +160,6 @@ class Function:
             params += '%s %s' % (p.neovim_type, p.name)
             params += ', '
         notes = ''
-        if self.can_fail:
-            notes += '!fails'
         return '%s %s(%s) %s' % (self.return_type.neovim_type,self.name,params, notes)
 
 

--- a/bindings/generate_bindings.py
+++ b/bindings/generate_bindings.py
@@ -212,5 +212,5 @@ if __name__ == '__main__':
             generate_file(name, outpath, **env)
 
     else:
-        print('Neovim api info:')
+        print('API info for %s:' % nvim)
         print_api(api)

--- a/bindings/generate_bindings.py
+++ b/bindings/generate_bindings.py
@@ -109,6 +109,9 @@ class Function:
     """
     Representation for a Neovim API Function
     """
+
+    # Attributes names that we support, see src/function.c for details
+    __KNOWN_ATTRIBUTES = set(['name', 'parameters', 'return_type', 'can_fail', 'deprecated_since', 'since', 'method', 'async', 'impl_name', 'noeval', 'receives_channel_id'])
     def __init__(self, nvim_fun):
         self.valid = False
         self.fun = nvim_fun
@@ -121,12 +124,28 @@ class Function:
         except UnsupportedType as ex:
             print('Found unsupported type(%s) when adding function %s(), skipping' % (ex,self.name))
             return
+
+        u_attrs = self.unknown_attributes()
+        if u_attrs:
+            print('Found unknown attributes for function %s: %s' % (self.name, u_attrs))
+
         self.argcount = len(self.parameters)
         self.can_fail = self.fun.get('can_fail', False)
 
         # Build the argument string - makes it easier for the templates
         self.argstring = ', '.join(['%s %s' % (tv.native_type, tv.name) for tv in self.parameters])
         self.valid = True
+
+    def is_method(self):
+        return self.fun.get('method', False)
+    def is_async(self):
+        return self.fun.get('async', False)
+    def deprecated(self):
+        return self.fun.get('deprecated_since', None)
+
+    def unknown_attributes(self):
+        attrs = set(self.fun.keys()) - Function.__KNOWN_ATTRIBUTES
+        return attrs
 
     def real_signature(self):
         params = ''
@@ -160,8 +179,12 @@ def print_api(api):
                 sig = fundef.signature()
                 realsig = fundef.real_signature()
                 print('\t%s'% sig)
+                deprecated = fundef.deprecated()
+                if deprecated:
+                    print('\t- Deprecated: %d' % deprecated)
                 if sig != realsig:
-                    print('\t[aka %s]\n' % realsig)
+                    print('\t- Native: %s\n' % realsig)
+
             print('')
         elif key == 'types':
             print('Data Types')
@@ -176,7 +199,7 @@ def print_api(api):
         elif key == 'features':
             pass
         else:
-            print('Unknown API info attribute: %s', key)
+            print('Unknown API info attribute: %s' % key)
 
 if __name__ == '__main__':
 

--- a/bindings/neovim.cpp
+++ b/bindings/neovim.cpp
@@ -69,11 +69,9 @@ void Neovim::handleResponseError(quint32 msgid, Function::FunctionId fun, const 
 
 	switch(fun) {
 {% for f in functions %}
-{% if f.can_fail %}
 	case Function::NEOVIM_FN_{{f.name.upper()}}:
 		emit err_{{f.name}}(errMsg, res);
 		break;
-{% endif %}
 {% endfor %}
 	default:
 		m_c->setError(NeovimConnector::RuntimeMsgpackError, QString("Received error for function that should not fail: %s").arg(fun));

--- a/bindings/neovim.h
+++ b/bindings/neovim.h
@@ -23,6 +23,9 @@ private:
 	NeovimConnector *m_c;
 public slots:
 {% for f in functions %}
+{% if f.deprecated() %}
+	// DEPRECATED
+{% endif %}
 	// {{f.signature()}}
 	MsgpackRequest* {{f.name}}({{f.argstring}});
 {% endfor %}

--- a/bindings/neovim.h
+++ b/bindings/neovim.h
@@ -33,9 +33,7 @@ public slots:
 signals:
 {% for f in functions %}
 	void on_{{f.name}}({{f.return_type.native_type}});
-{% if f.can_fail %}
 	void err_{{f.name}}(const QString&, const QVariant&);
-{% endif%}
 
 {% endfor %}
 };

--- a/src/function.cpp
+++ b/src/function.cpp
@@ -134,8 +134,16 @@ Function Function::fromVariant(const QVariant& fun)
 			// Deprecated
 		} else if ( it.key() == "receives_channel_id" ) {
 			// Internal
+		} else if ( it.key() == "impl_name" ) {
+			// Internal
+		} else if ( it.key() == "method" ) {
+			// Internal
+		} else if ( it.key() == "noeval" ) {
+			// API only function
 		} else if ( it.key() == "deferred" || it.key() == "async" ) {
 			// Internal, "deferred" renamed "async" in neovim/ccdeb91
+		} else if ( it.key() == "deprecated_since" || it.key() == "since" ) {
+			// Creation/Deprecation
 		} else {
 			qWarning() << "Unsupported function attribute"<< it.key() << it.value();
 		}

--- a/src/function.cpp
+++ b/src/function.cpp
@@ -75,10 +75,6 @@ bool Function::operator==(const Function& other)
 		return false;
 	}
 
-	if ( this->can_fail != other.can_fail ) {
-		return false;
-	}
-
 	if ( this->return_type != other.return_type ) {
 		return false;
 	}

--- a/src/function.cpp
+++ b/src/function.cpp
@@ -145,7 +145,7 @@ Function Function::fromVariant(const QVariant& fun)
 		} else if ( it.key() == "deprecated_since" || it.key() == "since" ) {
 			// Creation/Deprecation
 		} else {
-			qWarning() << "Unsupported function attribute"<< it.key() << it.value();
+			qDebug() << "Unsupported function attribute"<< it.key() << it.value();
 		}
 	}
 


### PR DESCRIPTION
- cmake -DNVIM=~/bin/nvim ..
- make bindings-preview
- avoid warnings about new API metadata in 0.1.6
- start ignoring can_fail for https://github.com/neovim/neovim/pull/5389
