### PR TITLE
GUI: Minimize window on suspend event

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -61,6 +61,8 @@ void MainWindow::init(NeovimConnector *c)
 			this, &MainWindow::neovimWidgetResized);
 	connect(m_shell, &Shell::neovimMaximized,
 			this, &MainWindow::neovimMaximized);
+	connect(m_shell, &Shell::neovimSuspend,
+			this, &MainWindow::neovimSuspend);
 	connect(m_shell, &Shell::neovimFullScreen,
 			this, &MainWindow::neovimFullScreen);
 	connect(m_shell, &Shell::neovimGuiCloseRequest,
@@ -151,6 +153,12 @@ void MainWindow::neovimMaximized(bool set)
 	} else {
 		setWindowState(windowState() & ~Qt::WindowMaximized);
 	}
+}
+
+void MainWindow::neovimSuspend()
+{
+	qDebug() << "Minimizing window";
+	setWindowState(windowState() | Qt::WindowMinimized);
 }
 
 void MainWindow::neovimFullScreen(bool set)

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -35,6 +35,7 @@ private slots:
 	void neovimSetTitle(const QString &title);
 	void neovimWidgetResized();
 	void neovimMaximized(bool);
+	void neovimSuspend();
 	void neovimFullScreen(bool);
 	void neovimGuiCloseRequest();
 	void neovimExited(int status);

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -463,6 +463,12 @@ void Shell::handleRedraw(const QByteArray& name, const QVariantList& opargs)
 		if (2 <= opargs.size()) {
 			handleSetOption(opargs.at(0).toString(), opargs.at(1));
 		}
+	} else if (name == "suspend") {
+		if (isWindow()) {
+			setWindowState(windowState() | Qt::WindowMinimized);
+		} else {
+			emit neovimSuspend();
+		}
 	} else {
 		qDebug() << "Received unknown redraw notification" << name << opargs;
 	}

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -57,6 +57,7 @@ signals:
 	void neovimResized(int rows, int cols);
 	void neovimAttached(bool);
 	void neovimMaximized(bool);
+	void neovimSuspend();
 	void neovimFullScreen(bool);
 	void neovimGuiCloseRequest();
 	/// This signal is emmited if the running neovim version is unsupported by the GUI


### PR DESCRIPTION
The suspend/stop() command in the console puts nvim in the background.
In the GUI it typically minimizes the window (gvim).

See #438