### PR TITLE
GUI: Add --timeout option

### DIFF
--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -113,6 +113,10 @@ void App::processCliOptions(QCommandLineParser &parser, const QStringList& argum
 				QCoreApplication::translate("main", "nvim executable path"),
 				QCoreApplication::translate("main", "nvim_path"),
 				"nvim"));
+	parser.addOption(QCommandLineOption("timeout",
+				QCoreApplication::translate("main", "Error if nvim does not responde after count milliseconds"),
+				QCoreApplication::translate("main", "ms"),
+				"5000"));
 	parser.addOption(QCommandLineOption("geometry",
 				QCoreApplication::translate("main", "Initial window geometry"),
 				QCoreApplication::translate("main", "geometry")));
@@ -158,6 +162,13 @@ void App::processCliOptions(QCommandLineParser &parser, const QStringList& argum
 
 	if (parser.positionalArguments().isEmpty() && parser.isSet("spawn")) {
 		qWarning() << "--spawn requires at least one positional argument\n";
+		::exit(-1);
+	}
+
+	bool valid_timeout;
+	int timeout_opt = parser.value("timeout").toInt(&valid_timeout);
+	if (!valid_timeout || timeout_opt <= 0) {
+		qWarning() << "Invalid argument for --timeout" << parser.value("timeout");
 		::exit(-1);
 	}
 }

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -13,7 +13,9 @@ int ui_main(int argc, char **argv)
 	QCommandLineParser parser;
 	NeovimQt::App::processCliOptions(parser, app.arguments());
 
+	int timeout = parser.value("timeout").toInt();
 	auto c = app.createConnector(parser);
+	c->setRequestTimeout(timeout);
 	app.showUi(c, parser);
 	return app.exec();
 }

--- a/src/neovimconnector.cpp
+++ b/src/neovimconnector.cpp
@@ -26,7 +26,7 @@ NeovimConnector::NeovimConnector(QIODevice *dev)
 
 NeovimConnector::NeovimConnector(MsgpackIODevice *dev)
 :QObject(), m_dev(dev), m_helper(0), m_error(NoError), m_neovimobj(NULL),
-	m_channel(0), m_ctype(OtherConnection), m_ready(false)
+	m_channel(0), m_ctype(OtherConnection), m_ready(false), m_timeout(5000)
 {
 	m_helper = new NeovimConnectorHelper(this);
 	qRegisterMetaType<NeovimError>("NeovimError");
@@ -38,6 +38,11 @@ NeovimConnector::NeovimConnector(MsgpackIODevice *dev)
 		return;
 	}
 	discoverMetadata();
+}
+
+void NeovimConnector::setRequestTimeout(int ms)
+{
+	this->m_timeout = ms;
 }
 
 /**
@@ -91,7 +96,7 @@ MsgpackRequest* NeovimConnector::attachUi(int64_t width, int64_t height)
 	MsgpackRequest *r = m_dev->startRequestUnchecked("ui_attach", 3);
 	connect(r, &MsgpackRequest::timeout,
 			this, &NeovimConnector::fatalTimeout);
-	r->setTimeout(5000);
+	r->setTimeout(m_timeout);
 
 	m_dev->send(width);
 	m_dev->send(height);
@@ -129,7 +134,7 @@ void NeovimConnector::discoverMetadata()
 			m_helper, &NeovimConnectorHelper::handleMetadataError);
 	connect(r, &MsgpackRequest::timeout,
 			this, &NeovimConnector::fatalTimeout);
-	r->setTimeout(5000);
+	r->setTimeout(m_timeout);
 }
 
 /**

--- a/src/neovimconnector.h
+++ b/src/neovimconnector.h
@@ -75,6 +75,8 @@ public:
 	QString decode(const QByteArray&);
 	QByteArray encode(const QString&);
 	NeovimConnectionType connectionType();
+	/** Some requests for metadata and ui attachment enforce a timeout in ms */
+	void setRequestTimeout(int);
 
 signals:
 	/** Emitted when Neovim is ready @see ready */
@@ -111,6 +113,7 @@ private:
 	QString m_connSocket, m_connHost;
 	int m_connPort;
 	bool m_ready;
+	int m_timeout;
 };
 } // namespace NeovimQt
 Q_DECLARE_METATYPE(NeovimQt::NeovimConnector::NeovimError)


### PR DESCRIPTION
The neovim connection assumes a timeout for some of the API requests

- API metadata retrieval
- ui attachment

The default value is 5000ms but just in case this is not enough for some
scenarios the GUI now accepts an arbitrary value using --timeout <ms>.

ref https://github.com/equalsraf/neovim-qt/issues/319