### PR TITLE
The implementation of adaptive colorscheme and font for GUI.

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -124,27 +124,28 @@ void MainWindow::updateStyle()
 
     m_palette.setColor(QPalette::Window, bg_color);
     m_palette.setColor(QPalette::WindowText, fg_color);
-    m_palette.setColor(QPalette::Disabled, QPalette::WindowText, QColor(127, 127, 127));//Disable default color
+    m_palette.setColor(QPalette::Disabled, QPalette::WindowText, Qt::white);
 
     m_palette.setColor(QPalette::Base, bg_color);
     m_palette.setColor(QPalette::AlternateBase, fg_color);
     m_palette.setColor(QPalette::Text, fg_color);
-    m_palette.setColor(QPalette::Disabled, QPalette::Text, QColor(127, 127, 127)); //Disable default color
+    m_palette.setColor(QPalette::Disabled, QPalette::Text, Qt::white); 
 
 	m_palette.setColor(QPalette::Highlight, fg_color);
-	m_palette.setColor(QPalette::Disabled, QPalette::Highlight, QColor(80, 80, 80)); //Disable default color
+	m_palette.setColor(QPalette::Disabled, QPalette::Highlight, Qt::white);
 	m_palette.setColor(QPalette::HighlightedText, bg_color);
-	m_palette.setColor(QPalette::Disabled, QPalette::HighlightedText, QColor(127, 127, 127)); //Disable default color
+	m_palette.setColor(QPalette::Disabled, QPalette::HighlightedText, Qt::black);
 
     m_palette.setColor(QPalette::ToolTipBase, bg_color);
     m_palette.setColor(QPalette::ToolTipText, fg_color);
 
 	m_palette.setColor(QPalette::Button, bg_color);
 	m_palette.setColor(QPalette::ButtonText, fg_color);
-    m_palette.setColor(QPalette::Disabled, QPalette::ButtonText, QColor(127, 127, 127)); //Disable default
+    m_palette.setColor(QPalette::Disabled, QPalette::ButtonText, Qt::white); 
 
-    m_palette.setColor(QPalette::BrightText, Qt::red); //defualt 
-    m_palette.setColor(QPalette::Link, QColor(42, 130, 218)); //default
+    m_palette.setColor(QPalette::BrightText, Qt::red); //defualt qt color
+    m_palette.setColor(QPalette::Link, Qt::blue); //default qt color
+    m_palette.setColor(QPalette::LinkVisited, Qt::magenta); //default qt color
 
     m_palette.setColor(QPalette::Dark, QColor(34, 34, 34));
     m_palette.setColor(QPalette::Shadow, QColor(21, 21, 21));

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -32,6 +32,9 @@ void MainWindow::init(NeovimConnector *c)
 		m_nvim->deleteLater();
 	}
 
+	m_last_fg_color = Qt::white;
+	m_last_bg_color = Qt::black;
+
 	m_tabline_bar = addToolBar("tabline");
 	m_tabline_bar->setObjectName("tabline");
 	m_tabline_bar->setAllowedAreas(Qt::TopToolBarArea);
