### PR TITLE
[WIP] Implement clipboard provider

### DIFF
--- a/contrib/appveyor.yml
+++ b/contrib/appveyor.yml
@@ -22,7 +22,7 @@ configuration:
 matrix:
   fast_finish: false
 install:
-- ps: appveyor DownloadFile -FileName Neovim.zip "https://ci.appveyor.com/api/projects/neovim/neovim/artifacts/build/Neovim.zip?branch=master&job=Configuration%3A%20MINGW_64"
+- ps: appveyor DownloadFile -FileName Neovim.zip "https://github.com/neovim/neovim/releases/download/nightly/nvim-win64.zip"
 - 7z x Neovim.zip
 - set PATH=%PATH%;%CD%\Neovim\bin;
 - nvim --version

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -520,6 +520,10 @@ void Shell::handleRedraw(const QByteArray& name, const QVariantList& opargs)
 		handlePopupMenuSelect(opargs.at(0).toLongLong());
 	} else if (name == "popupmenu_hide") {
 		m_pum.hide();
+	} else if (name == "mode_info_set") {
+		// TODO
+	} else if (name == "default_colors_set") {
+		// TODO
 	} else {
 		qDebug() << "Received unknown redraw notification" << name << opargs;
 	}
@@ -785,6 +789,13 @@ void Shell::handleSetOption(const QString& name, const QVariant& value)
 		emit neovimExtTablineSet(value.toBool());
 	} else if (name == "ext_popupmenu") {
 		emit neovimExtPopupmenuSet(value.toBool());
+	// TODO
+	} else if (name == "arabicshape") {
+	} else if (name == "ambiwidth") {
+	} else if (name == "emoji") {
+	} else if (name == "termguicolors") {
+	} else if (name == "ext_cmdline") {
+	} else if (name == "ext_wildmenu") {
 	} else {
 		qDebug() << "Received unknown option" << name << value;
 	}

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -73,6 +73,7 @@ signals:
 	/// as seen in Tab::tab.
 	void neovimTablineUpdate(int64_t curtab, QList<Tab> tabs);
 	void neovimShowtablineSet(int);
+	void fontChanged();
 
 public slots:
 	void handleNeovimNotification(const QByteArray &name, const QVariantList& args);
@@ -91,6 +92,8 @@ protected slots:
 	void init();
 	void fontError(const QString& msg);
 	void updateWindowId();
+	void handleGinitError(quint32 msgid, quint64 fun, const QVariant& err);
+	void handleShimError(quint32 msgid, quint64 fun, const QVariant& err);
 
 protected:
 	void tooltip(const QString& text);
@@ -134,6 +137,8 @@ protected:
 	virtual void mouseReleaseEvent(QMouseEvent *ev) Q_DECL_OVERRIDE;
 	virtual void mouseMoveEvent(QMouseEvent *ev) Q_DECL_OVERRIDE;
 
+	QString neovimErrorToString(const QVariant& err);
+
 private slots:
         void setAttached(bool attached=true);
 
@@ -173,6 +178,15 @@ private:
 	ShellOptions m_options;
 	PopupMenu m_pum;
 };
+
+class ShellRequestHandler: public QObject, public MsgpackRequestHandler
+{
+	Q_OBJECT
+public:
+	ShellRequestHandler(Shell *parent);
+	virtual void handleRequest(MsgpackIODevice* dev, quint32 msgid, const QByteArray& method, const QVariantList& args);
+};
+
 
 } // Namespace
 #endif

--- a/src/neovimconnector.cpp
+++ b/src/neovimconnector.cpp
@@ -381,6 +381,11 @@ void NeovimConnector::fatalTimeout()
 	setError(RuntimeMsgpackError, "Neovim is taking too long to respond");
 }
 
