### PR TITLE
Fix issue that popup menu was not displayed

### DIFF
--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -502,7 +502,8 @@ void Shell::handleRedraw(const QByteArray& name, const QVariantList& opargs)
 			emit neovimSuspend();
 		}
 	} else if (name == "popupmenu_show") {
-		if (opargs.size() != 4
+		if (!(opargs.size() == 4
+          || (opargs.size() == 5 && opargs.at(4).canConvert<qint64>()))
 				|| !opargs.at(1).canConvert<qint64>()
 				|| !opargs.at(2).canConvert<qint64>()
 				|| !opargs.at(3).canConvert<qint64>()) {

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -502,8 +502,10 @@ void Shell::handleRedraw(const QByteArray& name, const QVariantList& opargs)
 			emit neovimSuspend();
 		}
 	} else if (name == "popupmenu_show") {
-		if (!(opargs.size() == 4
-          || (opargs.size() == 5 && opargs.at(4).canConvert<qint64>()))
+    // The 5th argument was added to popupmenu_show in neovim/neovim@16c3337.
+    // Since neovim-qt does not use this argument, it checks that the argument
+    // is 4 or more.
+    if (opargs.size() < 4
 				|| !opargs.at(1).canConvert<qint64>()
 				|| !opargs.at(2).canConvert<qint64>()
 				|| !opargs.at(3).canConvert<qint64>()) {


### PR DESCRIPTION
Fix a problem that the popup menu did not display because the argument of
`popupmenu_show` was changed by https://github.com/neovim/neovim/commit/16c3337122955c1e18c5ff69dcb14b61c43c4ac0.