### PR TITLE
Fix Qchar width

### DIFF
--- a/src/gui/shellwidget/CMakeLists.txt
+++ b/src/gui/shellwidget/CMakeLists.txt
@@ -8,6 +8,10 @@ set(CMAKE_AUTOMOC ON)
 find_package(Qt5Widgets REQUIRED)
 find_package(Qt5Test REQUIRED)
 
+if (WIN32 AND USE_STATIC_QT)
+	add_definitions(-DUSE_STATIC_QT)
+endif ()
+
 set(SOURCES shellcontents.cpp helpers.cpp shellwidget.cpp konsole_wcwidth.cpp)
 add_library(qshellwidget STATIC ${SOURCES})
 target_link_libraries(qshellwidget Qt5::Widgets)

--- a/src/gui/shellwidget/test/CMakeLists.txt
+++ b/src/gui/shellwidget/test/CMakeLists.txt
@@ -1,5 +1,9 @@
 include_directories(..)
 
+if (WIN32 AND USE_STATIC_QT)
+	add_definitions(-DUSE_STATIC_QT)
+endif ()
+
 function(add_xtest SOURCE_NAME)
 	add_executable(${SOURCE_NAME} ${SOURCE_NAME}.cpp)
 	target_link_libraries(${SOURCE_NAME} Qt5::Widgets Qt5::Test qshellwidget)

--- a/src/gui/shellwidget/test/bench_cell.cpp
+++ b/src/gui/shellwidget/test/bench_cell.cpp
@@ -1,6 +1,11 @@
 #include <QtTest/QtTest>
 #include "cell.h"
 
+#if defined(Q_OS_WIN) && defined(USE_STATIC_QT)
+#include <QtPlugin>
+Q_IMPORT_PLUGIN (QWindowsIntegrationPlugin);
+#endif
+
 class Test: public QObject
 {
 	Q_OBJECT

--- a/src/gui/shellwidget/test/bench_scroll.cpp
+++ b/src/gui/shellwidget/test/bench_scroll.cpp
@@ -1,6 +1,11 @@
 #include <QtTest/QtTest>
 #include "shellcontents.h"
 
+#if defined(Q_OS_WIN) && defined(USE_STATIC_QT)
+#include <QtPlugin>
+Q_IMPORT_PLUGIN (QWindowsIntegrationPlugin);
+#endif
+
 class Test: public QObject
 {
 	Q_OBJECT

--- a/src/gui/shellwidget/test/test_cell.cpp
+++ b/src/gui/shellwidget/test/test_cell.cpp
@@ -1,6 +1,11 @@
 #include <QtTest/QtTest>
 #include "cell.h"
 
+#if defined(Q_OS_WIN) && defined(USE_STATIC_QT)
+#include <QtPlugin>
+Q_IMPORT_PLUGIN (QWindowsIntegrationPlugin);
+#endif
+
 class Test: public QObject
 {
 	Q_OBJECT

--- a/src/gui/shellwidget/test/test_shellcontents.cpp
+++ b/src/gui/shellwidget/test/test_shellcontents.cpp
@@ -2,6 +2,11 @@
 #include "shellcontents.h"
 #include "helpers.h"
 
+#if defined(Q_OS_WIN) && defined(USE_STATIC_QT)
+#include <QtPlugin>
+Q_IMPORT_PLUGIN (QWindowsIntegrationPlugin);
+#endif
+
 class Test: public QObject
 {
 	Q_OBJECT

--- a/src/gui/shellwidget/test/test_shellwidget.cpp
+++ b/src/gui/shellwidget/test/test_shellwidget.cpp
@@ -1,6 +1,11 @@
 #include <QtTest/QtTest>
 #include "shellwidget.h"
 
+#if defined(Q_OS_WIN) && defined(USE_STATIC_QT)
+#include <QtPlugin>
+Q_IMPORT_PLUGIN (QWindowsIntegrationPlugin);
+#endif
+
 class Test: public QObject
 {
 	Q_OBJECT

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,8 @@
 
 include_directories(${CMAKE_SOURCE_DIR}/src)
+if (WIN32 AND USE_STATIC_QT)
+	add_definitions(-DUSE_STATIC_QT)
+endif ()
 
 add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND})
 function(add_xtest SOURCE_NAME)

--- a/test/tst_shell.cpp
+++ b/test/tst_shell.cpp
@@ -5,6 +5,11 @@
 #include <msgpackrequest.h>
 #include "common.h"
 
+#if defined(Q_OS_WIN) && defined(USE_STATIC_QT)
+#include <QtPlugin>
+Q_IMPORT_PLUGIN (QWindowsIntegrationPlugin);
+#endif
+
 namespace NeovimQt {
 
 class Test: public QObject


### PR DESCRIPTION
We follow a basic assumption: the Latin character is one character width and the non-Latin character is two characters width.

 I am in the Far East, this approach is usually used to deal with.
Now https://github.com/equalsraf/neovim-qt/issues/384, https://github.com/equalsraf/neovim-qt/issues/110, https://github.com/equalsraf/neovim-qt/issues/140 shoud be fixed.