### PR TITLE
GuiDrop(): Avoid redundant BufEnter for nvim 0.2+

### DIFF
--- a/src/gui/runtime/plugin/nvim_gui_shim.vim
+++ b/src/gui/runtime/plugin/nvim_gui_shim.vim
@@ -69,5 +69,7 @@ function GuiDrop(...)
 	let l:fnames = deepcopy(a:000)
 	let l:args = map(l:fnames, 'fnameescape(v:val)')
 	exec 'drop '.join(l:args, ' ')
-	doautocmd BufEnter
+	if !has('nvim-0.2')
+		doautocmd BufEnter
+	endif
 endfunction


### PR DESCRIPTION
Nvim 0.2 fixed the Vim bug that made this BufEnter call necessary:

https://github.com/neovim/neovim/commit/42c922b32c0a22fbe078d03bac5de0cfa7bd0b9f