### PR TITLE
Launch nvim-qt from nvim

### DIFF
--- a/src/gui/runtime/doc/nvim_gui_shim.txt
+++ b/src/gui/runtime/doc/nvim_gui_shim.txt
@@ -132,6 +132,15 @@ GuiClose() notifies the GUI that it should close. The GUI may or may not
 respect this request. The shim setups an autocommand to call this function
 when the |'VimLeave'| event occurs.
 
+GuiStart({cmd}, {opts})					*GuiStart()*
+GuiStart is a wrapper around jobstart that launches a GUI process. When
+the GUI process exists, nvim will attempt to exit using :qa.
+The argument {cmd} specifies the command to be executed.
+
+    {opts} is a dictionary with these keys:
+	rpc     : If set, a msgpack-rpc channel is created on top of the
+		  process stdin/stdout.
+
 ==============================================================================
 4. Internals
 

--- a/src/gui/runtime/doc/nvim_gui_shim.txt
+++ b/src/gui/runtime/doc/nvim_gui_shim.txt
@@ -133,8 +133,7 @@ respect this request. The shim setups an autocommand to call this function
 when the |'VimLeave'| event occurs.
 
 GuiStart({cmd}, {opts})					*GuiStart()*
-GuiStart is a wrapper around jobstart that launches a GUI process. When
-the GUI process exists, nvim will attempt to exit using :qa.
+GuiStart is a wrapper around jobstart that launches a GUI process.
 The argument {cmd} specifies the command to be executed.
 
     {opts} is a dictionary with these keys:

--- a/src/gui/runtime/plugin/nvim_gui_shim.vim
+++ b/src/gui/runtime/plugin/nvim_gui_shim.vim
@@ -98,7 +98,6 @@ function! s:on_gui_event(jobid, data, event)
     if a:data != 0
       call chansend(v:stderr, ["GUI closed with exit code " . a:data, ''])
     endif
-	execute 'qa'
   elseif a:event ==# 'stderr'
     call chansend(v:stderr, a:data)
   endif

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -1019,8 +1019,9 @@ void Shell::updateGuiWindowState(Qt::WindowStates state)
 
 void Shell::closeEvent(QCloseEvent *ev)
 {
+	auto ctype = m_nvim->connectionType();
 	if (m_attached &&
-		m_nvim->connectionType() == NeovimConnector::SpawnedConnection) {
+		(ctype == NeovimConnector::SpawnedConnection || ctype == NeovimConnector::OtherConnection)) {
 		// If attached to a spawned Neovim process, ignore the event
 		// and try to close Neovim as :qa
 		ev->ignore();


### PR DESCRIPTION
ref https://github.com/equalsraf/neovim-qt/issues/449 https://github.com/equalsraf/neovim-qt/issues/275

- [ ] rtp is not set i.e. the shim is not loaded
- There is no way to restart nvim from the GUI
- [ ] There is no way to move the process to the background except through the calling shell
- [ ] Currently GUI stderr is sent to the nvim stderr, this might not be what you want
- [ ] Define global variables so that we can just use a function call or a command `nvim --headless -c GuiStart`
- [ ] Does `--embed` work properly on windows?
 
Examples

```sh
nvim --headless -c 'call GuiStart(["nvim-qt", "--nofork", "--embed"], {"rpc":1})'
```

If for some reason `--embed` is not working, use `['nvim-qt', '--nofork', '--server', $NVIM_LISTEN_ADDRESS]` instead

