### PR TITLE
Added link to README for shim plugin docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ for Windows both MSVC and Mingw are supported. Use the following
 
 The binaries will be under build/bin/. The GUI binary is called nvim-qt.
 
+## Configuration
+Commands for interacting with the GUI (e.g. to change the font) can be found by
+running [:help neovim-gui-shim](./src/gui/runtime/doc/neovim_gui_shim.txt).
+
 ## Design
 
 The *NeovimConnector* class is used to setup the connection to Neovim. It also


### PR DESCRIPTION
This PR adds a section to the README on how to change the font, since it's not immediately apparent.

On a related note, the shim plugin isn't loaded when following the build instructions, because `NVIM_QT_RUNTIME_PATH` is hard-coded to `/usr/local/share/nvim-qt/runtime` (which only works if Neovim-QT has been installed). 