### PR TITLE
"Flicker Free" startup

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -52,6 +52,11 @@ void MainWindow::init(NeovimConnector *c)
 	}
 }
 
+bool MainWindow::neovimResizing() const
+{
+	return (m_shell != NULL && m_shell->neovimResizing());
+}
+
 bool MainWindow::neovimAttached() const
 {
 	return (m_shell != NULL && m_shell->neovimAttached());
@@ -168,6 +173,9 @@ void MainWindow::delayedShow(DelayedShow type)
 
 void MainWindow::showIfDelayed()
 {
+	if(neovimResizing())
+		return;
+
 	if (!isVisible()) {
 		if (m_delayedShow == DelayedShow::Normal) {
 			show();

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -21,6 +21,7 @@ public:
 	};
 
 	MainWindow(NeovimConnector *, QWidget *parent=0);
+	bool neovimResizing() const;
 	bool neovimAttached() const;
 	Shell* shell();
 public slots:

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -876,6 +876,11 @@ bool Shell::neovimBusy() const
 	return m_neovimBusy;
 }
 
+bool Shell::neovimResizing() const
+{
+	return m_resizing;
+}
+
 bool Shell::neovimAttached() const
 {
 	return m_attached;

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -758,6 +758,8 @@ void Shell::neovimResizeFinished()
 				m_resize_neovim_pending.height());
 		m_resize_neovim_pending = QSize();
 	}
+
+	emit neovimResized(rows(), columns());
 }
 
 void Shell::changeEvent( QEvent *ev)

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -139,7 +139,7 @@ void Shell::setAttached(bool attached)
 		m_nvim->neovimObject()->vim_command("runtime plugin/nvim_gui_shim.vim");
 		m_nvim->neovimObject()->vim_command("runtime! ginit.vim");
 
-		// Noevim was not able to open urls till now. Check if we have any to open.
+		// Neovim was not able to open urls till now. Check if we have any to open.
 		if(!m_deferredOpen.isEmpty()){
 			openFiles(m_deferredOpen);
 			m_deferredOpen.clear();    //Neovim may change state. Clear to prevent reopening.

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -25,6 +25,7 @@ class Shell: public ShellWidget
 	Q_OBJECT
 	Q_PROPERTY(bool neovimBusy READ neovimBusy() NOTIFY neovimBusy())
 	Q_PROPERTY(bool neovimAttached READ neovimAttached() NOTIFY neovimAttached())
+	Q_PROPERTY(bool neovimResizing READ neovimResizing() NOTIFY neovimResizing())
 public:
 	Shell(NeovimConnector *nvim, QWidget *parent=0);
 	~Shell();
@@ -33,6 +34,7 @@ public:
 	static bool isBadMonospace(const QFont& f);
 	virtual QVariant inputMethodQuery(Qt::InputMethodQuery) const Q_DECL_OVERRIDE;
 	bool neovimBusy() const;
+	bool neovimResizing() const;
 	bool neovimAttached() const;
 	QString fontDesc();
 
@@ -40,6 +42,7 @@ signals:
 	void neovimTitleChanged(const QString &title);
 	void neovimBusy(bool);
 	void neovimResized(int rows, int cols);
+	void neovimResizing(bool);
 	void neovimAttached(bool);
 	void neovimMaximized(bool);
 	void neovimFullScreen(bool);


### PR DESCRIPTION
This pull request fixes some flickering issues during startup sequence when a custom font is selected (related to https://github.com/equalsraf/neovim-qt/issues/198).

The window is displayed after the first resizing sequence is completed, I have tested that and it doesn't slowdown the startup sequence.