@@ -105,32 +108,47 @@ void MainWindow::init(NeovimConnector *c)
 void MainWindow::updateStyle()
 {
 
-    //    //palette = m_tree->palette();
+
     auto bg_color = m_shell->getBackground();
     auto fg_color = m_shell->getForeground();
 
-    m_palette.setColor(QPalette::Window, /*QColor(53, 53, 53)*//*m_shell->getBackground()*/bg_color);
-    m_palette.setColor(QPalette::WindowText, /*Qt::white*//*m_shell->getForeground()*/fg_color);
-               // m_palette.setColor(QPalette::Disabled, QPalette::WindowText,
-               //                  QColor(127, 127, 127));
-    m_palette.setColor(QPalette::Base, /*QColor(42, 42, 42)*//*m_shell->getBackground()*/bg_color);
-    m_palette.setColor(QPalette::AlternateBase, /*QColor(66, 66, 66)*/fg_color);
-               // m_palette.setColor(QPalette::ToolTipBase, Qt::white);
-               // m_palette.setColor(QPalette::ToolTipText, QColor(53, 53, 53));
-    m_palette.setColor(QPalette::Text, /*m_shell->getForeground()*/fg_color);
-               // m_palette.setColor(QPalette::Disabled, QPalette::Text, QColor(127, 127, 127));
-    m_palette.setColor(QPalette::Dark, /*QColor(35, 35, 35)*/Qt::white);
-    m_palette.setColor(QPalette::Shadow, /*QColor(20, 20, 20)*/Qt::white);
-               // m_palette.setColor(QPalette::Button, QColor(53, 53, 53));
-               // m_palette.setColor(QPalette::ButtonText, Qt::white);
-               // m_palette.setColor(QPalette::Disabled, QPalette::ButtonText,
-               //                  QColor(127, 127, 127));
-               // m_palette.setColor(QPalette::BrightText, Qt::red);
-               // m_palette.setColor(QPalette::Link, QColor(42, 130, 218));
-	m_palette.setColor(QPalette::Highlight, /*QColor(42, 130, 218)*/ fg_color);
-	//m_palette.setColor(QPalette::Disabled, QPalette::Highlight, QColor(80, 80, 80));
-	m_palette.setColor(QPalette::HighlightedText, /*Qt::white*/bg_color);
-	//m_palette.setColor(QPalette::Disabled, QPalette::HighlightedText, QColor(127, 127, 127));
+    if (bg_color == fg_color) //usually in the default theme: bug or feature?
+    	return;
+
+    if (m_last_bg_color == bg_color && m_last_fg_color == fg_color)
+    	return;
+    else {
+    	m_last_bg_color = bg_color;
+    	m_last_fg_color = fg_color;
+    }
+
+    m_palette.setColor(QPalette::Window, bg_color);
+    m_palette.setColor(QPalette::WindowText, fg_color);
+    m_palette.setColor(QPalette::Disabled, QPalette::WindowText, QColor(127, 127, 127));//Disable default color
+
+    m_palette.setColor(QPalette::Base, bg_color);
+    m_palette.setColor(QPalette::AlternateBase, fg_color);
+    m_palette.setColor(QPalette::Text, fg_color);
+    m_palette.setColor(QPalette::Disabled, QPalette::Text, QColor(127, 127, 127)); //Disable default color
+
+	m_palette.setColor(QPalette::Highlight, fg_color);
+	m_palette.setColor(QPalette::Disabled, QPalette::Highlight, QColor(80, 80, 80)); //Disable default color
+	m_palette.setColor(QPalette::HighlightedText, bg_color);
+	m_palette.setColor(QPalette::Disabled, QPalette::HighlightedText, QColor(127, 127, 127)); //Disable default color
+
+    m_palette.setColor(QPalette::ToolTipBase, bg_color);
+    m_palette.setColor(QPalette::ToolTipText, fg_color);
+
+	m_palette.setColor(QPalette::Button, bg_color);
+	m_palette.setColor(QPalette::ButtonText, fg_color);
+    m_palette.setColor(QPalette::Disabled, QPalette::ButtonText, QColor(127, 127, 127)); //Disable default
+
+    m_palette.setColor(QPalette::BrightText, Qt::red); //defualt 
+    m_palette.setColor(QPalette::Link, QColor(42, 130, 218)); //default
+
+    m_palette.setColor(QPalette::Dark, QColor(34, 34, 34));
+    m_palette.setColor(QPalette::Shadow, QColor(21, 21, 21));
+
 
     
     m_window->setPalette(m_palette);

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -207,7 +207,7 @@ void MainWindow::neovimWidgetResized()
 		m_shell->resizeNeovim(m_shell->size());
 	}
 
