### PR TITLE
Avoid treating C-S- as C-space, fixes #344

### DIFF
--- a/src/gui/input.cpp
+++ b/src/gui/input.cpp
@@ -224,6 +224,10 @@ QString InputConv::convertKey(const QString& text, int k, Qt::KeyboardModifiers 
 			QList<Qt::Key> keys = { Key_Control, Key_Alt, Key_Cmd };
 			if (keys.contains((Qt::Key)k)) {
 				return QString();
+			} else if (mod & ShiftModifier) {
+				// Ignore event for Ctrl-Shift
+				// Fixes issue #344, C-S- being treated as C-Space
+				return QString();
 			} else {
 				// key code will be the value of the char (hopefully)
 				c = QChar(k);
@@ -238,7 +242,7 @@ QString InputConv::convertKey(const QString& text, int k, Qt::KeyboardModifiers 
 	}
 
 	// Remove SHIFT
-    if (c.unicode() >= 0x80 || (!c.isLetterOrNumber() && c.isPrint())) {
+	if (c.unicode() >= 0x80 || (!c.isLetterOrNumber() && c.isPrint())) {
 		mod &= ~ShiftModifier;
 	}
 


### PR DESCRIPTION
Pressing Ctrl-Shift seems to produce a separate event that gets treated as C-space. Probably that's layout-dependant, as current reporters are all using dvorak layouts.

This fix makes nvim-qt ignore an event that contains no other substance than the C-S modifiers.