### PR TITLE
[WIP] Implement clipboard provider

### DIFF
--- a/contrib/appveyor.yml
+++ b/contrib/appveyor.yml
@@ -22,7 +22,7 @@ configuration:
 matrix:
   fast_finish: false
 install:
-- ps: appveyor DownloadFile -FileName Neovim.zip "https://ci.appveyor.com/api/projects/neovim/neovim/artifacts/build/Neovim.zip?branch=master&job=Configuration%3A%20MINGW_64"
+- ps: appveyor DownloadFile -FileName Neovim.zip "https://github.com/neovim/neovim/releases/download/nightly/nvim-win64.zip"
 - 7z x Neovim.zip
 - set PATH=%PATH%;%CD%\Neovim\bin;
 - nvim --version

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -516,6 +516,10 @@ void Shell::handleRedraw(const QByteArray& name, const QVariantList& opargs)
 		handlePopupMenuSelect(opargs.at(0).toLongLong());
 	} else if (name == "popupmenu_hide") {
 		m_pum.hide();
+	} else if (name == "mode_info_set") {
+		// TODO
+	} else if (name == "default_colors_set") {
+		// TODO
 	} else {
 		qDebug() << "Received unknown redraw notification" << name << opargs;
 	}
@@ -748,6 +752,13 @@ void Shell::handleSetOption(const QString& name, const QVariant& value)
 		emit neovimExtTablineSet(value.toBool());
 	} else if (name == "ext_popupmenu") {
 		emit neovimExtPopupmenuSet(value.toBool());
+	// TODO
+	} else if (name == "arabicshape") {
+	} else if (name == "ambiwidth") {
+	} else if (name == "emoji") {
+	} else if (name == "termguicolors") {
+	} else if (name == "ext_cmdline") {
+	} else if (name == "ext_wildmenu") {
 	} else {
 		qDebug() << "Received unknown option" << name << value;
 	}

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -7,6 +7,7 @@
 #include <QApplication>
 #include <QKeyEvent>
 #include <QMimeData>
+#include <QClipboard>
 #include "msgpackrequest.h"
 #include "input.h"
 #include "konsole_wcwidth.h"
@@ -59,8 +60,12 @@ Shell::Shell(NeovimConnector *nvim, ShellOptions opts, QWidget *parent)
 			this, &Shell::neovimError);
 	connect(m_nvim, &NeovimConnector::processExited,
 			this, &Shell::neovimExited);
+	connect(this, &ShellWidget::shellFontChanged,
+			this, &Shell::fontChanged);
 	connect(this, &ShellWidget::fontError,
 			this, &Shell::fontError);
