### PR TITLE
Fix negative linespace

### DIFF
--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -536,7 +536,9 @@ void Shell::handleNeovimNotification(const QByteArray &name, const QVariantList&
 				emit neovimFullScreen(variant_not_zero(args.at(1)));
 			}
 		} else if (guiEvName == "Linespace" && args.size() == 2) {
-			auto val = args.at(1).toUInt();
+			// The conversion to string and then to int happens because of http://doc.qt.io/qt-5/qvariant.html#toUInt
+			// toUint() fails to detect an overflow i.e. it converts to ulonglong and then returns a MAX UINT
+			auto val = args.at(1).toString().toUInt();
 			setLineSpace(val);
 			m_nvim->api0()->vim_set_var("GuiLinespace", val);
 			resizeNeovim(size());


### PR DESCRIPTION
The Gui Linespace rpc, when given negative values applied different
behaviour when the value was a string or an integer.

For strings it coherced the value to 0.

For negative integers it coherced the value to max int.

Even if in practice large values are ignored in practice it created a
descrepancey based on the passed in type.

The core of the issues is that Qt allows a QVariant to be converted to
an unsigned in even if the value is a signed long long which is then
converted to an unsigned int i.e. overflowing it. This issue is
documented in the Qt docs

    http://doc.qt.io/qt-5/qvariant.html#toUInt

The workaround is to convert to string before converting to uint.

ref #369