### PR TITLE
Fix numbers in Programmer Dvorak keymap (#233, #222)

### DIFF
--- a/src/gui/input.cpp
+++ b/src/gui/input.cpp
@@ -1,4 +1,3 @@
-
 #include "input.h"
 #include <QDebug>
 
@@ -159,6 +158,7 @@ QString InputConv::convertKey(const QString& text, int k, Qt::KeyboardModifiers 
 
 	QChar c;
 	// Escape < and backslash
+
 	if (text == "<") {
 		return QString("<lt>");
 	} else if (text == "\\") {
@@ -199,6 +199,20 @@ QString InputConv::convertKey(const QString& text, int k, Qt::KeyboardModifiers 
 	// Format with prefix if necessary
 	QString prefix = modPrefix(mod);
 	if (!prefix.isEmpty()) {
+		if (prefix == "k"){
+			switch(c.toLatin1()) {
+				case '/':
+					return QString("<kDivide>");
+				case '*':
+					return QString("<kMultiply>");
+				case '-':
+					return QString("<kMinus>");
+				case '+':
+					return QString("<kPlus>");
+				case '.':
+					return QString("<kPoint>");
+			}
+		}
 		return QString("<%1%2>").arg(prefix).arg(c);
 	}
 

--- a/src/gui/input.cpp
+++ b/src/gui/input.cpp
@@ -170,6 +170,9 @@ QString InputConv::convertKey(const QString& text, int k, Qt::KeyboardModifiers 
 			QList<Qt::Key> keys = { Key_Control, Key_Alt, Key_Cmd };
 			if (keys.contains((Qt::Key)k)) {
 				return QString();
+			} else if (k == Qt::Key_Shift && mod&ControlModifier) {
+				// Ignore Ctrl+Shift combo
+				return QString();
 			} else {
 				// key code will be the value of the char (hopefully)
 				c = QChar(k);
@@ -184,7 +187,7 @@ QString InputConv::convertKey(const QString& text, int k, Qt::KeyboardModifiers 
 	}
 
 	// Remove SHIFT
-	if (c.unicode() < 0x100 && !c.isLetterOrNumber() && c.isPrint()) {
+	if (c.unicode() < 0x100 && c.isPrint()) {
 		mod &= ~ShiftModifier;
 	}
 


### PR DESCRIPTION
Shift-prefix handled incorrectly with Programmer Dvorak. The keymap move digits to upper layer — so, for example, you get `<S-7>` instead of `<7>` and neovim ignore mapping because of it.