+void NeovimConnector::setRequestHandler(MsgpackRequestHandler *h)
+{
+	m_dev->setRequestHandler(h);
+}
+
 /**
  * True if NeovimConnector::reconnect can be called to reconnect with Neovim. This
  * is true unless you built the NeovimConnector ctor directly instead

--- a/src/neovimconnector.h
+++ b/src/neovimconnector.h
@@ -5,6 +5,7 @@
 #include <QAbstractSocket>
 #include <QProcess>
 #include <QTextCodec>
+#include "msgpackiodevice.h"
 #include "auto/neovimapi0.h"
 #include "auto/neovimapi1.h"
 #include "auto/neovimapi2.h"
@@ -14,6 +15,7 @@
 namespace NeovimQt {
 
 class MsgpackIODevice;
+class MsgpackRequestHandler;
 class NeovimConnectorHelper;
 class NeovimConnector: public QObject
 {
@@ -85,6 +87,8 @@ public:
 	NeovimConnectionType connectionType();
 	/** Some requests for metadata and ui attachment enforce a timeout in ms */
 	void setRequestTimeout(int);
+	/** Set a handler for msgpack rpc requests **/
+	void setRequestHandler(MsgpackRequestHandler *);
 
 	quint64 apiCompatibility();
 	quint64 apiLevel();

--- a/test/clipboard/autoload/provider/clipboard.vim
+++ b/test/clipboard/autoload/provider/clipboard.vim
@@ -1,0 +1,20 @@
+function! provider#clipboard#Call(method, args) abort
+
+	let uis = nvim_list_uis()
+	if len(uis) == 0
+		echoerr "No UIs are attached"
+		return
+	endif
+	let ui_chan = uis[-1].chan
+
+	if a:method == 'get'
+		" a:args is a list with a register name
+		let reqargs = [ui_chan, 'Gui', 'GetClipboard'] + a:args
+		let result =  call(function("rpcrequest"), reqargs)
+		return result
+	elseif a:method == 'set'
+		" a:args is [list of lines, type, register name]
+		let notargs = [ui_chan, 'Gui', 'SetClipboard'] + a:args
+		let _ = call(function("rpcnotify"), notargs)
+	endif
+endfunction

--- a/test/common.h
+++ b/test/common.h
@@ -3,12 +3,12 @@
 
 // This is just a fix for QSignalSpy::wait
 // http://stackoverflow.com/questions/22390208/google-test-mock-with-qt-signals
-bool SPYWAIT(QSignalSpy &spy, int timeout=10000)
+bool SPYWAIT(QSignalSpy &spy, int timeout=30000)
 {
 	return spy.count()>0||spy.wait(timeout);
 }
 
-bool SPYWAIT2(QSignalSpy &spy, int timeout=5000)
+bool SPYWAIT2(QSignalSpy &spy, int timeout=30000)
 {
 	return spy.count()>0||spy.wait(timeout);
 }

--- a/test/tst_neovimconnector.cpp
+++ b/test/tst_neovimconnector.cpp
@@ -101,7 +101,7 @@ private slots:
 				.arg(server->serverPort()));
 		QSignalSpy onError(c, SIGNAL(error(NeovimError)));
 		QVERIFY(onError.isValid());
-		QVERIFY(SPYWAIT2(onError, 20000));
+		QVERIFY(SPYWAIT2(onError));
 		QCOMPARE(c->errorCause(), NeovimConnector::RuntimeMsgpackError);
 		c->deleteLater();
 	}

--- a/test/tst_shell.cpp
+++ b/test/tst_shell.cpp
@@ -2,6 +2,7 @@
 #include <QtTest/QtTest>
 #include <QLocalSocket>
 #include <QFontDatabase>
+#include <QClipboard>
 #include <gui/mainwindow.h>
 #include <msgpackrequest.h>
 #include "common.h"
@@ -73,6 +74,7 @@ private slots:
 		QStringList args = {"-u", "NONE"};
 		NeovimConnector *c = NeovimConnector::spawn(args);
 		MainWindow *s = new MainWindow(c, ShellOptions());
+		s->show();
 		QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
 		QVERIFY(onAttached.isValid());
 		QVERIFY(SPYWAIT(onAttached));
@@ -125,55 +127,147 @@ private slots:
 		QVERIFY(SPYWAIT(onAttached));
 		QVERIFY(s->neovimAttached());
 
