### PR TITLE
[WIP] externalize cmdline

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -21,7 +21,10 @@ add_subdirectory(shellwidget)
 
 include(GNUInstallDirs)
 set(RUNTIME_PATH )
-add_library(neovim-qt-gui shell.cpp input.cpp treeview.cpp errorwidget.cpp mainwindow.cpp app.cpp
+add_library(neovim-qt-gui shell.cpp input.cpp errorwidget.cpp mainwindow.cpp app.cpp
+	treeview.cpp
+	cmdline.cpp
+	cmdblock.cpp
 	cmdwidget.cpp
 	popupmenumodel.cpp
 	popupmenu.cpp

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -22,6 +22,7 @@ add_subdirectory(shellwidget)
 include(GNUInstallDirs)
 set(RUNTIME_PATH )
 add_library(neovim-qt-gui shell.cpp input.cpp treeview.cpp errorwidget.cpp mainwindow.cpp app.cpp
+	cmdwidget.cpp
 	popupmenumodel.cpp
 	popupmenu.cpp
 	${CMAKE_SOURCE_DIR}/third-party/konsole_wcwidth.cpp

--- a/src/gui/cmdblock.cpp
+++ b/src/gui/cmdblock.cpp
@@ -3,106 +3,108 @@
 namespace NeovimQt {
 
 CmdBlock::CmdBlock(ShellWidget *parent) : QTextEdit(parent) {
-    hide();
-    setReadOnly(true);
-    document()->setDefaultFont(parent->font());
+	hide();
+	setReadOnly(true);
+	document()->setDefaultFont(parent->font());
 
-    setTextBackgroundColor(parent->background());
-    setTextColor(parent->foreground());
+	setTextBackgroundColor(parent->background());
+	setTextColor(parent->foreground());
 
-    connect(parent, &ShellWidget::shellFontChanged,
-            this, &CmdBlock::setDefaultFont);
+	connect(parent, &ShellWidget::shellFontChanged,
+		    this, &CmdBlock::setDefaultFont);
 }
 
 void CmdBlock::setDefaultFont() {
-    auto shell_parent = dynamic_cast<ShellWidget*>(parent());
-    setFont(shell_parent->font());
+	auto shell_parent = dynamic_cast<ShellWidget*>(parent());
+	setFont(shell_parent->font());
 }
 
 void CmdBlock::compute_block(const QList<QVariantList> &lines) {
-    foreach(QVariantList line, lines) {
-        append_block(line);
-    }
+	foreach(QVariantList line, lines) {
+		append_block(line);
+	}
 }
 
 void CmdBlock::append_block(const QVariantList &content) {
-    QString plaintext_content;
-    foreach(QVariant piece, content){
-        qDebug() << piece.toList();
-        style_cursor_CharFormat(piece.toList().at(0).toMap());
-        plaintext_content = piece.toStringList().at(1);
-        textCursor().insertText(plaintext_content);
-    }
-    textCursor().insertText("\n");
-    line_count++;
+	QString plaintext_content;
+	foreach(QVariant piece, content){
+		qDebug() << piece.toList();
+		style_cursor_CharFormat(piece.toList().at(0).toMap());
+		plaintext_content = piece.toStringList().at(1);
+		textCursor().insertText(plaintext_content);
+	}
+	textCursor().insertText("\n");
+	line_count++;
 }
 
 QColor CmdBlock::color(qint64 color, const QColor& fallback) const
 {
-    if (color == -1) {
-        return fallback;
-    }
-    return QRgb(color);
+	if (color == -1) {
+		return fallback;
+	}
+	return QRgb(color);
 }
 
 void CmdBlock::style_cursor_CharFormat(const QVariantMap& attrs) {
-    QTextCharFormat cur_format;
+	QTextCharFormat cur_format;
 
-    auto shell_parent = dynamic_cast<ShellWidget*>(parent());
-    QColor cur_foreground, cur_background, cur_special;
-    if (attrs.contains("foreground")) {
-        // TODO: When does Neovim send -1
-        cur_foreground = color(attrs.value("foreground").toLongLong(), shell_parent->foreground());
-    } else {
-        cur_foreground = shell_parent->foreground();
-    }
+	auto shell_parent = dynamic_cast<ShellWidget*>(parent());
+	QColor cur_foreground, cur_background, cur_special;
+	if (attrs.contains("foreground")) {
+		// TODO: When does Neovim send -1
+		cur_foreground = color(attrs.value("foreground").toLongLong(),
+                                       shell_parent->foreground());
+	} else {
+		cur_foreground = shell_parent->foreground();
+	}
 
-    if (attrs.contains("background")) {
-        cur_background = color(attrs.value("background").toLongLong(), shell_parent->background());
-    } else {
-        cur_background = shell_parent->background();
-    }
+	if (attrs.contains("background")) {
+		cur_background = color(attrs.value("background").toLongLong(),
+                                       shell_parent->background());
+	} else {
+		cur_background = shell_parent->background();
+	}
 
-    // FIXME : the supported HTML tags do not seem to support special ( = different color for underline/undercurl)
-    if (attrs.contains(("special"))) {
-        cur_special = color(attrs.value("special").toLongLong(), shell_parent->special());
-    } else {
-        cur_special = shell_parent->special();
-    }
+	if (attrs.contains(("special"))) {
+		cur_special = color(attrs.value("special").toLongLong(),
+                                    shell_parent->special());
+	} else {
+		cur_special = shell_parent->special();
+	}
 
-    if (attrs.contains("reverse")) {
-        auto tmp = cur_background;
-        cur_background = cur_foreground;
-        cur_foreground = tmp;
-    }
+	if (attrs.contains("reverse")) {
+		auto tmp = cur_background;
+		cur_background = cur_foreground;
+		cur_foreground = tmp;
+	}
 
-    if (attrs.value("bold").toBool()) {
-        cur_format.setFontWeight(QFont::Bold);
-    } else {
-        cur_format.setFontWeight(QFont::Normal);
-    }
-    cur_format.setFontItalic(attrs.value("italic").toBool());
+	if (attrs.value("bold").toBool()) {
+		cur_format.setFontWeight(QFont::Bold);
+	} else {
+		cur_format.setFontWeight(QFont::Normal);
+	}
+	cur_format.setFontItalic(attrs.value("italic").toBool());
 
-    if (attrs.value("underline").toBool()) {
-        cur_format.setFontUnderline(true);
-        cur_format.setUnderlineStyle(QTextCharFormat::SingleUnderline);
-    } else if (attrs.value("undercurl").toBool()){
-        cur_format.setFontUnderline(true);
-        cur_format.setUnderlineStyle(QTextCharFormat::WaveUnderline);
-    } else {
-        cur_format.setFontUnderline(false);
-    }
+	if (attrs.value("underline").toBool()) {
+		cur_format.setFontUnderline(true);
+		cur_format.setUnderlineStyle(QTextCharFormat::SingleUnderline);
+	} else if (attrs.value("undercurl").toBool()){
+		cur_format.setFontUnderline(true);
+		cur_format.setUnderlineStyle(QTextCharFormat::WaveUnderline);
+	} else {
+		cur_format.setFontUnderline(false);
+	}
 
-    cur_format.setForeground(cur_foreground);
-    cur_format.setBackground(cur_background);
-    cur_format.setUnderlineColor(cur_special);
-    setCurrentCharFormat(cur_format);
+	cur_format.setForeground(cur_foreground);
+	cur_format.setBackground(cur_background);
+	cur_format.setUnderlineColor(cur_special);
+	setCurrentCharFormat(cur_format);
 }
 
 void CmdBlock::keyPressEvent(QKeyEvent *ev)
 {
-    // TODO : should it just eat the QKeyEvent ?
-    QWidget::keyPressEvent(ev);
+	// TODO : should it just eat the QKeyEvent ?
+	QWidget::keyPressEvent(ev);
 }
 
 }  // namespace NeovimQt

--- a/src/gui/cmdblock.cpp
+++ b/src/gui/cmdblock.cpp
@@ -1,0 +1,34 @@
+#include "cmdblock.h"
+
+namespace NeovimQt {
+
+CmdBlock::CmdBlock(ShellWidget *parent) : QTextEdit(parent) {
+    hide();
+    setReadOnly(true);
+    document()->setDefaultFont(parent->font());
+}
+
+void CmdBlock::compute_block(const QList<QVariantList> &lines) {
+    foreach(QVariantList line, lines) {
+        append_block(line);
+    }
+}
+
+void CmdBlock::append_block(const QVariantList &content) {
+    QString plaintext_content;
+    foreach(QVariant piece, content){
+        qDebug() << piece.toList();
+        plaintext_content += piece.toStringList().at(1);
+    }
+    append(plaintext_content);
+    line_count++;
+}
+
+void CmdBlock::keyPressEvent(QKeyEvent *ev)
+{
+    // TODO : should it just eat the QKeyEvent ?
+    QWidget::keyPressEvent(ev);
+}
+
+}  // namespace NeovimQt
+

--- a/src/gui/cmdblock.cpp
+++ b/src/gui/cmdblock.cpp
@@ -6,6 +6,9 @@ CmdBlock::CmdBlock(ShellWidget *parent) : QTextEdit(parent) {
     hide();
     setReadOnly(true);
     document()->setDefaultFont(parent->font());
+
+    setTextBackgroundColor(parent->background());
+    setTextColor(parent->foreground());
 }
 
 void CmdBlock::compute_block(const QList<QVariantList> &lines) {
@@ -16,12 +19,79 @@ void CmdBlock::compute_block(const QList<QVariantList> &lines) {
 
 void CmdBlock::append_block(const QVariantList &content) {
     QString plaintext_content;
+    QString html_content;
     foreach(QVariant piece, content){
         qDebug() << piece.toList();
+        auto style = html_style_attribute(piece.toList().at(0).toMap());
         plaintext_content += piece.toStringList().at(1);
+        html_content += "<span " + style + ">" + piece.toStringList().at(1) + "</span>";
     }
-    append(plaintext_content);
+    append(html_content);
     line_count++;
+}
+
+QColor CmdBlock::color(qint64 color, const QColor& fallback) const
+{
+    if (color == -1) {
+        return fallback;
+    }
+    return QRgb(color);
+}
+
+QString CmdBlock::html_style_attribute(const QVariantMap& attrs) {
+    QString style = "style=\"white-space: pre; ";
+
+    auto shell_parent = dynamic_cast<ShellWidget*>(parent());
+    QColor cur_foreground, cur_background, cur_special;
+    if (attrs.contains("foreground")) {
+        // TODO: When does Neovim send -1
+        cur_foreground = color(attrs.value("foreground").toLongLong(), shell_parent->foreground());
+    } else {
+        cur_foreground = shell_parent->foreground();
+    }
+
+    if (attrs.contains("background")) {
+        cur_background = color(attrs.value("background").toLongLong(), shell_parent->background());
+    } else {
+        cur_background = shell_parent->background();
+    }
+
+    // FIXME : the supported HTML tags do not seem to support special ( = different color for underline/undercurl)
+    if (attrs.contains(("special"))) {
+        cur_special = color(attrs.value("special").toLongLong(), shell_parent->special());
+    } else {
+        cur_special = shell_parent->special();
+    }
+
+    if (attrs.contains("reverse")) {
+        auto tmp = cur_background;
+        cur_background = cur_foreground;
+        cur_foreground = tmp;
+    }
+
+    if (attrs.value("bold").toBool()) {
+        style += "font-weight: bold; ";
+    } else {
+        style += "font-weight: normal; ";
+    }
+    if (attrs.value("italic").toBool()) {
+        style += "font-style: italic; ";
+    } else {
+        style += "font-style: normal; ";
+    }
+
+    if (attrs.value("underline").toBool()) {
+        style += "text-decoration: underline; ";
+    } else if (attrs.value("undercurl").toBool()){
+        style += "text-decoration: underline; ";
+    } else {
+        style += "text-decoration: normal; ";
+    }
+
+    style += "color: " + cur_foreground.toRgb().name() + "; ";
+    style += "background-color: " + cur_background.toRgb().name() + "; ";
+    style += "\"";
+    return style;
 }
 
 void CmdBlock::keyPressEvent(QKeyEvent *ev)

--- a/src/gui/cmdblock.cpp
+++ b/src/gui/cmdblock.cpp
@@ -6,12 +6,18 @@ CmdBlock::CmdBlock(ShellWidget *parent) : QTextEdit(parent) {
 	hide();
 	setReadOnly(true);
 	document()->setDefaultFont(parent->font());
+        setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+        setHorizontalScrollBarPolicy(Qt::ScrollBarAsNeeded);
 
 	setTextBackgroundColor(parent->background());
 	setTextColor(parent->foreground());
+        setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Preferred);
+        setSizeAdjustPolicy(QAbstractScrollArea::AdjustToContents);
 
 	connect(parent, &ShellWidget::shellFontChanged,
 		    this, &CmdBlock::setDefaultFont);
+        connect(this, &QTextEdit::textChanged,
+                this, &CmdBlock::fitSizeToDocument);
 }
 
 void CmdBlock::setDefaultFont() {
@@ -34,6 +40,7 @@ void CmdBlock::append_block(const QVariantList &content) {
 	}
 	textCursor().insertText("\n");
 	line_count++;
+        adjustSize();
 }
 
 QColor CmdBlock::color(qint64 color, const QColor& fallback) const
@@ -102,6 +109,24 @@ void CmdBlock::style_cursor_CharFormat(const QVariantMap& attrs) {
 void CmdBlock::keyPressEvent(QKeyEvent *ev)
 {
 	QWidget::keyPressEvent(ev);
+}
+
+QSize CmdBlock::sizeHint() const {
+        QSize sizehint = QTextEdit::sizeHint();
+        sizehint.setHeight(fitted_height);
+        qDebug() << "Current CmdBlock size hint : " << sizehint;
+        return sizehint;
+}
+
+QSize CmdBlock::minimumSizeHint() const {
+        return sizeHint();
+}
+
+void CmdBlock::fitSizeToDocument() {
+        document()->setTextWidth(viewport()->width());
+        QSize document_size(document()->size().toSize());
+        fitted_height = document_size.height();
+        updateGeometry();
 }
 
 }  // namespace NeovimQt

--- a/src/gui/cmdblock.cpp
+++ b/src/gui/cmdblock.cpp
@@ -28,7 +28,6 @@ void CmdBlock::compute_block(const QList<QVariantList> &lines) {
 void CmdBlock::append_block(const QVariantList &content) {
 	QString plaintext_content;
 	foreach(QVariant piece, content){
-		qDebug() << piece.toList();
 		style_cursor_CharFormat(piece.toList().at(0).toMap());
 		plaintext_content = piece.toStringList().at(1);
 		textCursor().insertText(plaintext_content);
@@ -51,7 +50,6 @@ void CmdBlock::style_cursor_CharFormat(const QVariantMap& attrs) {
 	auto shell_parent = dynamic_cast<ShellWidget*>(parent());
 	QColor cur_foreground, cur_background, cur_special;
 	if (attrs.contains("foreground")) {
-		// TODO: When does Neovim send -1
 		cur_foreground = color(attrs.value("foreground").toLongLong(),
                                        shell_parent->foreground());
 	} else {
@@ -103,7 +101,6 @@ void CmdBlock::style_cursor_CharFormat(const QVariantMap& attrs) {
 
 void CmdBlock::keyPressEvent(QKeyEvent *ev)
 {
-	// TODO : should it just eat the QKeyEvent ?
 	QWidget::keyPressEvent(ev);
 }
 

--- a/src/gui/cmdblock.cpp
+++ b/src/gui/cmdblock.cpp
@@ -19,14 +19,13 @@ void CmdBlock::compute_block(const QList<QVariantList> &lines) {
 
 void CmdBlock::append_block(const QVariantList &content) {
     QString plaintext_content;
-    QString html_content;
     foreach(QVariant piece, content){
         qDebug() << piece.toList();
-        auto style = html_style_attribute(piece.toList().at(0).toMap());
-        plaintext_content += piece.toStringList().at(1);
-        html_content += "<span " + style + ">" + piece.toStringList().at(1) + "</span>";
+        style_cursor_CharFormat(piece.toList().at(0).toMap());
+        plaintext_content = piece.toStringList().at(1);
+        textCursor().insertText(plaintext_content);
     }
-    append(html_content);
+    textCursor().insertText("\n");
     line_count++;
 }
 
@@ -38,8 +37,8 @@ QColor CmdBlock::color(qint64 color, const QColor& fallback) const
     return QRgb(color);
 }
 
-QString CmdBlock::html_style_attribute(const QVariantMap& attrs) {
-    QString style = "style=\"white-space: pre; ";
+void CmdBlock::style_cursor_CharFormat(const QVariantMap& attrs) {
+    QTextCharFormat cur_format;
 
     auto shell_parent = dynamic_cast<ShellWidget*>(parent());
     QColor cur_foreground, cur_background, cur_special;
@@ -70,28 +69,26 @@ QString CmdBlock::html_style_attribute(const QVariantMap& attrs) {
     }
 
     if (attrs.value("bold").toBool()) {
-        style += "font-weight: bold; ";
+        cur_format.setFontWeight(QFont::Bold);
     } else {
-        style += "font-weight: normal; ";
+        cur_format.setFontWeight(QFont::Normal);
     }
-    if (attrs.value("italic").toBool()) {
-        style += "font-style: italic; ";
-    } else {
-        style += "font-style: normal; ";
-    }
+    cur_format.setFontItalic(attrs.value("italic").toBool());
 
     if (attrs.value("underline").toBool()) {
-        style += "text-decoration: underline; ";
+        cur_format.setFontUnderline(true);
+        cur_format.setUnderlineStyle(QTextCharFormat::SingleUnderline);
     } else if (attrs.value("undercurl").toBool()){
-        style += "text-decoration: underline; ";
+        cur_format.setFontUnderline(true);
+        cur_format.setUnderlineStyle(QTextCharFormat::WaveUnderline);
     } else {
-        style += "text-decoration: normal; ";
+        cur_format.setFontUnderline(false);
     }
 
-    style += "color: " + cur_foreground.toRgb().name() + "; ";
-    style += "background-color: " + cur_background.toRgb().name() + "; ";
-    style += "\"";
-    return style;
+    cur_format.setForeground(cur_foreground);
+    cur_format.setBackground(cur_background);
+    cur_format.setUnderlineColor(cur_special);
+    setCurrentCharFormat(cur_format);
 }
 
 void CmdBlock::keyPressEvent(QKeyEvent *ev)
@@ -101,4 +98,3 @@ void CmdBlock::keyPressEvent(QKeyEvent *ev)
 }
 
 }  // namespace NeovimQt
-

--- a/src/gui/cmdblock.cpp
+++ b/src/gui/cmdblock.cpp
@@ -3,7 +3,6 @@
 namespace NeovimQt {
 
 CmdBlock::CmdBlock(ShellWidget *parent) : QTextEdit(parent) {
-	hide();
 	setReadOnly(true);
 	document()->setDefaultFont(parent->font());
         setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);

--- a/src/gui/cmdblock.cpp
+++ b/src/gui/cmdblock.cpp
@@ -9,6 +9,14 @@ CmdBlock::CmdBlock(ShellWidget *parent) : QTextEdit(parent) {
 
     setTextBackgroundColor(parent->background());
     setTextColor(parent->foreground());
+
+    connect(parent, &ShellWidget::shellFontChanged,
+            this, &CmdBlock::setDefaultFont);
+}
+
+void CmdBlock::setDefaultFont() {
+    auto shell_parent = dynamic_cast<ShellWidget*>(parent());
+    setFont(shell_parent->font());
 }
 
 void CmdBlock::compute_block(const QList<QVariantList> &lines) {

--- a/src/gui/cmdblock.h
+++ b/src/gui/cmdblock.h
@@ -13,35 +13,35 @@ namespace NeovimQt {
 class CmdBlock: public QTextEdit {
 	Q_OBJECT
 public:
-    CmdBlock(ShellWidget *parent=nullptr);
-    /**
-     * @brief compute_block sets the underlying QTextDocument as a cmdline_block
-     * @param lines the list of lines with content-syntax following :h ui-event-highlight_set specs
-     * This typically means that lines is QVariantList of QVariantLists
-     */
-    void compute_block(const QList<QVariantList>& lines);
+	CmdBlock(ShellWidget *parent=nullptr);
+	/**
+	 * @brief compute_block sets the underlying QTextDocument as a cmdline_block
+	 * @param lines the list of lines with content-syntax following :h ui-event-highlight_set specs
+	 * This typically means that lines is QVariantList of QVariantLists
+	 */
+	void compute_block(const QList<QVariantList>& lines);
 
-    /**
-     * @brief append_block appends the underlying QTextDocument with the line "content"
-     * @param content the new line to append
-     */
-    void append_block(const QVariantList& content);
+	/**
+	 * @brief append_block appends the underlying QTextDocument with the line "content"
+	 * @param content the new line to append
+	 */
+	void append_block(const QVariantList& content);
 
-    inline uint16_t lines() const { return line_count; }
+	inline uint16_t lines() const { return line_count; }
 
 public slots:
-    void setDefaultFont();
+	void setDefaultFont();
 
 signals:
 	void reconnectNeovim();
 
 protected:
 	virtual void keyPressEvent(QKeyEvent *ev) Q_DECL_OVERRIDE;
-    QColor color(qint64 color, const QColor& fallback) const;
-    void style_cursor_CharFormat(const QVariantMap& attrs);
+	QColor color(qint64 color, const QColor& fallback) const;
+	void style_cursor_CharFormat(const QVariantMap& attrs);
 
 private:
-    uint16_t line_count{0};
+	uint16_t line_count{0};
 };
 
 } // Namespace

--- a/src/gui/cmdblock.h
+++ b/src/gui/cmdblock.h
@@ -36,6 +36,8 @@ signals:
 
 protected:
 	virtual void keyPressEvent(QKeyEvent *ev) Q_DECL_OVERRIDE;
+    QColor color(qint64 color, const QColor& fallback) const;
+    QString html_style_attribute(const QVariantMap& attrs);
 
 private:
     uint16_t line_count{0};

--- a/src/gui/cmdblock.h
+++ b/src/gui/cmdblock.h
@@ -30,6 +30,7 @@ public:
     inline uint16_t lines() const { return line_count; }
 
 public slots:
+    void setDefaultFont();
 
 signals:
 	void reconnectNeovim();

--- a/src/gui/cmdblock.h
+++ b/src/gui/cmdblock.h
@@ -31,17 +31,21 @@ public:
 
 public slots:
 	void setDefaultFont();
+        void fitSizeToDocument();
 
 signals:
 	void reconnectNeovim();
 
 protected:
 	virtual void keyPressEvent(QKeyEvent *ev) Q_DECL_OVERRIDE;
+        virtual QSize sizeHint() const Q_DECL_OVERRIDE;
+        virtual QSize minimumSizeHint() const Q_DECL_OVERRIDE;
 	QColor color(qint64 color, const QColor& fallback) const;
 	void style_cursor_CharFormat(const QVariantMap& attrs);
 
 private:
 	uint16_t line_count{0};
+        int64_t fitted_height{0};
 };
 
 } // Namespace

--- a/src/gui/cmdblock.h
+++ b/src/gui/cmdblock.h
@@ -37,7 +37,7 @@ signals:
 protected:
 	virtual void keyPressEvent(QKeyEvent *ev) Q_DECL_OVERRIDE;
     QColor color(qint64 color, const QColor& fallback) const;
-    QString html_style_attribute(const QVariantMap& attrs);
+    void style_cursor_CharFormat(const QVariantMap& attrs);
 
 private:
     uint16_t line_count{0};
@@ -46,4 +46,3 @@ private:
 } // Namespace
 
 #endif
-

--- a/src/gui/cmdblock.h
+++ b/src/gui/cmdblock.h
@@ -1,0 +1,47 @@
+#ifndef NEOVIM_QT_CMDBLOCK
+#define NEOVIM_QT_CMDBLOCK
+
+#include <QTextEdit>
+
+#include "input.h"
+#include "neovimconnector.h"
+#include "shellwidget/shellwidget.h"
+
+namespace NeovimQt {
+
+// A Widget that complies to Neovim ui-cmdline API
+class CmdBlock: public QTextEdit {
+	Q_OBJECT
+public:
+    CmdBlock(ShellWidget *parent=nullptr);
+    /**
+     * @brief compute_block sets the underlying QTextDocument as a cmdline_block
+     * @param lines the list of lines with content-syntax following :h ui-event-highlight_set specs
+     * This typically means that lines is QVariantList of QVariantLists
+     */
+    void compute_block(const QList<QVariantList>& lines);
+
+    /**
+     * @brief append_block appends the underlying QTextDocument with the line "content"
+     * @param content the new line to append
+     */
+    void append_block(const QVariantList& content);
+
+    inline uint16_t lines() const { return line_count; }
+
+public slots:
+
+signals:
+	void reconnectNeovim();
+
+protected:
+	virtual void keyPressEvent(QKeyEvent *ev) Q_DECL_OVERRIDE;
+
+private:
+    uint16_t line_count{0};
+};
+
+} // Namespace
+
+#endif
+

--- a/src/gui/cmdblock.h
+++ b/src/gui/cmdblock.h
@@ -9,11 +9,16 @@
 
 namespace NeovimQt {
 
-// A Widget that complies to Neovim ui-cmdline API
+// A Widget that complies to Neovim ui-cmdline API. It handles cmdline_block calls
 class CmdBlock: public QTextEdit {
 	Q_OBJECT
 public:
+        /**
+         * @brief constructor defining the ShellWidget parent
+         * @param parent is a pointer to the ShellWidget parent.
+         */
 	CmdBlock(ShellWidget *parent=nullptr);
+
 	/**
 	 * @brief compute_block sets the underlying QTextDocument as a cmdline_block
 	 * @param lines the list of lines with content-syntax following :h ui-event-highlight_set specs

--- a/src/gui/cmdblock.h
+++ b/src/gui/cmdblock.h
@@ -32,13 +32,14 @@ public:
 public slots:
 	void setDefaultFont();
         void fitSizeToDocument();
+        void clear();
 
 signals:
 	void reconnectNeovim();
 
 protected:
 	virtual void keyPressEvent(QKeyEvent *ev) Q_DECL_OVERRIDE;
-        virtual QSize sizeHint() const Q_DECL_OVERRIDE;
+        virtual QSize viewportSizeHint() const Q_DECL_OVERRIDE;
         virtual QSize minimumSizeHint() const Q_DECL_OVERRIDE;
 	QColor color(qint64 color, const QColor& fallback) const;
 	void style_cursor_CharFormat(const QVariantMap& attrs);
@@ -46,6 +47,8 @@ protected:
 private:
 	uint16_t line_count{0};
         int64_t fitted_height{0};
+        int64_t fitted_width{0};
+        int32_t longest_line_pix{0};
 };
 
 } // Namespace

--- a/src/gui/cmdline.cpp
+++ b/src/gui/cmdline.cpp
@@ -1,0 +1,41 @@
+#include "cmdline.h"
+
+namespace NeovimQt {
+
+CmdLine::CmdLine(QWidget *parent) : QTextEdit(parent) {
+    hide();
+    cursor = QTextCursor(document());
+    setTextCursor(cursor);
+    document()->setDefaultFont(parent->font());
+}
+
+void CmdLine::compute_document(const QString& firstc, const QString& prompt, const QVariantList& content) {
+    QString plaintext_content;
+    foreach(QVariant piece, content){
+        qDebug() << piece.toList();
+        plaintext_content += piece.toStringList().at(1);
+    }
+    qDebug() << prompt << firstc;
+    setPlainText(firstc + prompt + plaintext_content);
+    cursor = QTextCursor(document());
+}
+
+void CmdLine::add_special_char(const QString &c, bool shift_c) {
+    if (!shift_c) {
+        setOverwriteMode(true);
+    }
+    cursor.insertText(c);
+    setOverwriteMode(false);
+}
+
+void CmdLine::setPos(int64_t pos) {
+    cursor.movePosition(QTextCursor::StartOfLine);
+    cursor.movePosition(QTextCursor::Right, QTextCursor::MoveAnchor, pos);
+}
+
+void CmdLine::keyPressEvent(QKeyEvent *ev)
+{
+    QWidget::keyPressEvent(ev);
+}
+
+}  // namespace NeovimQt

--- a/src/gui/cmdline.cpp
+++ b/src/gui/cmdline.cpp
@@ -4,113 +4,115 @@
 namespace NeovimQt {
 
 CmdLine::CmdLine(QWidget *parent) : QTextEdit(parent) {
-    hide();
+        hide();
 
-    setFrameShape(QFrame::NoFrame);
-    setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+        setFrameShape(QFrame::NoFrame);
+        setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
 
-    document()->setDefaultFont(parent->font());
+        document()->setDefaultFont(parent->font());
 
-    auto cmdwidget_parent = dynamic_cast<CmdWidget*>(parent);
-    setTextBackgroundColor(cmdwidget_parent->shell()->background());
-    setTextColor(cmdwidget_parent->shell()->foreground());
+        auto cmdwidget_parent = dynamic_cast<CmdWidget*>(parent);
+        setTextBackgroundColor(cmdwidget_parent->shell()->background());
+        setTextColor(cmdwidget_parent->shell()->foreground());
 }
 
 void CmdLine::compute_document(const QString& firstc, const QString& prompt, const QVariantList& content) {
-    QString plaintext_content;
-    QString html_content;
-    clear();
-    style_cursor_CharFormat(QVariantMap());
-    textCursor().insertText(firstc + prompt);
-    foreach(QVariant piece, content){
-        qDebug() << piece.toList();
-        style_cursor_CharFormat(piece.toList().at(0).toMap());
-        plaintext_content = piece.toStringList().at(1);
-        textCursor().insertText(plaintext_content, textCursor().charFormat());
-    }
-    setFocus();
+        QString plaintext_content;
+        QString html_content;
+        clear();
+        style_cursor_CharFormat(QVariantMap());
+        textCursor().insertText(firstc + prompt);
+        foreach(QVariant piece, content){
+                qDebug() << piece.toList();
+                style_cursor_CharFormat(piece.toList().at(0).toMap());
+                plaintext_content = piece.toStringList().at(1);
+                textCursor().insertText(plaintext_content, textCursor().charFormat());
+        }
+        setFocus();
 }
 
-QColor CmdLine::color(qint64 color, const QColor& fallback) const
-{
-    if (color == -1) {
-        return fallback;
-    }
-    return QRgb(color);
+QColor CmdLine::color(qint64 color, const QColor& fallback) const {
+        if (color == -1) {
+                return fallback;
+        }
+        return QRgb(color);
 }
 
 void CmdLine::style_cursor_CharFormat(const QVariantMap& attrs) {
-    QTextCharFormat cur_format;
+        QTextCharFormat cur_format;
 
-    auto cmdwidget_parent = dynamic_cast<CmdWidget*>(parent());
-    QColor cur_foreground, cur_background, cur_special;
-    if (attrs.contains("foreground")) {
-        // TODO: When does Neovim send -1
-        cur_foreground = color(attrs.value("foreground").toLongLong(), cmdwidget_parent->shell()->foreground());
-    } else {
-        cur_foreground = cmdwidget_parent->shell()->foreground();
-    }
+        auto cmdwidget_parent = dynamic_cast<CmdWidget*>(parent());
+        QColor cur_foreground, cur_background, cur_special;
+        if (attrs.contains("foreground")) {
+                // TODO: When does Neovim send -1
+                cur_foreground = color(attrs.value("foreground").toLongLong(),
+                                       cmdwidget_parent->shell()->foreground());
+        } else {
+                cur_foreground = cmdwidget_parent->shell()->foreground();
+        }
 
-    if (attrs.contains("background")) {
-        cur_background = color(attrs.value("background").toLongLong(), cmdwidget_parent->shell()->background());
-    } else {
-        cur_background = cmdwidget_parent->shell()->background();
-    }
+        if (attrs.contains("background")) {
+                cur_background = color(attrs.value("background").toLongLong(),
+                                       cmdwidget_parent->shell()->background());
+        } else {
+                cur_background = cmdwidget_parent->shell()->background();
+        }
 
-    // FIXME : the supported HTML tags do not seem to support special ( = different color for underline/undercurl)
-    if (attrs.contains(("special"))) {
-        cur_special = color(attrs.value("special").toLongLong(), cmdwidget_parent->shell()->special());
-    } else {
-        cur_special = cmdwidget_parent->shell()->special();
-    }
 
-    if (attrs.contains("reverse")) {
-        auto tmp = cur_background;
-        cur_background = cur_foreground;
-        cur_foreground = tmp;
-    }
+        if (attrs.contains(("special"))) {
+                cur_special = color(attrs.value("special").toLongLong(), cmdwidget_parent->shell()->special());
+        } else {
+                cur_special = cmdwidget_parent->shell()->special();
+        }
 
-    if (attrs.value("bold").toBool()) {
-        cur_format.setFontWeight(QFont::Bold);
-    } else {
-        cur_format.setFontWeight(QFont::Normal);
-    }
-    cur_format.setFontItalic(attrs.value("italic").toBool());
+        if (attrs.contains("reverse")) {
+                auto tmp = cur_background;
+                cur_background = cur_foreground;
+                cur_foreground = tmp;
+        }
 
-    if (attrs.value("underline").toBool()) {
-        cur_format.setFontUnderline(true);
-        cur_format.setUnderlineStyle(QTextCharFormat::SingleUnderline);
-    } else if (attrs.value("undercurl").toBool()){
-        cur_format.setFontUnderline(true);
-        cur_format.setUnderlineStyle(QTextCharFormat::WaveUnderline);
-    } else {
-        cur_format.setFontUnderline(false);
-    }
+        if (attrs.value("bold").toBool()) {
+                cur_format.setFontWeight(QFont::Bold);
+        } else {
+                cur_format.setFontWeight(QFont::Normal);
+        }
 
-    cur_format.setForeground(cur_foreground);
-    cur_format.setBackground(cur_background);
-    cur_format.setUnderlineColor(cur_special);
-    setCurrentCharFormat(cur_format);
+        cur_format.setFontItalic(attrs.value("italic").toBool());
+
+        if (attrs.value("underline").toBool()) {
+                cur_format.setFontUnderline(true);
+                cur_format.setUnderlineStyle(QTextCharFormat::SingleUnderline);
+        } else if (attrs.value("undercurl").toBool()) {
+                cur_format.setFontUnderline(true);
+                cur_format.setUnderlineStyle(QTextCharFormat::WaveUnderline);
+        } else {
+                cur_format.setFontUnderline(false);
+        }
+
+        cur_format.setForeground(cur_foreground);
+        cur_format.setBackground(cur_background);
+        cur_format.setUnderlineColor(cur_special);
+        setCurrentCharFormat(cur_format);
 }
 
 void CmdLine::add_special_char(const QString &c, bool shift_c) {
-    if (!shift_c) {
-        setOverwriteMode(true);
-    }
-    textCursor().insertText(c);
-    setOverwriteMode(false);
+	if (!shift_c) {
+                setOverwriteMode(true);
+	}
+	textCursor().insertText(c);
+	setOverwriteMode(false);
 }
 
 void CmdLine::setPos(int64_t pos) {
-    moveCursor(QTextCursor::StartOfLine);
-    for (int i = 0; i < pos; ++i) {
-        moveCursor(QTextCursor::Right, QTextCursor::MoveAnchor);
-    }
+	moveCursor(QTextCursor::StartOfLine);
+	for (int i = 0; i < pos; ++i) {
+                moveCursor(QTextCursor::Right, QTextCursor::MoveAnchor);
+	}
 }
 
 void CmdLine::keyPressEvent(QKeyEvent *ev)
 {
-    QWidget::keyPressEvent(ev);
+	QWidget::keyPressEvent(ev);
 }
 
 }  // namespace NeovimQt

--- a/src/gui/cmdline.cpp
+++ b/src/gui/cmdline.cpp
@@ -1,25 +1,99 @@
 #include "cmdline.h"
+#include "cmdwidget.h"
 
 namespace NeovimQt {
 
 CmdLine::CmdLine(QWidget *parent) : QTextEdit(parent) {
     hide();
+
     cursor = QTextCursor(document());
     setTextCursor(cursor);
     setFrameShape(QFrame::NoFrame);
     setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+
     document()->setDefaultFont(parent->font());
+
+    auto cmdwidget_parent = dynamic_cast<CmdWidget*>(parent);
+    setTextBackgroundColor(cmdwidget_parent->shell()->background());
+    setTextColor(cmdwidget_parent->shell()->foreground());
 }
 
 void CmdLine::compute_document(const QString& firstc, const QString& prompt, const QVariantList& content) {
     QString plaintext_content;
+    QString html_content;
     foreach(QVariant piece, content){
         qDebug() << piece.toList();
+        auto style = html_style_attribute(piece.toList().at(0).toMap());
         plaintext_content += piece.toStringList().at(1);
+        html_content += "<span " + style + ">" + piece.toStringList().at(1) + "</span>";
     }
-    qDebug() << prompt << firstc;
-    setPlainText(firstc + prompt + plaintext_content);
+    QString header = "<span " + html_style_attribute(QVariantMap()) + ">" + firstc + prompt + "</span>";
+    setText(header + html_content);
     cursor = QTextCursor(document());
+}
+
+QColor CmdLine::color(qint64 color, const QColor& fallback) const
+{
+    if (color == -1) {
+        return fallback;
+    }
+    return QRgb(color);
+}
+
+QString CmdLine::html_style_attribute(const QVariantMap& attrs) {
+    QString style = "style=\"white-space: pre; ";
+
+    auto cmdwidget_parent = dynamic_cast<CmdWidget*>(parent());
+    QColor cur_foreground, cur_background, cur_special;
+    if (attrs.contains("foreground")) {
+        // TODO: When does Neovim send -1
+        cur_foreground = color(attrs.value("foreground").toLongLong(), cmdwidget_parent->shell()->foreground());
+    } else {
+        cur_foreground = cmdwidget_parent->shell()->foreground();
+    }
+
+    if (attrs.contains("background")) {
+        cur_background = color(attrs.value("background").toLongLong(), cmdwidget_parent->shell()->background());
+    } else {
+        cur_background = cmdwidget_parent->shell()->background();
+    }
+
+    // FIXME : the supported HTML tags do not seem to support special ( = different color for underline/undercurl)
+    if (attrs.contains(("special"))) {
+        cur_special = color(attrs.value("special").toLongLong(), cmdwidget_parent->shell()->special());
+    } else {
+        cur_special = cmdwidget_parent->shell()->special();
+    }
+
+    if (attrs.contains("reverse")) {
+        auto tmp = cur_background;
+        cur_background = cur_foreground;
+        cur_foreground = tmp;
+    }
+
+    if (attrs.value("bold").toBool()) {
+        style += "font-weight: bold; ";
+    } else {
+        style += "font-weight: normal; ";
+    }
+    if (attrs.value("italic").toBool()) {
+        style += "font-style: italic; ";
+    } else {
+        style += "font-style: normal; ";
+    }
+
+    if (attrs.value("underline").toBool()) {
+        style += "text-decoration: underline; ";
+    } else if (attrs.value("undercurl").toBool()){
+        style += "text-decoration: underline; ";
+    } else {
+        style += "text-decoration: normal; ";
+    }
+
+    style += "color: " + cur_foreground.toRgb().name() + "; ";
+    style += "background-color: " + cur_background.toRgb().name() + "; ";
+    style += "\"";
+    return style;
 }
 
 void CmdLine::add_special_char(const QString &c, bool shift_c) {

--- a/src/gui/cmdline.cpp
+++ b/src/gui/cmdline.cpp
@@ -6,6 +6,8 @@ CmdLine::CmdLine(QWidget *parent) : QTextEdit(parent) {
     hide();
     cursor = QTextCursor(document());
     setTextCursor(cursor);
+    setFrameShape(QFrame::NoFrame);
+    setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
     document()->setDefaultFont(parent->font());
 }
 

--- a/src/gui/cmdline.cpp
+++ b/src/gui/cmdline.cpp
@@ -23,7 +23,6 @@ void CmdLine::compute_document(const QString& firstc, const QString& prompt, con
         style_cursor_CharFormat(QVariantMap());
         textCursor().insertText(firstc + prompt);
         foreach(QVariant piece, content){
-                qDebug() << piece.toList();
                 style_cursor_CharFormat(piece.toList().at(0).toMap());
                 plaintext_content = piece.toStringList().at(1);
                 textCursor().insertText(plaintext_content, textCursor().charFormat());

--- a/src/gui/cmdline.cpp
+++ b/src/gui/cmdline.cpp
@@ -3,7 +3,7 @@
 
 namespace NeovimQt {
 
-CmdLine::CmdLine(QWidget *parent) : QTextEdit(parent) {
+CmdLine::CmdLine(CmdWidget *parent) : QTextEdit(parent), cmdwidget_parent(parent) {
         hide();
 
         setFrameShape(QFrame::NoFrame);
@@ -41,7 +41,6 @@ QColor CmdLine::color(qint64 color, const QColor& fallback) const {
 void CmdLine::style_cursor_CharFormat(const QVariantMap& attrs) {
         QTextCharFormat cur_format;
 
-        auto cmdwidget_parent = dynamic_cast<CmdWidget*>(parent());
         QColor cur_foreground, cur_background, cur_special;
         if (attrs.contains("foreground")) {
                 // TODO: When does Neovim send -1

--- a/src/gui/cmdline.cpp
+++ b/src/gui/cmdline.cpp
@@ -28,6 +28,7 @@ void CmdLine::compute_document(const QString& firstc, const QString& prompt, con
         plaintext_content = piece.toStringList().at(1);
         textCursor().insertText(plaintext_content, textCursor().charFormat());
     }
+    setFocus();
 }
 
 QColor CmdLine::color(qint64 color, const QColor& fallback) const

--- a/src/gui/cmdline.h
+++ b/src/gui/cmdline.h
@@ -37,10 +37,9 @@ signals:
 protected:
 	virtual void keyPressEvent(QKeyEvent *ev) Q_DECL_OVERRIDE;
     QColor color(qint64 color, const QColor& fallback) const;
-    QString html_style_attribute(const QVariantMap& attrs);
+    void style_cursor_CharFormat(const QVariantMap& attrs);
 
 private:
-    QTextCursor cursor;
 };
 
 } // Namespace NeovimQt

--- a/src/gui/cmdline.h
+++ b/src/gui/cmdline.h
@@ -13,21 +13,21 @@ namespace NeovimQt {
 class CmdLine: public QTextEdit {
 	Q_OBJECT
 public:
-    CmdLine(QWidget *parent=nullptr);
-    /**
-     * @brief compute_document sets the underlying QTextDocument properly with highlights
-     * @param content the list of content following :h ui-event-highlight_set specs
-     */
-    void compute_document(const QString& firstc, const QString& prompt, const QVariantList& content);
+        CmdLine(QWidget *parent=nullptr);
+        /**
+         * @brief compute_document sets the underlying QTextDocument properly with highlights
+         * @param content the list of content following :h ui-event-highlight_set specs
+         */
+        void compute_document(const QString& firstc, const QString& prompt, const QVariantList& content);
 
-    /**
-     * @brief add_special_char sets QTextDocument after cmdline_special_char is received
-     * @param c is the char to show to mark the pending state
-     * @param shift_c is true if c should be printed at the end of the line; if false, c overwrites last user written char
-     */
-    void add_special_char(const QString& c, bool shift_c);
+        /**
+         * @brief add_special_char sets QTextDocument after cmdline_special_char is received
+         * @param c is the char to show to mark the pending state
+         * @param shift_c is true if c should be printed at the end of the line; if false, c overwrites last user written char
+         */
+        void add_special_char(const QString& c, bool shift_c);
 
-    void setPos(int64_t pos);
+        void setPos(int64_t pos);
 
 public slots:
 
@@ -36,8 +36,8 @@ signals:
 
 protected:
 	virtual void keyPressEvent(QKeyEvent *ev) Q_DECL_OVERRIDE;
-    QColor color(qint64 color, const QColor& fallback) const;
-    void style_cursor_CharFormat(const QVariantMap& attrs);
+        QColor color(qint64 color, const QColor& fallback) const;
+        void style_cursor_CharFormat(const QVariantMap& attrs);
 
 private:
 };

--- a/src/gui/cmdline.h
+++ b/src/gui/cmdline.h
@@ -15,7 +15,12 @@ class CmdWidget;
 class CmdLine: public QTextEdit {
 	Q_OBJECT
 public:
+        /**
+         * @brief constructor defining the CmdWidget parent
+         * @param parent a pointer to the CmdWidget parent.
+         */
         CmdLine(CmdWidget *parent=nullptr);
+
         /**
          * @brief compute_document sets the underlying QTextDocument properly with highlights
          * @param content the list of content following :h ui-event-highlight_set specs

--- a/src/gui/cmdline.h
+++ b/src/gui/cmdline.h
@@ -1,0 +1,46 @@
+#ifndef NEOVIM_QT_CMDLINE
+#define NEOVIM_QT_CMDLINE
+
+#include <QTextEdit>
+
+#include "input.h"
+#include "neovimconnector.h"
+#include "shellwidget/shellwidget.h"
+
+namespace NeovimQt {
+
+// A Widget that holds one cmdline
+class CmdLine: public QTextEdit {
+	Q_OBJECT
+public:
+    CmdLine(QWidget *parent=nullptr);
+    /**
+     * @brief compute_document sets the underlying QTextDocument properly with highlights
+     * @param content the list of content following :h ui-event-highlight_set specs
+     */
+    void compute_document(const QString& firstc, const QString& prompt, const QVariantList& content);
+
+    /**
+     * @brief add_special_char sets QTextDocument after cmdline_special_char is received
+     * @param c is the char to show to mark the pending state
+     * @param shift_c is true if c should be printed at the end of the line; if false, c overwrites last user written char
+     */
+    void add_special_char(const QString& c, bool shift_c);
+
+    void setPos(int64_t pos);
+
+public slots:
+
+signals:
+	void reconnectNeovim();
+
+protected:
+	virtual void keyPressEvent(QKeyEvent *ev) Q_DECL_OVERRIDE;
+
+private:
+    QTextCursor cursor;
+};
+
+} // Namespace NeovimQt
+
+#endif

--- a/src/gui/cmdline.h
+++ b/src/gui/cmdline.h
@@ -36,6 +36,8 @@ signals:
 
 protected:
 	virtual void keyPressEvent(QKeyEvent *ev) Q_DECL_OVERRIDE;
+    QColor color(qint64 color, const QColor& fallback) const;
+    QString html_style_attribute(const QVariantMap& attrs);
 
 private:
     QTextCursor cursor;

--- a/src/gui/cmdline.h
+++ b/src/gui/cmdline.h
@@ -9,11 +9,13 @@
 
 namespace NeovimQt {
 
+class CmdWidget;
+
 // A Widget that holds one cmdline
 class CmdLine: public QTextEdit {
 	Q_OBJECT
 public:
-        CmdLine(QWidget *parent=nullptr);
+        CmdLine(CmdWidget *parent=nullptr);
         /**
          * @brief compute_document sets the underlying QTextDocument properly with highlights
          * @param content the list of content following :h ui-event-highlight_set specs
@@ -40,6 +42,7 @@ protected:
         void style_cursor_CharFormat(const QVariantMap& attrs);
 
 private:
+        CmdWidget* cmdwidget_parent;
 };
 
 } // Namespace NeovimQt

--- a/src/gui/cmdwidget.cpp
+++ b/src/gui/cmdwidget.cpp
@@ -33,18 +33,20 @@ CmdLine *CmdWidget::getLevel(int64_t level) {
 }
 
 void CmdWidget::compute_layout() {
-	auto current_layout = dynamic_cast<QVBoxLayout *>(layout());
-	if (!current_layout) {
-		current_layout = new QVBoxLayout(this);
-		current_layout->setDirection(QBoxLayout::BottomToTop);
-		current_layout->setSpacing(0);
-		current_layout->setContentsMargins(0, 0, 0, 0);
-	}
+	auto old_layout = layout();
+	if (old_layout) {
+                delete old_layout;
+        }
+
+	auto new_layout = new QVBoxLayout(this);
+	new_layout->setDirection(QBoxLayout::BottomToTop);
+	new_layout->setSpacing(0);
+	new_layout->setContentsMargins(0, 0, 0, 0);
 
 	for (auto line : cmd_lines) {
-		current_layout->addWidget(line);
+		new_layout->addWidget(line);
 	}
-	setLayout(current_layout);
+	setLayout(new_layout);
 }
 
 void CmdWidget::setGeometry2() {
@@ -86,9 +88,10 @@ void CmdWidget::handleCmdlineHide() {
 	// Clear layout and cmd_lines
 	hide();
 	for (auto line : cmd_lines) {
-		line->clear();
-		line->hide();
+                delete line;
 	}
+        cmd_lines.clear();
+        levels = 0;
 }
 
 void CmdWidget::keyPressEvent(QKeyEvent *ev) {

--- a/src/gui/cmdwidget.cpp
+++ b/src/gui/cmdwidget.cpp
@@ -1,0 +1,22 @@
+#include "cmdwidget.h"
+
+namespace NeovimQt {
+
+CmdWidget::CmdWidget(QWidget *parent) {
+    setParent(parent);
+}
+
+void CmdWidget::keyPressEvent(QKeyEvent *ev)
+{
+    QWidget::keyPressEvent(ev);
+
+	// QString inp = Input.convertKey(ev->text(), ev->key(), ev->modifiers());
+	// if (inp.isEmpty()) {
+	// 	QWidget::keyPressEvent(ev);
+	// 	return;
+	// }
+
+	// m_nvim->api0()->vim_input(m_nvim->encode(inp));
+	// FIXME: bytes might not be written, and need to be buffered
+}
+}  // namespace NeovimQt

--- a/src/gui/cmdwidget.cpp
+++ b/src/gui/cmdwidget.cpp
@@ -2,8 +2,7 @@
 
 namespace NeovimQt {
 
-CmdWidget::CmdWidget(ShellWidget *parent) {
-    setParent(parent);
+CmdWidget::CmdWidget(ShellWidget *parent) : QTextEdit(parent) {
     hide();
     cursor = QTextCursor(document());
     setTextCursor(cursor);

--- a/src/gui/cmdwidget.cpp
+++ b/src/gui/cmdwidget.cpp
@@ -4,96 +4,95 @@
 namespace NeovimQt {
 
 CmdWidget::CmdWidget(ShellWidget *parent) : QFrame(parent) {
-  shell_parent = parent;
-  hide();
-  cmd_lines.reserve(5);
-  setFrameShape(QFrame::Panel);
-  setFrameShadow(QFrame::Raised);
-  connect(shell_parent, &ShellWidget::shellFontChanged,
-          this, &CmdWidget::setDefaultFont);
+	shell_parent = parent;
+	hide();
+	cmd_lines.reserve(5);
+	setFrameShape(QFrame::Panel);
+	setFrameShadow(QFrame::Raised);
+	connect(shell_parent, &ShellWidget::shellFontChanged,
+                this, &CmdWidget::setDefaultFont);
 }
 
-void CmdWidget::setDefaultFont() {
-    setFont(shell_parent->font());
-}
+void CmdWidget::setDefaultFont() { setFont(shell_parent->font()); }
 
-CmdLine* CmdWidget::getLevel(int64_t level) {
-  if (level <= 0) {
-    qWarning() << "Wrong level asked : " << level;
-    return nullptr;
-  }
+CmdLine *CmdWidget::getLevel(int64_t level) {
+	if (level <= 0) {
+		qWarning() << "Wrong level asked : " << level;
+		return nullptr;
+	}
 
-  if (level <= levels) {
-    return cmd_lines[level - 1];
-  }
+	if (level <= levels) {
+		return cmd_lines[level - 1];
+	}
 
-  for (int i = levels; i < level; ++i) {
-    cmd_lines.push_back(new CmdLine(this));
-    ++levels;
-  }
-  return cmd_lines[level - 1];
+	for (int i = levels; i < level; ++i) {
+		cmd_lines.push_back(new CmdLine(this));
+		++levels;
+	}
+	return cmd_lines[level - 1];
 }
 
 void CmdWidget::compute_layout() {
-  auto current_layout = dynamic_cast<QVBoxLayout*>(layout());
-  if (!current_layout) {
-    current_layout = new QVBoxLayout(this);
-    current_layout->setDirection(QBoxLayout::BottomToTop);
-    current_layout->setSpacing(0);
-    current_layout->setContentsMargins(0, 0, 0, 0);
-  }
+	auto current_layout = dynamic_cast<QVBoxLayout *>(layout());
+	if (!current_layout) {
+		current_layout = new QVBoxLayout(this);
+		current_layout->setDirection(QBoxLayout::BottomToTop);
+		current_layout->setSpacing(0);
+		current_layout->setContentsMargins(0, 0, 0, 0);
+	}
 
-  for (auto line : cmd_lines) {
-    current_layout->addWidget(line);
-  }
-  setLayout(current_layout);
+	for (auto line : cmd_lines) {
+		current_layout->addWidget(line);
+	}
+	setLayout(current_layout);
 }
 
 void CmdWidget::setGeometry2() {
-  auto anchor_x = 0;
-  // FIXME : this anchor_y definition will break with cmdline_block commands
-  // FIXME : Magic number : 5 is a tiny amount of pixels so chars fit the line
-  auto anchor_y = (shell_parent->rows() - levels) * shell_parent->cellSize().height()
-                  - 5 * levels;
-  auto cmdline_width = shell_parent->columns() * shell_parent->cellSize().width();
-  auto cmdline_height = shell_parent->cellSize().height() + 5; // cmdline_show is always called for one line
-  setGeometry(anchor_x, anchor_y, cmdline_width, levels*cmdline_height);
+	auto anchor_x = 0;
+	// FIXME : this anchor_y definition will break with cmdline_block commands
+	// FIXME : Magic number : 5 is a tiny amount of pixels so chars fit the line
+	auto anchor_y = (shell_parent->rows() - levels)
+                * shell_parent->cellSize().height()
+                - 5 * levels;
+	auto cmdline_width = shell_parent->columns()
+                * shell_parent->cellSize().width();
+        // cmdline_show is always called for one line
+	auto cmdline_height = shell_parent->cellSize().height() + 5;
+	setGeometry(anchor_x, anchor_y, cmdline_width, levels * cmdline_height);
 
-  compute_layout();
+	compute_layout();
 }
 
-void CmdWidget::compute_document(const QString& firstc, const QString& prompt, const QVariantList& content, int64_t level) {
-  auto current_line = getLevel(level);
-  current_line->compute_document(firstc, prompt, content);
-  current_line->show();
+void CmdWidget::compute_document(const QString &firstc, const QString &prompt,
+		                 const QVariantList &content, int64_t level) {
+	auto current_line = getLevel(level);
+	current_line->compute_document(firstc, prompt, content);
+	current_line->show();
 }
 
-void CmdWidget::add_special_char(const QString &c, bool shift_c, int64_t level) {
-  auto current_line = getLevel(level);
-  current_line->add_special_char(c, shift_c);
-  current_line->show();
+void CmdWidget::add_special_char(const QString &c, bool shift_c,
+		                 int64_t level) {
+	auto current_line = getLevel(level);
+	current_line->add_special_char(c, shift_c);
+	current_line->show();
 }
 
 void CmdWidget::setPos(int64_t pos, int64_t level) {
-  auto current_line = getLevel(level);
-  current_line->setPos(pos);
+	auto current_line = getLevel(level);
+	current_line->setPos(pos);
 }
 
 void CmdWidget::handleCmdlineHide() {
-  // Clear layout and cmd_lines
-  hide();
-  for (auto line : cmd_lines) {
-    delete line;
-  }
-  cmd_lines.clear();
-  levels = 0;
-  auto old_layout = layout();
-  delete old_layout;
+	// Clear layout and cmd_lines
+	hide();
+	for (auto line : cmd_lines) {
+		line->clear();
+		line->hide();
+	}
 }
 
-void CmdWidget::keyPressEvent(QKeyEvent *ev)
-{
-  QWidget::keyPressEvent(ev);
+void CmdWidget::keyPressEvent(QKeyEvent *ev) {
+        QWidget::keyPressEvent(ev);
 }
 
-}  // namespace NeovimQt
+} // namespace NeovimQt

--- a/src/gui/cmdwidget.cpp
+++ b/src/gui/cmdwidget.cpp
@@ -49,7 +49,8 @@ void CmdWidget::setGeometry2() {
   }
   setGeometry(anchor_x, anchor_y, cmdline_width, levels*cmdline_height);
   setLayout(current_layout);
-  setFrameShape(QFrame::NoFrame);
+  setFrameShape(QFrame::Panel);
+  setFrameShadow(QFrame::Raised);
 }
 
 void CmdWidget::compute_document(const QString& firstc, const QString& prompt, const QVariantList& content, int64_t level) {

--- a/src/gui/cmdwidget.cpp
+++ b/src/gui/cmdwidget.cpp
@@ -5,7 +5,6 @@ namespace NeovimQt {
 
 CmdWidget::CmdWidget(ShellWidget *parent) : QFrame(parent) {
 	shell_parent = parent;
-	hide();
 	cmd_lines.reserve(5);
 	setFrameShape(QFrame::Panel);
 	setFrameShadow(QFrame::Raised);

--- a/src/gui/cmdwidget.cpp
+++ b/src/gui/cmdwidget.cpp
@@ -2,9 +2,36 @@
 
 namespace NeovimQt {
 
-CmdWidget::CmdWidget(QWidget *parent) {
+CmdWidget::CmdWidget(ShellWidget *parent) {
     setParent(parent);
-    setReadOnly(true);
+    hide();
+    cursor = QTextCursor(document());
+    setTextCursor(cursor);
+    document()->setDefaultFont(parent->font());
+}
+
+void CmdWidget::compute_document(const QString& firstc, const QString& prompt, const QVariantList& content) {
+    QString plaintext_content;
+    foreach(QVariant piece, content){
+        qDebug() << piece.toList();
+        plaintext_content += piece.toStringList().at(1);
+    }
+    qDebug() << prompt << firstc;
+    setPlainText(firstc + prompt + plaintext_content);
+    cursor = QTextCursor(document());
+}
+
+void CmdWidget::add_special_char(const QString &c, bool shift_c) {
+    if (!shift_c) {
+        setOverwriteMode(true);
+    }
+    cursor.insertText(c);
+    setOverwriteMode(false);
+}
+
+void CmdWidget::setPos(int64_t pos) {
+    cursor.movePosition(QTextCursor::StartOfLine);
+    cursor.movePosition(QTextCursor::Right, QTextCursor::MoveAnchor, pos);
 }
 
 void CmdWidget::keyPressEvent(QKeyEvent *ev)

--- a/src/gui/cmdwidget.cpp
+++ b/src/gui/cmdwidget.cpp
@@ -9,14 +9,6 @@ CmdWidget::CmdWidget(QWidget *parent) {
 void CmdWidget::keyPressEvent(QKeyEvent *ev)
 {
     QWidget::keyPressEvent(ev);
-
-	// QString inp = Input.convertKey(ev->text(), ev->key(), ev->modifiers());
-	// if (inp.isEmpty()) {
-	// 	QWidget::keyPressEvent(ev);
-	// 	return;
-	// }
-
-	// m_nvim->api0()->vim_input(m_nvim->encode(inp));
-	// FIXME: bytes might not be written, and need to be buffered
 }
+
 }  // namespace NeovimQt

--- a/src/gui/cmdwidget.cpp
+++ b/src/gui/cmdwidget.cpp
@@ -7,6 +7,8 @@ CmdWidget::CmdWidget(ShellWidget *parent) : QFrame(parent) {
   shell_parent = parent;
   hide();
   cmd_lines.reserve(5);
+  setFrameShape(QFrame::Panel);
+  setFrameShadow(QFrame::Raised);
   connect(shell_parent, &ShellWidget::shellFontChanged,
           this, &CmdWidget::setDefaultFont);
 }
@@ -32,15 +34,7 @@ CmdLine* CmdWidget::getLevel(int64_t level) {
   return cmd_lines[level - 1];
 }
 
-void CmdWidget::setGeometry2() {
-  auto anchor_x = 0;
-  // FIXME : this anchor_y definition will break with cmdline_block commands
-  // FIXME : Magic number : 5 is a tiny amount of pixels so chars fit the line
-  auto anchor_y = (shell_parent->rows() - levels) * shell_parent->cellSize().height()
-                  - 5 * levels;
-  auto cmdline_width = shell_parent->columns() * shell_parent->cellSize().width();
-  auto cmdline_height = shell_parent->cellSize().height() + 5; // cmdline_show is always called for one line
-
+void CmdWidget::compute_layout() {
   auto current_layout = dynamic_cast<QVBoxLayout*>(layout());
   if (!current_layout) {
     current_layout = new QVBoxLayout(this);
@@ -50,13 +44,22 @@ void CmdWidget::setGeometry2() {
   }
 
   for (auto line : cmd_lines) {
-    line->setGeometry(anchor_x, anchor_y, cmdline_width, cmdline_height);
     current_layout->addWidget(line);
   }
-  setGeometry(anchor_x, anchor_y, cmdline_width, levels*cmdline_height);
   setLayout(current_layout);
-  setFrameShape(QFrame::Panel);
-  setFrameShadow(QFrame::Raised);
+}
+
+void CmdWidget::setGeometry2() {
+  auto anchor_x = 0;
+  // FIXME : this anchor_y definition will break with cmdline_block commands
+  // FIXME : Magic number : 5 is a tiny amount of pixels so chars fit the line
+  auto anchor_y = (shell_parent->rows() - levels) * shell_parent->cellSize().height()
+                  - 5 * levels;
+  auto cmdline_width = shell_parent->columns() * shell_parent->cellSize().width();
+  auto cmdline_height = shell_parent->cellSize().height() + 5; // cmdline_show is always called for one line
+  setGeometry(anchor_x, anchor_y, cmdline_width, levels*cmdline_height);
+
+  compute_layout();
 }
 
 void CmdWidget::compute_document(const QString& firstc, const QString& prompt, const QVariantList& content, int64_t level) {

--- a/src/gui/cmdwidget.cpp
+++ b/src/gui/cmdwidget.cpp
@@ -54,9 +54,10 @@ void CmdWidget::setGeometry2() {
         // How wide the CmdWidget should be w.r.t. grid width
         auto ratio_width = 0.66;
 	auto anchor_x = static_cast<int64_t>((1 - ratio_width) / 2 * cols_in_px);
-	auto anchor_y = 0;
+	auto anchor_y = shell_parent->frameGeometry().bottom();
 	auto cmdline_width = static_cast<int64_t>(ratio_width * cols_in_px);
 	auto cmdline_height = shell_parent->cellSize().height() + 5;
+        anchor_y -= levels * cmdline_height - frameWidth();
 	setGeometry(anchor_x, anchor_y, cmdline_width, levels * cmdline_height);
 
 	compute_layout();

--- a/src/gui/cmdwidget.cpp
+++ b/src/gui/cmdwidget.cpp
@@ -29,7 +29,9 @@ CmdLine* CmdWidget::getLevel(int64_t level) {
 void CmdWidget::setGeometry2() {
   auto anchor_x = 0;
   // FIXME : this anchor_y definition will break with cmdline_block commands
-  auto anchor_y = (shell_parent->rows() - levels) * shell_parent->cellSize().height();
+  // FIXME : Magic number : 5 is a tiny amount of pixels so chars fit the line
+  auto anchor_y = (shell_parent->rows() - levels) * shell_parent->cellSize().height()
+                  - 5 * levels;
   auto cmdline_width = shell_parent->columns() * shell_parent->cellSize().width();
   auto cmdline_height = shell_parent->cellSize().height() + 5; // cmdline_show is always called for one line
 

--- a/src/gui/cmdwidget.cpp
+++ b/src/gui/cmdwidget.cpp
@@ -50,15 +50,12 @@ void CmdWidget::compute_layout() {
 }
 
 void CmdWidget::setGeometry2() {
-	auto anchor_x = 0;
-	// FIXME : this anchor_y definition will break with cmdline_block commands
-	// FIXME : Magic number : 5 is a tiny amount of pixels so chars fit the line
-	auto anchor_y = (shell_parent->rows() - levels)
-                * shell_parent->cellSize().height()
-                - 5 * levels;
-	auto cmdline_width = shell_parent->columns()
-                * shell_parent->cellSize().width();
-        // cmdline_show is always called for one line
+        auto cols_in_px = shell_parent->columns() * shell_parent->cellSize().width();
+        // How wide the CmdWidget should be w.r.t. grid width
+        auto ratio_width = 0.66;
+	auto anchor_x = static_cast<int64_t>((1 - ratio_width) / 2 * cols_in_px);
+	auto anchor_y = 0;
+	auto cmdline_width = static_cast<int64_t>(ratio_width * cols_in_px);
 	auto cmdline_height = shell_parent->cellSize().height() + 5;
 	setGeometry(anchor_x, anchor_y, cmdline_width, levels * cmdline_height);
 

--- a/src/gui/cmdwidget.cpp
+++ b/src/gui/cmdwidget.cpp
@@ -29,6 +29,25 @@ void CmdWidget::add_special_char(const QString &c, bool shift_c) {
     setOverwriteMode(false);
 }
 
+void CmdWidget::compute_block(const QList<QVariantList> &lines) {
+    foreach(QVariantList line, lines) {
+        append_block(line);
+    }
+    cursor = QTextCursor(document());
+    cursor.movePosition(QTextCursor::End, QTextCursor::MoveAnchor);
+    cursor.movePosition(QTextCursor::StartOfBlock, QTextCursor::MoveAnchor);
+}
+
+void CmdWidget::append_block(const QVariantList &content) {
+    QString plaintext_content;
+    foreach(QVariant piece, content){
+        qDebug() << piece.toList();
+        plaintext_content += piece.toStringList().at(1);
+    }
+    append(plaintext_content);
+    line_count++;
+}
+
 void CmdWidget::setPos(int64_t pos) {
     cursor.movePosition(QTextCursor::StartOfLine);
     cursor.movePosition(QTextCursor::Right, QTextCursor::MoveAnchor, pos);

--- a/src/gui/cmdwidget.cpp
+++ b/src/gui/cmdwidget.cpp
@@ -7,6 +7,12 @@ CmdWidget::CmdWidget(ShellWidget *parent) : QFrame(parent) {
   shell_parent = parent;
   hide();
   cmd_lines.reserve(5);
+  connect(shell_parent, &ShellWidget::shellFontChanged,
+          this, &CmdWidget::setDefaultFont);
+}
+
+void CmdWidget::setDefaultFont() {
+    setFont(shell_parent->font());
 }
 
 CmdLine* CmdWidget::getLevel(int64_t level) {

--- a/src/gui/cmdwidget.cpp
+++ b/src/gui/cmdwidget.cpp
@@ -4,6 +4,7 @@ namespace NeovimQt {
 
 CmdWidget::CmdWidget(QWidget *parent) {
     setParent(parent);
+    setReadOnly(true);
 }
 
 void CmdWidget::keyPressEvent(QKeyEvent *ev)

--- a/src/gui/cmdwidget.h
+++ b/src/gui/cmdwidget.h
@@ -42,6 +42,7 @@ public:
     void handleCmdlineHide();
 
 public slots:
+    void setDefaultFont();
 
 signals:
 	void reconnectNeovim();

--- a/src/gui/cmdwidget.h
+++ b/src/gui/cmdwidget.h
@@ -1,8 +1,10 @@
 #ifndef NEOVIM_QT_CMDWIDGET
 #define NEOVIM_QT_CMDWIDGET
 
-#include <QTextEdit>
+#include <QFrame>
+#include <vector>
 
+#include "cmdline.h"
 #include "input.h"
 #include "neovimconnector.h"
 #include "shellwidget/shellwidget.h"
@@ -10,7 +12,7 @@
 namespace NeovimQt {
 
 // A Widget that complies to Neovim ui-cmdline API
-class CmdWidget: public QTextEdit {
+class CmdWidget: public QFrame {
 	Q_OBJECT
 public:
     CmdWidget(ShellWidget *parent=nullptr);
@@ -18,31 +20,26 @@ public:
      * @brief compute_document sets the underlying QTextDocument properly with highlights
      * @param content the list of content following :h ui-event-highlight_set specs
      */
-    void compute_document(const QString& firstc, const QString& prompt, const QVariantList& content);
+    void compute_document(const QString& firstc, const QString& prompt, const QVariantList& content, int64_t level);
 
     /**
      * @brief add_special_char sets QTextDocument after cmdline_special_char is received
      * @param c is the char to show to mark the pending state
      * @param shift_c is true if c should be printed at the end of the line; if false, c overwrites last user written char
      */
-    void add_special_char(const QString& c, bool shift_c);
+    void add_special_char(const QString& c, bool shift_c, int64_t level);
 
-    /**
-     * @brief compute_block sets the underlying QTextDocument as a cmdline_block
-     * @param lines the list of lines with content-syntax following :h ui-event-highlight_set specs
-     * This typically means that lines is QVariantList of QVariantLists
-     */
-    void compute_block(const QList<QVariantList>& lines);
+    void setPos(int64_t pos, int64_t level);
 
-    /**
-     * @brief append_block appends the underlying QTextDocument with the line "content"
-     * @param content the new line to append
-     */
-    void append_block(const QVariantList& content);
+    void setGeometry2();
 
-    void setPos(int64_t pos);
+    inline uint16_t lines() const { return levels; }
 
-    inline uint16_t lines() const { return line_count; }
+    inline const ShellWidget* shell() {return shell_parent;}
+
+    inline const QFont font() const {return shell_parent->font(); }
+
+    void handleCmdlineHide();
 
 public slots:
 
@@ -51,10 +48,13 @@ signals:
 
 protected:
 	virtual void keyPressEvent(QKeyEvent *ev) Q_DECL_OVERRIDE;
+        CmdLine* getLevel(int64_t level);
 
 private:
-    QTextCursor cursor;
-    uint16_t line_count{0};
+    uint16_t levels{0};
+    std::vector<CmdLine*> cmd_lines;
+    ShellWidget* shell_parent{nullptr};
+    QFont current_font;
 };
 
 } // Namespace

--- a/src/gui/cmdwidget.h
+++ b/src/gui/cmdwidget.h
@@ -50,12 +50,12 @@ signals:
 protected:
 	virtual void keyPressEvent(QKeyEvent *ev) Q_DECL_OVERRIDE;
         CmdLine* getLevel(int64_t level);
+    void compute_layout();
 
 private:
     uint16_t levels{0};
     std::vector<CmdLine*> cmd_lines;
     ShellWidget* shell_parent{nullptr};
-    QFont current_font;
 };
 
 } // Namespace

--- a/src/gui/cmdwidget.h
+++ b/src/gui/cmdwidget.h
@@ -11,35 +11,61 @@
 
 namespace NeovimQt {
 
-// A Widget that complies to Neovim ui-cmdline API
+// A Widget that complies to Neovim ui-cmdline API. It holds all single cmdlines
 class CmdWidget: public QFrame {
 	Q_OBJECT
 public:
-    CmdWidget(ShellWidget *parent=nullptr);
-    /**
-     * @brief compute_document sets the underlying QTextDocument properly with highlights
-     * @param content the list of content following :h ui-event-highlight_set specs
-     */
-    void compute_document(const QString& firstc, const QString& prompt, const QVariantList& content, int64_t level);
+        /**
+         * @brief Contstructor from a parent ShellWidget
+         * @param parent is the parent ShellWidget,
+         *               mostly useful for appearance consistency
+         */
+        CmdWidget(ShellWidget *parent=nullptr);
 
-    /**
-     * @brief add_special_char sets QTextDocument after cmdline_special_char is received
-     * @param c is the char to show to mark the pending state
-     * @param shift_c is true if c should be printed at the end of the line; if false, c overwrites last user written char
-     */
-    void add_special_char(const QString& c, bool shift_c, int64_t level);
+        /**
+         * @brief compute_document sets the underlying QTextDocument
+         * 			   properly with highlights
+         * @param firstc is the first char of a computed line like ':' or '='
+         * @param prompt is the read-only text for input()-style prompts
+         * @param content the list of content following :h ui-event-highlight_set specs
+         * @param level is the targeted cmdline level
+         */
+        void compute_document(const QString& firstc, const QString& prompt,
+                              const QVariantList& content, int64_t level);
 
-    void setPos(int64_t pos, int64_t level);
+        /**
+         * @brief add_special_char sets QTextDocument after cmdline_special_char
+         *                         is received
+         * @param c is the char to show to mark the pending state
+         * @param shift_c if true, c should be printed at the end of the line;
+         *                if false, c overwrites last user written char
+         * @param level is the targeted cmdline level
+         */
+        void add_special_char(const QString& c, bool shift_c, int64_t level);
 
-    void setGeometry2();
+        /**
+         * @brief setPos sets the cursor position in a cmdline
+         * @param pos the wanted position
+         * @param level is the targeted cmdline level
+         */
+        void setPos(int64_t pos, int64_t level);
 
-    inline uint16_t lines() const { return levels; }
+        /**
+         * @brief setGeometry2 sets the geometry of the widget.
+         *                     It should probably be a slot or an override ?
+         */
+        void setGeometry2();
 
-    inline const ShellWidget* shell() {return shell_parent;}
+        inline uint16_t lines() const { return levels; }
 
-    inline const QFont font() const {return shell_parent->font(); }
+        inline const ShellWidget* shell() { return shell_parent; }
 
-    void handleCmdlineHide();
+        inline const QFont font() const { return shell_parent->font(); }
+
+        /**
+         * @brief handleCmdlineHide handles cmdline_hide events. It clears cmdlines
+         */
+        void handleCmdlineHide();
 
 public slots:
         void setDefaultFont();

--- a/src/gui/cmdwidget.h
+++ b/src/gui/cmdwidget.h
@@ -32,15 +32,17 @@ public:
      * @param lines the list of lines with content-syntax following :h ui-event-highlight_set specs
      * This typically means that lines is QVariantList of QVariantLists
      */
-    // void compute_block(const QVariantList& lines);
+    void compute_block(const QList<QVariantList>& lines);
 
     /**
      * @brief append_block appends the underlying QTextDocument with the line "content"
      * @param content the new line to append
      */
-    // void append_block(const QVariantList& content);
+    void append_block(const QVariantList& content);
 
     void setPos(int64_t pos);
+
+    inline uint16_t lines() const { return line_count; }
 
 public slots:
 
@@ -52,6 +54,7 @@ protected:
 
 private:
     QTextCursor cursor;
+    uint16_t line_count{0};
 };
 
 } // Namespace

--- a/src/gui/cmdwidget.h
+++ b/src/gui/cmdwidget.h
@@ -5,6 +5,7 @@
 
 #include "input.h"
 #include "neovimconnector.h"
+#include "shellwidget/shellwidget.h"
 
 namespace NeovimQt {
 
@@ -12,7 +13,21 @@ namespace NeovimQt {
 class CmdWidget: public QTextEdit {
 	Q_OBJECT
 public:
-	CmdWidget(QWidget *parent=nullptr);
+    CmdWidget(ShellWidget *parent=nullptr);
+    /**
+     * @brief compute_document sets the underlying QTextDocument properly with highlights
+     * @param content the list of content following :h ui-event-highlight_set specs
+     */
+    void compute_document(const QString& firstc, const QString& prompt, const QVariantList& content);
+
+    /**
+     * @brief add_special_char sets QTextDocument after cmdline_special_char is received
+     * @param c is the char to show to mark the pending state
+     * @param shift_c is true if c should be printed at the end of the line; if false, c overwrites last user written char
+     */
+    void add_special_char(const QString& c, bool shift_c);
+
+    void setPos(int64_t pos);
 
 public slots:
 
@@ -23,6 +38,7 @@ protected:
 	virtual void keyPressEvent(QKeyEvent *ev) Q_DECL_OVERRIDE;
 
 private:
+    QTextCursor cursor;
 };
 
 } // Namespace

--- a/src/gui/cmdwidget.h
+++ b/src/gui/cmdwidget.h
@@ -1,0 +1,30 @@
+#ifndef NEOVIM_QT_CMDWIDGET
+#define NEOVIM_QT_CMDWIDGET
+
+#include <QTextEdit>
+
+#include "input.h"
+#include "neovimconnector.h"
+
+namespace NeovimQt {
+
+// A Widget that complies to Neovim ui-cmdline API
+class CmdWidget: public QTextEdit {
+	Q_OBJECT
+public:
+	CmdWidget(QWidget *parent=nullptr);
+
+public slots:
+
+signals:
+	void reconnectNeovim();
+
+protected:
+	virtual void keyPressEvent(QKeyEvent *ev) Q_DECL_OVERRIDE;
+
+private:
+};
+
+} // Namespace
+
+#endif

--- a/src/gui/cmdwidget.h
+++ b/src/gui/cmdwidget.h
@@ -27,6 +27,19 @@ public:
      */
     void add_special_char(const QString& c, bool shift_c);
 
+    /**
+     * @brief compute_block sets the underlying QTextDocument as a cmdline_block
+     * @param lines the list of lines with content-syntax following :h ui-event-highlight_set specs
+     * This typically means that lines is QVariantList of QVariantLists
+     */
+    // void compute_block(const QVariantList& lines);
+
+    /**
+     * @brief append_block appends the underlying QTextDocument with the line "content"
+     * @param content the new line to append
+     */
+    // void append_block(const QVariantList& content);
+
     void setPos(int64_t pos);
 
 public slots:

--- a/src/gui/cmdwidget.h
+++ b/src/gui/cmdwidget.h
@@ -42,7 +42,7 @@ public:
     void handleCmdlineHide();
 
 public slots:
-    void setDefaultFont();
+        void setDefaultFont();
 
 signals:
 	void reconnectNeovim();
@@ -50,12 +50,12 @@ signals:
 protected:
 	virtual void keyPressEvent(QKeyEvent *ev) Q_DECL_OVERRIDE;
         CmdLine* getLevel(int64_t level);
-    void compute_layout();
+        void compute_layout();
 
 private:
-    uint16_t levels{0};
-    std::vector<CmdLine*> cmd_lines;
-    ShellWidget* shell_parent{nullptr};
+        uint16_t levels{0};
+        std::vector<CmdLine*> cmd_lines;
+        ShellWidget* shell_parent{nullptr};
 };
 
 } // Namespace

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -579,6 +579,8 @@ void Shell::handleRedraw(const QByteArray& name, const QVariantList& opargs)
 		}
 		int64_t level = opargs.at(5).toInt();
 
+                qDebug() << name << content << pos << firstc << prompt
+                         << indent << level;
 		handleCmdlineShow(content, pos, firstc, prompt, indent, level);
 	} else if (name == "cmdline_pos") {
 		if (opargs.size() < 2 || !opargs.at(0).canConvert<int64_t>()
@@ -617,27 +619,29 @@ void Shell::handleRedraw(const QByteArray& name, const QVariantList& opargs)
 		qDebug() << name << c << shift << level;
 		handleCmdlineSpecialChar(c, shift, level);
 	} else if (name == "cmdline_hide") {
-		m_cmdline_widget->handleCmdlineHide();
+                qDebug() << name;
+                m_cmdline_widget->handleCmdlineHide();
 	} else if (name == "cmdline_block_show") {
 		if (opargs.size() < 1) {
 			qWarning() << "Unexpected argument for cmdline_block_show:" << opargs;
 			return;
 		}
-        qDebug() << "cmdline_block_show" << opargs;
         foreach(QVariant line, opargs.at(0).toList()) {
             qDebug() << line.toList() << "\n";
             m_cmdline_block->append_block(line.toList());
         }
         // TODO : setGeometry for m_cmdline_block
         m_cmdline_block->show();
+                qDebug() << "cmdline_block_show" << opargs;
 	} else if (name == "cmdline_block_append") {
 		if (opargs.size() < 1) {
 			qWarning() << "Unexpected argument for cmdline_block_append:" << opargs;
 			return;
 		}
 		qDebug() << "cmdline_block_append" << opargs;
-        m_cmdline_block->append_block(opargs.at(0).toList());
+                m_cmdline_block->append_block(opargs.at(0).toList());
 	} else if (name == "cmdline_block_hide") {
+                qDebug() << name;
                 m_cmdline_block->clear();
                 m_cmdline_block->hide();
 	} else {

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -51,7 +51,9 @@ Shell::Shell(NeovimConnector *nvim, ShellOptions opts, QWidget *parent)
 
 	// Command line (instantiate the first one)
 	m_cmdline_widget = new CmdWidget(this);
+        m_cmdline_widget->hide();
 	m_cmdline_block = new CmdBlock(this);
+        m_cmdline_block->hide();
 
 	if (m_nvim == NULL) {
 		qWarning() << "Received NULL as Neovim Connector";

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -1469,9 +1469,8 @@ void Shell::moveCmdBlockToLines() {
         auto max_height = (rows() - m_cmdline_widget->lines()) * cellSize().height();
 
         m_cmdline_block->move(anchor_x, anchor_y);
-        m_cmdline_block->setMinimumWidth(width);
-        m_cmdline_block->setMaximumHeight(max_height);
-        qDebug() << "New CmdBlock max height : " << max_height;
+        m_cmdline_block->setMaximumSize(width, max_height);
+        m_cmdline_block->adjustSize();
 }
 
 void Shell::handleCmdlineSpecialChar(QString c, bool shift, int64_t level) {

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -589,8 +589,8 @@ void Shell::handleRedraw(const QByteArray& name, const QVariantList& opargs)
 		int64_t pos = opargs.at(0).toInt();
 		int64_t level = opargs.at(1).toInt();
 		qDebug() << name << pos << level;
-		// TODO : failure handling if the cmdline doesn't exist
-		m_cmdline_widget->setPos(pos, level);
+                // +1 to account for first char like in cmdline_show
+		m_cmdline_widget->setPos(pos + 1, level);
 	} else if (name == "cmdline_special_char") {
 		if (opargs.size() < 3) {
 			qWarning() << "Unexpected argument for cmdline_special_char:" << opargs;
@@ -1447,7 +1447,7 @@ void Shell::handleCmdlineShow(QVariantList content, int64_t pos, QString firstc,
 			QString prompt, int64_t indent, int64_t level)
 {
     m_cmdline_widget->compute_document(firstc, prompt, content, level);
-    m_cmdline_widget->setPos(pos + indent + 1, level);
+    m_cmdline_widget->setPos(pos + 1, level);
     m_cmdline_widget->setGeometry2();
     m_cmdline_widget->show();
 }

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -1449,6 +1449,7 @@ void Shell::handleCmdlineShow(QVariantList content, int64_t pos, QString firstc,
     m_cmdline_widget->compute_document(firstc, prompt, content, level);
     m_cmdline_widget->setPos(pos + 1, level);
     m_cmdline_widget->setGeometry2();
+    moveCmdBlockToLines();
     m_cmdline_widget->show();
 }
 
@@ -1457,16 +1458,20 @@ void Shell::handleCmdlineBlockShow(QVariantList lines) {
                 qDebug() << line.toList() << "\n";
                 m_cmdline_block->append_block(line.toList());
         }
+        moveCmdBlockToLines();
+        m_cmdline_block->show();
+}
+
+void Shell::moveCmdBlockToLines() {
         auto anchor_x = m_cmdline_widget->frameGeometry().left();
         auto anchor_y = m_cmdline_widget->frameGeometry().bottom();
         auto width = m_cmdline_widget->geometry().width();
         auto max_height = (rows() - m_cmdline_widget->lines()) * cellSize().height();
-        qDebug() << "New CmdBlock max height : " << max_height;
+
         m_cmdline_block->move(anchor_x, anchor_y);
         m_cmdline_block->setMinimumWidth(width);
         m_cmdline_block->setMaximumHeight(max_height);
-        m_cmdline_block->show();
-        update();
+        qDebug() << "New CmdBlock max height : " << max_height;
 }
 
 void Shell::handleCmdlineSpecialChar(QString c, bool shift, int64_t level) {

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -638,7 +638,8 @@ void Shell::handleRedraw(const QByteArray& name, const QVariantList& opargs)
 		qDebug() << "cmdline_block_append" << opargs;
         m_cmdline_block->append_block(opargs.at(0).toList());
 	} else if (name == "cmdline_block_hide") {
-        m_cmdline_block->hide();
+                m_cmdline_block->clear();
+                m_cmdline_block->hide();
 	} else {
 		qDebug() << "Received unknown redraw notification" << name << opargs;
 	}

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -883,6 +883,8 @@ void Shell::handleSetOption(const QString& name, const QVariant& value)
 		setLineSpace(value.toString().toInt());
 	} else if (name == "showtabline") {
 		emit neovimShowtablineSet(value.toString().toInt());
+	} else if (name == "ext_cmdline") {
+		emit neovimExtCmdlineSet(value.toBool());
 	} else if (name == "ext_tabline") {
 		emit neovimExtTablineSet(value.toBool());
 	} else if (name == "ext_popupmenu") {

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -1464,7 +1464,9 @@ void Shell::handleCmdlineBlockShow(QVariantList lines) {
 
 void Shell::moveCmdBlockToLines() {
         auto anchor_x = m_cmdline_widget->frameGeometry().left();
-        auto anchor_y = m_cmdline_widget->frameGeometry().bottom();
+        auto anchor_y = m_cmdline_widget->frameGeometry().top();
+        auto offset = m_cmdline_block->frameGeometry().height();
+        anchor_y -= offset;
         auto width = m_cmdline_widget->geometry().width();
         auto max_height = (rows() - m_cmdline_widget->lines()) * cellSize().height();
 

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -404,6 +404,9 @@ void Shell::handleRedraw(const QByteArray& name, const QVariantList& opargs)
 			setForeground(QRgb(val));
 		}
 		m_hg_foreground = foreground();
+		QPalette p = palette();
+		p.setColor(QPalette::Text, foreground());
+		setPalette(p);
 	} else if (name == "update_bg") {
 		if (opargs.size() < 1 || !opargs.at(0).canConvert<quint64>()) {
 			qWarning() << "Unexpected arguments for redraw:" << name << opargs;
@@ -414,6 +417,10 @@ void Shell::handleRedraw(const QByteArray& name, const QVariantList& opargs)
 			setBackground(QRgb(val));
 		}
 		m_hg_background = background();
+		QPalette p = palette();
+		p.setColor(QPalette::Base, background());
+		setAutoFillBackground(true);
+		setPalette(p);
 		update();
 	} else if (name == "update_sp") {
 		if (opargs.size() < 1 || !opargs.at(0).canConvert<quint64>()) {

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -230,6 +230,9 @@ void Shell::init()
 	if (m_options.enable_ext_popupmenu) {
 		options.insert("ext_popupmenu", true);
 	}
+	if (m_options.enable_ext_cmdline) {
+		options.insert("ext_cmdline", true);
+	}
 	options.insert("rgb", true);
 
 	MsgpackRequest *req;
@@ -527,6 +530,98 @@ void Shell::handleRedraw(const QByteArray& name, const QVariantList& opargs)
 		// TODO
 	} else if (name == "default_colors_set") {
 		// TODO
+	} else if (name == "cmdline_show") {
+		if (opargs.size() < 6) {
+			qWarning() << "Unexpected argument for cmdline_show:" << opargs;
+			return;
+		}
+
+		QVariantList content = opargs.at(0).toList();
+
+		if (!opargs.at(1).canConvert<int64_t>()) {
+			qWarning() << "Invalid type for cmdline_show pos:" << opargs.at(1);
+			return;
+		}
+		int64_t pos = opargs.at(1).toInt();
+
+		if (!opargs.at(2).canConvert<QString>()) {
+			qWarning() << "Invalid type for cmdline_show firstc:" << opargs.at(2);
+			return;
+		}
+		QString firstc = opargs.at(2).toString();
+
+		if (!opargs.at(3).canConvert<QString>()) {
+			qWarning() << "Invalid type for cmdline_show prompt:" << opargs.at(3);
+			return;
+		}
+		QString prompt = opargs.at(3).toString();
+
+		if (!opargs.at(4).canConvert<int64_t>()) {
+			qWarning() << "Invalid type for cmdline_show indent:" << opargs.at(4);
+			return;
+		}
+		int64_t indent = opargs.at(4).toInt();
+
+		if (!opargs.at(5).canConvert<int64_t>()) {
+			qWarning() << "Invalid type for cmdline_show level:" << opargs.at(5);
+			return;
+		}
+		int64_t level = opargs.at(5).toInt();
+
+		handleCmdlineShow(content, pos, firstc, prompt, indent, level);
+	} else if (name == "cmdline_pos") {
+		if (opargs.size() < 2 || !opargs.at(0).canConvert<int64_t>()
+				|| !opargs.at(1).canConvert<int64_t>()) {
+			qWarning() << "Unexpected argument for cmdline_pos:" << opargs;
+			return;
+		}
+		int64_t pos = opargs.at(0).toInt();
+		int64_t level = opargs.at(1).toInt();
+		qDebug() << name << pos << level;
+	} else if (name == "cmdline_special_char") {
+		if (opargs.size() < 3) {
+			qWarning() << "Unexpected argument for cmdline_special_char:" << opargs;
+			return;
+		}
+
+		if (!opargs.at(0).canConvert<QString>()) {
+			qWarning() << "Invalid type for cmdline_special_char c:" << opargs.at(0);
+			return;
+		}
+		QString c = opargs.at(0).toString();
+
+		if (!opargs.at(1).canConvert<bool>()) {
+			qWarning() << "Invalid type for cmdline_special_char shift:" << opargs.at(1);
+			return;
+		}
+		bool shift = opargs.at(1).toBool();
+
+		if (!opargs.at(2).canConvert<int64_t>()) {
+			qWarning() << "Invalid type for cmdline_special_char level:" << opargs.at(2);
+			return;
+		}
+		int64_t level = opargs.at(2).toInt();
+		qDebug() << name << c << shift << level;
+	} else if (name == "cmdline_hide") {
+		qDebug() << name;
+		//handleCmdlineHide();
+	} else if (name == "cmdline_block_show") {
+		if (opargs.size() < 1) {
+			qWarning() << "Unexpected argument for cmdline_block_show:" << opargs;
+			return;
+		}
+		// - lines
+		qDebug() << "cmdline_block_show" << opargs;
+	} else if (name == "cmdline_block_append") {
+		if (opargs.size() < 1) {
+			qWarning() << "Unexpected argument for cmdline_block_append:" << opargs;
+			return;
+		}
+		qDebug() << "cmdline_block_append" << opargs;
+		// - line
+	} else if (name == "cmdline_block_hide") {
+		qDebug() << name;
+		//handleCmdlineBlockHide();
 	} else {
 		qDebug() << "Received unknown redraw notification" << name << opargs;
 	}
@@ -1436,6 +1531,15 @@ void Shell::handleGinitError(quint32 msgid, quint64 fun, const QVariant& err)
 void Shell::handleShimError(quint32 msgid, quint64 fun, const QVariant& err)
 {
 	qDebug() << "GUI shim error " << err;
+}
+
+void Shell::handleCmdlineShow(QVariantList content, int64_t pos, QString firstc,
+			QString prompt, int64_t indent, int64_t level)
+{
+	foreach(QVariant piece, content) {
+		qDebug() << piece.toList();
+	}
+	qDebug() << prompt << firstc;
 }
 
 } // Namespace

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -1431,16 +1431,25 @@ void Shell::openFiles(QList<QUrl> urls)
 void Shell::handleCmdlineShow(QVariantList content, int64_t pos, QString firstc,
 			QString prompt, int64_t indent, int64_t level)
 {
-	foreach(QVariant piece, content) {
-		qDebug() << piece.toList();
-	}
-	qDebug() << prompt << firstc;
 	auto anchor_x = 0;
-	auto anchor_y = 0;
+    auto anchor_y = (rows()-1)*cellSize().height();
 	auto cmdline_width = columns()*cellSize().width();
-	auto cmdline_height = (rows()-1)*cellSize().height();
+    // TODO : deduce a better height than taking everything below last grid row
+    auto cmdline_height = height() - anchor_y;
 	m_cmdline.setGeometry(anchor_x, anchor_y, cmdline_width, cmdline_height);
-	m_cmdline.updateGeometry();
+    m_cmdline.setFrameShape(QFrame::NoFrame);
+
+    // TODO : display more than just the first char and prompt
+    // We'll need to tamper with QDocument to handle highlight and stuff like
+    // that properly. Maybe with a m_cmdline.computeDocument(content) method ?
+    QString plaintext_content;
+    foreach(QVariant piece, content){
+        qDebug() << piece.toList();
+        plaintext_content += piece.toStringList().at(1);
+    }
+    qDebug() << prompt << firstc;
+    m_cmdline.setPlainText(firstc + prompt + plaintext_content);
+
 	m_cmdline.show();
 }
 

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -612,7 +612,6 @@ void Shell::handleRedraw(const QByteArray& name, const QVariantList& opargs)
 		qDebug() << name << c << shift << level;
         handleCmdlineSpecialChar(c, shift, level);
 	} else if (name == "cmdline_hide") {
-        // TODO : check the level in the command
         for (auto cmdline : m_cmdline_list) {
                 cmdline->hide();
         }

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -607,8 +607,7 @@ void Shell::handleRedraw(const QByteArray& name, const QVariantList& opargs)
 		int64_t level = opargs.at(2).toInt();
 		qDebug() << name << c << shift << level;
 	} else if (name == "cmdline_hide") {
-		qDebug() << name;
-		//handleCmdlineHide();
+        m_cmdline.hide();
 	} else if (name == "cmdline_block_show") {
 		if (opargs.size() < 1) {
 			qWarning() << "Unexpected argument for cmdline_block_show:" << opargs;
@@ -624,8 +623,7 @@ void Shell::handleRedraw(const QByteArray& name, const QVariantList& opargs)
 		qDebug() << "cmdline_block_append" << opargs;
 		// - line
 	} else if (name == "cmdline_block_hide") {
-		qDebug() << name;
-		//handleCmdlineBlockHide();
+        m_cmdline.hide();
 	} else {
 		qDebug() << "Received unknown redraw notification" << name << opargs;
 	}
@@ -894,13 +892,12 @@ void Shell::handleSetOption(const QString& name, const QVariant& value)
 		emit neovimExtTablineSet(value.toBool());
 	} else if (name == "ext_popupmenu") {
 		emit neovimExtPopupmenuSet(value.toBool());
-	// TODO
+    // TODO
 	} else if (name == "arabicshape") {
 	} else if (name == "ambiwidth") {
 	} else if (name == "emoji") {
 	} else if (name == "termguicolors") {
-	} else if (name == "ext_cmdline") {
-	} else if (name == "ext_wildmenu") {
+    } else if (name == "ext_wildmenu") {
 	} else {
 		qDebug() << "Received unknown option" << name << value;
 	}

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -1463,9 +1463,6 @@ void Shell::handleCmdlineBlockShow(QVariantList lines) {
 }
 
 void Shell::moveCmdBlockToLines() {
-        if (!m_cmdline_block->isVisible()) {
-                return;
-        }
         auto anchor_x = m_cmdline_widget->frameGeometry().left();
         auto anchor_y = m_cmdline_widget->frameGeometry().bottom();
         auto width = m_cmdline_widget->geometry().width();

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -1463,6 +1463,9 @@ void Shell::handleCmdlineBlockShow(QVariantList lines) {
 }
 
 void Shell::moveCmdBlockToLines() {
+        if (!m_cmdline_block->isVisible()) {
+                return;
+        }
         auto anchor_x = m_cmdline_widget->frameGeometry().left();
         auto anchor_y = m_cmdline_widget->frameGeometry().bottom();
         auto width = m_cmdline_widget->geometry().width();

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -49,6 +49,10 @@ Shell::Shell(NeovimConnector *nvim, ShellOptions opts, QWidget *parent)
 	m_pum.setParent(this);
 	m_pum.hide();
 
+	// Command line
+	m_cmdline.setParent(this);
+	m_cmdline.hide();
+
 	if (m_nvim == NULL) {
 		qWarning() << "Received NULL as Neovim Connector";
 		return;
@@ -865,6 +869,7 @@ void Shell::handleExtGuiOption(const QString& name, const QVariant& value)
 	} else if (name == "Popupmenu") {
 		m_nvim->api2()->nvim_ui_set_option("ext_popupmenu", value.toBool());
 	} else if (name == "Cmdline") {
+		m_nvim->api2()->nvim_ui_set_option("ext_cmdline", value.toBool());
 	} else if (name == "Wildmenu") {
 	} else {
 		qDebug() << "Unknown GUI Option" << name << value;
@@ -1426,6 +1431,22 @@ void Shell::openFiles(QList<QUrl> urls)
 	}
 }
 
+void Shell::handleCmdlineShow(QVariantList content, int64_t pos, QString firstc,
+			QString prompt, int64_t indent, int64_t level)
+{
+	foreach(QVariant piece, content) {
+		qDebug() << piece.toList();
+	}
+	qDebug() << prompt << firstc;
+	auto anchor_x = 0;
+	auto anchor_y = 0;
+	auto cmdline_width = columns()*cellSize().width();
+	auto cmdline_height = (rows()-1)*cellSize().height();
+	m_cmdline.setGeometry(anchor_x, anchor_y, cmdline_width, cmdline_height);
+	m_cmdline.updateGeometry();
+	m_cmdline.show();
+}
+
 // If neovim is blocked waiting for input, attempt to bailout from
 // whatever neovim is doing by pressing Ctrl-C.
 void Shell::bailoutIfinputBlocking()
@@ -1534,14 +1555,4 @@ void Shell::handleShimError(quint32 msgid, quint64 fun, const QVariant& err)
 {
 	qDebug() << "GUI shim error " << err;
 }
-
-void Shell::handleCmdlineShow(QVariantList content, int64_t pos, QString firstc,
-			QString prompt, int64_t indent, int64_t level)
-{
-	foreach(QVariant piece, content) {
-		qDebug() << piece.toList();
-	}
-	qDebug() << prompt << firstc;
-}
-
 } // Namespace

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -626,13 +626,8 @@ void Shell::handleRedraw(const QByteArray& name, const QVariantList& opargs)
 			qWarning() << "Unexpected argument for cmdline_block_show:" << opargs;
 			return;
 		}
-        foreach(QVariant line, opargs.at(0).toList()) {
-            qDebug() << line.toList() << "\n";
-            m_cmdline_block->append_block(line.toList());
-        }
-        // TODO : setGeometry for m_cmdline_block
-        m_cmdline_block->show();
                 qDebug() << "cmdline_block_show" << opargs;
+                handleCmdlineBlockShow(opargs.at(0).toList());
 	} else if (name == "cmdline_block_append") {
 		if (opargs.size() < 1) {
 			qWarning() << "Unexpected argument for cmdline_block_append:" << opargs;
@@ -1455,6 +1450,23 @@ void Shell::handleCmdlineShow(QVariantList content, int64_t pos, QString firstc,
     m_cmdline_widget->setPos(pos + 1, level);
     m_cmdline_widget->setGeometry2();
     m_cmdline_widget->show();
+}
+
+void Shell::handleCmdlineBlockShow(QVariantList lines) {
+        foreach (QVariant line, lines) {
+                qDebug() << line.toList() << "\n";
+                m_cmdline_block->append_block(line.toList());
+        }
+        auto anchor_x = m_cmdline_widget->frameGeometry().left();
+        auto anchor_y = m_cmdline_widget->frameGeometry().bottom();
+        auto width = m_cmdline_widget->geometry().width();
+        auto max_height = (rows() - m_cmdline_widget->lines()) * cellSize().height();
+        qDebug() << "New CmdBlock max height : " << max_height;
+        m_cmdline_block->move(anchor_x, anchor_y);
+        m_cmdline_block->setMinimumWidth(width);
+        m_cmdline_block->setMaximumHeight(max_height);
+        m_cmdline_block->show();
+        update();
 }
 
 void Shell::handleCmdlineSpecialChar(QString c, bool shift, int64_t level) {

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -14,6 +14,7 @@
 #include "shellwidget/shellwidget.h"
 #include "popupmenu.h"
 #include "popupmenumodel.h"
+#include "cmdwidget.h"
 
 namespace NeovimQt {
 
@@ -186,6 +187,7 @@ private:
 	ShellOptions m_options;
 	PopupMenu m_pum;
 	bool m_mouseEnabled;
+	CmdWidget m_cmdline;
 };
 
 class ShellRequestHandler: public QObject, public MsgpackRequestHandler

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -33,11 +33,13 @@ public:
 	ShellOptions() {
 		enable_ext_tabline = true;
 		enable_ext_popupmenu = true;
+		enable_ext_cmdline = true;
 		nvim_show_tabline = 1;
 	}
 	bool enable_ext_tabline;
 	int nvim_show_tabline;
 	bool enable_ext_popupmenu;
+	bool enable_ext_cmdline;
 };
 
 class Shell: public ShellWidget
@@ -133,6 +135,8 @@ protected:
 			int64_t row, int64_t col);
 	void handlePopupMenuSelect(int64_t selected);
 	virtual void handleMouse(bool);
+	virtual void handleCmdlineShow(QVariantList content, int64_t pos, QString firstc,
+			QString prompt, int64_t indent, int64_t level);
 
 	void neovimMouseEvent(QMouseEvent *ev);
 	virtual void mousePressEvent(QMouseEvent *ev) Q_DECL_OVERRIDE;

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -139,9 +139,9 @@ protected:
 			int64_t row, int64_t col);
 	void handlePopupMenuSelect(int64_t selected);
 	virtual void handleMouse(bool);
-	virtual void handleCmdlineShow(QVariantList content, int64_t pos, QString firstc,
-			QString prompt, int64_t indent, int64_t level);
-    virtual void handleCmdlineSpecialChar(QString c, bool shift, int64_t level);
+        virtual void handleCmdlineShow(QVariantList content, int64_t pos, QString firstc,
+                                       QString prompt, int64_t indent, int64_t level);
+        virtual void handleCmdlineSpecialChar(QString c, bool shift, int64_t level);
 
 	void neovimMouseEvent(QMouseEvent *ev);
 	virtual void mousePressEvent(QMouseEvent *ev) Q_DECL_OVERRIDE;

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -139,10 +139,12 @@ protected:
 			int64_t row, int64_t col);
 	void handlePopupMenuSelect(int64_t selected);
 	virtual void handleMouse(bool);
+
         virtual void handleCmdlineShow(QVariantList content, int64_t pos, QString firstc,
                                        QString prompt, int64_t indent, int64_t level);
         virtual void handleCmdlineSpecialChar(QString c, bool shift, int64_t level);
         virtual void handleCmdlineBlockShow(QVariantList lines);
+        void moveCmdBlockToLines();
 
 	void neovimMouseEvent(QMouseEvent *ev);
 	virtual void mousePressEvent(QMouseEvent *ev) Q_DECL_OVERRIDE;

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -16,6 +16,7 @@
 #include "popupmenu.h"
 #include "popupmenumodel.h"
 #include "cmdwidget.h"
+#include "cmdblock.h"
 
 namespace NeovimQt {
 
@@ -189,8 +190,8 @@ private:
 	ShellOptions m_options;
 	PopupMenu m_pum;
 	bool m_mouseEnabled;
-    std::vector<CmdWidget*> m_cmdline_list;
-    CmdWidget *m_cmdline_block{nullptr};
+	CmdWidget *m_cmdline_widget{nullptr};
+	CmdBlock *m_cmdline_block{nullptr};
 };
 
 class ShellRequestHandler: public QObject, public MsgpackRequestHandler

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -69,6 +69,7 @@ signals:
 	void neovimGuiCloseRequest();
 	/// This signal is emmited if the running neovim version is unsupported by the GUI
 	void neovimIsUnsupported();
+	void neovimExtCmdlineSet(bool);
 	void neovimExtTablineSet(bool);
 	void neovimExtPopupmenuSet(bool);
 	/// The tabline needs updating. curtab is the handle of the current tab (not its index)

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -10,6 +10,7 @@
 #include <QUrl>
 #include <QList>
 #include <QMenu>
+#include <vector>
 #include "neovimconnector.h"
 #include "shellwidget/shellwidget.h"
 #include "popupmenu.h"
@@ -139,6 +140,7 @@ protected:
 	virtual void handleMouse(bool);
 	virtual void handleCmdlineShow(QVariantList content, int64_t pos, QString firstc,
 			QString prompt, int64_t indent, int64_t level);
+    virtual void handleCmdlineSpecialChar(QString c, bool shift, int64_t level);
 
 	void neovimMouseEvent(QMouseEvent *ev);
 	virtual void mousePressEvent(QMouseEvent *ev) Q_DECL_OVERRIDE;
@@ -187,7 +189,7 @@ private:
 	ShellOptions m_options;
 	PopupMenu m_pum;
 	bool m_mouseEnabled;
-	CmdWidget m_cmdline;
+    std::vector<CmdWidget*> m_cmdline_list;
 };
 
 class ShellRequestHandler: public QObject, public MsgpackRequestHandler

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -142,6 +142,7 @@ protected:
         virtual void handleCmdlineShow(QVariantList content, int64_t pos, QString firstc,
                                        QString prompt, int64_t indent, int64_t level);
         virtual void handleCmdlineSpecialChar(QString c, bool shift, int64_t level);
+        virtual void handleCmdlineBlockShow(QVariantList lines);
 
 	void neovimMouseEvent(QMouseEvent *ev);
 	virtual void mousePressEvent(QMouseEvent *ev) Q_DECL_OVERRIDE;

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -190,6 +190,7 @@ private:
 	PopupMenu m_pum;
 	bool m_mouseEnabled;
     std::vector<CmdWidget*> m_cmdline_list;
+    CmdWidget *m_cmdline_block{nullptr};
 };
 
 class ShellRequestHandler: public QObject, public MsgpackRequestHandler

--- a/test/runtime/colors/default.vim
+++ b/test/runtime/colors/default.vim
@@ -1,0 +1,23 @@
+" Vim color file
+" Maintainer:	Bram Moolenaar <Bram@vim.org>
+" Last Change:	2001 Jul 23
+
+" This is the default color scheme.  It doesn't define the Normal
+" highlighting, it uses whatever the colors used to be.
+
+" Set 'background' back to the default.  The value can't always be estimated
+" and is then guessed.
+hi clear Normal
+set bg&
+
+" Remove all existing highlighting and set the defaults.
+hi clear
+
+" Load the syntax highlighting defaults, if it's enabled.
+if exists("syntax_on")
+  syntax reset
+endif
+
+let colors_name = "default"
+
+" vim: sw=2

--- a/test/runtime/colors/desert.vim
+++ b/test/runtime/colors/desert.vim
@@ -1,0 +1,106 @@
+" Vim color file
+" Maintainer:	Hans Fugal <hans@fugal.net>
+" Last Change:	$Date: 2004/06/13 19:30:30 $
+" Last Change:	$Date: 2004/06/13 19:30:30 $
+" URL:		http://hans.fugal.net/vim/colors/desert.vim
+" Version:	$Id: desert.vim,v 1.1 2004/06/13 19:30:30 vimboss Exp $
+
+" cool help screens
+" :he group-name
+" :he highlight-groups
+" :he cterm-colors
+
+set background=dark
+if version > 580
+    " no guarantees for version 5.8 and below, but this makes it stop
+    " complaining
+    hi clear
+    if exists("syntax_on")
+	syntax reset
+    endif
+endif
+let g:colors_name="desert"
+
+hi Normal	guifg=White guibg=grey20
+
+" highlight groups
+hi Cursor	guibg=khaki guifg=slategrey
+"hi CursorIM
+"hi Directory
+"hi DiffAdd
+"hi DiffChange
+"hi DiffDelete
+"hi DiffText
+"hi ErrorMsg
+hi VertSplit	guibg=#c2bfa5 guifg=grey50 gui=none
+hi Folded	guibg=grey30 guifg=gold
+hi FoldColumn	guibg=grey30 guifg=tan
+hi IncSearch	guifg=slategrey guibg=khaki
+"hi LineNr
+hi ModeMsg	guifg=goldenrod
+hi MoreMsg	guifg=SeaGreen
+hi NonText	guifg=LightBlue guibg=grey30
+hi Question	guifg=springgreen
+hi Search	guibg=peru guifg=wheat
+hi SpecialKey	guifg=yellowgreen
+hi StatusLine	guibg=#c2bfa5 guifg=black gui=none
+hi StatusLineNC	guibg=#c2bfa5 guifg=grey50 gui=none
+hi Title	guifg=indianred
+hi Visual	gui=none guifg=khaki guibg=olivedrab
+hi WarningMsg	guifg=salmon
+"hi WildMenu
+"hi Menu
+"hi Scrollbar
+"hi Tooltip
+
+" syntax highlighting groups
+hi Comment	guifg=SkyBlue
+hi Constant	guifg=#ffa0a0
+hi Identifier	guifg=palegreen
+hi Statement	guifg=khaki
+hi PreProc	guifg=indianred
+hi Type		guifg=darkkhaki
+hi Special	guifg=navajowhite
+"hi Underlined
+hi Ignore	guifg=grey40
+"hi Error
+hi Todo		guifg=orangered guibg=yellow2
+
+" color terminal definitions
+hi SpecialKey	ctermfg=darkgreen
+hi NonText	cterm=bold ctermfg=darkblue
+hi Directory	ctermfg=darkcyan
+hi ErrorMsg	cterm=bold ctermfg=7 ctermbg=1
+hi IncSearch	cterm=NONE ctermfg=yellow ctermbg=green
+hi Search	cterm=NONE ctermfg=grey ctermbg=blue
+hi MoreMsg	ctermfg=darkgreen
+hi ModeMsg	cterm=NONE ctermfg=brown
+hi LineNr	ctermfg=3
+hi Question	ctermfg=green
+hi StatusLine	cterm=bold,reverse
+hi StatusLineNC cterm=reverse
+hi VertSplit	cterm=reverse
+hi Title	ctermfg=5
+hi Visual	cterm=reverse
+hi WarningMsg	ctermfg=1
+hi WildMenu	ctermfg=0 ctermbg=3
+hi Folded	ctermfg=darkgrey ctermbg=NONE
+hi FoldColumn	ctermfg=darkgrey ctermbg=NONE
+hi DiffAdd	ctermbg=4
+hi DiffChange	ctermbg=5
+hi DiffDelete	cterm=bold ctermfg=4 ctermbg=6
+hi DiffText	cterm=bold ctermbg=1
+hi Comment	ctermfg=darkcyan
+hi Constant	ctermfg=brown
+hi Special	ctermfg=5
+hi Identifier	ctermfg=6
+hi Statement	ctermfg=3
+hi PreProc	ctermfg=5
+hi Type		ctermfg=2
+hi Underlined	cterm=underline ctermfg=5
+hi Ignore	cterm=bold ctermfg=7
+hi Ignore	ctermfg=darkgrey
+hi Error	cterm=bold ctermfg=7 ctermbg=1
+
+
+"vim: sw=4

--- a/test/runtime/colors/elflord.vim
+++ b/test/runtime/colors/elflord.vim
@@ -1,0 +1,50 @@
+" local syntax file - set colors on a per-machine basis:
+" vim: tw=0 ts=4 sw=4
+" Vim color file
+" Maintainer:	Ron Aaron <ron@ronware.org>
+" Last Change:	2003 May 02
+
+set background=dark
+hi clear
+if exists("syntax_on")
+  syntax reset
+endif
+let g:colors_name = "elflord"
+hi Normal		guifg=cyan			guibg=black
+hi Comment	term=bold		ctermfg=DarkCyan		guifg=#80a0ff
+hi Constant	term=underline	ctermfg=Magenta		guifg=Magenta
+hi Special	term=bold		ctermfg=DarkMagenta	guifg=Red
+hi Identifier term=underline	cterm=bold			ctermfg=Cyan guifg=#40ffff
+hi Statement term=bold		ctermfg=Yellow gui=bold	guifg=#aa4444
+hi PreProc	term=underline	ctermfg=LightBlue	guifg=#ff80ff
+hi Type	term=underline		ctermfg=LightGreen	guifg=#60ff60 gui=bold
+hi Function	term=bold		ctermfg=White guifg=White
+hi Repeat	term=underline	ctermfg=White		guifg=white
+hi Operator				ctermfg=Red			guifg=Red
+hi Ignore				ctermfg=black		guifg=bg
+hi Error	term=reverse ctermbg=Red ctermfg=White guibg=Red guifg=White
+hi Todo	term=standout ctermbg=Yellow ctermfg=Black guifg=Blue guibg=Yellow
+
+" Common groups that link to default highlighting.
+" You can specify other highlighting easily.
+hi link String	Constant
+hi link Character	Constant
+hi link Number	Constant
+hi link Boolean	Constant
+hi link Float		Number
+hi link Conditional	Repeat
+hi link Label		Statement
+hi link Keyword	Statement
+hi link Exception	Statement
+hi link Include	PreProc
+hi link Define	PreProc
+hi link Macro		PreProc
+hi link PreCondit	PreProc
+hi link StorageClass	Type
+hi link Structure	Type
+hi link Typedef	Type
+hi link Tag		Special
+hi link SpecialChar	Special
+hi link Delimiter	Special
+hi link SpecialComment Special
+hi link Debug		Special

--- a/test/runtime/colors/evening.vim
+++ b/test/runtime/colors/evening.vim
@@ -1,0 +1,55 @@
+" Vim color file
+" Maintainer:	Bram Moolenaar <Bram@vim.org>
+" Last Change:	2016 Oct 10
+
+" This color scheme uses a dark grey background.
+
+" First remove all existing highlighting.
+set background=dark
+hi clear
+if exists("syntax_on")
+  syntax reset
+endif
+
+let colors_name = "evening"
+
+hi Normal ctermbg=DarkGrey ctermfg=White guifg=White guibg=grey20
+
+" Groups used in the 'highlight' and 'guicursor' options default value.
+hi ErrorMsg term=standout ctermbg=DarkRed ctermfg=White guibg=Red guifg=White
+hi IncSearch term=reverse cterm=reverse gui=reverse
+hi ModeMsg term=bold cterm=bold gui=bold
+hi StatusLine term=reverse,bold cterm=reverse,bold gui=reverse,bold
+hi StatusLineNC term=reverse cterm=reverse gui=reverse
+hi VertSplit term=reverse cterm=reverse gui=reverse
+hi Visual term=reverse ctermbg=black guibg=grey60
+hi DiffText term=reverse cterm=bold ctermbg=Red gui=bold guibg=Red
+hi Cursor guibg=Green guifg=Black
+hi lCursor guibg=Cyan guifg=Black
+hi Directory term=bold ctermfg=LightCyan guifg=Cyan
+hi LineNr term=underline ctermfg=Yellow guifg=Yellow
+hi MoreMsg term=bold ctermfg=LightGreen gui=bold guifg=SeaGreen
+hi NonText term=bold ctermfg=LightBlue gui=bold guifg=LightBlue guibg=grey30
+hi Question term=standout ctermfg=LightGreen gui=bold guifg=Green
+hi Search term=reverse ctermbg=Yellow ctermfg=Black guibg=Yellow guifg=Black
+hi SpecialKey term=bold ctermfg=LightBlue guifg=Cyan
+hi Title term=bold ctermfg=LightMagenta gui=bold guifg=Magenta
+hi WarningMsg term=standout ctermfg=LightRed guifg=Red
+hi WildMenu term=standout ctermbg=Yellow ctermfg=Black guibg=Yellow guifg=Black
+hi Folded term=standout ctermbg=LightGrey ctermfg=DarkBlue guibg=LightGrey guifg=DarkBlue
+hi FoldColumn term=standout ctermbg=LightGrey ctermfg=DarkBlue guibg=Grey guifg=DarkBlue
+hi DiffAdd term=bold ctermbg=DarkBlue guibg=DarkBlue
+hi DiffChange term=bold ctermbg=DarkMagenta guibg=DarkMagenta
+hi DiffDelete term=bold ctermfg=Blue ctermbg=DarkCyan gui=bold guifg=Blue guibg=DarkCyan
+hi CursorColumn term=reverse ctermbg=Black guibg=grey40
+hi CursorLine term=underline cterm=underline guibg=grey40
+
+" Groups for syntax highlighting
+hi Constant term=underline ctermfg=Magenta guifg=#ffa0a0
+hi Special term=bold ctermfg=LightRed guifg=Orange
+if &t_Co > 8
+  hi Statement term=bold cterm=bold ctermfg=Yellow guifg=#ffff60 gui=bold
+endif
+hi Ignore ctermfg=DarkGrey guifg=grey20
+
+" vim: sw=2

--- a/test/runtime/syntax/syncolor.vim
+++ b/test/runtime/syntax/syncolor.vim
@@ -1,0 +1,85 @@
+" Vim syntax support file
+" Maintainer:	Bram Moolenaar <Bram@vim.org>
+" Last Change:	2001 Sep 12
+
+" This file sets up the default methods for highlighting.
+" It is loaded from "synload.vim" and from Vim for ":syntax reset".
+" Also used from init_highlight().
+
+if !exists("syntax_cmd") || syntax_cmd == "on"
+  " ":syntax on" works like in Vim 5.7: set colors but keep links
+  command -nargs=* SynColor hi <args>
+  command -nargs=* SynLink hi link <args>
+else
+  if syntax_cmd == "enable"
+    " ":syntax enable" keeps any existing colors
+    command -nargs=* SynColor hi def <args>
+    command -nargs=* SynLink hi def link <args>
+  elseif syntax_cmd == "reset"
+    " ":syntax reset" resets all colors to the default
+    command -nargs=* SynColor hi <args>
+    command -nargs=* SynLink hi! link <args>
+  else
+    " User defined syncolor file has already set the colors.
+    finish
+  endif
+endif
+
+" Many terminals can only use six different colors (plus black and white).
+" Therefore the number of colors used is kept low. It doesn't look nice with
+" too many colors anyway.
+" Careful with "cterm=bold", it changes the color to bright for some terminals.
+" There are two sets of defaults: for a dark and a light background.
+if &background == "dark"
+  SynColor Comment	term=bold cterm=NONE ctermfg=Cyan ctermbg=NONE gui=NONE guifg=#80a0ff guibg=NONE
+  SynColor Constant	term=underline cterm=NONE ctermfg=Magenta ctermbg=NONE gui=NONE guifg=#ffa0a0 guibg=NONE
+  SynColor Special	term=bold cterm=NONE ctermfg=LightRed ctermbg=NONE gui=NONE guifg=Orange guibg=NONE
+  SynColor Identifier	term=underline cterm=bold ctermfg=Cyan ctermbg=NONE gui=NONE guifg=#40ffff guibg=NONE
+  SynColor Statement	term=bold cterm=NONE ctermfg=Yellow ctermbg=NONE gui=bold guifg=#ffff60 guibg=NONE
+  SynColor PreProc	term=underline cterm=NONE ctermfg=LightBlue ctermbg=NONE gui=NONE guifg=#ff80ff guibg=NONE
+  SynColor Type		term=underline cterm=NONE ctermfg=LightGreen ctermbg=NONE gui=bold guifg=#60ff60 guibg=NONE
+  SynColor Underlined	term=underline cterm=underline ctermfg=LightBlue gui=underline guifg=#80a0ff
+  SynColor Ignore	term=NONE cterm=NONE ctermfg=black ctermbg=NONE gui=NONE guifg=bg guibg=NONE
+else
+  SynColor Comment	term=bold cterm=NONE ctermfg=DarkBlue ctermbg=NONE gui=NONE guifg=Blue guibg=NONE
+  SynColor Constant	term=underline cterm=NONE ctermfg=DarkRed ctermbg=NONE gui=NONE guifg=Magenta guibg=NONE
+  SynColor Special	term=bold cterm=NONE ctermfg=DarkMagenta ctermbg=NONE gui=NONE guifg=SlateBlue guibg=NONE
+  SynColor Identifier	term=underline cterm=NONE ctermfg=DarkCyan ctermbg=NONE gui=NONE guifg=DarkCyan guibg=NONE
+  SynColor Statement	term=bold cterm=NONE ctermfg=Brown ctermbg=NONE gui=bold guifg=Brown guibg=NONE
+  SynColor PreProc	term=underline cterm=NONE ctermfg=DarkMagenta ctermbg=NONE gui=NONE guifg=Purple guibg=NONE
+  SynColor Type		term=underline cterm=NONE ctermfg=DarkGreen ctermbg=NONE gui=bold guifg=SeaGreen guibg=NONE
+  SynColor Underlined	term=underline cterm=underline ctermfg=DarkMagenta gui=underline guifg=SlateBlue
+  SynColor Ignore	term=NONE cterm=NONE ctermfg=white ctermbg=NONE gui=NONE guifg=bg guibg=NONE
+endif
+SynColor Error		term=reverse cterm=NONE ctermfg=White ctermbg=Red gui=NONE guifg=White guibg=Red
+SynColor Todo		term=standout cterm=NONE ctermfg=Black ctermbg=Yellow gui=NONE guifg=Blue guibg=Yellow
+
+" Common groups that link to default highlighting.
+" You can specify other highlighting easily.
+SynLink String		Constant
+SynLink Character	Constant
+SynLink Number		Constant
+SynLink Boolean		Constant
+SynLink Float		Number
+SynLink Function	Identifier
+SynLink Conditional	Statement
+SynLink Repeat		Statement
+SynLink Label		Statement
+SynLink Operator	Statement
+SynLink Keyword		Statement
+SynLink Exception	Statement
+SynLink Include		PreProc
+SynLink Define		PreProc
+SynLink Macro		PreProc
+SynLink PreCondit	PreProc
+SynLink StorageClass	Type
+SynLink Structure	Type
+SynLink Typedef		Type
+SynLink Tag		Special
+SynLink SpecialChar	Special
+SynLink Delimiter	Special
+SynLink SpecialComment	Special
+SynLink Debug		Special
+
+delcommand SynColor
+delcommand SynLink

--- a/test/runtime/syntax/synload.vim
+++ b/test/runtime/syntax/synload.vim
@@ -1,0 +1,81 @@
+" Vim syntax support file
+" Maintainer:	Bram Moolenaar <Bram@vim.org>
+" Last Change:	2016 Nov 04
+
+" This file sets up for syntax highlighting.
+" It is loaded from "syntax.vim" and "manual.vim".
+" 1. Set the default highlight groups.
+" 2. Install Syntax autocommands for all the available syntax files.
+
+if !has("syntax")
+  finish
+endif
+
+" let others know that syntax has been switched on
+let syntax_on = 1
+
+" Set the default highlighting colors.  Use a color scheme if specified.
+if exists("colors_name")
+  exe "colors " . colors_name
+else
+  runtime! syntax/syncolor.vim
+endif
+
+" Line continuation is used here, remove 'C' from 'cpoptions'
+let s:cpo_save = &cpo
+set cpo&vim
+
+" First remove all old syntax autocommands.
+au! Syntax
+
+au Syntax *		call s:SynSet()
+
+fun! s:SynSet()
+  " clear syntax for :set syntax=OFF  and any syntax name that doesn't exist
+  syn clear
+  if exists("b:current_syntax")
+    unlet b:current_syntax
+  endif
+
+  let s = expand("<amatch>")
+  if s == "ON"
+    " :set syntax=ON
+    if &filetype == ""
+      echohl ErrorMsg
+      echo "filetype unknown"
+      echohl None
+    endif
+    let s = &filetype
+  elseif s == "OFF"
+    let s = ""
+  endif
+
+  if s != ""
+    " Load the syntax file(s).  When there are several, separated by dots,
+    " load each in sequence.
+    for name in split(s, '\.')
+      exe "runtime! syntax/" . name . ".vim syntax/" . name . "/*.vim"
+    endfor
+  endif
+endfun
+
+
+" Handle adding doxygen to other languages (C, C++, C#, IDL, java, php, DataScript)
+au Syntax c,cpp,cs,idl,java,php,datascript
+	\ if (exists('b:load_doxygen_syntax') && b:load_doxygen_syntax)
+	\	|| (exists('g:load_doxygen_syntax') && g:load_doxygen_syntax)
+	\   | runtime! syntax/doxygen.vim
+	\ | endif
+
+
+" Source the user-specified syntax highlighting file
+if exists("mysyntaxfile")
+  let s:fname = expand(mysyntaxfile)
+  if filereadable(s:fname)
+    execute "source " . fnameescape(s:fname)
+  endif
+endif
+
+" Restore 'cpoptions'
+let &cpo = s:cpo_save
+unlet s:cpo_save

--- a/test/tst_shell.cpp
+++ b/test/tst_shell.cpp
@@ -104,9 +104,35 @@ private slots:
 		QVERIFY(SPYWAIT(onOptionSet));
 	}
 
