### PR TITLE
Prevent TreeView from changing cwd on connect()

### DIFF
--- a/src/gui/treeview.cpp
+++ b/src/gui/treeview.cpp
@@ -28,8 +28,6 @@ TreeView::TreeView(NeovimConnector *nvim, QWidget *parent)
 }
 
 void TreeView::connector_ready_cb() {
-	setDirectory(QStandardPaths::writableLocation(QStandardPaths::HomeLocation));
-
 	connect(this, &TreeView::doubleClicked, this, &TreeView::open);
 
 	connect(m_nvim->neovimObject(), &NeovimApi1::neovimNotification, this,


### PR DESCRIPTION
Starting `nvim-qt` from a terminal will still change the current working directory to `$HOME` because of this line. I think this is the red line TreeView should not cross to not be invasive.

I thought it was an innocent change at first and let it this way from the former PR, but this is actually quite unintuitive now that I use it a little more