-		checkCommand(c, "GuiFont");
-		checkCommand(c, "GuiLinespace");
+		QObject::connect(c->neovimObject(), &NeovimApi1::err_vim_command_output, [](QString msg, const QVariant& err) {
+				qDebug() << msg << err;
+			});
+
+		QSignalSpy cmd_font(c->neovimObject()->vim_command_output(c->encode("GuiFont")), &MsgpackRequest::finished);
+		QVERIFY(cmd_font.isValid());
+		QVERIFY2(SPYWAIT(cmd_font), "Waiting for GuiFont");
+
+		QSignalSpy cmd_ls(c->neovimObject()->vim_command_output(c->encode("GuiLinespace")), &MsgpackRequest::finished);
+		QVERIFY(cmd_ls.isValid());
+		QVERIFY2(SPYWAIT(cmd_ls), "Waiting for GuiLinespace");
 
 		// Test font attributes
 #ifdef Q_OS_MAC
-		checkCommand(c, "GuiFont Monaco:h14", false);
+		QSignalSpy cmd_gf(c->neovimObject()->vim_command_output(c->encode("GuiFont Monaco:h14")), &MsgpackRequest::finished);
+#else
+		QSignalSpy cmd_gf(c->neovimObject()->vim_command_output(c->encode("GuiFont DejaVu Sans Mono:h14")), &MsgpackRequest::finished);
+#endif
+		QVERIFY(cmd_gf.isValid());
+		QVERIFY(SPYWAIT(cmd_gf));
+
+		QSignalSpy spy_fontchange(s->shell(), &Shell::fontChanged);
+		SPYWAIT(spy_fontchange);
+#ifdef Q_OS_MAC
 		QCOMPARE(s->shell()->fontDesc(), QString("Monaco:h14"));
 #else
-		checkCommand(c, "GuiFont DejaVu Sans Mono:h14", false);
 		QCOMPARE(s->shell()->fontDesc(), QString("DejaVu Sans Mono:h14"));
 #endif
 
 		// Normalization removes the :b attribute
 #ifdef Q_OS_MAC
-		checkCommand(c, "GuiFont Monaco:h14:b:l", false);
+		QSignalSpy cmd_gf2(c->neovimObject()->vim_command_output(c->encode("GuiFont Monaco:h14:b:l")), &MsgpackRequest::finished);
+#else
+		QSignalSpy cmd_gf2(c->neovimObject()->vim_command_output(c->encode("GuiFont DejaVu Sans Mono:h14:b:l")), &MsgpackRequest::finished);
+#endif
+		QVERIFY(cmd_gf2.isValid());
+		QVERIFY(SPYWAIT(cmd_gf2));
+
+		QSignalSpy spy_fontchange2(s->shell(), &Shell::fontChanged);
+		SPYWAIT(spy_fontchange2);
+#ifdef Q_OS_MAC
 		QCOMPARE(s->shell()->fontDesc(), QString("Monaco:h14:l"));
 #else
-		checkCommand(c, "GuiFont DejaVu Sans Mono:h14:b:l", false);
 		QCOMPARE(s->shell()->fontDesc(), QString("DejaVu Sans Mono:h14:l"));
 #endif
+
+		// GuiTabline
 		QSignalSpy onOptionSet(s->shell(), &Shell::neovimExtTablineSet);
-		checkCommand(c, "GuiTabline 0");
 		QVERIFY(onOptionSet.isValid());