-	void guiExtCmdlineScreenshot() {
+        void guiExtCmdlineScreenshot_data() {
+                // Colorscheme command
+		QTest::addColumn<QString>("colorscheme_command");
+                // Name of the screenshot
+		QTest::addColumn<QString>("screenshot_name");
+
+		QTest::newRow("Default")
+			<< ":colorscheme default"
+                        << "tst_shell_cmdline_default.png";
+		QTest::newRow("Desert")
+			<< ":colorscheme desert"
+                        << "tst_shell_cmdline_desert.png";
+		QTest::newRow("Elflord")
+			<< ":colorscheme elflord"
+                        << "tst_shell_cmdline_elflord.png";
+		QTest::newRow("Evening")
+			<< ":colorscheme evening"
+                        << "tst_shell_cmdline_evening.png";
+
+        }
+
+        // Test that simulates typing to showcase ext_cmdline in different highlights
+        void guiExtCmdlineScreenshot() {
+		QFETCH(QString, colorscheme_command);
+		QFETCH(QString, screenshot_name);
+
 		QStringList args;
-		args << "-u" << "NONE";
+		args << "-u" << "NONE" << "--cmd"
+                     << "set rtp=" + QString(CMAKE_SOURCE_DIR).append("/").append("test/runtime");
 		NeovimConnector *c = NeovimConnector::spawn(args);
 		Shell *s = new Shell(c, ShellOptions());
 
@@ -117,6 +143,10 @@ private slots:
 
 		// The delay is to let nvim time to process the calls.
 		// the 20 ms delay is 3.3 ms more than 60 fps.
+		QTest::keyClicks(s, ":syntax on");
+		QTest::keyClick(s, Qt::Key_Enter, Qt::NoModifier, 20);
+		QTest::keyClicks(s, colorscheme_command);
+		QTest::keyClick(s, Qt::Key_Enter, Qt::NoModifier, 20);
 		QTest::keyClicks(s, "iThis should appear in screenshot because it is a long line now that you think about it");
 		QTest::keyClick(s, Qt::Key_Escape, Qt::NoModifier, 20);
 		QTest::keyClicks(s, ":function Test()");
@@ -135,7 +165,7 @@ private slots:
 
 		s->repaint();
 		auto p = s->grab();
-		p.save("tst_shell_cmdline.png");
+		p.save(screenshot_name);
 	}
 
 	void gviminit() {

--- a/test/tst_shell.cpp
+++ b/test/tst_shell.cpp
@@ -104,6 +104,40 @@ private slots:
 		QVERIFY(SPYWAIT(onOptionSet));
 	}
 
+	void guiExtCmdlineScreenshot() {
+		QStringList args;
+		args << "-u" << "NONE";
+		NeovimConnector *c = NeovimConnector::spawn(args);
+		Shell *s = new Shell(c, ShellOptions());
+
+		QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
+		QVERIFY(onAttached.isValid());
+		QVERIFY(SPYWAIT(onAttached));
+		QVERIFY(s->neovimAttached());
+
+		// The delay is to let nvim time to process the calls.
+		// the 20 ms delay is 3.3 ms more than 60 fps.
+		QTest::keyClicks(s, "iThis should appear in screenshot because it is a long line now that you think about it");
+		QTest::keyClick(s, Qt::Key_Escape, Qt::NoModifier, 20);
+		QTest::keyClicks(s, ":function Test()");
+		QTest::keyClick(s, Qt::Key_Enter, Qt::NoModifier, 20);
+		QTest::keyClicks(s, "if !has('nvim')");
+		QTest::keyClick(s, Qt::Key_Enter, Qt::NoModifier, 20);
+		QTest::keyClicks(s, "finish");
+		QTest::keyClick(s, Qt::Key_Enter, Qt::NoModifier, 20);
+		QTest::keyClicks(s, "endif");
+		QTest::keyClick(s, Qt::Key_Enter, Qt::NoModifier, 20);
+		QTest::keyClicks(s, "let l:indent = 1");
+		QTest::keyClick(s, Qt::Key_Enter, Qt::NoModifier, 20);
+		QTest::keyClicks(s, "Here I type ^R=");
+		QTest::keyClick(s, 'r', Qt::ControlModifier, 20);
+		QTest::keyClicks(s, "=strftime('%H')", Qt::NoModifier, 20);
+
+		s->repaint();
+		auto p = s->grab();
+		p.save("tst_shell_cmdline.png");
+	}
+
 	void gviminit() {
 		qputenv("GVIMINIT", "let g:test_gviminit = 1");
 		QStringList args;

--- a/test/tst_shell.cpp
+++ b/test/tst_shell.cpp
@@ -164,7 +164,7 @@ private slots:
 		QTest::keyClicks(s, "=strftime('%H')", Qt::NoModifier, 20);
 
 		s->repaint();
-		auto p = s->grab();
+		auto p = s->grab(s->frameGeometry());
 		p.save(screenshot_name);
 	}
 

--- a/test/tst_shell.cpp
+++ b/test/tst_shell.cpp
@@ -94,6 +94,16 @@ private slots:
 		QVERIFY(SPYWAIT(onOptionSet));
 	}
 
