### PR TITLE
GUI: Show prompt dialog if closing without changes

### DIFF
--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -1035,7 +1035,7 @@ void Shell::closeEvent(QCloseEvent *ev)
 		// and try to close Neovim as :qa
 		ev->ignore();
 		bailoutIfinputBlocking();
-		m_nvim->api0()->vim_command("qa");
+		m_nvim->api0()->vim_command("confirm qa");
 	} else {
 		QWidget::closeEvent(ev);
 	}


### PR DESCRIPTION
When the shell widget was closed a call to ':qa' was made using
vim_command().

But vim_command does not display error messages, and :qa prints an error
msg and blocks waiting for user input. In our case no messages was being
displayed, but the user was still prompted to press a key.

This commit uses ':confirm qa' instead of simply, ':qa'. The user is
then prompted to save/discard/cancel for each buffer.

Fixes #310.