### PR TITLE
Add ways to disable the externalized tabline

### DIFF
--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -86,6 +86,11 @@ bool App::event(QEvent *event)
 
 void App::showUi(NeovimConnector *c, const QCommandLineParser& parser)
 {
+	auto opts = ShellOptions();
+	if (parser.isSet("no-ext-tabline")) {
+		opts.enable_ext_tabline = false;
+	}
+
 #ifdef NEOVIMQT_GUI_WIDGET
 	NeovimQt::Shell *win = new NeovimQt::Shell(c);
 	win->show();
@@ -97,7 +102,7 @@ void App::showUi(NeovimConnector *c, const QCommandLineParser& parser)
 		win->show();
 	}
 #else
-	NeovimQt::MainWindow *win = new NeovimQt::MainWindow(c);
+	NeovimQt::MainWindow *win = new NeovimQt::MainWindow(c, opts);
 
 	QObject::connect(instance(), SIGNAL(openFilesTriggered(const QList<QUrl>)),
 		win->shell(), SLOT(openFiles(const QList<QUrl>)));
@@ -135,6 +140,8 @@ void App::processCliOptions(QCommandLineParser &parser, const QStringList& argum
 				QCoreApplication::translate("main", "stylesheet")));
 	parser.addOption(QCommandLineOption("maximized",
 				QCoreApplication::translate("main", "Maximize the window on startup")));
+	parser.addOption(QCommandLineOption("no-ext-tabline",
+				QCoreApplication::translate("main", "Disable the external GUI tabline")));
 	parser.addOption(QCommandLineOption("fullscreen",
 				QCoreApplication::translate("main", "Open the window in fullscreen on startup")));
 	parser.addOption(QCommandLineOption("embed",

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -21,7 +21,7 @@ public:
 		FullScreen,
 	};
 
-	MainWindow(NeovimConnector *, QWidget *parent=0);
+	MainWindow(NeovimConnector *, ShellOptions opts, QWidget *parent=0);
 	bool neovimAttached() const;
 	Shell* shell();
 public slots:
@@ -54,6 +54,7 @@ private:
 	QStackedWidget m_stack;
 	QTabBar *m_tabline;
 	QToolBar *m_tabline_bar;
+	ShellOptions m_shell_options;
 };
 
 } // Namespace

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -14,7 +14,7 @@
 
 namespace NeovimQt {
 
-Shell::Shell(NeovimConnector *nvim, QWidget *parent)
+Shell::Shell(NeovimConnector *nvim, ShellOptions opts, QWidget *parent)
 :ShellWidget(parent), m_attached(false), m_nvim(nvim),
 	m_font_bold(false), m_font_italic(false), m_font_underline(false), m_font_undercurl(false),
 	m_mouseHide(true),
@@ -22,7 +22,8 @@ Shell::Shell(NeovimConnector *nvim, QWidget *parent)
 	m_cursor_color(Qt::white), m_cursor_pos(0,0), m_insertMode(false),
 	m_resizing(false),
 	m_mouse_wheel_delta_fraction(0, 0),
-	m_neovimBusy(false)
+	m_neovimBusy(false),
+	m_options(opts)
 {
 	setAttribute(Qt::WA_KeyCompression, false);
 
@@ -194,7 +195,9 @@ void Shell::init()
 	int64_t width = screenRect.width()*0.66/cellSize().width();
 	int64_t height = screenRect.height()*0.66/cellSize().height();
 	QVariantMap options;
-	options.insert("ext_tabline", true);
+	if (m_options.enable_ext_tabline) {
+		options.insert("ext_tabline", true);
+	}
 	options.insert("rgb", true);
 
 	MsgpackRequest *req;

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -25,13 +25,21 @@ public:
 	QString name;
 };
 
+class ShellOptions {
+public:
+	ShellOptions() {
+		enable_ext_tabline = true;
+	}
+	bool enable_ext_tabline;
+};
+
 class Shell: public ShellWidget
 {
 	Q_OBJECT
 	Q_PROPERTY(bool neovimBusy READ neovimBusy() NOTIFY neovimBusy())
 	Q_PROPERTY(bool neovimAttached READ neovimAttached() NOTIFY neovimAttached())
 public:
-	Shell(NeovimConnector *nvim, QWidget *parent=0);
+	Shell(NeovimConnector *nvim, ShellOptions opts, QWidget *parent=0);
 	~Shell();
 	QSize sizeIncrement() const;
 	static QColor color(qint64 color, const QColor& fallback=QColor());
@@ -146,6 +154,7 @@ private:
 
 	// Properties
 	bool m_neovimBusy;
+	ShellOptions m_options;
 };
 
 } // Namespace

--- a/test/tst_shell.cpp
+++ b/test/tst_shell.cpp
@@ -28,7 +28,7 @@ private slots:
 			QVERIFY(onReady.isValid());
 			QVERIFY(SPYWAIT(onReady));
 
-			Shell *s = new Shell(c);
+			Shell *s = new Shell(c, ShellOptions());
 			QSignalSpy onResize(s, SIGNAL(neovimResized(int, int)));
 			QVERIFY(onResize.isValid());
 			QVERIFY(SPYWAIT(onResize));
@@ -39,7 +39,7 @@ private slots:
 		QStringList args;
 		args << "-u" << "NONE";
 		NeovimConnector *c = NeovimConnector::spawn(args);
-		Shell *s = new Shell(c);
+		Shell *s = new Shell(c, ShellOptions());
 		QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
 		QVERIFY(onAttached.isValid());
 		QVERIFY(SPYWAIT(onAttached));
@@ -55,7 +55,7 @@ private slots:
 	void startVarsShellWidget() {
 		QStringList args = {"-u", "NONE"};
 		NeovimConnector *c = NeovimConnector::spawn(args);
-		Shell *s = new Shell(c);
+		Shell *s = new Shell(c, ShellOptions());
 		QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
 		QVERIFY(onAttached.isValid());
 		QVERIFY(SPYWAIT(onAttached));
@@ -66,7 +66,7 @@ private slots:
 	void startVarsMainWindow() {
 		QStringList args = {"-u", "NONE"};
 		NeovimConnector *c = NeovimConnector::spawn(args);
-		MainWindow *s = new MainWindow(c);
+		MainWindow *s = new MainWindow(c, ShellOptions());
 		QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
 		QVERIFY(onAttached.isValid());
 		QVERIFY(SPYWAIT(onAttached));
@@ -82,7 +82,7 @@ private slots:
 		QStringList args = {"-u", "NONE",
 			"--cmd", "set rtp+=" + fi.absoluteFilePath()};
 		NeovimConnector *c = NeovimConnector::spawn(args);
-		MainWindow *s = new MainWindow(c);
+		MainWindow *s = new MainWindow(c, ShellOptions());
 		QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
 		QVERIFY(onAttached.isValid());
 		QVERIFY(SPYWAIT(onAttached));


### PR DESCRIPTION
From https://github.com/equalsraf/neovim-qt/issues/361 so far it adds a cli option to disable the tabline in the GUI.

@unclechu pointed out that neovim-gtk uses an option in ginit.vim to disable the gui tabline (https://github.com/equalsraf/neovim-qt/issues/361#issuecomment-345920286). Main issue for me is that ginit.vim is after the UI is attached.