### PR TITLE
[RFC] Only use mouse scroll pixel delta on OSX

### DIFF
--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -667,6 +667,7 @@ void Shell::mouseMoveEvent(QMouseEvent *ev)
 
 void Shell::wheelEvent(QWheelEvent *ev)
 {
+#ifdef Q_OS_MAC
 	// For some reason <ScrollWheel*> scrolls multiple lines at once
 	// we have to account for it, to make sure that pixelDelta() is used correctly.
 	const int scroll_columns = 6;
@@ -683,6 +684,11 @@ void Shell::wheelEvent(QWheelEvent *ev)
 
 	int horiz = cell_delta.x();
 	int vert = cell_delta.y();
+#else
+	int horiz, vert;
+	horiz = ev->angleDelta().x();
+	vert = ev->angleDelta().y();
+#endif
 
 	if (horiz == 0 && vert == 0) {
 		return;


### PR DESCRIPTION
3a5a3d1 added support for high resolution mouse scrolling, but this
is not available in all platforms. In platforms that do not mouse scrolling is currently not working.

Need to figure out in which platforms we use pixelDelta, or fallback to angleDelta.

ping @koalefant @diefans