### PR TITLE
Split 'linespace' evenly in the line

### DIFF
--- a/src/gui/shellwidget/shellwidget.cpp
+++ b/src/gui/shellwidget/shellwidget.cpp
@@ -155,7 +155,7 @@ void ShellWidget::paintEvent(QPaintEvent *ev)
 					}
 
 					// Draw chars at the baseline
-					QPoint pos(r.left(), r.top()+m_ascent+m_lineSpace);
+					QPoint pos(r.left(), r.top()+m_ascent+(m_lineSpace / 2));
 					p.drawText(pos, QString(cell.c));
 				}
 


### PR DESCRIPTION
The linespace option can be used to increase/decrease the height of a
line. Previously in neovim-qt this additional space caused the text
baseline to be placed lower in the line. This commit changes the
baseline placement to keep the text vertically centered by dividing the
additional 'linespace' by 2.

ref #370 

@Leandros I made no changes for text clipping, so in some fonts text might still spill out of its line when using a negative value.