-		QVERIFY(SPYWAIT(onOptionSet));
-		qDebug() << onOptionSet << onOptionSet.size();
+
+//		QSignalSpy cmd_gtab(c->neovimObject()->vim_command_output(c->encode("GuiTabline 0")), &MsgpackRequest::finished);
+//		QVERIFY(cmd_gtab.isValid());
+//		QVERIFY(SPYWAIT2(cmd_gtab));
+//
+//		QVERIFY(SPYWAIT(onOptionSet));
+//		qDebug() << onOptionSet << onOptionSet.size();
+	}
+
+	void guiClipboard_data() {
+		// * or +
+		QTest::addColumn<char>("reg");
+		// data set in the register when starting test, this is set
+		// externaly (i.e. without going through the provider)
+		QTest::addColumn<QByteArray>("register_data");
+		// Some nvim input keys
+		QTest::addColumn<QString>("input_cmd");
+		// The expected data in the buffer after running the cmd
+		QTest::addColumn<QList<QByteArray>>("expected_buffer");
+
+		QTest::newRow("empty *")
+			<< '*' << QByteArray() << "" << QList<QByteArray>({""});
+		QTest::newRow("set *")
+			<< '*' << QByteArray("something") << "" << QList<QByteArray>({""});
+		QTest::newRow("empty +")
+			<< '+' << QByteArray() << "" << QList<QByteArray>({""});
+		QTest::newRow("set +")
+			<< '+' << QByteArray("something") << "" << QList<QByteArray>({""});
+		QTest::newRow("paste *")
+			<< '*' << QByteArray("something") << "\"*p"
+			<< QList<QByteArray>({"something"});
+		QTest::newRow("paste +")
+			<< '+' << QByteArray("something") << "\"+p"
+			<< QList<QByteArray>({"something"});
+	}
+
+	void guiClipboard() {
+		QFETCH(char, reg);
+		QFETCH(QByteArray, register_data);
+		QFETCH(QString, input_cmd);
+		QFETCH(QList<QByteArray>, expected_buffer);
+
+		// A clipboard provider
+		QFileInfo fi = QFileInfo("test/clipboard");
+		QVERIFY2(fi.exists(), "Unable to find test runtime");
+		QStringList args = {"-u", "NORC",
+			"--cmd", "let &rtp='" + fi.absoluteFilePath() + ",' . &rtp"};
+		NeovimConnector *c = NeovimConnector::spawn(args);
+		MainWindow *s = new MainWindow(c, ShellOptions());
+		QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
+		QVERIFY(onAttached.isValid());
+		QVERIFY(SPYWAIT(onAttached));
+		QVERIFY(s->neovimAttached());
+
+		QObject::connect(c->neovimObject(), &NeovimApi1::err_vim_command_output, [](QString msg, const QVariant& err) {
+				qDebug() << msg << err;
+			});
+
+#if defined(Q_OS_MAC) || defined(Q_OS_WIN32)
+		QGuiApplication::clipboard()->setText(register_data, QClipboard::Clipboard);
+#else
+		if (reg == '+') {
+			QGuiApplication::clipboard()->setText(register_data, QClipboard::Clipboard);
+		} else {
+			QGuiApplication::clipboard()->setText(register_data, QClipboard::Selection);
+		}
+#endif
+
+		QString getreg_cmd = QString("echo getreg('%1')").arg(reg);
+		QSignalSpy cmd_clip(c->neovimObject()->vim_command_output(c->encode(getreg_cmd)), &MsgpackRequest::finished);
+		QVERIFY(cmd_clip.isValid());
+		QVERIFY(SPYWAIT(cmd_clip));
+		QCOMPARE(cmd_clip.takeFirst().at(2), QVariant(register_data));
+
+		// execute a command
+		QSignalSpy spy_cmd(c->neovimObject()->vim_input(c->encode(input_cmd)), &MsgpackRequest::finished);
+		SPYWAIT(spy_cmd);
+		// because vim_input is asynchronous we call feedkeys here to force neovim to
+		// handle our previous input
+		QSignalSpy spy_sync(c->neovimObject()->vim_feedkeys("", "", false), &MsgpackRequest::finished);
+		SPYWAIT(spy_sync);
+
+		QSignalSpy cmd_buf(c->neovimObject(), &NeovimApi1::on_nvim_buf_get_lines);
+		QVERIFY(cmd_buf.isValid());
+
+		c->neovimObject()->nvim_buf_get_lines(0, 0, -1, false);
+		QVERIFY(SPYWAIT(cmd_buf));
+		QByteArrayList lines = qvariant_cast<QByteArrayList>(cmd_buf.takeFirst().at(0));
+		QCOMPARE(lines, expected_buffer);
 	}
 
 protected:
