### PR TITLE
Touchpad scroll fixes

### DIFF
--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -701,7 +701,7 @@ void Shell::wheelEvent(QWheelEvent *ev)
 	if (horiz != 0) {
 		inp += QString("<%1ScrollWheel%2><%3,%4>")
 			.arg(Input.modPrefix(ev->modifiers()))
-			.arg(horiz > 0 ? "Right" : "Left")
+			.arg(horiz > 0 ? "Left" : "Right")
 			.arg(pos.x()).arg(pos.y());
 	}
 	m_nvim->neovimObject()->vim_input(inp.toLatin1());

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -125,6 +125,8 @@ private:
 	QTimer m_mouseclick_timer;
 	short m_mouseclick_count;
 	Qt::MouseButton m_mouseclick_pending;
+	// Accumulates remainder of steppy scroll
+	QPoint m_mouse_wheel_delta_fraction;
 
 	// Properties
 	bool m_neovimBusy;


### PR DESCRIPTION
I am running neovim-qt on a laptop with a touchpad that sends fine wheel events way more often than a discrete mouse wheel would do. This fixes super-fast scroll and flips horizontal scroll direction to match other applications.