### PR TITLE
test: Do not QVERIFY the spy in connectToNeovimTCP

### DIFF
--- a/test/tst_neovimconnector.cpp
+++ b/test/tst_neovimconnector.cpp
@@ -59,7 +59,8 @@ private slots:
 		QCOMPARE(c->connectionType(), NeovimConnector::HostConnection);
 		QSignalSpy onError(c, SIGNAL(error(NeovimError)));
 		QVERIFY(onError.isValid());
-		QVERIFY(SPYWAIT(onError));
+		// The signal might be emited before we get to connect
+		SPYWAIT(onError);
 
 		QCOMPARE(c->errorCause(), NeovimConnector::SocketError);
 		c->deleteLater();


### PR DESCRIPTION
This test contains the same race condition as in connectToNeovimSocket,
where the error may have already happened before SPYWAIT() is called.