-        updateStyle();
+    updateStyle();
 }
 
 void MainWindow::neovimMaximized(bool set)

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -119,17 +119,17 @@ void MainWindow::updateStyle()
                // m_palette.setColor(QPalette::ToolTipText, QColor(53, 53, 53));
     m_palette.setColor(QPalette::Text, /*m_shell->getForeground()*/fg_color);
                // m_palette.setColor(QPalette::Disabled, QPalette::Text, QColor(127, 127, 127));
-               m_palette.setColor(QPalette::Dark, /*QColor(35, 35, 35)*/Qt::white);
-               m_palette.setColor(QPalette::Shadow, /*QColor(20, 20, 20)*/Qt::white);
+    m_palette.setColor(QPalette::Dark, /*QColor(35, 35, 35)*/Qt::white);
+    m_palette.setColor(QPalette::Shadow, /*QColor(20, 20, 20)*/Qt::white);
                // m_palette.setColor(QPalette::Button, QColor(53, 53, 53));
                // m_palette.setColor(QPalette::ButtonText, Qt::white);
                // m_palette.setColor(QPalette::Disabled, QPalette::ButtonText,
                //                  QColor(127, 127, 127));
                // m_palette.setColor(QPalette::BrightText, Qt::red);
                // m_palette.setColor(QPalette::Link, QColor(42, 130, 218));
-	m_palette.setColor(QPalette::Highlight, /*QColor(42, 130, 218)*/ /*fg_color*/);
+	m_palette.setColor(QPalette::Highlight, /*QColor(42, 130, 218)*/ fg_color);
 	//m_palette.setColor(QPalette::Disabled, QPalette::Highlight, QColor(80, 80, 80));
-	m_palette.setColor(QPalette::HighlightedText, /*Qt::white*//*bg_color*/);
+	m_palette.setColor(QPalette::HighlightedText, /*Qt::white*/bg_color);
 	//m_palette.setColor(QPalette::Disabled, QPalette::HighlightedText, QColor(127, 127, 127));
 
     
@@ -138,7 +138,6 @@ void MainWindow::updateStyle()
     m_tabline_bar->setPalette(m_palette);
     m_tabline->setPalette(m_palette);
     setPalette(m_palette);