+
+	m_nvim->setRequestHandler(new ShellRequestHandler(this));
 
 	if (m_nvim->isReady()) {
 		init();
@@ -144,10 +149,12 @@ void Shell::setAttached(bool attached)
 		if (isWindow()) {
 			updateGuiWindowState(windowState());
 		}
-		m_nvim->api0()->vim_command("runtime plugin/nvim_gui_shim.vim");
+		auto req_shim = m_nvim->api0()->vim_command("runtime plugin/nvim_gui_shim.vim");
+		connect(req_shim, &MsgpackRequest::error, this, &Shell::handleShimError);
 		auto gviminit = qgetenv("GVIMINIT");
 		if (gviminit.isEmpty()) {
-			m_nvim->api0()->vim_command("runtime! ginit.vim");
+			auto req_ginit = m_nvim->api0()->vim_command("runtime! ginit.vim");
+			connect(req_ginit, &MsgpackRequest::error, this, &Shell::handleGinitError);
 		} else {
 			m_nvim->api0()->vim_command(gviminit);
 		}
@@ -689,6 +696,39 @@ void Shell::handleNeovimNotification(const QByteArray &name, const QVariantList&
 		} else if (guiEvName == "Option" && args.size() >= 3) {
 			QString option = m_nvim->decode(args.at(1).toByteArray());
 			handleExtGuiOption(option, args.at(2));
+		} else if (guiEvName == "SetClipboard" && args.size() >= 4) {
+			QStringList lines = args.at(1).toStringList();
+			QString type = args.at(2).toString();
+			QString reg_name = args.at(3).toString();
+
+			if (reg_name != "*" && reg_name != "+") {
+				m_nvim->api0()->vim_report_error(m_nvim->encode("Cannot set register via GUI"));
+				return;
+			}
+
+			// FIXME proper newline char
+			QString data = lines.join("\n");
+
+			QByteArray payload;
+			QDataStream serialize(&payload, QIODevice::WriteOnly);
+			serialize << type;
+
+			// Store the selection type in the clipboard
+			QMimeData *clipData = new QMimeData();
+			clipData->setText(data);
+			clipData->setData("application/x-nvim-selection-type", payload);
+
+			auto clipboard = QClipboard::Clipboard;
+			if (reg_name == "*") {
+#if defined(Q_OS_MAC) || defined(Q_OS_WIN32)
+				clipboard = QClipboard::Clipboard;
+#else
+				clipboard = QClipboard::Selection;
+#endif
+			}
+
+			qDebug() << "Neovim changed clipboard" << data << type << reg_name << clipboard;
+			QGuiApplication::clipboard()->setMimeData(clipData, clipboard);
 		}
 		return;
 	} else if (name != "redraw") {
@@ -972,6 +1012,7 @@ void Shell::updateClientInfo()
 			version.insert("patch", PROJECT_VERSION_PATCH);
 			QVariantMap attrs;
 			attrs.insert("windowid", window_id);
+			attrs.insert("gui-clipboard", true);
 			api4->nvim_set_client_info("nvim-qt", version, "ui", QVariantMap(), attrs);
 		}
 	}
@@ -1296,6 +1337,98 @@ void Shell::bailoutIfinputBlocking()
 				}
 		});
 	}
+}
+
+ShellRequestHandler::ShellRequestHandler(Shell *parent)
+:QObject(parent)
+{
+}
+
+const char SELECTION_MIME_TYPE[] = "application/x-nvim-selection-type";
+void ShellRequestHandler::handleRequest(MsgpackIODevice* dev, quint32 msgid, const QByteArray& method, const QVariantList& args)
+{
+	if (method == "Gui" && args.size() > 0) {
+		QString ctx = args.at(0).toString();
+		if (ctx == "GetClipboard" && args.size() > 1) {
+			QVariant reg = args.at(1);
+			QString reg_name = reg.toString();
+
+			if (reg_name != "*" && reg_name != "+") {
+				dev->sendResponse(msgid, QString("Unknown register"), QVariant());
+				return;
+			}
+
+			// + by default
+			auto mode = QClipboard::Clipboard;
+			if (reg_name == "*") {
+#if defined(Q_OS_MAC) || defined(Q_OS_WIN32)
+				mode = QClipboard::Clipboard;
+#else
+				mode = QClipboard::Selection;
+#endif
+			}
+
+			// Check nvim, ops.c/get_clipboard() - Expected to return a list with two items
+			// [register data, selection type]. The type can be ommited.
+			QVariantList result;
+
+			auto clipboard_data = QGuiApplication::clipboard()->mimeData(mode);
+			auto data = clipboard_data->text();
+			qDebug() << data << "<<<<< clipboard text";
+			// The register data is either a string with a single line,
+			// or a list of strings for multiple lines.
+			if (data.contains("\n")) {
+				result.append(data.split("\n"));
+			} else {
+				result.append(QStringList() << data);
+			}
+
+			// If available, deserialize the motion type from the clipboard
+			if (clipboard_data->hasFormat(SELECTION_MIME_TYPE)) {
+				QString type;
+				QDataStream serialize(clipboard_data->data(SELECTION_MIME_TYPE));
+				serialize >> type;
+				result.append(type);
+			} else {
+				result.append("");
+			}
+
+			qDebug() << "Neovim requested clipboard contents" << args << mode << "->" << result;
+			dev->sendResponse(msgid, QVariant(), result);
+			return;
+		}
+	}
+	// be sure to return early or this message will be sent
+	dev->sendResponse(msgid, QString("Unknown method"), QVariant());
+}
+
+/**
+ * Convert neovim error response into an error message string. If this fails
+ * serialize the entire error response as with QDebug.
+ */
+QString Shell::neovimErrorToString(const QVariant& err)
+{
+	auto lst = err.toList();
+	if (1 < lst.size()) {
+		return lst.at(1).toByteArray();
+	} else {
+		QString payload;
+		QDebug dbg(&payload);
+		dbg << err;
+		return payload;
+	}
+}
+
+void Shell::handleGinitError(quint32 msgid, quint64 fun, const QVariant& err)
+{
+	qDebug() << "ginit.vim error " << err;
+	auto msg = neovimErrorToString(err);
+	m_nvim->api0()->vim_report_error("ginit.vim error: " + msg.toUtf8());
+}
+
+void Shell::handleShimError(quint32 msgid, quint64 fun, const QVariant& err)
+{
+	qDebug() << "GUI shim error " << err;
 }
 
 } // Namespace

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -73,6 +73,7 @@ signals:
 	/// as seen in Tab::tab.
 	void neovimTablineUpdate(int64_t curtab, QList<Tab> tabs);
 	void neovimShowtablineSet(int);
