### PR TITLE
Fix wrong api version used in GUI

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -262,12 +262,12 @@ void MainWindow::neovimTablineUpdate(int64_t curtab, QList<Tab> tabs)
 
 void MainWindow::changeTab(int index)
 {
-	if (m_nvim->api1() == NULL) {
+	if (m_nvim->api2() == NULL) {
 		return;
 	}
 
 	int64_t tab = m_tabline->tabData(index).toInt();
-	m_nvim->api1()->nvim_set_current_tabpage(tab);
+	m_nvim->api2()->nvim_set_current_tabpage(tab);
 }
 } // Namespace
 

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -198,8 +198,8 @@ void Shell::init()
 	options.insert("rgb", true);
 
 	MsgpackRequest *req;
-	if (m_nvim->api1()) {
-		req = m_nvim->api1()->nvim_ui_attach(width, height, options);
+	if (m_nvim->api2()) {
+		req = m_nvim->api2()->nvim_ui_attach(width, height, options);
 	} else {
 		req = m_nvim->api0()->ui_attach(width, height, true);
 	}


### PR DESCRIPTION
The ext_tabline feature requires api2, but I was using api1.

The deeper issue is that we have no mechanism to automatically fallback
to an earlier api version if attachment fails. And when it happens the
UI just blocks. So maybe we need a parameter to specify the api version
we want to use.

This commit simply moves up the requirement for api2. If api2 is not
available we use api0.