-    m_tree->show();
 }
 
 bool MainWindow::neovimAttached() const

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -328,9 +328,14 @@ void MainWindow::showIfDelayed()
 
 void MainWindow::neovimAttachmentChanged(bool attached)
 {
-	emit neovimAttached(attached);
-	if (isWindow() && m_shell != NULL) {
-		m_shell->updateGuiWindowState(windowState());
+	emit neovimAttached(attached)
+	if (attached) {
+		if (isWindow() && m_shell != NULL) {
+			m_shell->updateGuiWindowState(windowState());
+		}
+	} else {
+		m_tabline->deleteLater();
+		m_tabline_bar->deleteLater();
 	}
 }
 

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -12,6 +12,7 @@ MainWindow::MainWindow(NeovimConnector *c, ShellOptions opts, QWidget *parent)
 	m_shell_options(opts), m_neovim_requested_close(false)
 {
 	m_errorWidget = new ErrorWidget();
+        m_style = QStyleFactory::create("Fusion");
 	m_stack.addWidget(m_errorWidget);
 	connect(m_errorWidget, &ErrorWidget::reconnectNeovim,
 			this, &MainWindow::reconnectNeovim);
@@ -92,7 +93,47 @@ void MainWindow::init(NeovimConnector *c)
 
 	if (m_nvim->errorCause()) {
 		neovimError(m_nvim->errorCause());
-	}
+        }
+}
+
+void MainWindow::updateStyle()
+{
+
+    //    //palette = m_tree->palette();
+    m_palette.setColor(QPalette::Window, /*QColor(53, 53, 53)*/m_shell->getBackground());
+    m_palette.setColor(QPalette::WindowText, /*Qt::white*/m_shell->getForeground());
+    //            m_palette.setColor(QPalette::Disabled, QPalette::WindowText,
+    //                             QColor(127, 127, 127));
+    m_palette.setColor(QPalette::Base, /*QColor(42, 42, 42)*/m_shell->getBackground());
+    //            m_palette.setColor(QPalette::AlternateBase, QColor(66, 66, 66));
+    //            m_palette.setColor(QPalette::ToolTipBase, Qt::white);
+    //            m_palette.setColor(QPalette::ToolTipText, QColor(53, 53, 53));
+    m_palette.setColor(QPalette::Text, m_shell->getForeground());
+    //            m_palette.setColor(QPalette::Disabled, QPalette::Text, QColor(127, 127, 127));
+    //            m_palette.setColor(QPalette::Dark, QColor(35, 35, 35));
+    //            m_palette.setColor(QPalette::Shadow, QColor(20, 20, 20));
+    //            m_palette.setColor(QPalette::Button, QColor(53, 53, 53));
+    //            m_palette.setColor(QPalette::ButtonText, Qt::white);
+    //            m_palette.setColor(QPalette::Disabled, QPalette::ButtonText,
+    //                             QColor(127, 127, 127));
+    //            m_palette.setColor(QPalette::BrightText, Qt::red);
+    //            m_palette.setColor(QPalette::Link, QColor(42, 130, 218));
+    //            m_palette.setColor(QPalette::Highlight, QColor(42, 130, 218));
+    //            m_palette.setColor(QPalette::Disabled, QPalette::Highlight, QColor(80, 80, 80));
+    //            m_palette.setColor(QPalette::HighlightedText, Qt::white);
+    //            m_palette.setColor(QPalette::Disabled, QPalette::HighlightedText,
+    //                             QColor(127, 127, 127));
+
+    m_window->setStyle(m_style);
+    m_window->setPalette(m_palette);
+    m_tree->setStyle(m_style);
+    m_tree->setPalette(m_palette);
+    m_tabline_bar->setStyle(m_style);
+    m_tabline_bar->setPalette(m_palette);
+    m_tabline->setStyle(m_style);
+    m_tabline->setPalette(m_palette);
+    this->setStyle(m_style);
+    this->setPalette(m_palette);
 }
 
 bool MainWindow::neovimAttached() const
@@ -154,9 +195,9 @@ void MainWindow::neovimWidgetResized()
 	// size, not the other way around.
 	if (isMaximized() || isFullScreen()) {
 		QSize size = geometry().size();
-        if (m_tabline_bar->isVisible()) {
-            size.setHeight(size.height() - m_tabline_bar->geometry().size().height());
-        }
+		if (m_tabline_bar->isVisible()) {
+			size.setHeight(size.height() - m_tabline_bar->geometry().size().height());
+		}
 		if (m_tree->isVisible()) {
 			size.scale(size.width() - m_tree->geometry().size().width(),
 				size.height(), Qt::IgnoreAspectRatio);
@@ -165,6 +206,8 @@ void MainWindow::neovimWidgetResized()
 	} else {
 		m_shell->resizeNeovim(m_shell->size());
 	}
+
+        updateStyle();
 }
 
 void MainWindow::neovimMaximized(bool set)