+	void fontChanged();
 
 public slots:
 	void handleNeovimNotification(const QByteArray &name, const QVariantList& args);
@@ -92,6 +93,8 @@ protected slots:
 	void fontError(const QString& msg);
 	void updateWindowId();
 	void updateClientInfo();
+	void handleGinitError(quint32 msgid, quint64 fun, const QVariant& err);
+	void handleShimError(quint32 msgid, quint64 fun, const QVariant& err);
 
 protected:
 	void tooltip(const QString& text);
@@ -137,6 +140,8 @@ protected:
 	virtual void mouseMoveEvent(QMouseEvent *ev) Q_DECL_OVERRIDE;
 	void bailoutIfinputBlocking();
 
+	QString neovimErrorToString(const QVariant& err);
+
 private slots:
         void setAttached(bool attached=true);
 
@@ -177,6 +182,15 @@ private:
 	PopupMenu m_pum;
 	bool m_mouseEnabled;
 };
+
+class ShellRequestHandler: public QObject, public MsgpackRequestHandler
+{
+	Q_OBJECT
+public:
+	ShellRequestHandler(Shell *parent);
+	virtual void handleRequest(MsgpackIODevice* dev, quint32 msgid, const QByteArray& method, const QVariantList& args);
+};
+
 
 } // Namespace
 #endif

--- a/src/neovimconnector.cpp
+++ b/src/neovimconnector.cpp
@@ -381,6 +381,11 @@ void NeovimConnector::fatalTimeout()
 	setError(RuntimeMsgpackError, "Neovim is taking too long to respond");
 }
 
+void NeovimConnector::setRequestHandler(MsgpackRequestHandler *h)
+{
+	m_dev->setRequestHandler(h);
+}
+
 /**
  * True if NeovimConnector::reconnect can be called to reconnect with Neovim. This
  * is true unless you built the NeovimConnector ctor directly instead

--- a/src/neovimconnector.h
+++ b/src/neovimconnector.h
@@ -5,6 +5,7 @@
 #include <QAbstractSocket>
 #include <QProcess>
 #include <QTextCodec>
+#include "msgpackiodevice.h"
 #include "auto/neovimapi0.h"
 #include "auto/neovimapi1.h"
 #include "auto/neovimapi2.h"
@@ -14,6 +15,7 @@
 namespace NeovimQt {
 
 class MsgpackIODevice;
+class MsgpackRequestHandler;
 class NeovimConnectorHelper;
 class NeovimConnector: public QObject
 {
@@ -85,6 +87,8 @@ public:
 	NeovimConnectionType connectionType();
 	/** Some requests for metadata and ui attachment enforce a timeout in ms */
 	void setRequestTimeout(int);
+	/** Set a handler for msgpack rpc requests **/
+	void setRequestHandler(MsgpackRequestHandler *);
 
 	quint64 apiCompatibility();
 	quint64 apiLevel();

--- a/test/common.h
+++ b/test/common.h
@@ -3,12 +3,12 @@
 
 // This is just a fix for QSignalSpy::wait
 // http://stackoverflow.com/questions/22390208/google-test-mock-with-qt-signals
