### PR TITLE
WIP: fix widget placement for input method

### DIFF
--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -1191,7 +1191,7 @@ QVariant Shell::inputMethodQuery(Qt::InputMethodQuery query) const
 {
 	if ( query == Qt::ImFont) {
 		return font();
-	} else if ( query == Qt::ImMicroFocus ) {
+	} else if ( query == Qt::ImMicroFocus || query == Qt::ImCursorRectangle ) {
 		return QRect(neovimCursorTopLeft(), QSize(0, cellSize().height()));
 	}
 

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -614,6 +614,7 @@ void Shell::setNeovimCursor(quint64 row, quint64 col)
 	update(neovimCursorRect());
 	m_cursor_pos = QPoint(col, row);
 	update(neovimCursorRect());
+	qApp->inputMethod()->update(Qt::ImCursorRectangle);
 }
 
 void Shell::handleModeChange(const QString& mode)
@@ -1192,7 +1193,7 @@ QVariant Shell::inputMethodQuery(Qt::InputMethodQuery query) const
 	if ( query == Qt::ImFont) {
 		return font();
 	} else if ( query == Qt::ImMicroFocus || query == Qt::ImCursorRectangle ) {
-		return QRect(neovimCursorTopLeft(), QSize(0, cellSize().height()));
+		return QRect(neovimCursorTopLeft(), cellSize());
 	}
 
 	return QVariant();


### PR DESCRIPTION
Reported by @wsdjeg. @bfredl suggested calling setInputItemRectangle()
on cursor change would address this.

---

In truth I have no way to test this, crossing my fingers :)