### PR TITLE
Update README with how to run GUI from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ For MSVC build you may have to specify the VS version and build type. Always mak
 	$ cmake -G "Visual Studio 14" -DCMAKE_BUILD_TYPE=Release ..
 	$ cmake --build . --config Release --target install
 
-The binaries will be under build/bin/. The GUI binary is called nvim-qt.
+The binaries will be under build/bin/. The GUI binary is called nvim-qt. Run make install to install it, or execute from the source setting the environment variable NVIM_QT_RUNTIME as the path holding the GUI shim plugin
+
+	$ NVIM_QT_RUNTIME_PATH=../src/gui/runtime bin/nvim-qt
 
 ## Using the GUI
 


### PR DESCRIPTION
To run nvim-qt from source one needs to add the GUI shim to the vim
runtime manually, this can be done with the NVIM_QT_RUNTIME variable.

ref #334

@e00E does this work for you?