@@ -263,13 +306,8 @@ void MainWindow::showIfDelayed()
 void MainWindow::neovimAttachmentChanged(bool attached)
 {
 	emit neovimAttached(attached);
-	if (attached) {
-		if (isWindow() && m_shell != NULL) {
-			m_shell->updateGuiWindowState(windowState());
-		}
-	} else {
-		m_tabline->deleteLater();
-		m_tabline_bar->deleteLater();
+	if (isWindow() && m_shell != NULL) {
+		m_shell->updateGuiWindowState(windowState());
 	}
 }
 

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -12,7 +12,8 @@ MainWindow::MainWindow(NeovimConnector *c, ShellOptions opts, QWidget *parent)
 	m_shell_options(opts), m_neovim_requested_close(false)
 {
 	m_errorWidget = new ErrorWidget();
-        m_style = QStyleFactory::create("Fusion");
+    m_style = QStyleFactory::create("Fusion");
+    setStyle(m_style);
 	m_stack.addWidget(m_errorWidget);
 	connect(m_errorWidget, &ErrorWidget::reconnectNeovim,
 			this, &MainWindow::reconnectNeovim);
@@ -60,6 +61,11 @@ void MainWindow::init(NeovimConnector *c)
 	m_tree->hide();
 	m_window->addWidget(m_shell);
 
+    m_window->setStyle(m_style);
+    m_tree->setStyle(m_style);
+    m_tabline_bar->setStyle(m_style);
+    m_tabline->setStyle(m_style);
+
 	m_stack.insertWidget(1, m_window);
 	m_stack.setCurrentIndex(1);
 
@@ -100,40 +106,39 @@ void MainWindow::updateStyle()
 {
 
     //    //palette = m_tree->palette();
-    m_palette.setColor(QPalette::Window, /*QColor(53, 53, 53)*/m_shell->getBackground());
-    m_palette.setColor(QPalette::WindowText, /*Qt::white*/m_shell->getForeground());
-    //            m_palette.setColor(QPalette::Disabled, QPalette::WindowText,
-    //                             QColor(127, 127, 127));
-    m_palette.setColor(QPalette::Base, /*QColor(42, 42, 42)*/m_shell->getBackground());
-    //            m_palette.setColor(QPalette::AlternateBase, QColor(66, 66, 66));
-    //            m_palette.setColor(QPalette::ToolTipBase, Qt::white);
-    //            m_palette.setColor(QPalette::ToolTipText, QColor(53, 53, 53));
-    m_palette.setColor(QPalette::Text, m_shell->getForeground());
-    //            m_palette.setColor(QPalette::Disabled, QPalette::Text, QColor(127, 127, 127));
-    //            m_palette.setColor(QPalette::Dark, QColor(35, 35, 35));
-    //            m_palette.setColor(QPalette::Shadow, QColor(20, 20, 20));
-    //            m_palette.setColor(QPalette::Button, QColor(53, 53, 53));
-    //            m_palette.setColor(QPalette::ButtonText, Qt::white);
-    //            m_palette.setColor(QPalette::Disabled, QPalette::ButtonText,
-    //                             QColor(127, 127, 127));
-    //            m_palette.setColor(QPalette::BrightText, Qt::red);
-    //            m_palette.setColor(QPalette::Link, QColor(42, 130, 218));
-    //            m_palette.setColor(QPalette::Highlight, QColor(42, 130, 218));
-    //            m_palette.setColor(QPalette::Disabled, QPalette::Highlight, QColor(80, 80, 80));
-    //            m_palette.setColor(QPalette::HighlightedText, Qt::white);
-    //            m_palette.setColor(QPalette::Disabled, QPalette::HighlightedText,
-    //                             QColor(127, 127, 127));
+    auto bg_color = m_shell->getBackground();
+    auto fg_color = m_shell->getForeground();
 
-    m_window->setStyle(m_style);
+    m_palette.setColor(QPalette::Window, /*QColor(53, 53, 53)*//*m_shell->getBackground()*/bg_color);
+    m_palette.setColor(QPalette::WindowText, /*Qt::white*//*m_shell->getForeground()*/fg_color);
+               // m_palette.setColor(QPalette::Disabled, QPalette::WindowText,
+               //                  QColor(127, 127, 127));
+    m_palette.setColor(QPalette::Base, /*QColor(42, 42, 42)*//*m_shell->getBackground()*/bg_color);
+    m_palette.setColor(QPalette::AlternateBase, /*QColor(66, 66, 66)*/fg_color);
+               // m_palette.setColor(QPalette::ToolTipBase, Qt::white);
+               // m_palette.setColor(QPalette::ToolTipText, QColor(53, 53, 53));
+    m_palette.setColor(QPalette::Text, /*m_shell->getForeground()*/fg_color);
+               // m_palette.setColor(QPalette::Disabled, QPalette::Text, QColor(127, 127, 127));
+               m_palette.setColor(QPalette::Dark, /*QColor(35, 35, 35)*/Qt::white);
+               m_palette.setColor(QPalette::Shadow, /*QColor(20, 20, 20)*/Qt::white);
+               // m_palette.setColor(QPalette::Button, QColor(53, 53, 53));
+               // m_palette.setColor(QPalette::ButtonText, Qt::white);
+               // m_palette.setColor(QPalette::Disabled, QPalette::ButtonText,
+               //                  QColor(127, 127, 127));
+               // m_palette.setColor(QPalette::BrightText, Qt::red);
+               // m_palette.setColor(QPalette::Link, QColor(42, 130, 218));
+	m_palette.setColor(QPalette::Highlight, /*QColor(42, 130, 218)*/ /*fg_color*/);
+	//m_palette.setColor(QPalette::Disabled, QPalette::Highlight, QColor(80, 80, 80));
+	m_palette.setColor(QPalette::HighlightedText, /*Qt::white*//*bg_color*/);
+	//m_palette.setColor(QPalette::Disabled, QPalette::HighlightedText, QColor(127, 127, 127));
+
+    
     m_window->setPalette(m_palette);
-    m_tree->setStyle(m_style);
     m_tree->setPalette(m_palette);
-    m_tabline_bar->setStyle(m_style);
     m_tabline_bar->setPalette(m_palette);
-    m_tabline->setStyle(m_style);
     m_tabline->setPalette(m_palette);
-    this->setStyle(m_style);
-    this->setPalette(m_palette);
+    setPalette(m_palette);
+    m_tree->show();
 }
 
 bool MainWindow::neovimAttached() const

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -328,7 +328,7 @@ void MainWindow::showIfDelayed()
 
 void MainWindow::neovimAttachmentChanged(bool attached)
 {
-	emit neovimAttached(attached)
+	emit neovimAttached(attached);
 	if (attached) {
 		if (isWindow() && m_shell != NULL) {
 			m_shell->updateGuiWindowState(windowState());

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -54,8 +54,8 @@ private slots:
 	void changeTab(int index);
 private:
 	void init(NeovimConnector *);
-        void updateStyle();
-        NeovimConnector *m_nvim;
+    void updateStyle();
+    NeovimConnector *m_nvim;
 	ErrorWidget *m_errorWidget;
 	QSplitter *m_window;
 	TreeView *m_tree;
@@ -65,9 +65,11 @@ private:
 	QTabBar *m_tabline;
 	QToolBar *m_tabline_bar;
 	ShellOptions m_shell_options;
-        bool m_neovim_requested_close;
-        QStyle *m_style;
-        QPalette m_palette;
+    bool m_neovim_requested_close;
+    QStyle *m_style;
+    QPalette m_palette;
+    QColor m_last_fg_color;
+    QColor m_last_bg_color;
 };
 
 } // Namespace

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -52,9 +52,12 @@ private slots:
 	void neovimTablineUpdate(int64_t curtab, QList<Tab> tabs);
 	void extTablineSet(bool);
 	void changeTab(int index);
+	void neovimGuiColorsAdaptiveChanged(bool);
+	void neovimGuiFontAdaptiveChanged(bool);
 private:
 	void init(NeovimConnector *);
     void updateStyle();
+    void setNewPalette();
     NeovimConnector *m_nvim;
 	ErrorWidget *m_errorWidget;
 	QSplitter *m_window;
@@ -70,6 +73,10 @@ private:
     QPalette m_palette;
     QColor m_last_fg_color;
     QColor m_last_bg_color;
+    bool m_neovim_gui_style_requested_update;
+    bool m_neovim_gui_font_requested_update;
+    QFont m_default_font;
+    QPalette m_default_palette;
 };
 
 } // Namespace

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -5,6 +5,8 @@
 #include <QStackedWidget>
 #include <QTabBar>
 #include <QSplitter>
+#include <QStyleFactory>
+#include <QPalette>
 #include "treeview.h"
 #include "neovimconnector.h"
 #include "errorwidget.h"
@@ -52,6 +54,7 @@ private slots:
 	void changeTab(int index);
 private:
 	void init(NeovimConnector *);
+        void updateStyle();
         NeovimConnector *m_nvim;
 	ErrorWidget *m_errorWidget;
 	QSplitter *m_window;
@@ -62,7 +65,9 @@ private:
 	QTabBar *m_tabline;
 	QToolBar *m_tabline_bar;
 	ShellOptions m_shell_options;
-	bool m_neovim_requested_close;
+        bool m_neovim_requested_close;
+        QStyle *m_style;
+        QPalette m_palette;
 };
 
 } // Namespace

