### PR TITLE
Fix some issues with tests

### DIFF
--- a/test/tst_callallmethods.cpp
+++ b/test/tst_callallmethods.cpp
@@ -31,7 +31,7 @@ private:
 
 void TestCallAllMethods::initTestCase()
 {
-	m_c = NeovimQt::NeovimConnector::spawn();
+	m_c = NeovimQt::NeovimConnector::spawn({"-u", "NORC"});
 	QSignalSpy onReady(m_c, SIGNAL(ready()));
 	QVERIFY(onReady.isValid());
 

--- a/test/tst_encoding.cpp
+++ b/test/tst_encoding.cpp
@@ -76,7 +76,7 @@ void TestEncoding::stringsAreBinaryNotUtf8()
 void TestEncoding::initTestCase()
 {
 	bool ready = false;
-	m_c = NeovimQt::NeovimConnector::spawn();
+	m_c = NeovimQt::NeovimConnector::spawn({"-u", "NORC"});
 	QVERIFY(m_c->errorCause() == NeovimQt::NeovimConnector::NoError);
 	connect(m_c, &NeovimQt::NeovimConnector::ready,
 		[&ready](){

--- a/test/tst_neovimconnector.cpp
+++ b/test/tst_neovimconnector.cpp
@@ -19,7 +19,7 @@ private slots:
 		NeovimConnector c(new QBuffer());
 		QCOMPARE(c.canReconnect(), false);
 
-		NeovimConnector *spawned = NeovimConnector::spawn();
+		NeovimConnector *spawned = NeovimConnector::spawn({"-u", "NORC"});
 		QCOMPARE(spawned->connectionType(), NeovimConnector::SpawnedConnection);
 		QCOMPARE(spawned->canReconnect(), true);
 
@@ -28,7 +28,7 @@ private slots:
 
 	void isReady() {
 
-		NeovimConnector *c = NeovimConnector::spawn();
+		NeovimConnector *c = NeovimConnector::spawn({"-u", "NORC"});
 		QSignalSpy onReady(c, SIGNAL(ready()));
 		QVERIFY(onReady.isValid());
 
@@ -37,7 +37,7 @@ private slots:
 	}
 
 	void encodeDecode() {
-		NeovimConnector *c = NeovimConnector::spawn();
+		NeovimConnector *c = NeovimConnector::spawn({"-u", "NORC"});
 
 		// This will print a warning, but should succeed
 		QString s = "ç日本語";

--- a/test/tst_neovimobject.cpp
+++ b/test/tst_neovimobject.cpp
@@ -68,7 +68,7 @@ void TestNeovimObject::eventTypes()
 
 void TestNeovimObject::initTestCase()
 {
-	m_c = NeovimQt::NeovimConnector::spawn();
+	m_c = NeovimQt::NeovimConnector::spawn({"-u", "NORC"});
 	connect(m_c, &NeovimQt::NeovimConnector::ready,
 			this, &TestNeovimObject::delayedSetup);
 	QTest::qWait(1500);

--- a/test/tst_shell.cpp
+++ b/test/tst_shell.cpp
@@ -23,7 +23,7 @@ private slots:
 
 	void benchStart() {
 		QBENCHMARK {
-			NeovimConnector *c = NeovimConnector::spawn();
+			NeovimConnector *c = NeovimConnector::spawn({"-u", "NORC"});
 			QSignalSpy onReady(c, SIGNAL(ready()));
 			QVERIFY(onReady.isValid());
 			QVERIFY(SPYWAIT(onReady));

--- a/test/tst_shell.cpp
+++ b/test/tst_shell.cpp
@@ -92,13 +92,22 @@ private slots:
 		checkCommand(c, "GuiLinespace");
 
 		// Test font attributes
+#ifdef Q_OS_MAC
+		checkCommand(c, "GuiFont Monaco:h14", false);
+		QCOMPARE(s->shell()->fontDesc(), QString("Monaco:h14"));
+#else
 		checkCommand(c, "GuiFont DejaVu Sans Mono:h14", false);
 		QCOMPARE(s->shell()->fontDesc(), QString("DejaVu Sans Mono:h14"));
+#endif
 
 		// Normalization removes the :b attribute
+#ifdef Q_OS_MAC
+		checkCommand(c, "GuiFont Monaco:h14:b:l", false);
+		QCOMPARE(s->shell()->fontDesc(), QString("Monaco:h14:l"));
+#else
 		checkCommand(c, "GuiFont DejaVu Sans Mono:h14:b:l", false);
-		QCOMPARE(s->shell()->fontDesc(),
-				QString("DejaVu Sans Mono:h14:l"));
+		QCOMPARE(s->shell()->fontDesc(), QString("DejaVu Sans Mono:h14:l"));
+#endif
 	}
 
 protected:


### PR DESCRIPTION
- Spawn nvim with -u NORC in the tests, avoids failling the tests due to local issues. The connectToNeovim() test was left unchanged, because the API does not provide a way to pass spawn arguments.
- Avoid using the shipped DejaVu with Mac OS X, test using Monaco instead.