-bool SPYWAIT(QSignalSpy &spy, int timeout=10000)
+bool SPYWAIT(QSignalSpy &spy, int timeout=30000)
 {
 	return spy.count()>0||spy.wait(timeout);
 }
 
-bool SPYWAIT2(QSignalSpy &spy, int timeout=5000)
+bool SPYWAIT2(QSignalSpy &spy, int timeout=30000)
 {
 	return spy.count()>0||spy.wait(timeout);
 }

--- a/test/tst_neovimconnector.cpp
+++ b/test/tst_neovimconnector.cpp
@@ -101,7 +101,7 @@ private slots:
 				.arg(server->serverPort()));
 		QSignalSpy onError(c, SIGNAL(error(NeovimError)));
 		QVERIFY(onError.isValid());
-		QVERIFY(SPYWAIT2(onError, 20000));
+		QVERIFY(SPYWAIT2(onError));
 		QCOMPARE(c->errorCause(), NeovimConnector::RuntimeMsgpackError);
 		c->deleteLater();
 	}

--- a/test/tst_shell.cpp
+++ b/test/tst_shell.cpp
@@ -43,7 +43,7 @@ private slots:
 
 	void uiStart() {
 		QStringList args;
-		args << "-u" << "NONE";
+		args << "-u" << "NORC";
 		NeovimConnector *c = NeovimConnector::spawn(args);
 		Shell *s = new Shell(c, ShellOptions());
 		QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
@@ -59,7 +59,7 @@ private slots:
 	}
 
 	void startVarsShellWidget() {
-		QStringList args = {"-u", "NONE"};
+		QStringList args = {"-u", "NORC"};
 		NeovimConnector *c = NeovimConnector::spawn(args);
 		Shell *s = new Shell(c, ShellOptions());
 		QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
@@ -70,7 +70,7 @@ private slots:
 	}
 
 	void startVarsMainWindow() {
-		QStringList args = {"-u", "NONE"};
+		QStringList args = {"-u", "NORC"};
 		NeovimConnector *c = NeovimConnector::spawn(args);
 		MainWindow *s = new MainWindow(c, ShellOptions());
 		QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
@@ -82,7 +82,7 @@ private slots:
 
 	void guiExtTablineSet() {
 		QStringList args;
-		args << "-u" << "NONE";
+		args << "-u" << "NORC";
 		NeovimConnector *c = NeovimConnector::spawn(args);
 		Shell *s = new Shell(c, ShellOptions());
 		QSignalSpy onOptionSet(s, &Shell::neovimExtTablineSet);
@@ -93,7 +93,7 @@ private slots:
 	void gviminit() {
 		qputenv("GVIMINIT", "let g:test_gviminit = 1");
 		QStringList args;
-		args << "-u" << "NONE";
+		args << "-u" << "NORC";
 		NeovimConnector *c = NeovimConnector::spawn(args);
 		Shell *s = new Shell(c, ShellOptions());
 
@@ -116,7 +116,7 @@ private slots:
 		// plugin or this test WILL FAIL
 		QFileInfo fi = QFileInfo("src/gui/runtime");
 		QVERIFY2(fi.exists(), "Unable to find GUI runtime");
-		QStringList args = {"-u", "NONE",
+		QStringList args = {"-u", "NORC",
 			"--cmd", "set rtp+=" + fi.absoluteFilePath()};
 		NeovimConnector *c = NeovimConnector::spawn(args);
 		MainWindow *s = new MainWindow(c, ShellOptions());


### PR DESCRIPTION
A clipboard provider implemented by the GUI. This requires neovim from the master branch (v0.3.2)

It currently supports both clipboards and stores the selection type. Big question now is what happens with multiple GUIs attached, etc.

 - [x] detect UI support at runtime
- [ ] Test on windows with multi-line data on the clipboard (newline char)
- [x] There are some bugs on the provider, sometimes it returns invalid data, i.e. our function is returning an unexpected data structure
- [ ]  Add tests - in particular cover different types of selections

ref https://github.com/equalsraf/neovim-qt/issues/298