### PR TITLE
Avoid repeated setup for signal ::reconnectNeovim

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -10,6 +10,8 @@ MainWindow::MainWindow(NeovimConnector *c, QWidget *parent)
 {
 	m_errorWidget = new ErrorWidget();
 	m_stack.addWidget(m_errorWidget);
+	connect(m_errorWidget, &ErrorWidget::reconnectNeovim,
+			this, &MainWindow::reconnectNeovim);
 	setCentralWidget(&m_stack);
 
 	init(c);
@@ -43,8 +45,6 @@ void MainWindow::init(NeovimConnector *c)
 			this, &MainWindow::neovimExited);
 	connect(m_nvim, &NeovimConnector::error,
 			this, &MainWindow::neovimError);
-	connect(m_errorWidget, &ErrorWidget::reconnectNeovim,
-			this, &MainWindow::reconnectNeovim);
 	m_shell->setFocus(Qt::OtherFocusReason);
 
 	if (m_nvim->errorCause()) {


### PR DESCRIPTION
The reconnect signal emited by the error dialog was being connect
with each call to MainWindow::init(), this meant that with each
reconnection the signal connected again, and emmited multiple times
for the same button push. One consequence was that the nvim process
was spawned multiple times as well.

Moved signal initialization to the MainWindow constructor.

- fixes #227