### PR TITLE
Support forwarded UI options

### DIFF
--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -459,6 +459,10 @@ void Shell::handleRedraw(const QByteArray& name, const QVariantList& opargs)
 		}
 
 		emit neovimTablineUpdate(curtab, tabs);
+	} else if (name == "option_set") {
+		if (2 <= opargs.size()) {
+			handleSetOption(opargs.at(0).toString(), opargs.at(1));
+		}
 	} else {
 		qDebug() << "Received unknown redraw notification" << name << opargs;
 	}
@@ -579,6 +583,21 @@ void Shell::handleNeovimNotification(const QByteArray &name, const QVariantList&
 			const QVariantList& opargs = opargs_var.toList();
 			handleRedraw(name, opargs);
 		}
+	}
+}
+
+void Shell::handleSetOption(const QString& name, const QVariant& value)
+{
+	if (name == "guifont") {
+		setGuiFont(value.toString());
+	} else if (name == "guifontset") {
+	} else if (name == "guifontwide") {
+	} else if (name == "linespace") {
+		// The conversion to string and then to int happens because of http://doc.qt.io/qt-5/qvariant.html#toUInt
+		// toUint() fails to detect an overflow i.e. it converts to ulonglong and then returns a MAX UINT
+		setLineSpace(value.toString().toInt());
+	} else {
+		qDebug() << "Received unknown option" << name << value;
 	}
 }
 

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -112,6 +112,7 @@ protected:
 	virtual void handleSetTitle(const QVariantList& opargs);
 	virtual void handleSetScrollRegion(const QVariantList& opargs);
 	virtual void handleBusy(bool);
+	virtual void handleSetOption(const QString& name, const QVariant& value);
 
 	void neovimMouseEvent(QMouseEvent *ev);
 	virtual void mousePressEvent(QMouseEvent *ev) Q_DECL_OVERRIDE;


### PR DESCRIPTION
nvim 0.2.3 will start forwarding UI configuration options as redraw
events. This adds support for

- guifont
- linespace

and ignores the following

- guifontset
- guifontwide

a quick note about 'guifont' is that the options requires escaping
spaces e.g.

    :set guifont=DejaVu\ Sans\ Mono:h24

where the shim command did not.