### PR TITLE
Appveyor change Qt to version 5.11.1

### DIFF
--- a/contrib/appveyor-mingw.bat
+++ b/contrib/appveyor-mingw.bat
@@ -1,7 +1,7 @@
 rem CMake/MinGW workaround - remove sh.exe from PATH
 where sh
 set MINGW=C:\Qt\Tools\mingw530_32
-set QTDIR=C:\Qt\5.11.0\mingw53_32
+set QTDIR=C:\Qt\5.11.1\mingw53_32
 set PATH=%PATH:C:\Program Files\Git\usr\bin;=%
 set CMAKE_PREFIX_PATH=%QTDIR%
 set PATH=%MINGW%\bin;%PATH%;%QTDIR%\bin


### PR DESCRIPTION
It seems the builds were failing because version 5.11.0 was not available at the expected path.