--- a/src/gui/runtime/plugin/nvim_gui_shim.vim
+++ b/src/gui/runtime/plugin/nvim_gui_shim.vim
@@ -91,6 +91,18 @@ function! s:GuiTabline(enable) abort
 endfunction
 command! -nargs=1 GuiTabline call s:GuiTabline(<args>)
 
+" Set Gui Colors adaptive for nvim colorscheme
+function! s:GuiColorsAdaptive(enable) abort
+	call rpcnotify(0, 'Gui', 'ColorsAdaptive', a:enable)
+endfunction
+command! -nargs=1 GuiColorsAdaptive call s:GuiColorsAdaptive(<args>)
+
+" Set Gui Font adaptive fot nvim font
+function! s:GuiFontAdaptive(enable) abort
+	call rpcnotify(0, 'Gui', 'FontAdaptive', a:enable)
+endfunction
+command! -nargs=1 GuiFontAdaptive call s:GuiFontAdaptive(<args>)
+
 function! s:GuiPopupmenu(enable) abort
 	call rpcnotify(0, 'Gui', 'Option', 'Popupmenu', a:enable)
 endfunction

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -21,7 +21,7 @@ Shell::Shell(NeovimConnector *nvim, ShellOptions opts, QWidget *parent)
 	m_font_bold(false), m_font_italic(false), m_font_underline(false), m_font_undercurl(false),
 	m_mouseHide(true),
 	m_hg_foreground(Qt::black), m_hg_background(Qt::white), m_hg_special(QColor()),
