### PR TITLE
Increase wait time for TCP test

### DIFF
--- a/test/tst_neovimconnector.cpp
+++ b/test/tst_neovimconnector.cpp
@@ -60,7 +60,7 @@ private slots:
 		QSignalSpy onError(c, SIGNAL(error(NeovimError)));
 		QVERIFY(onError.isValid());
 		// The signal might be emited before we get to connect
-		SPYWAIT(onError);
+		SPYWAIT2(onError, 15000);
 
 		QCOMPARE(c->errorCause(), NeovimConnector::SocketError);
 		c->deleteLater();


### PR DESCRIPTION
ref #289, in FreeBSD the test fails because it times out.