### PR TITLE
Handle blocked input

### DIFF
--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -791,7 +791,7 @@ void Shell::paintEvent(QPaintEvent *ev)
 
 void Shell::keyPressEvent(QKeyEvent *ev)
 {
-	if (!m_nvim || !m_attached) {
+	if (!m_nvim) {
 		QWidget::keyPressEvent(ev);
 		return;
 	}

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -239,6 +239,8 @@ void Shell::init()
 	connect(req, &MsgpackRequest::finished,
 			this, &Shell::setAttached);
 
+	bailoutIfinputBlocking();
+
 	// Subscribe to GUI events
 	m_nvim->api0()->vim_subscribe("Gui");
 }


### PR DESCRIPTION
Continues https://github.com/equalsraf/neovim-qt/pull/462

Related
- https://github.com/equalsraf/neovim-qt/issues/322
- https://github.com/equalsraf/neovim-qt/issues/363
- https://github.com/equalsraf/neovim-qt/issues/78

## Issues

### Swap files :o:

To reproduce just open the same file twice with nvim.

In terminal nvim simply pressing `<C-c>` is not sufficient to dismiss the last error message. However in nvim-qt the behaviour seems to differ. More importantly as it stands the user never sees the error message, and is left with a Read Only buffer.

In other words we are better off than we were before (we dont just hang). But it is pretty cryptic for the user to figure out what happened.

### Startup errors :heavy_check_mark: 

To reproduce call `nvim-qt --cmd AAAAAA`. Or add some error command to init.vim.

Both cases work. ~~The primary issue is that the user gets no feedback. Errors are kept in `:messages`.~~

### Blocking on external program :x:

One case I've been unable to solve is `nvim-qt -- --cmd '!sleep 100'`. I never get a response for `nvim_get_mode`. The same can also be observed when attaching to an instance running a command.

Sending a `<C-c>` without the call to `nvim_get_mode()` cancels ongoing calls, but this might not be what we want.