-
-	void checkCommand(NeovimConnector *c, const QString& cmd,
-			bool output=false) {
-		auto req = c->neovimObject()->vim_command_output(c->encode(cmd));
-		QSignalSpy cmdOk(req, SIGNAL(finished(quint32, quint64, QVariant)));
-		QVERIFY(cmdOk.isValid());
-		QObject::connect(c->neovimObject(), &NeovimApi1::err_vim_command_output, [cmd](QString msg, const QVariant& err) {
-				qDebug() << cmd << msg;
-			});
-		qDebug() << cmd;
-		// Force the Neovim event loop to advance with async vim_input()
-		c->neovimObject()->vim_input("<cr>");
-		QVERIFY(SPYWAIT(cmdOk));
-		qDebug() << cmdOk << cmdOk.size();
-
-		if (output) {
-			// Make sure the command output is not empty
-			QVERIFY(!cmdOk.at(0).at(2).toByteArray().isEmpty());
-		}
-	}
-
 	/// Check for the presence of the GUI variables in Neovim
 	void checkStartVars(NeovimQt::NeovimConnector *conn) {
 		auto *nvim = conn->api1();

--- a/test/tst_shell.cpp
+++ b/test/tst_shell.cpp
@@ -44,7 +44,7 @@ private slots:
 
 	void uiStart() {
 		QStringList args;
-		args << "-u" << "NONE";
+		args << "-u" << "NORC";
 		NeovimConnector *c = NeovimConnector::spawn(args);
 		Shell *s = new Shell(c, ShellOptions());
 		QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
@@ -60,7 +60,7 @@ private slots:
 	}
 
 	void startVarsShellWidget() {
-		QStringList args = {"-u", "NONE"};
+		QStringList args = {"-u", "NORC"};
 		NeovimConnector *c = NeovimConnector::spawn(args);
 		Shell *s = new Shell(c, ShellOptions());
 		QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
@@ -71,7 +71,7 @@ private slots:
 	}
 
 	void startVarsMainWindow() {
-		QStringList args = {"-u", "NONE"};
+		QStringList args = {"-u", "NORC"};
 		NeovimConnector *c = NeovimConnector::spawn(args);
 		MainWindow *s = new MainWindow(c, ShellOptions());
 		s->show();
@@ -84,7 +84,7 @@ private slots:
 
 	void guiExtTablineSet() {
 		QStringList args;
-		args << "-u" << "NONE";
+		args << "-u" << "NORC";
 		NeovimConnector *c = NeovimConnector::spawn(args);
 		Shell *s = new Shell(c, ShellOptions());
 		QSignalSpy onOptionSet(s, &Shell::neovimExtTablineSet);
@@ -95,7 +95,7 @@ private slots:
 	void gviminit() {
 		qputenv("GVIMINIT", "let g:test_gviminit = 1");
 		QStringList args;
-		args << "-u" << "NONE";
+		args << "-u" << "NORC";
 		NeovimConnector *c = NeovimConnector::spawn(args);
 		Shell *s = new Shell(c, ShellOptions());
 
@@ -118,7 +118,7 @@ private slots:
 		// plugin or this test WILL FAIL
 		QFileInfo fi = QFileInfo("src/gui/runtime");
 		QVERIFY2(fi.exists(), "Unable to find GUI runtime");
-		QStringList args = {"-u", "NONE",
+		QStringList args = {"-u", "NORC",
 			"--cmd", "set rtp+=" + fi.absoluteFilePath()};
 		NeovimConnector *c = NeovimConnector::spawn(args);
 		MainWindow *s = new MainWindow(c, ShellOptions());


### PR DESCRIPTION
A clipboard provider implemented by the GUI

It currently supports both clipboards and stores the selection type. Big question now is what happens with multiple GUIs attached, etc.

This is based on the approach from [neovim-gtk](https://github.com/daa84/neovim-gtk/blob/master/runtime/plugin/nvim_gui_shim.vim#L7). As it stands the call signatures are not compatible, ~~but I think they could be.~~ we use all the arguments in the set event and the api in neovim-gtk only passes arg0 and 2. The event names are different so there should be no conflict.

## TODO

- [x] get the correct channel id instead of **1**
- [ ] Test on windows with multi-line data on the clipboard (newline char)
- [x] ~~Add guards to the provider, merge with the shim, etc~~
- [x] Remove from the shim for now
- [ ] There are some bugs on the provider, sometimes it returns invalid data, i.e. our function is returning an unexpected data structure
- [ ] Add tests - in particular cover different types of selections

ref https://github.com/equalsraf/neovim-qt/issues/298
