### PR TITLE
[RFC] Implement rpc interface for setting external GUI features

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ Commands for interacting with the GUI are regular commands, available in the doc
 
 	:Guifont DejaVu Sans Mono:h13
 
+To disable the GUI tabline and use the nvim TUI tabline, call
+
+	:GuiTabline 0
+
 You can set GUI options on startup, in the GUI configuration file (:help ginit.vim).
 
 ## Development

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -45,6 +45,7 @@ private slots:
 	void neovimIsUnsupported();
 	void neovimShowtablineSet(int);
 	void neovimTablineUpdate(int64_t curtab, QList<Tab> tabs);
+	void extTablineSet(bool);
 	void changeTab(int index);
 private:
 	void init(NeovimConnector *);

--- a/src/gui/runtime/doc/nvim_gui_shim.txt
+++ b/src/gui/runtime/doc/nvim_gui_shim.txt
@@ -45,6 +45,9 @@ GuiLinespace	When called with no arguments this command displays the
 		linespace, the number of extra pixels each line will have.
                 A single argument is accepted as the new linespace height.
 
+								*GuiTabline*
+GuiTabline	Enable or disable the external GUI tabline
+
 
 ==============================================================================
 2. GUI variables

--- a/src/gui/runtime/plugin/nvim_gui_shim.vim
+++ b/src/gui/runtime/plugin/nvim_gui_shim.vim
@@ -71,6 +71,11 @@ function s:GuiLinespaceCommand(height) abort
 endfunction
 command! -nargs=? GuiLinespace call s:GuiLinespaceCommand("<args>")
 
+function! s:GuiTabline(enable) abort
+	call rpcnotify(0, 'Gui', 'Option', 'Tabline', a:enable)
+endfunction
+command! -nargs=1 GuiTabline call s:GuiTabline(<args>)
+
 " GuiDrop('file1', 'file2', ...) is similar to :drop file1 file2 ...
 " but it calls fnameescape() over all arguments
 function GuiDrop(...)

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -553,6 +553,9 @@ void Shell::handleNeovimNotification(const QByteArray &name, const QVariantList&
 		} else if (guiEvName == "Close" && args.size() == 1) {
 			qDebug() << "Neovim requested a GUI close";
 			emit neovimGuiCloseRequest();
+		} else if (guiEvName == "Option" && args.size() >= 3) {
+			QString option = m_nvim->decode(args.at(1).toByteArray());
+			handleExtGuiOption(option, args.at(2));
 		}
 		return;
 	} else if (name != "redraw") {
@@ -586,6 +589,19 @@ void Shell::handleNeovimNotification(const QByteArray &name, const QVariantList&
 	}
 }
 
+void Shell::handleExtGuiOption(const QString& name, const QVariant& value)
+{
+	if (!m_nvim->api2()) return;
+	if (name == "Tabline") {
+		m_nvim->api2()->nvim_ui_set_option("ext_tabline", value.toBool());
+	} else if (name == "Popupmenu") {
+	} else if (name == "Cmdline") {
+	} else if (name == "Wildmenu") {
+	} else {
+		qDebug() << "Unknown GUI Option" << name << value;
+	}
+}
+
 void Shell::handleSetOption(const QString& name, const QVariant& value)
 {
 	if (name == "guifont") {
@@ -598,6 +614,8 @@ void Shell::handleSetOption(const QString& name, const QVariant& value)
 		setLineSpace(value.toString().toInt());
 	} else if (name == "showtabline") {
 		emit neovimShowtablineSet(value.toString().toInt());
+	} else if (name == "ext_tabline") {
+		emit neovimExtTablineSet(value.toBool());
 	} else {
 		qDebug() << "Received unknown option" << name << value;
 	}

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -61,6 +61,7 @@ signals:
 	void neovimGuiCloseRequest();
 	/// This signal is emmited if the running neovim version is unsupported by the GUI
 	void neovimIsUnsupported();
+	void neovimExtTablineSet(bool);
 	/// The tabline needs updating. curtab is the handle of the current tab (not its index)
 	/// as seen in Tab::tab.
 	void neovimTablineUpdate(int64_t curtab, QList<Tab> tabs);
@@ -116,6 +117,7 @@ protected:
 	virtual void handleSetScrollRegion(const QVariantList& opargs);
 	virtual void handleBusy(bool);
 	virtual void handleSetOption(const QString& name, const QVariant& value);
+	void handleExtGuiOption(const QString& name, const QVariant& value);
 
 	void neovimMouseEvent(QMouseEvent *ev);
 	virtual void mousePressEvent(QMouseEvent *ev) Q_DECL_OVERRIDE;

--- a/test/tst_shell.cpp
+++ b/test/tst_shell.cpp
@@ -79,6 +79,16 @@ private slots:
 		checkStartVars(c);
 	}
 
+	void guiExtTablineSet() {
+		QStringList args;
+		args << "-u" << "NONE";
+		NeovimConnector *c = NeovimConnector::spawn(args);
+		Shell *s = new Shell(c, ShellOptions());
+		QSignalSpy onOptionSet(s, &Shell::neovimExtTablineSet);
+		QVERIFY(onOptionSet.isValid());
+		QVERIFY(SPYWAIT(onOptionSet));
+	}
+
 	void guiShimCommands() {
 		// This function needs to be able to find the GUI runtime
 		// plugin or this test WILL FAIL
@@ -113,6 +123,11 @@ private slots:
 		checkCommand(c, "GuiFont DejaVu Sans Mono:h14:b:l", false);
 		QCOMPARE(s->shell()->fontDesc(), QString("DejaVu Sans Mono:h14:l"));
 #endif
+		QSignalSpy onOptionSet(s->shell(), &Shell::neovimExtTablineSet);
+		checkCommand(c, "GuiTabline 0");
+		QVERIFY(onOptionSet.isValid());
+		QVERIFY(SPYWAIT(onOptionSet));
+		qDebug() << onOptionSet << onOptionSet.size();
 	}
 
 protected:


### PR DESCRIPTION
This will allow GUI options such as the GUI tabline, cmdline (#351), popupmenu (#349) and wildmenu to be enabled and disabled from `ginit.vim` instead of command line switches. 

The interface will be `:call rpcnotify(0, "Gui", "Option", <option_name>, <value>)`, the same as [neovim-gtk](https://github.com/daa84/neovim-gtk/wiki/Configuration#options).

Ref #361 #362 #366

## TODO
 - [x] Check to make sure appropriate api level is available
 - [x] Use info reported by nvim to control status
 - [x] Hide gui tabline when disabled
 - [x] Create widget as hidden even when --no-ext-tabline is specified
 - [x] Add tests

