### PR TITLE
Isolate MacOS from Unix

### DIFF
--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -37,7 +37,7 @@ int cli_main(int argc, char **argv)
 
 int main(int argc, char **argv)
 {
-#ifdef Q_OS_UNIX
+#if defined (Q_OS_UNIX) && ! defined (Q_OS_MAC)
 	// Do an early check for --nofork. We need to do this here, before
 	// creating a QApplication, since QCommandLineParser requires one
 	bool nofork = false;


### PR DESCRIPTION
Q_OS_UNIX is set for MacOS too, so make sure that Q_OS_MAC is not set.
Without this change, in MacOS launching **nvim-qt.app** does nothing.