### PR TITLE
Fix #499

### DIFF
--- a/src/gui/shellwidget/shellwidget.cpp
+++ b/src/gui/shellwidget/shellwidget.cpp
@@ -114,7 +114,7 @@ void ShellWidget::paintEvent(QPaintEvent *ev)
 			end_col = m_contents.columns();
 		}
 		if (end_row > m_contents.rows()) {
-			end_col = m_contents.columns();
+			end_row = m_contents.rows();
 		}
 
 		// end_col/row is inclusive


### PR DESCRIPTION
In the shellwidget the paint event rounds down the row/column to comply
to the actual shell dimensions. Turns out the statment that handles the
rows is actually readjusting the columns - this has two potential
consequences

1. we could be painting wrong data below the last row
2. we could be painting areas (columns) that do not need painting

I was unable to reproduce cases of 1. It should be noted that because
the widget always resizes the shell when a resize occurs, the difference
between the last row/column would always be fractional.

----

One instance of 2. would be a vertical resize that would cause other areas of the widget to be repainted without need. I cant think a concrete case though.