### PR TITLE
Create entry-point to interact with neovim-qt

### DIFF
--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -139,6 +139,7 @@ void Shell::setAttached(bool attached)
 		}
 		m_nvim->neovimObject()->vim_command("runtime plugin/nvim_gui_shim.vim");
 		m_nvim->neovimObject()->vim_command("runtime! ginit.vim");
+		m_nvim->neovimObject()->vim_command(QByteArrayLiteral("doautocmd User NeovimGuiAttached"));
 
 		// Noevim was not able to open urls till now. Check if we have any to open.
 		if(!m_deferredOpen.isEmpty()){


### PR DESCRIPTION
This PR is based on #156 and #158. The only difference is that it only
introduces the autocmd. So we can leave the shim loading optimization
for later.