### PR TITLE
Use Q_ENUM for MsgpackError and NeovimError

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ include(MacOSXPaths)
 
 # Qt
 set(CMAKE_AUTOMOC ON)
+find_package(Qt5Core REQUIRED)
 find_package(Qt5Widgets REQUIRED)
 find_package(Qt5Network REQUIRED)
 find_package(Qt5Test REQUIRED)

--- a/src/msgpackiodevice.h
+++ b/src/msgpackiodevice.h
@@ -12,7 +12,6 @@ class MsgpackRequestHandler;
 class MsgpackIODevice: public QObject
 {
 	Q_OBJECT
-	Q_ENUMS(MsgpackError)
 	Q_PROPERTY(MsgpackError error READ errorCause NOTIFY error)
 	Q_PROPERTY(QByteArray encoding READ encoding WRITE setEncoding)
 public:
@@ -22,6 +21,11 @@ public:
 		InvalidMsgpack,
 		UnsupportedEncoding,
 	};
+#ifdef Q_ENUM
+	Q_ENUM(MsgpackError)
+#else
+	Q_ENUMS(MsgpackError)
+#endif
 	MsgpackIODevice(QIODevice *, QObject *parent=0);
 	~MsgpackIODevice();
         static MsgpackIODevice* fromStdinOut(QObject *parent=0);
@@ -117,5 +121,4 @@ public:
 
 } // Namespace NeovimQt
 Q_DECLARE_METATYPE(NeovimQt::MsgpackIODevice::MsgpackError)
-
 #endif

--- a/src/neovimconnector.h
+++ b/src/neovimconnector.h
@@ -22,7 +22,6 @@ class NeovimConnector: public QObject
 	 * @see neovimObject
 	 */
 	Q_PROPERTY(bool ready READ isReady NOTIFY ready)
-	Q_ENUMS(NeovimError)
 public:
 	enum NeovimError {
 		NoError=0,
@@ -37,6 +36,11 @@ public:
 		MsgpackError,
 		RuntimeMsgpackError,
 	};
+#ifdef Q_ENUM
+	Q_ENUM(NeovimError)
+#else
+	Q_ENUMS(NeovimError)
+#endif
 
 	/** Underlying connection used to read Neovim */
         enum NeovimConnectionType {


### PR DESCRIPTION
Q_ENUM gives better feedback when checking the value of an enum in
tests.

```
FAIL!  : NeovimQt::Test::connectToNeovimTCP() Compared values are not the same
   Loc: [/«PKGBUILDDIR»/test/tst_neovimconnector.cpp(65)]
```

vs.

```
FAIL!  : NeovimQt::Test::connectToNeovimTCP() Compared values are not the same
   Actual   (c->errorCause())             : NoError
   Expected (NeovimConnector::SocketError): SocketError
   Loc: [/home/jamessan/neovim-qt-0.2.7/test/tst_neovimconnector.cpp(65)]
```

Also, Q_ENUMS is [deprecated] in favor of Q_ENUM, introduced in Qt 5.5.

[deprecated]: https://doc.qt.io/archives/qt-5.5/qobject-obsolete.html#Q_ENUMS