### PR TITLE
Fix crash with --no-ext-tabline

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -240,9 +240,7 @@ Shell* MainWindow::shell()
 
 void MainWindow::neovimShowtablineSet(int val)
 {
-	m_shell_options.enable_ext_tabline = val>0;
-	m_tabline_bar->setVisible(val>0);
-	m_shell_options.force_tabline = val==2;
+	m_shell_options.nvim_show_tabline = val;
 }
 
 void MainWindow::neovimTablineUpdate(int64_t curtab, QList<Tab> tabs)
@@ -277,7 +275,13 @@ void MainWindow::neovimTablineUpdate(int64_t curtab, QList<Tab> tabs)
 	}
 
 	// hide/show the tabline toolbar
-	m_tabline_bar->setVisible((tabs.size() > 1)||(m_shell_options.force_tabline));
+	if (m_shell_options.nvim_show_tabline==0) {
+		m_tabline_bar->setVisible(false);
+	} else if (m_shell_options.nvim_show_tabline==2) {
+		m_tabline_bar->setVisible(true);
+	} else {
+		m_tabline_bar->setVisible(tabs.size() > 1);
+	}
 
 	Q_ASSERT(tabs.size() == m_tabline->count());
 }

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -29,10 +29,10 @@ class ShellOptions {
 public:
 	ShellOptions() {
 		enable_ext_tabline = true;
-		force_tabline = false;
+		nvim_show_tabline = 1;
 	}
 	bool enable_ext_tabline;
-	bool force_tabline;
+	int nvim_show_tabline;
 };
 
 class Shell: public ShellWidget


### PR DESCRIPTION
Apologies, but in my previous pull request I broke the `--no-ext-tabline` command line switch. I refactored the changes I made to ensure that nothing breaks regardless of the status of the tabline. 

The cause was changing the visibility state of the tabline, since `--no-ext-tabline` completely prevents the creation of the tabline widget, and noevimShowTablineSet would unconditionally try to change it's visibility. I changed the neovimTablineUpdate slot to handle the visibility in all cases and also changed neovimShowtablineSet slot to only update a parameter to hold the state of `showtabline`.

I'm very sorry to have introduced a bug like that.