### PR TITLE
Force default fonts even for bad Monospace fonts

### DIFF
--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -12,12 +12,6 @@
 #include "neovimconnector.h"
 #include "shellwidget/shellwidget.h"
 
-#if defined(Q_OS_MAC)
-#  define DEFAULT_FONT "Courier New"
-#else
-#  define DEFAULT_FONT "Monospace"
-#endif
-
 namespace NeovimQt {
 
 class Shell: public ShellWidget

--- a/src/gui/shellwidget/shellwidget.cpp
+++ b/src/gui/shellwidget/shellwidget.cpp
@@ -28,9 +28,9 @@ ShellWidget* ShellWidget::fromFile(const QString& path)
 void ShellWidget::setDefaultFont()
 {
 #if defined(Q_OS_MAC)
-	setShellFont("Courier New", 11);
+	setShellFont("Courier New", 11, -1, false, true);
 #else
-	setShellFont("Monospace", 11);
+	setShellFont("Monospace", 11, -1, false, true);
 #endif
 }
 

--- a/src/gui/shellwidget/shellwidget.cpp
+++ b/src/gui/shellwidget/shellwidget.cpp
@@ -28,10 +28,13 @@ ShellWidget* ShellWidget::fromFile(const QString& path)
 void ShellWidget::setDefaultFont()
 {
 #if defined(Q_OS_MAC)
-	setShellFont("Courier New", 11, -1, false, true);
+#  define DEFAULT_FONT "Courier New"
+#elif defined(Q_OS_WIN)
+#  define DEFAULT_FONT "Consolas"
 #else
-	setShellFont("Monospace", 11, -1, false, true);
+#  define DEFAULT_FONT "Monospace"
 #endif
+	setShellFont(DEFAULT_FONT, 11, -1, false, true);
 }
 
 bool ShellWidget::setShellFont(const QString& family, int ptSize, int weight, bool italic, bool force)


### PR DESCRIPTION
See #130 in some systems we fail to load a default font, force the
loading of the font for the default startup font.