### PR TITLE
connector: don't use --headless when connecting

### DIFF
--- a/src/neovimconnector.cpp
+++ b/src/neovimconnector.cpp
@@ -232,12 +232,12 @@ NeovimConnector* NeovimConnector::spawn(const QStringList& params, const QString
 	// Neovim accepts a `--' argument after which only filenames are passed.
 	// If the user has supplied it, our arguments must appear before.
 	if (params.indexOf("--") == -1) {
-		args << "--embed" << "--headless";
+		args << "--embed";
 		args.append(params);
 	} else {
 		int idx = params.indexOf("--");
 		args.append(params.mid(0, idx));
-		args << "--embed" << "--headless";
+		args << "--embed";
 		args.append(params.mid(idx));
 	}
 


### PR DESCRIPTION
In Nvim 0.3.2 and later, this enables more reliable UI initialization. Ref neovim/neovim#9024
In Nvim 0.3.1 and earlier, it makes no difference.