### PR TITLE
Fix #394, dont try to close the shell on GuiClose

### DIFF
--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -56,6 +56,7 @@ private:
 	QTabBar *m_tabline;
 	QToolBar *m_tabline_bar;
 	ShellOptions m_shell_options;
+	bool m_neovim_requested_close;
 };
 
 } // Namespace


### PR DESCRIPTION
If the shim is running the VimLeave event sends a notification to the
Gui (GuiClose) so that it shuts down too.

This notification triggers the neovimGuiCloseRequest which causes the
main window to call Shell::close() which in turn calls "qa". So a loop
is established where nvim calls the GUI to shutdown and the GUI calls
"qa" that triggers again the notification.

Avoid this with a boolean flag in the main window i.e. if a closeEvent
is triggered in the main window, and nvim already requested a close,
just close the window.