+	void guiExtCmdlineSet() {
+		QStringList args;
+		args << "-u" << "NORC";
+		NeovimConnector *c = NeovimConnector::spawn(args);
+		Shell *s = new Shell(c, ShellOptions());
+		QSignalSpy onOptionSet(s, &Shell::neovimExtCmdlineSet);
+		QVERIFY(onOptionSet.isValid());
+		QVERIFY(SPYWAIT(onOptionSet));
+	}
+
 	void gviminit() {
 		qputenv("GVIMINIT", "let g:test_gviminit = 1");
 		QStringList args;

--- a/test/tst_shell.cpp
+++ b/test/tst_shell.cpp
@@ -96,7 +96,7 @@ private slots:
 
 	void guiExtCmdlineSet() {
 		QStringList args;
-		args << "-u" << "NORC";
+		args << "-u" << "NONE";
 		NeovimConnector *c = NeovimConnector::spawn(args);
 		Shell *s = new Shell(c, ShellOptions());
 		QSignalSpy onOptionSet(s, &Shell::neovimExtCmdlineSet);


### PR DESCRIPTION
This is also a RFC since I'm still pretty unsure about the way to go with this.

## Summary
- [x] cmdline_show
    - [x] "functionnal"
    - [x] complete
- [x] cmdline_special_char
    - [x] "functionnal"
    - [x] complete
- [x] cmdline_hide
    - [x] "functionnal"
    - [x] complete
- [x] cmdline_block_show
    - [x] "functionnal"
    - [x] complete
- [x] cmdline_block_append
    - [x] "functionnal"
    - [x] complete
- [x] cmdline_block_hide
    - [x] "functionnal"
    - [x] complete

## Result
We want `ext_cmdline` to be fully respected

## How
The externalized command line is currently implemented as a `CmdWidget`, a list of which is owned by the main `ShellWidget`. There is one `CmdWidget` per `level` of cmdline as described in `:h ui-cmdline`

## Progress

### cmdline_show
- The content is shown, but only as plain text
- Levels are handled by assuming cmdlines are only one-liners and not block (which is obviously going to be a problem later). See how `anchor_y` is computed in `Shell::handleCmdlineShow()`
- Tests should be added to test the correct handling of `firstc`, `prompt` and how `pos` is affected
- I can't find how to make the cursor visible yet, which is pretty sad.

### cmdline_special_char
- This works as expected, but it probably needs to get a special Rich Text treatment for clarity

### cmdline_hide
- Currently hides all cmdlines found in the Cmdline list member of `Shell`.
- Since there is no `level` argument yet, this is probably the good behaviour.

### cmdline_block_show
Unimplemented.

I think using the Paragraphs/Blocks features of the underlying QTextDocument should be really helpful there. Basically this would mean using [QTextEdit::append(QString)](http://doc.qt.io/qt-5/qtextedit.html#append) method to handle each line of the cmdline_block

### cmdline_block_append
Unimplemented.

This one is clearly for [QTextEdit::append(QString)](http://doc.qt.io/qt-5/qtextedit.html#append), at least in this starting implementation of CmdWidget

### cmdline_block_hide
Unimplemented.

This will probably just be the same `QWidget::hide()` function as in `cmdline_hide`
