### PR TITLE
Fixing touchpad scroll - attempt #2

### DIFF
--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -677,9 +677,12 @@ void Shell::wheelEvent(QWheelEvent *ev)
 #endif
 	QPointF scroll_delta_f(float(ev->angleDelta().x()) / defaultDeltasPerStep,
 						   float(ev->angleDelta().y()) / defaultDeltasPerStep);
+
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 7, 0))
 	if (ev->inverted()) {
 		scroll_delta_f = -scroll_delta_f;
 	}
+#endif
 
 	// Reset scroll remainder if we change scroll direction;
 	int direction_x = int(scroll_delta_f.x() < 0.0f ? -1 :

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -670,8 +670,13 @@ void Shell::wheelEvent(QWheelEvent *ev)
 {
 	// QApplication::wheelScrollLines() is ignored here, its default value (3)
 	// matches amount of lines that nvim scrolls when receiving single scroll command.
-	QPointF scroll_delta_f(float(ev->angleDelta().x()) / QWheelEvent::DefaultDeltasPerStep,
-						   float(ev->angleDelta().y()) / QWheelEvent::DefaultDeltasPerStep);
+#if (QT_VERSION < QT_VERSION_CHECK(5, 5, 0))
+	int defaultDeltasPerStep = 120;
+#else
+	int defaultDeltasPerStep = QWheelEvent::DefaultDeltasPerStep;
+#endif
+	QPointF scroll_delta_f(float(ev->angleDelta().x()) / defaultDeltasPerStep,
+						   float(ev->angleDelta().y()) / defaultDeltasPerStep);
 	if (ev->inverted()) {
 		scroll_delta_f = -scroll_delta_f;
 	}

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -126,7 +126,9 @@ private:
 	short m_mouseclick_count;
 	Qt::MouseButton m_mouseclick_pending;
 	// Accumulates remainder of steppy scroll
-	QPoint m_mouse_wheel_delta_fraction;
+	QPointF m_scroll_remainder;
+	// Used to track when scroll direction changes to reset remainder
+	QPoint m_scroll_last_direction;
 
 	// Properties
 	bool m_neovimBusy;


### PR DESCRIPTION
After a bit of digging into Qt source code, this is now similar to how QScrollBar implements handling of the mouse wheel event.  To fix speed it was crucial to divide angleDelta by 120 (QWheelEvent::DefaultDeltasPerStep).

I also tried to compare pixelDelta() to this approach and it does not feel to be smoother. nvim scrolls 3 lines at a time anyway.

This is tested on X11 with touchpad and mouse.