-	m_cursor_color(Qt::white), m_cursor_pos(0,0), m_insertMode(false),
+	m_cursor_color(Qt::white), m_theme_foreground(Qt::black), m_theme_background(Qt::black), m_cursor_pos(0,0), m_insertMode(false),
 	m_resizing(false),
 	m_mouse_wheel_delta_fraction(0, 0),
 	m_neovimBusy(false),

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -523,7 +523,25 @@ void Shell::handleRedraw(const QByteArray& name, const QVariantList& opargs)
 		m_pum.hide();
 	} else if (name == "mode_info_set") {
 		// TODO
-	} else if (name == "default_colors_set") {
+        } else if (name == "default_colors_set") {
+
+        	//"default_colors_set" have 5 parameters
+        	// 0 - foreground (default = -1)
+        	// 1 - background (default = -1)
+        	//...
+
+        	//don't handle default 
+        	if(opargs.at(0) == -1 || opargs.at(1) == -1) {
+        		return;
+        	}
+
+            if (opargs.at(0).canConvert<quint64>() && opargs.at(1).canConvert<quint64>()) {
+                auto b_val = opargs.at(1).toLongLong();
+                auto f_val = opargs.at(0).toLongLong();
+                m_theme_background = QRgb(b_val);
+                m_theme_foreground = QRgb(f_val);
+            }
+
 		// TODO
 	} else {
 		qDebug() << "Received unknown redraw notification" << name << opargs;
@@ -1047,6 +1065,7 @@ void Shell::resizeNeovim(const QSize& newSize)
 {
 	int n_cols = newSize.width()/cellSize().width();
 	int n_rows = newSize.height()/cellSize().height();
+        qWarning() << m_theme_foreground << m_theme_background;
 	resizeNeovim(n_cols, n_rows);
 }
 
@@ -1155,7 +1174,17 @@ QColor Shell::color(qint64 color, const QColor& fallback)
 	if (color == -1) {
 		return fallback;
 	}
-	return QRgb(color);
+        return QRgb(color);
+}
+
+QColor Shell::getBackground()
+{
+    return m_theme_background;
+}
+
+QColor Shell::getForeground()
+{
+    return m_theme_foreground;
 }
 
 /*

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -752,6 +752,10 @@ void Shell::handleNeovimNotification(const QByteArray &name, const QVariantList&
 
 			qDebug() << "Neovim changed clipboard" << data << type << reg_name << clipboard;
 			QGuiApplication::clipboard()->setMimeData(clipData, clipboard);
+		} else if (guiEvName == "ColorsAdaptive" && args.size() >= 2) {
+			emit neovimGuiColorsAdaptiveEnabled(args.at(1).toBool());
+		} else if (guiEvName == "FontAdaptive" && args.size() >= 2) {
+			emit neovimGuiFontAdaptiveEnabled(args.at(1).toBool());
 		}
 		return;
 	} else if (name != "redraw") {

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -50,6 +50,8 @@ public:
 	~Shell();
 	QSize sizeIncrement() const;
 	static QColor color(qint64 color, const QColor& fallback=QColor());
+    QColor getBackground();
+    QColor getForeground();
 	static bool isBadMonospace(const QFont& f);
 	virtual QVariant inputMethodQuery(Qt::InputMethodQuery) const Q_DECL_OVERRIDE;
 	bool neovimBusy() const;
@@ -160,6 +162,7 @@ private:
 	// use the values from above
 	QColor m_hg_foreground, m_hg_background, m_hg_special;
 	QColor m_cursor_color;
+    QColor m_theme_foreground, m_theme_background;
 
 	/// Cursor position in shell coordinates
 	QPoint m_cursor_pos;

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -76,6 +76,8 @@ signals:
 	void neovimTablineUpdate(int64_t curtab, QList<Tab> tabs);
 	void neovimShowtablineSet(int);
 	void fontChanged();
+	void neovimGuiColorsAdaptiveEnabled(bool);
+	void neovimGuiFontAdaptiveEnabled(bool);
 
 public slots:
 	void handleNeovimNotification(const QByteArray &name, const QVariantList& args);


### PR DESCRIPTION
I added an automatic  color scheme adaptation for the neovim-qt GUI based on nvim colorscheme.

This implementation uses QPalette to create and set colors in the GUI by parsing a "default_colors_set" parameter.

So I added 2 commands to activate the GUI adaptation (GuiColorsAdaptive) and font adaptation (GuiFontAdaptive) to a nvim_gui_shim.vim file.


How it looks:
(Mac OS Ui behavior )
![2019-02-18 22 42 25 mov](https://user-images.githubusercontent.com/10284309/52975034-d4ee9680-33d4-11e9-91ae-48fbb263c8fd.gif)

(Windows 10, gruvbox colorscheme, GuiColorsAdaptive enabled,GuiFontAdaptive enabled )
<img width="1280" alt="2019-02-18 23 36 48" src="https://user-images.githubusercontent.com/10284309/52975340-29dedc80-33d6-11e9-990c-ad44cbb5ff69.png">

I guess, this feature may be related to the following issues: #494 #478 #489