### PR TITLE
Tests : Change the -u NORC invocations to -u NONE

### DIFF
--- a/test/tst_callallmethods.cpp
+++ b/test/tst_callallmethods.cpp
@@ -30,7 +30,7 @@ private:
 
 void TestCallAllMethods::initTestCase()
 {
-	m_c = NeovimQt::NeovimConnector::spawn({"-u", "NORC"});
+	m_c = NeovimQt::NeovimConnector::spawn({"-u", "NONE"});
 	QSignalSpy onReady(m_c, SIGNAL(ready()));
 	QVERIFY(onReady.isValid());
 

--- a/test/tst_encoding.cpp
+++ b/test/tst_encoding.cpp
@@ -76,7 +76,7 @@ void TestEncoding::stringsAreBinaryNotUtf8()
 void TestEncoding::initTestCase()
 {
 	bool ready = false;
-	m_c = NeovimQt::NeovimConnector::spawn({"-u", "NORC"});
+	m_c = NeovimQt::NeovimConnector::spawn({"-u", "NONE"});
 	QVERIFY(m_c->errorCause() == NeovimQt::NeovimConnector::NoError);
 	connect(m_c, &NeovimQt::NeovimConnector::ready,
 		[&ready](){

--- a/test/tst_neovimconnector.cpp
+++ b/test/tst_neovimconnector.cpp
@@ -19,7 +19,7 @@ private slots:
 		NeovimConnector c(new QBuffer());
 		QCOMPARE(c.canReconnect(), false);
 
-		NeovimConnector *spawned = NeovimConnector::spawn({"-u", "NORC"});
+		NeovimConnector *spawned = NeovimConnector::spawn({"-u", "NONE"});
 		QCOMPARE(spawned->connectionType(), NeovimConnector::SpawnedConnection);
 		QCOMPARE(spawned->canReconnect(), true);
 
@@ -28,7 +28,7 @@ private slots:
 
 	void isReady() {
 
-		NeovimConnector *c = NeovimConnector::spawn({"-u", "NORC"});
+		NeovimConnector *c = NeovimConnector::spawn({"-u", "NONE"});
 		QSignalSpy onReady(c, SIGNAL(ready()));
 		QVERIFY(onReady.isValid());
 
@@ -37,7 +37,7 @@ private slots:
 	}
 
 	void encodeDecode() {
-		NeovimConnector *c = NeovimConnector::spawn({"-u", "NORC"});
+		NeovimConnector *c = NeovimConnector::spawn({"-u", "NONE"});
 
 		// This will print a warning, but should succeed
 		QString s = "ç日本語";

--- a/test/tst_neovimobject.cpp
+++ b/test/tst_neovimobject.cpp
@@ -109,7 +109,7 @@ void TestNeovimObject::initTestCase()
 {
 	// needed for the nvim api signal spy
 	qRegisterMetaType<int64_t>("int64_t");
-	m_c = NeovimQt::NeovimConnector::spawn({"-u", "NORC"});
+	m_c = NeovimQt::NeovimConnector::spawn({"-u", "NONE"});
 	connect(m_c, &NeovimQt::NeovimConnector::ready,
 			this, &TestNeovimObject::delayedSetup);
 	QTest::qWait(1500);

--- a/test/tst_shell.cpp
+++ b/test/tst_shell.cpp
@@ -16,166 +16,166 @@ namespace NeovimQt {
 
 class Test: public QObject
 {
-	Q_OBJECT
+    Q_OBJECT
 private slots:
-	void initTestCase() {
-		QStringList fonts;
-		fonts << "third-party/DejaVuSansMono.ttf"
-			<< "third-party/DejaVuSansMono-Bold.ttf"
-			<< "third-party/DejaVuSansMono-BoldOblique.ttf";
-		foreach(QString path, fonts) {
-			QFontDatabase::addApplicationFont(path);
-		}
-	}
+    void initTestCase() {
+        QStringList fonts;
+        fonts << "third-party/DejaVuSansMono.ttf"
+            << "third-party/DejaVuSansMono-Bold.ttf"
+            << "third-party/DejaVuSansMono-BoldOblique.ttf";
+        foreach(QString path, fonts) {
+            QFontDatabase::addApplicationFont(path);
+        }
+    }
 
-	void benchStart() {
-		QBENCHMARK {
-			NeovimConnector *c = NeovimConnector::spawn({"-u", "NORC"});
-			QSignalSpy onReady(c, SIGNAL(ready()));
-			QVERIFY(onReady.isValid());
-			QVERIFY(SPYWAIT(onReady));
+    void benchStart() {
+        QBENCHMARK {
+            NeovimConnector *c = NeovimConnector::spawn({"-u", "NONE"});
+            QSignalSpy onReady(c, SIGNAL(ready()));
+            QVERIFY(onReady.isValid());
+            QVERIFY(SPYWAIT(onReady));
 
-			Shell *s = new Shell(c, ShellOptions());
-			QSignalSpy onResize(s, SIGNAL(neovimResized(int, int)));
-			QVERIFY(onResize.isValid());
-			QVERIFY(SPYWAIT(onResize));
-		}
-	}
+            Shell *s = new Shell(c, ShellOptions());
+            QSignalSpy onResize(s, SIGNAL(neovimResized(int, int)));
+            QVERIFY(onResize.isValid());
+            QVERIFY(SPYWAIT(onResize));
+        }
+    }
 
-	void uiStart() {
-		QStringList args;
-		args << "-u" << "NORC";
-		NeovimConnector *c = NeovimConnector::spawn(args);
-		Shell *s = new Shell(c, ShellOptions());
-		QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
-		QVERIFY(onAttached.isValid());
-		QVERIFY(SPYWAIT(onAttached));
-		QVERIFY(s->neovimAttached());
+    void uiStart() {
+        QStringList args;
+        args << "-u" << "NONE";
+        NeovimConnector *c = NeovimConnector::spawn(args);
+        Shell *s = new Shell(c, ShellOptions());
+        QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
+        QVERIFY(onAttached.isValid());
+        QVERIFY(SPYWAIT(onAttached));
+        QVERIFY(s->neovimAttached());
 
-		s->repaint();
+        s->repaint();
 
-		QPixmap p = s->grab();
-		p.save("tst_shell_start.jpg");
+        QPixmap p = s->grab();
+        p.save("tst_shell_start.jpg");
 
-	}
+    }
 
-	void startVarsShellWidget() {
-		QStringList args = {"-u", "NORC"};
-		NeovimConnector *c = NeovimConnector::spawn(args);
-		Shell *s = new Shell(c, ShellOptions());
-		QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
-		QVERIFY(onAttached.isValid());
-		QVERIFY(SPYWAIT(onAttached));
-		QVERIFY(s->neovimAttached());
-		checkStartVars(c);
-	}
+    void startVarsShellWidget() {
+        QStringList args = {"-u", "NONE"};
+        NeovimConnector *c = NeovimConnector::spawn(args);
+        Shell *s = new Shell(c, ShellOptions());
+        QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
+        QVERIFY(onAttached.isValid());
+        QVERIFY(SPYWAIT(onAttached));
+        QVERIFY(s->neovimAttached());
+        checkStartVars(c);
+    }
 
-	void startVarsMainWindow() {
-		QStringList args = {"-u", "NORC"};
-		NeovimConnector *c = NeovimConnector::spawn(args);
-		MainWindow *s = new MainWindow(c, ShellOptions());
-		s->show();
-		QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
-		QVERIFY(onAttached.isValid());
-		QVERIFY(SPYWAIT(onAttached));
-		QVERIFY(s->neovimAttached());
-		checkStartVars(c);
-	}
+    void startVarsMainWindow() {
+        QStringList args = {"-u", "NONE"};
+        NeovimConnector *c = NeovimConnector::spawn(args);
+        MainWindow *s = new MainWindow(c, ShellOptions());
+        s->show();
+        QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
+        QVERIFY(onAttached.isValid());
+        QVERIFY(SPYWAIT(onAttached));
+        QVERIFY(s->neovimAttached());
+        checkStartVars(c);
+    }
 
-	void guiExtTablineSet() {
-		QStringList args;
-		args << "-u" << "NORC";
-		NeovimConnector *c = NeovimConnector::spawn(args);
-		Shell *s = new Shell(c, ShellOptions());
-		QSignalSpy onOptionSet(s, &Shell::neovimExtTablineSet);
-		QVERIFY(onOptionSet.isValid());
-		QVERIFY(SPYWAIT(onOptionSet));
-	}
+    void guiExtTablineSet() {
+        QStringList args;
+        args << "-u" << "NONE";
+        NeovimConnector *c = NeovimConnector::spawn(args);
+        Shell *s = new Shell(c, ShellOptions());
+        QSignalSpy onOptionSet(s, &Shell::neovimExtTablineSet);
+        QVERIFY(onOptionSet.isValid());
+        QVERIFY(SPYWAIT(onOptionSet));
+    }
 
-	void gviminit() {
-		qputenv("GVIMINIT", "let g:test_gviminit = 1");
-		QStringList args;
-		args << "-u" << "NORC";
-		NeovimConnector *c = NeovimConnector::spawn(args);
-		Shell *s = new Shell(c, ShellOptions());
+    void gviminit() {
+        qputenv("GVIMINIT", "let g:test_gviminit = 1");
+        QStringList args;
+        args << "-u" << "NONE";
+        NeovimConnector *c = NeovimConnector::spawn(args);
+        Shell *s = new Shell(c, ShellOptions());
 
-		QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
-		QVERIFY(onAttached.isValid());
-		QVERIFY(SPYWAIT(onAttached));
-		QVERIFY(s->neovimAttached());
+        QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
+        QVERIFY(onAttached.isValid());
+        QVERIFY(SPYWAIT(onAttached));
+        QVERIFY(s->neovimAttached());
 
-		auto req = c->api0()->vim_command_output(c->encode("echo g:test_gviminit"));
-		QSignalSpy cmd(req, SIGNAL(finished(quint32, quint64, QVariant)));
-		QVERIFY(cmd.isValid());
-		QVERIFY(SPYWAIT(cmd));
-		qDebug() << cmd;
+        auto req = c->api0()->vim_command_output(c->encode("echo g:test_gviminit"));
+        QSignalSpy cmd(req, SIGNAL(finished(quint32, quint64, QVariant)));
+        QVERIFY(cmd.isValid());
+        QVERIFY(SPYWAIT(cmd));
+        qDebug() << cmd;
 
-		QCOMPARE(cmd.at(0).at(2).toByteArray(), QByteArray("1"));
-	}
+        QCOMPARE(cmd.at(0).at(2).toByteArray(), QByteArray("1"));
+    }
 
-	void guiShimCommands() {
-		// This function needs to be able to find the GUI runtime
-		// plugin or this test WILL FAIL
-		QFileInfo fi = QFileInfo("src/gui/runtime");
-		QVERIFY2(fi.exists(), "Unable to find GUI runtime");
-		QStringList args = {"-u", "NORC",
-			"--cmd", "set rtp+=" + fi.absoluteFilePath()};
-		NeovimConnector *c = NeovimConnector::spawn(args);
-		MainWindow *s = new MainWindow(c, ShellOptions());
-		QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
-		QVERIFY(onAttached.isValid());
-		QVERIFY(SPYWAIT(onAttached));
-		QVERIFY(s->neovimAttached());
+    void guiShimCommands() {
+        // This function needs to be able to find the GUI runtime
+        // plugin or this test WILL FAIL
+        QFileInfo fi = QFileInfo("src/gui/runtime");
+        QVERIFY2(fi.exists(), "Unable to find GUI runtime");
+        QStringList args = {"-u", "NONE",
+            "--cmd", "set rtp+=" + fi.absoluteFilePath()};
+        NeovimConnector *c = NeovimConnector::spawn(args);
+        MainWindow *s = new MainWindow(c, ShellOptions());
+        QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
+        QVERIFY(onAttached.isValid());
+        QVERIFY(SPYWAIT(onAttached));
+        QVERIFY(s->neovimAttached());
 
-		QObject::connect(c->neovimObject(), &NeovimApi1::err_vim_command_output, [](QString msg, const QVariant& err) {
-				qDebug() << msg << err;
-			});
+        QObject::connect(c->neovimObject(), &NeovimApi1::err_vim_command_output, [](QString msg, const QVariant& err) {
+                qDebug() << msg << err;
+            });
 
-		QSignalSpy cmd_font(c->neovimObject()->vim_command_output(c->encode("GuiFont")), &MsgpackRequest::finished);
-		QVERIFY(cmd_font.isValid());
-		QVERIFY2(SPYWAIT(cmd_font), "Waiting for GuiFont");
+        QSignalSpy cmd_font(c->neovimObject()->vim_command_output(c->encode("GuiFont")), &MsgpackRequest::finished);
+        QVERIFY(cmd_font.isValid());
+        QVERIFY2(SPYWAIT(cmd_font), "Waiting for GuiFont");
 
-		QSignalSpy cmd_ls(c->neovimObject()->vim_command_output(c->encode("GuiLinespace")), &MsgpackRequest::finished);
-		QVERIFY(cmd_ls.isValid());
-		QVERIFY2(SPYWAIT(cmd_ls), "Waiting for GuiLinespace");
+        QSignalSpy cmd_ls(c->neovimObject()->vim_command_output(c->encode("GuiLinespace")), &MsgpackRequest::finished);
+        QVERIFY(cmd_ls.isValid());
+        QVERIFY2(SPYWAIT(cmd_ls), "Waiting for GuiLinespace");
 
-		// Test font attributes
+        // Test font attributes
 #ifdef Q_OS_MAC
-		QSignalSpy cmd_gf(c->neovimObject()->vim_command_output(c->encode("GuiFont Monaco:h14")), &MsgpackRequest::finished);
+        QSignalSpy cmd_gf(c->neovimObject()->vim_command_output(c->encode("GuiFont Monaco:h14")), &MsgpackRequest::finished);
 #else
-		QSignalSpy cmd_gf(c->neovimObject()->vim_command_output(c->encode("GuiFont DejaVu Sans Mono:h14")), &MsgpackRequest::finished);
+        QSignalSpy cmd_gf(c->neovimObject()->vim_command_output(c->encode("GuiFont DejaVu Sans Mono:h14")), &MsgpackRequest::finished);
 #endif
-		QVERIFY(cmd_gf.isValid());
-		QVERIFY(SPYWAIT(cmd_gf));
+        QVERIFY(cmd_gf.isValid());
+        QVERIFY(SPYWAIT(cmd_gf));
 
-		QSignalSpy spy_fontchange(s->shell(), &Shell::fontChanged);
-		SPYWAIT(spy_fontchange);
+        QSignalSpy spy_fontchange(s->shell(), &Shell::fontChanged);
+        SPYWAIT(spy_fontchange);
 #ifdef Q_OS_MAC
-		QCOMPARE(s->shell()->fontDesc(), QString("Monaco:h14"));
+        QCOMPARE(s->shell()->fontDesc(), QString("Monaco:h14"));
 #else
-		QCOMPARE(s->shell()->fontDesc(), QString("DejaVu Sans Mono:h14"));
-#endif
-
-		// Normalization removes the :b attribute
-#ifdef Q_OS_MAC
-		QSignalSpy cmd_gf2(c->neovimObject()->vim_command_output(c->encode("GuiFont Monaco:h14:b:l")), &MsgpackRequest::finished);
-#else
-		QSignalSpy cmd_gf2(c->neovimObject()->vim_command_output(c->encode("GuiFont DejaVu Sans Mono:h14:b:l")), &MsgpackRequest::finished);
-#endif
-		QVERIFY(cmd_gf2.isValid());
-		QVERIFY(SPYWAIT(cmd_gf2));
-
-		QSignalSpy spy_fontchange2(s->shell(), &Shell::fontChanged);
-		SPYWAIT(spy_fontchange2);
-#ifdef Q_OS_MAC
-		QCOMPARE(s->shell()->fontDesc(), QString("Monaco:h14:l"));
-#else
-		QCOMPARE(s->shell()->fontDesc(), QString("DejaVu Sans Mono:h14:l"));
+        QCOMPARE(s->shell()->fontDesc(), QString("DejaVu Sans Mono:h14"));
 #endif
 
-		// GuiTabline
-		QSignalSpy onOptionSet(s->shell(), &Shell::neovimExtTablineSet);
-		QVERIFY(onOptionSet.isValid());
+        // Normalization removes the :b attribute
+#ifdef Q_OS_MAC
+        QSignalSpy cmd_gf2(c->neovimObject()->vim_command_output(c->encode("GuiFont Monaco:h14:b:l")), &MsgpackRequest::finished);
+#else
+        QSignalSpy cmd_gf2(c->neovimObject()->vim_command_output(c->encode("GuiFont DejaVu Sans Mono:h14:b:l")), &MsgpackRequest::finished);
+#endif
+        QVERIFY(cmd_gf2.isValid());
+        QVERIFY(SPYWAIT(cmd_gf2));
+
+        QSignalSpy spy_fontchange2(s->shell(), &Shell::fontChanged);
+        SPYWAIT(spy_fontchange2);
+#ifdef Q_OS_MAC
+        QCOMPARE(s->shell()->fontDesc(), QString("Monaco:h14:l"));
+#else
+        QCOMPARE(s->shell()->fontDesc(), QString("DejaVu Sans Mono:h14:l"));
+#endif
+
+        // GuiTabline
+        QSignalSpy onOptionSet(s->shell(), &Shell::neovimExtTablineSet);
+        QVERIFY(onOptionSet.isValid());
 
 //		QSignalSpy cmd_gtab(c->neovimObject()->vim_command_output(c->encode("GuiTabline 0")), &MsgpackRequest::finished);
 //		QVERIFY(cmd_gtab.isValid());
@@ -183,155 +183,155 @@ private slots:
 //
 //		QVERIFY(SPYWAIT(onOptionSet));
 //		qDebug() << onOptionSet << onOptionSet.size();
-	}
+    }
 
-	void GetClipboard_data() {
-		// * or +
-		QTest::addColumn<char>("reg");
-		// data set in the register when starting test, this is set
-		// externaly (i.e. without going through the provider)
-		QTest::addColumn<QByteArray>("register_data");
+    void GetClipboard_data() {
+        // * or +
+        QTest::addColumn<char>("reg");
+        // data set in the register when starting test, this is set
+        // externaly (i.e. without going through the provider)
+        QTest::addColumn<QByteArray>("register_data");
 
-		QTest::newRow("empty *")
-			<< '*' << QByteArray();
-		QTest::newRow("set *")
-			<< '*' << QByteArray("something");
-		QTest::newRow("empty +")
-			<< '+' << QByteArray();
-		QTest::newRow("set +")
-			<< '+' << QByteArray("something");
-		QTest::newRow("paste *")
-			<< '*' << QByteArray("something");
-		QTest::newRow("paste +")
-			<< '+' << QByteArray("something");
-	}
+        QTest::newRow("empty *")
+            << '*' << QByteArray();
+        QTest::newRow("set *")
+            << '*' << QByteArray("something");
+        QTest::newRow("empty +")
+            << '+' << QByteArray();
+        QTest::newRow("set +")
+            << '+' << QByteArray("something");
+        QTest::newRow("paste *")
+            << '*' << QByteArray("something");
+        QTest::newRow("paste +")
+            << '+' << QByteArray("something");
+    }
 
-	void GetClipboard() {
-		QFETCH(char, reg);
-		QFETCH(QByteArray, register_data);
+    void GetClipboard() {
+        QFETCH(char, reg);
+        QFETCH(QByteArray, register_data);
 
-		QFileInfo fi = QFileInfo("src/gui/runtime");
-		QStringList args = {"-u", "NORC",
-			"--cmd", "set rtp+=" + fi.absoluteFilePath()};
-		NeovimConnector *c = NeovimConnector::spawn(args);
-		MainWindow *s = new MainWindow(c, ShellOptions());
-		QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
-		QVERIFY(onAttached.isValid());
-		QVERIFY(SPYWAIT(onAttached));
-		QVERIFY(s->neovimAttached());
+        QFileInfo fi = QFileInfo("src/gui/runtime");
+        QStringList args = {"-u", "NONE",
+            "--cmd", "set rtp+=" + fi.absoluteFilePath()};
+        NeovimConnector *c = NeovimConnector::spawn(args);
+        MainWindow *s = new MainWindow(c, ShellOptions());
+        QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
+        QVERIFY(onAttached.isValid());
+        QVERIFY(SPYWAIT(onAttached));
+        QVERIFY(s->neovimAttached());
 
-		QObject::connect(c->neovimObject(), &NeovimApi1::err_vim_command_output, [](QString msg, const QVariant& err) {
-				qDebug() << msg << err;
-			});
+        QObject::connect(c->neovimObject(), &NeovimApi1::err_vim_command_output, [](QString msg, const QVariant& err) {
+                qDebug() << msg << err;
+            });
 
-		// provided by the GUI shim
-		c->api0()->vim_command(c->encode("call GuiClipboard()"));
+        // provided by the GUI shim
+        c->api0()->vim_command(c->encode("call GuiClipboard()"));
 
 #if defined(Q_OS_MAC) || defined(Q_OS_WIN32)
-		QGuiApplication::clipboard()->setText(register_data, QClipboard::Clipboard);
+        QGuiApplication::clipboard()->setText(register_data, QClipboard::Clipboard);
 #else
-		if (reg == '+') {
-			QGuiApplication::clipboard()->setText(register_data, QClipboard::Clipboard);
-		} else {
-			QGuiApplication::clipboard()->setText(register_data, QClipboard::Selection);
-		}
+        if (reg == '+') {
+            QGuiApplication::clipboard()->setText(register_data, QClipboard::Clipboard);
+        } else {
+            QGuiApplication::clipboard()->setText(register_data, QClipboard::Selection);
+        }
 #endif
 
-		QString getreg_cmd = QString("getreg('%1')").arg(reg);
-		QSignalSpy cmd_clip(c->api1()->nvim_eval(c->encode(getreg_cmd)), &MsgpackRequest::finished);
-		QVERIFY(cmd_clip.isValid());
-		QVERIFY(SPYWAIT(cmd_clip));
-		QCOMPARE(cmd_clip.takeFirst().at(2), QVariant(register_data));
-	}
+        QString getreg_cmd = QString("getreg('%1')").arg(reg);
+        QSignalSpy cmd_clip(c->api1()->nvim_eval(c->encode(getreg_cmd)), &MsgpackRequest::finished);
+        QVERIFY(cmd_clip.isValid());
+        QVERIFY(SPYWAIT(cmd_clip));
+        QCOMPARE(cmd_clip.takeFirst().at(2), QVariant(register_data));
+    }
 
-	void SetClipboard_data() {
-		// * or +
-		QTest::addColumn<char>("reg");
-		// data set in the register when starting test, this is set
-		// externaly (i.e. without going through the provider)
-		QTest::addColumn<QByteArray>("register_data");
+    void SetClipboard_data() {
+        // * or +
+        QTest::addColumn<char>("reg");
+        // data set in the register when starting test, this is set
+        // externaly (i.e. without going through the provider)
+        QTest::addColumn<QByteArray>("register_data");
 
-		QTest::newRow("empty *")
-			<< '*' << QByteArray();
-		QTest::newRow("set *")
-			<< '*' << QByteArray("something");
-		QTest::newRow("empty +")
-			<< '+' << QByteArray();
-		QTest::newRow("set +")
-			<< '+' << QByteArray("something");
-		QTest::newRow("paste *")
-			<< '*' << QByteArray("something");
-		QTest::newRow("paste +")
-			<< '+' << QByteArray("something");
-	}
+        QTest::newRow("empty *")
+            << '*' << QByteArray();
+        QTest::newRow("set *")
+            << '*' << QByteArray("something");
+        QTest::newRow("empty +")
+            << '+' << QByteArray();
+        QTest::newRow("set +")
+            << '+' << QByteArray("something");
+        QTest::newRow("paste *")
+            << '*' << QByteArray("something");
+        QTest::newRow("paste +")
+            << '+' << QByteArray("something");
+    }
 
-	void SetClipboard() {
-		QFETCH(char, reg);
-		QFETCH(QByteArray, register_data);
+    void SetClipboard() {
+        QFETCH(char, reg);
+        QFETCH(QByteArray, register_data);
 
-		QFileInfo fi = QFileInfo("src/gui/runtime");
-		QStringList args = {"-u", "NORC",
-			"--cmd", "set rtp+=" + fi.absoluteFilePath()};
-		NeovimConnector *c = NeovimConnector::spawn(args);
-		MainWindow *s = new MainWindow(c, ShellOptions());
-		QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
-		QVERIFY(onAttached.isValid());
-		QVERIFY(SPYWAIT(onAttached));
-		QVERIFY(s->neovimAttached());
+        QFileInfo fi = QFileInfo("src/gui/runtime");
+        QStringList args = {"-u", "NONE",
+            "--cmd", "set rtp+=" + fi.absoluteFilePath()};
+        NeovimConnector *c = NeovimConnector::spawn(args);
+        MainWindow *s = new MainWindow(c, ShellOptions());
+        QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
+        QVERIFY(onAttached.isValid());
+        QVERIFY(SPYWAIT(onAttached));
+        QVERIFY(s->neovimAttached());
 
-		QObject::connect(c->neovimObject(), &NeovimApi1::err_vim_command_output, [](QString msg, const QVariant& err) {
-				qDebug() << msg << err;
-			});
+        QObject::connect(c->neovimObject(), &NeovimApi1::err_vim_command_output, [](QString msg, const QVariant& err) {
+                qDebug() << msg << err;
+            });
 
-		// provided by the GUI shim
-		c->api0()->vim_command(c->encode("call GuiClipboard()"));
+        // provided by the GUI shim
+        c->api0()->vim_command(c->encode("call GuiClipboard()"));
 
-		QString setreg_cmd = QString("setreg('%1', '%2')\n").arg(reg).arg(QString::fromUtf8(register_data));
-		c->neovimObject()->vim_command(c->encode(setreg_cmd));
-		QSignalSpy spy_sync(c->neovimObject()->vim_feedkeys("", "", false), &MsgpackRequest::finished);
+        QString setreg_cmd = QString("setreg('%1', '%2')\n").arg(reg).arg(QString::fromUtf8(register_data));
+        c->neovimObject()->vim_command(c->encode(setreg_cmd));
+        QSignalSpy spy_sync(c->neovimObject()->vim_feedkeys("", "", false), &MsgpackRequest::finished);
 SPYWAIT(spy_sync);
-		QVERIFY(spy_sync.isValid());
-		QVERIFY(SPYWAIT(spy_sync));
+        QVERIFY(spy_sync.isValid());
+        QVERIFY(SPYWAIT(spy_sync));
 
 #if defined(Q_OS_MAC) || defined(Q_OS_WIN32)
-		QString data = QGuiApplication::clipboard()->text(QClipboard::Clipboard);
+        QString data = QGuiApplication::clipboard()->text(QClipboard::Clipboard);
 #else
-		if (reg == '+') {
-			QGuiApplication::clipboard()->text(QClipboard::Clipboard);
-		} else {
-			QGuiApplication::clipboard()->text(QClipboard::Selection);
-		}
+        if (reg == '+') {
+            QGuiApplication::clipboard()->text(QClipboard::Clipboard);
+        } else {
+            QGuiApplication::clipboard()->text(QClipboard::Selection);
+        }
 #endif
 
-		// the additional \n seems to be a side effect from vim_command_output()
+        // the additional \n seems to be a side effect from vim_command_output()
 //		QCOMPARE(cmd_clip.takeFirst().at(2), QVariant(register_data + "\n"));
-	}
+    }
 
 protected:
-	/// Check for the presence of the GUI variables in Neovim
-	void checkStartVars(NeovimQt::NeovimConnector *conn) {
-		auto *nvim = conn->api1();
-		connect(nvim, &NeovimQt::NeovimApi1::err_vim_get_var,
-			[](const QString& err, const QVariant& v) {
-				qDebug() << err<< v;
-			});
+    /// Check for the presence of the GUI variables in Neovim
+    void checkStartVars(NeovimQt::NeovimConnector *conn) {
+        auto *nvim = conn->api1();
+        connect(nvim, &NeovimQt::NeovimApi1::err_vim_get_var,
+            [](const QString& err, const QVariant& v) {
+                qDebug() << err<< v;
+            });
 
-		QStringList vars = {"GuiWindowId", "GuiWindowMaximized",
-			"GuiWindowFullScreen", "GuiFont"};
-		foreach(const QString& var, vars) {
-			qDebug() << "Checking Neovim for Gui var" << var;
-			QSignalSpy onVar(nvim, SIGNAL(on_vim_get_var(QVariant)));
-			QVERIFY(onVar.isValid());
-			nvim->vim_get_var(conn->encode(var));
-			QVERIFY(SPYWAIT(onVar));
-		}
+        QStringList vars = {"GuiWindowId", "GuiWindowMaximized",
+            "GuiWindowFullScreen", "GuiFont"};
+        foreach(const QString& var, vars) {
+            qDebug() << "Checking Neovim for Gui var" << var;
+            QSignalSpy onVar(nvim, SIGNAL(on_vim_get_var(QVariant)));
+            QVERIFY(onVar.isValid());
+            nvim->vim_get_var(conn->encode(var));
+            QVERIFY(SPYWAIT(onVar));
+        }
 
-		// v:windowid
-		QSignalSpy onVarWindowId(nvim, SIGNAL(on_vim_get_vvar(QVariant)));
-		QVERIFY(onVarWindowId.isValid());
-		nvim->vim_get_vvar(conn->encode("windowid"));
-		QVERIFY(SPYWAIT(onVarWindowId));
-	}
+        // v:windowid
+        QSignalSpy onVarWindowId(nvim, SIGNAL(on_vim_get_vvar(QVariant)));
+        QVERIFY(onVarWindowId.isValid());
+        nvim->vim_get_vvar(conn->encode("windowid"));
+        QVERIFY(SPYWAIT(onVarWindowId));
+    }
 };
 
 } // Namespace NeovimQt


### PR DESCRIPTION
This ensures that $HOME/.config/nvim/ginit.vim does not get picked up
when running the tests.

This caused issues when I tried to run tests locally, as my ginit.vim
tries to call an autoloaded function (which was not found during ctests)

I thought that replacing `NORC` with `NONE` would break the tests reading and using commands in `src/runtime/plugin/nvim_gui_shim.vim`, but I think that the `--cmd "set rtp+=...` flag works well because the tests still pass locally.

Here's to hoping they'll pass on the CI :beers: 