### PR TITLE
[RFC] Input Ctrl-C if Neovim is blocked waiting for input

### DIFF
--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -133,6 +133,7 @@ protected:
 	virtual void mousePressEvent(QMouseEvent *ev) Q_DECL_OVERRIDE;
 	virtual void mouseReleaseEvent(QMouseEvent *ev) Q_DECL_OVERRIDE;
 	virtual void mouseMoveEvent(QMouseEvent *ev) Q_DECL_OVERRIDE;
+	void bailoutIfinputBlocking();
 
 private slots:
         void setAttached(bool attached=true);


### PR DESCRIPTION
Currently this is only being used for #425. If the user is trying to close the window, we send in a Ctrl-C if neovim is blocked waiting for input.

We might use this in other cases too, but I have not looked into this further.