### PR TITLE
RFC: Background images & X11 Psuedotransparency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,9 @@ find_package(Qt5Widgets REQUIRED)
 find_package(Qt5Network REQUIRED)
 find_package(Qt5Test REQUIRED)
 
+# X11
+find_package(X11 REQUIRED)
+
 # msgpack
 option(USE_SYSTEM_MSGPACK "Use system msgpack libraries " OFF)
 if(USE_SYSTEM_MSGPACK)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ find_package(Qt5Network REQUIRED)
 find_package(Qt5Test REQUIRED)
 
 # X11
-find_package(X11 REQUIRED)
+find_package(X11 QUIET)
 
 # msgpack
 option(USE_SYSTEM_MSGPACK "Use system msgpack libraries " OFF)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,6 @@ if(WIN32)
 endif()
 
 add_library(neovim-qt STATIC ${NEOVIM_QT_SOURCES})
-target_link_libraries(neovim-qt Qt5::Network ${MSGPACK_LIBRARIES})
+target_link_libraries(neovim-qt X11 Qt5::Network ${MSGPACK_LIBRARIES})
 
 add_subdirectory(gui)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,12 @@ if(WIN32)
 endif()
 
 add_library(neovim-qt STATIC ${NEOVIM_QT_SOURCES})
-target_link_libraries(neovim-qt X11 Qt5::Network ${MSGPACK_LIBRARIES})
+
+if(X11_FOUND)
+    set(X11_LIBRARIES X11)
+    add_definitions(-DWITH_X11)
+endif()
+
+target_link_libraries(neovim-qt ${X11_LIBRARIES} Qt5::Network ${MSGPACK_LIBRARIES})
 
 add_subdirectory(gui)

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -54,9 +54,8 @@ namespace NeovimQt {
                         for(int y=0; y<attrs.height; y++) {
                                 for(int x=0; x<attrs.width; x++) {
                                         //unsigned long px = XGetPixel(img, x, y);
-                                        unsigned char* px<D-Space> = &img->data[y*img->bytes_per_line+x*pixelSize]
-                                        unsigned char* data = (unsigned char*)&px;
-                                        unsigned char* base = &bgData[y*attrs.width*4+x*4];
+                                        unsigned char* data = (unsigned char *)img->data + y*img->bytes_per_line+x*pixelSize;
+                                        unsigned char* base = bgData + y*attrs.width*4+x*4;
                                         base[3] = 0xff;
                                         base[0] = data[0];
                                         base[1] = data[1];

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -39,21 +39,22 @@ namespace NeovimQt {
                         Display *dsp = XOpenDisplay(0);
 
                         unsigned char* bgData;
-                        const int pixelSize = 3;
                         XWindowAttributes attrs;
 
                         int screen = DefaultScreen(dsp);
                         Window root = RootWindow(dsp, DefaultScreen(dsp));
                         XGetWindowAttributes(dsp, root, &attrs);
                         Pixmap bg = GetRootPixmap(dsp, &root);
-                        XImage* img = XGetImage(dsp, bg, 0, 0, attrs.width, attrs.height, ~0, XYPixmap);
+                        XImage* img = XGetImage(dsp, bg, 0, 0, attrs.width, attrs.height, ~0, ZPixmap);
+                        const int pixelSize = img->bits_per_pixel/8;
                         XFreePixmap(dsp, bg);
 
                         bgData = (unsigned char*)malloc(attrs.width*attrs.height*4);
 
                         for(int y=0; y<attrs.height; y++) {
                                 for(int x=0; x<attrs.width; x++) {
-                                        unsigned long px = XGetPixel(img, x, y);
+                                        //unsigned long px = XGetPixel(img, x, y);
+                                        unsigned char* px<D-Space> = &img->data[y*img->bytes_per_line+x*pixelSize]
                                         unsigned char* data = (unsigned char*)&px;
                                         unsigned char* base = &bgData[y*attrs.width*4+x*4];
                                         base[3] = 0xff;

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1,76 +1,10 @@
 #include "mainwindow.h"
-#include <X11/Intrinsic.h>
-#include <X11/Xatom.h>
-
 #include <QCloseEvent>
 #include <QToolBar>
 #include <QLayout>
 #include <QPainter>
 
 namespace NeovimQt {
-        QPixmap* bkgnd = NULL;
-
-        // Stolen from https://gist.github.com/ehamberg/767824/b4b4b0d1732d565d96b585723ebcc976cf6ca6a9
-        Pixmap GetRootPixmap(Display* dsp, Window *root)
-        {
-                Pixmap currentRootPixmap;
-                Atom act_type;
-                int act_format;
-                unsigned long nitems, bytes_after;
-                unsigned char *data = NULL;
-                Atom _XROOTPMAP_ID;
-
-                _XROOTPMAP_ID = XInternAtom(dsp, "_XROOTPMAP_ID", False);
-
-                if (XGetWindowProperty(dsp, *root, _XROOTPMAP_ID, 0, 1, False,
-                            XA_PIXMAP, &act_type, &act_format, &nitems, &bytes_after,
-                            &data) == Success) {
-                        if (data) {
-                                currentRootPixmap = *((Pixmap *) data);
-                                XFree(data);
-                        }
-                }
-
-                return currentRootPixmap;
-        }
-
-        QPixmap* bgInit() {
-                if(bkgnd == NULL) {
-                        Display *dsp = XOpenDisplay(0);
-
-                        unsigned char* bgData;
-                        XWindowAttributes attrs;
-
-                        int screen = DefaultScreen(dsp);
-                        Window root = RootWindow(dsp, DefaultScreen(dsp));
-                        XGetWindowAttributes(dsp, root, &attrs);
-                        Pixmap bg = GetRootPixmap(dsp, &root);
-                        XImage* img = XGetImage(dsp, bg, 0, 0, attrs.width, attrs.height, ~0, ZPixmap);
-                        const int pixelSize = img->bits_per_pixel/8;
-                        XFreePixmap(dsp, bg);
-
-                        bgData = (unsigned char*)malloc(attrs.width*attrs.height*4);
-
-                        for(int y=0; y<attrs.height; y++) {
-                                for(int x=0; x<attrs.width; x++) {
-                                        //unsigned long px = XGetPixel(img, x, y);
-                                        unsigned char* data = (unsigned char *)img->data + y*img->bytes_per_line+x*pixelSize;
-                                        unsigned char* base = bgData + y*attrs.width*4+x*4;
-                                        base[3] = 0xff;
-                                        base[0] = data[0];
-                                        base[1] = data[1];
-                                        base[2] = data[2];
-                                }
-                        }
-
-                        bkgnd = new QPixmap(QPixmap::fromImage(*new QImage(bgData, attrs.width, attrs.height, QImage::Format_RGB32)));
-                        QPainter p(bkgnd);
-                        p.fillRect(QRect(0,0,attrs.width,attrs.height), QColor(0, 0, 0, 200));
-                }
-
-                return bkgnd;
-        }
-
 MainWindow::MainWindow(NeovimConnector *c, QWidget *parent)
 :QMainWindow(parent), m_nvim(0), m_errorWidget(0), m_shell(0),
 	m_delayedShow(DelayedShow::Disabled), m_tabline(0), m_tabline_bar(0)
@@ -138,17 +72,6 @@ void MainWindow::init(NeovimConnector *c)
 	connect(m_shell, &Shell::neovimTablineUpdate,
 			this, &MainWindow::neovimTablineUpdate);
 	m_shell->setFocus(Qt::OtherFocusReason);
-
-        if(bgInit() != NULL) {
-               m_shell->setBackgroundPixmap(bgInit());
-               // TODO: proper BG for main window as well - but right now it doesn't go screen-relative very well
-               // QPalette pal = palette();
-               // pal.setBrush(QPalette::Window, *bgInit());
-               // pal.setBrush(QPalette::Background, *bgInit());
-               // setAutoFillBackground(true);
-               // setPalette(pal);
-               // m_shell->setPalette(pal);
-        }
 
 	if (m_nvim->errorCause()) {
 		neovimError(m_nvim->errorCause());

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -10,6 +10,7 @@ MainWindow::MainWindow(NeovimConnector *c, QWidget *parent)
 :QMainWindow(parent), m_nvim(0), m_errorWidget(0), m_shell(0),
 	m_delayedShow(DelayedShow::Disabled), m_tabline(0), m_tabline_bar(0)
 {
+        
 	m_errorWidget = new ErrorWidget();
 	m_stack.addWidget(m_errorWidget);
 	connect(m_errorWidget, &ErrorWidget::reconnectNeovim,
@@ -129,7 +130,7 @@ void MainWindow::neovimSetTitle(const QString &title)
 	this->setWindowTitle(title);
 }
 
-void MainWindow::neovimWidgetResized()
+void MaijnWindow::neovimWidgetResized()
 {
 	// Neovim finished resizing, resize it back to the actual
 	// widget size - this avoids situations when neovim wants a size that

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -30,6 +30,7 @@ signals:
 	void neovimAttached(bool);
 protected:
 	virtual void closeEvent(QCloseEvent *ev) Q_DECL_OVERRIDE;
+        virtual void moveEvent( QMoveEvent *ev) Q_DECL_OVERRIDE;
 	virtual void changeEvent(QEvent *ev) Q_DECL_OVERRIDE;
 private slots:
 	void neovimSetTitle(const QString &title);

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -7,49 +7,12 @@
 #include <QApplication>
 #include <QKeyEvent>
 #include <QMimeData>
-#include <X11/Intrinsic.h>
 #include "msgpackrequest.h"
 #include "input.h"
 #include "konsole_wcwidth.h"
 #include "util.h"
 
 namespace NeovimQt {
-        QImage* bgInit() {
-            Display *dsp = XOpenDisplay(0);
-            Window root;
-            unsigned long bg = 0x1200001;
-            int xo, yo;
-            unsigned int width, height, border_width, depth;
-            unsigned char* bgData;
-
-            XGetGeometry(dsp, 0x1200001, &root, &xo, &yo, &width, &height, &border_width, &depth); 
-            fprintf(stderr, "%d,%d %dx%d %dbpp", xo, yo, width, height, depth);
-
-            int pixelSize = depth/8;
-            
-            XImage *img = XGetImage(dsp, 0x1200001, 0, 0, width, height, 0xFFFFFF, XYPixmap);
-
-            bgData = (unsigned char*)malloc(width*height*pixelSize);
-
-            for(int y=0; y<height; y++) {
-                for(int x=0; x<width; x++) {
-                    unsigned long px = XGetPixel(img, x, y);
-                    unsigned char* data = (unsigned char*)&px;
-                    unsigned char* base = &bgData[y*width*pixelSize+x*pixelSize];
-                    base[0] = data[2];
-                    base[1] = data[1];
-                    base[2] = data[0];
-                }
-            }
-
-            return new QImage(bgData, width, height, QImage::Format_RGB888);
-        }
-
-        //QRect rec = QApplication::desktop()->screenGeometry();
-        //bkgnd = new QPixmap(bkgnd->scaled(rec.width(), rec.height(), Qt::IgnoreAspectRatio));
-        //QPainter p(&bkgnd);
-        //p.fillRect(QRect(0,0,width,height), QColor(0, 0, 0, 128));
-
 Shell::Shell(NeovimConnector *nvim, QWidget *parent)
 :ShellWidget(parent), m_attached(false), m_nvim(nvim),
 	m_font_bold(false), m_font_italic(false), m_font_underline(false), m_font_undercurl(false),
@@ -62,8 +25,6 @@ Shell::Shell(NeovimConnector *nvim, QWidget *parent)
 {
 	setAttribute(Qt::WA_KeyCompression, false);
 
-        QPixmap* bkgnd = new QPixmap(QPixmap::fromImage(*bgInit()));
-        setBackgroundPixmap(bkgnd);
 	setAcceptDrops(true);
 	setMouseTracking(true);
 	m_mouseclick_timer.setInterval(QApplication::doubleClickInterval());
@@ -637,7 +598,10 @@ void Shell::paintEvent(QPaintEvent *ev)
 		} else if (wide) {
 			cursorRect.setWidth(cursorRect.width()*2);
 		}
+
 		QPainter painter(this);
+                // white outline to show us where the cursor is even if colors would make this ambiguous:
+                painter.drawRect(cursorRect.adjusted(0,0,-1,-1));
 		painter.setCompositionMode(QPainter::RasterOp_SourceXorDestination);
 		painter.fillRect(cursorRect, m_cursor_color);
 	}

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -22,7 +22,7 @@ namespace NeovimQt {
 	// Stolen from https://gist.github.com/ehamberg/767824/b4b4b0d1732d565d96b585723ebcc976cf6ca6a9
 	Pixmap GetRootPixmap(Display* dsp, Window *root)
 	{
-		Pixmap currentRootPixmap;
+		Pixmap currentRootPixmap = 0;
 		Atom act_type;
 		int act_format;
 		unsigned long nitems, bytes_after;

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -13,66 +13,66 @@
 #include "util.h"
 
 namespace NeovimQt {
-        QPixmap* bkgnd = NULL;
+	QPixmap* bkgnd = NULL;
 
 #ifdef WITH_X11
-        #include <X11/Intrinsic.h>
-        #include <X11/Xatom.h>
+	#include <X11/Intrinsic.h>
+	#include <X11/Xatom.h>
 
-        // Stolen from https://gist.github.com/ehamberg/767824/b4b4b0d1732d565d96b585723ebcc976cf6ca6a9
-        Pixmap GetRootPixmap(Display* dsp, Window *root)
-        {
-                Pixmap currentRootPixmap;
-                Atom act_type;
-                int act_format;
-                unsigned long nitems, bytes_after;
-                unsigned char *data = NULL;
-                Atom _XROOTPMAP_ID;
+	// Stolen from https://gist.github.com/ehamberg/767824/b4b4b0d1732d565d96b585723ebcc976cf6ca6a9
+	Pixmap GetRootPixmap(Display* dsp, Window *root)
+	{
+		Pixmap currentRootPixmap;
+		Atom act_type;
+		int act_format;
+		unsigned long nitems, bytes_after;
+		unsigned char *data = NULL;
+		Atom _XROOTPMAP_ID;
 
-                _XROOTPMAP_ID = XInternAtom(dsp, "_XROOTPMAP_ID", False);
+		_XROOTPMAP_ID = XInternAtom(dsp, "_XROOTPMAP_ID", False);
 
-                if (XGetWindowProperty(dsp, *root, _XROOTPMAP_ID, 0, 1, False,
-                            XA_PIXMAP, &act_type, &act_format, &nitems, &bytes_after,
-                            &data) == Success) {
-                        if (data) {
-                                currentRootPixmap = *((Pixmap *) data);
-                                XFree(data);
-                        }
-                }
+		if (XGetWindowProperty(dsp, *root, _XROOTPMAP_ID, 0, 1, False,
+			    XA_PIXMAP, &act_type, &act_format, &nitems, &bytes_after,
+			    &data) == Success) {
+			if (data) {
+				currentRootPixmap = *((Pixmap *) data);
+				XFree(data);
+			}
+		}
 
-                return currentRootPixmap;
-        }
+		return currentRootPixmap;
+	}
 #endif
 
-        QPixmap* bgInit() {
-                if(bkgnd == NULL) {
+	QPixmap* bgInit() {
+		if(bkgnd == NULL) {
 #ifdef WITH_X11
-                        Display *dsp = XOpenDisplay(0);
-                        if(!dsp) return NULL;
+			Display *dsp = XOpenDisplay(0);
+			if(!dsp) return NULL;
 
-                        XWindowAttributes attrs;
+			XWindowAttributes attrs;
 
-                        Window root = RootWindow(dsp, DefaultScreen(dsp));
-                        if(!root) return NULL;
+			Window root = RootWindow(dsp, DefaultScreen(dsp));
+			if(!root) return NULL;
 
-                        Pixmap bg = GetRootPixmap(dsp, &root);
-                        if(!bg) return NULL;
+			Pixmap bg = GetRootPixmap(dsp, &root);
+			if(!bg) return NULL;
 
-                        XGetWindowAttributes(dsp, root, &attrs);
-                        XImage* img = XGetImage(dsp, bg, 0, 0, attrs.width, attrs.height, ~0, ZPixmap);
-                        if(!img) return NULL;
+			XGetWindowAttributes(dsp, root, &attrs);
+			XImage* img = XGetImage(dsp, bg, 0, 0, attrs.width, attrs.height, ~0, ZPixmap);
+			if(!img) return NULL;
 
-                        // XXX might be fragile: Assumes result from XGetImage to be in RGB32 format (but almost always is on modern systems)
-                        bkgnd = new QPixmap(QPixmap::fromImage(*new QImage((uchar*)img->data, attrs.width, attrs.height, img->bytes_per_line, QImage::Format_RGB32)));
-                        QPainter p(bkgnd);
-                        p.fillRect(QRect(0,0,attrs.width,attrs.height), QColor(0, 0, 0, 200));
+			// XXX might be fragile: Assumes result from XGetImage to be in RGB32 format (but almost always is on modern systems)
+			bkgnd = new QPixmap(QPixmap::fromImage(*new QImage((uchar*)img->data, attrs.width, attrs.height, img->bytes_per_line, QImage::Format_RGB32)));
+			QPainter p(bkgnd);
+			p.fillRect(QRect(0,0,attrs.width,attrs.height), QColor(0, 0, 0, 200));
 
-                        XCloseDisplay(dsp);
+			XCloseDisplay(dsp);
 #endif
-                }
+		}
 
-                return bkgnd;
-        }
+		return bkgnd;
+	}
 
 Shell::Shell(NeovimConnector *nvim, QWidget *parent)
 :ShellWidget(parent), m_attached(false), m_nvim(nvim),
@@ -599,12 +599,12 @@ void Shell::handleNeovimNotification(const QByteArray &name, const QVariantList&
 			resizeNeovim(size());
 		} else if (guiEvName == "BgImage" && args.size() == 2) {
 			QString imgDesc = m_nvim->decode(args.at(1).toByteArray());
-                        if(imgDesc == "desktop") {
-                                setBackgroundPixmap(bgInit());
-                        } else {
-                                setBackgroundPixmap(NULL);
-                        }
-                        update();
+			if(imgDesc == "desktop") {
+				setBackgroundPixmap(bgInit());
+			} else {
+				setBackgroundPixmap(NULL);
+			}
+			update();
 		} else if (guiEvName == "Mousehide" && args.size() == 2) {
 			m_mouseHide = variant_not_zero(args.at(1));
 			int val = m_mouseHide ? 1 : 0;
@@ -669,8 +669,8 @@ void Shell::paintEvent(QPaintEvent *ev)
 		}
 
 		QPainter painter(this);
-                // white outline to show us where the cursor is even if colors would make this ambiguous:
-                painter.drawRect(cursorRect.adjusted(0,0,-1,-1));
+		// white outline to show us where the cursor is even if colors would make this ambiguous:
+		painter.drawRect(cursorRect.adjusted(0,0,-1,-1));
 		painter.setCompositionMode(QPainter::RasterOp_SourceXorDestination);
 		painter.fillRect(cursorRect, m_cursor_color);
 	}

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -62,8 +62,6 @@ namespace NeovimQt {
                         XImage* img = XGetImage(dsp, bg, 0, 0, attrs.width, attrs.height, ~0, ZPixmap);
                         if(!img) return NULL;
 
-                        const int pixelSize = img->bits_per_pixel/8;
-
                         // XXX might be fragile: Assumes result from XGetImage to be in RGB32 format (but almost always is on modern systems)
                         bkgnd = new QPixmap(QPixmap::fromImage(*new QImage((uchar*)img->data, attrs.width, attrs.height, img->bytes_per_line, QImage::Format_RGB32)));
                         QPainter p(bkgnd);
@@ -601,10 +599,9 @@ void Shell::handleNeovimNotification(const QByteArray &name, const QVariantList&
 			resizeNeovim(size());
 		} else if (guiEvName == "BgImage" && args.size() == 2) {
 			QString imgDesc = m_nvim->decode(args.at(1).toByteArray());
-                        if(!imgDesc.compare("desktop")) {
+                        if(imgDesc == "desktop") {
                                 setBackgroundPixmap(bgInit());
-                        }
-                        else {
+                        } else {
                                 setBackgroundPixmap(NULL);
                         }
                         update();

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -44,23 +44,25 @@ namespace NeovimQt {
 	}
 #endif
 
+        #define nullRetAssert(test, msg) if(!(test)) { qDebug() << "Initializing background image:" << (msg); return NULL; }
+
 	QPixmap* bgInit() {
 		if(bkgnd == NULL) {
 #ifdef WITH_X11
 			Display *dsp = XOpenDisplay(0);
-			if(!dsp) return NULL;
+			nullRetAssert(dsp, "Could not open X display.");
 
 			XWindowAttributes attrs;
 
 			Window root = RootWindow(dsp, DefaultScreen(dsp));
-			if(!root) return NULL;
+			nullRetAssert(root, "Could not get root window pointer.");
 
 			Pixmap bg = GetRootPixmap(dsp, &root);
-			if(!bg) return NULL;
+			nullRetAssert(bg, "Could not get root pixmap ID");
 
 			XGetWindowAttributes(dsp, root, &attrs);
 			XImage* img = XGetImage(dsp, bg, 0, 0, attrs.width, attrs.height, ~0, ZPixmap);
-			if(!img) return NULL;
+			nullRetAssert(img, "Could not get root pixmap image.");
 
 			// XXX might be fragile: Assumes result from XGetImage to be in RGB32 format (but almost always is on modern systems)
 			bkgnd = new QPixmap(QPixmap::fromImage(*new QImage((uchar*)img->data, attrs.width, attrs.height, img->bytes_per_line, QImage::Format_RGB32)));

--- a/src/gui/shellwidget/shellwidget.cpp
+++ b/src/gui/shellwidget/shellwidget.cpp
@@ -1,13 +1,25 @@
+#include <QApplication>
+#include <QDesktopWidget>
 #include <QPainter>
 #include <QPaintEvent>
 #include <QDebug>
 #include "shellwidget.h"
 #include "helpers.h"
 
+namespace {
+        QPixmap* bkgnd;
+}
+
 ShellWidget::ShellWidget(QWidget *parent)
 :QWidget(parent), m_contents(0,0), m_bgColor(Qt::white),
 	m_fgColor(Qt::black), m_spColor(QColor()), m_lineSpace(0)
 {
+        bkgnd = new QPixmap("/home/lharding/Downloads/space-bridge-desktop-background.jpg");
+        QRect rec = QApplication::desktop()->screenGeometry();
+        bkgnd = new QPixmap(bkgnd->scaled(rec.width(), rec.height(), Qt::IgnoreAspectRatio));
+        QPainter p(bkgnd);
+        p.fillRect(rec, QColor(0, 0, 0, 128));
+
 	setAttribute(Qt::WA_OpaquePaintEvent);
 	setAttribute(Qt::WA_KeyCompression, false);
 	setFocusPolicy(Qt::StrongFocus);
@@ -129,10 +141,11 @@ void ShellWidget::paintEvent(QPaintEvent *ev)
 				if (j <= 0 || !contents().constValue(i, j-1).doubleWidth) {
 					// Only paint bg/fg if this is not the second cell
 					// of a wide char
-					if (cell.backgroundColor.isValid()) {
+					if (cell.backgroundColor.isValid() && cell.backgroundColor != m_bgColor) {
 						p.fillRect(r, cell.backgroundColor);
-					} else {
-						p.fillRect(r, m_bgColor);
+                                        } else {
+//						p.fillRect(r, m_bgColor);
+                                                p.drawPixmap(r, *bkgnd, r.translated(mapToGlobal(QPoint(0, 0))));
 					}
 
 					if (cell.c == ' ') {

--- a/src/gui/shellwidget/shellwidget.cpp
+++ b/src/gui/shellwidget/shellwidget.cpp
@@ -8,7 +8,7 @@
 
 ShellWidget::ShellWidget(QWidget *parent)
 :QWidget(parent), m_contents(0,0), m_bgColor(Qt::white),
-	m_fgColor(Qt::black), m_spColor(QColor()), m_lineSpace(0)
+	m_fgColor(Qt::black), m_spColor(QColor()), m_lineSpace(0), m_bgPixmap(NULL)
 {
 	setAttribute(Qt::WA_OpaquePaintEvent);
 	setAttribute(Qt::WA_KeyCompression, false);
@@ -142,7 +142,7 @@ void ShellWidget::paintEvent(QPaintEvent *ev)
 				if (j <= 0 || !contents().constValue(i, j-1).doubleWidth) {
 					// Only paint bg/fg if this is not the second cell
 					// of a wide char
-					if (cell.backgroundColor.isValid() && cell.backgroundColor != m_bgColor) {
+					if (cell.backgroundColor.isValid() && (m_bgPixmap == NULL || cell.backgroundColor != m_bgColor)) {
 						p.fillRect(r, cell.backgroundColor);
                                         } else {
                                                 paintCellBg(screenOrigin, p, r);

--- a/src/gui/shellwidget/shellwidget.h
+++ b/src/gui/shellwidget/shellwidget.h
@@ -19,6 +19,7 @@ public:
 	ShellWidget(QWidget *parent=0);
 	bool setShellFont(const QString& family, int ptSize, int weight = -1, bool italic = false, bool force = false);
 
+        QPixmap* backgroundPixmap() const;
 	QColor background() const;
 	QColor foreground() const;
 	QColor special() const;
@@ -37,6 +38,7 @@ signals:
 public slots:
 	void resizeShell(int rows, int columns);
 	void setSpecial(const QColor& color);
+        void setBackgroundPixmap(QPixmap* pm);
 	void setBackground(const QColor& color);
 	void setForeground(const QColor& color);
 	void setDefaultFont();
@@ -65,6 +67,7 @@ private:
 	QSize m_cellSize;
 	int m_ascent;
 	QColor m_bgColor, m_fgColor, m_spColor;
+        QPixmap* m_bgPixmap;
         unsigned int m_lineSpace;
 };
 

--- a/src/gui/shellwidget/shellwidget.h
+++ b/src/gui/shellwidget/shellwidget.h
@@ -62,6 +62,7 @@ protected:
 
 private:
 	void setFont(const QFont&);
+        void paintCellBg(QPoint& screenOrigin, QPainter& p, QRect& r);
 
 	ShellContents m_contents;
 	QSize m_cellSize;


### PR DESCRIPTION
### DISCLAIMER: This is not meant to be ready to merge just yet

Instead I'm trying to generate comment. I've been implementing this for my own use and it's reached the stage where it's working for my use case but isn't really in a state to go upstream because of the following questions:

1. How to turn this feature on and off? It's not properly neovim-internal or even (IMHO) semi-universal like GuiFont. Should there be a command-line switch/environment variable/etc? Add something like GuiFont after all, that toggles it from nvim?

2. Does anyone care about using a background image from a file instead? Displaying the image from that file in a non-screen-relative way?

3. It's in need of disablement on non-X11 platforms and I haven't looked into that yet.

4. My highly-visible-cursor hack is in here and probably needs a separate toggle.

5. Refactoring? I'm on the fence as to whether the bg pixmap loader should be part of MainWindow, Shell, live by itself, etc.

Thoughts?