### PR TITLE
generate helptags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .*
 build/
+src/gui/runtime/doc/tags
 third-party/msgpack*

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -64,3 +64,13 @@ if(WIN32 AND NOT CMAKE_CROSSCOMPILING)
 			DESTINATION ${CMAKE_INSTALL_BINDIR})
 	endif()
 endif()
+
+# Generate help tags
+add_custom_command(
+	OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/runtime/doc/tags"
+	COMMAND ${NEOVIM_EXEC} -i NONE -u NONE -e --headless
+	-c "helptags ${CMAKE_CURRENT_SOURCE_DIR}/runtime/doc" -c "quit"
+	COMMENT "Generating helptags")
+
+add_custom_target(helptags ALL
+	DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/runtime/doc/tags")


### PR DESCRIPTION
This is to fix #190 

This commit generates helptags (using nvim). Running "make install" installs the tags file at the right location.

I'm open to suggestions if how I did it can be improved (I'm far from a CMake expert!)
