### PR TITLE
Keep arguments to nvim before any filenames; fixes #417.

### DIFF
--- a/src/neovimconnector.cpp
+++ b/src/neovimconnector.cpp
@@ -195,12 +195,12 @@ NeovimConnector* NeovimConnector::spawn(const QStringList& params, const QString
 {
 	QProcess *p = new QProcess();
 	QStringList args;
+        // Neovim accepts a `--' argument after which only filenames are passed.
+        // If the user has supplied it, our arguments must appear before.
 	if (params.indexOf("--") == -1) {
-		args.append(params);
 		args << "--embed" << "--headless";
+		args.append(params);
 	} else {
-		// Neovim accepts a -- argument after which only
-		// filenames are passed
 		int idx = params.indexOf("--");
 		args.append(params.mid(0, idx));
 		args << "--embed" << "--headless";

--- a/src/neovimconnector.cpp
+++ b/src/neovimconnector.cpp
@@ -195,8 +195,8 @@ NeovimConnector* NeovimConnector::spawn(const QStringList& params, const QString
 {
 	QProcess *p = new QProcess();
 	QStringList args;
-        // Neovim accepts a `--' argument after which only filenames are passed.
-        // If the user has supplied it, our arguments must appear before.
+	// Neovim accepts a `--' argument after which only filenames are passed.
+	// If the user has supplied it, our arguments must appear before.
 	if (params.indexOf("--") == -1) {
 		args << "--embed" << "--headless";
 		args.append(params);


### PR DESCRIPTION
As noted in issue #417, Neovim v3.* inexplicably seems to open an empty buffer when option parameters appear after filenames. This could be solved by adding a `--` parameter before the filenames, but the easier thing to do is to simply move nvim-qt's additional arguments before any user specified ones and let Neovim sort out this strange bug. Although it may not be 100% reproducible, at least a few people besides myself have noticed this, and this tiny patch seems to fix it without causing any problems I can think of, so it should be harmless at worst.

I also added one small comment (and initially committed with spaces instead of tabs: fixed).

EDIT: I have absolutely no idea why the build failed in the Windows test environment. I didn't change anything that has anything to do with that... I barely changed anything at all.