### PR TITLE
Add support for floating-point font sizes

### DIFF
--- a/src/gui/runtime/doc/nvim_gui_shim.txt
+++ b/src/gui/runtime/doc/nvim_gui_shim.txt
@@ -28,9 +28,13 @@ GuiFont		When called with no arguments this command display the
 
 		    :GuiFont Monaco:h13
 <
+		You can also use floating-point sizes:
+>
+		    :GuiFont Monaco:h13.5
+<
 		The following attributes are available
 
-			hXX - height is XX in points
+			hXX - height is XX in points (can be floating-point)
 			b   - bold weight
 			l   - light weight
 			i   - italic

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -104,13 +104,13 @@ bool Shell::setGuiFont(const QString& fdesc, bool force)
 		return false;
 	}
 
-	int pointSize = font().pointSize();
+	qreal pointSize = font().pointSizeF();
 	int weight = -1;
 	bool italic = false;
 	foreach(QString attr, attrs) {
 		if (attr.size() >= 2 && attr[0] == 'h') {
 			bool ok = false;
-			int height = attr.mid(1).toInt(&ok);
+			qreal height = attr.mid(1).toFloat(&ok);
 			if (!ok) {
 				m_nvim->api0()->vim_report_error("Invalid font height");
 				return false;

--- a/src/gui/shellwidget/shellwidget.cpp
+++ b/src/gui/shellwidget/shellwidget.cpp
@@ -37,9 +37,10 @@ void ShellWidget::setDefaultFont()
 	setShellFont(DEFAULT_FONT, 11, -1, false, true);
 }
 
-bool ShellWidget::setShellFont(const QString& family, int ptSize, int weight, bool italic, bool force)
+bool ShellWidget::setShellFont(const QString& family, qreal ptSize, int weight, bool italic, bool force)
 {
-	QFont f(family, ptSize, weight, italic);
+	QFont f(family, -1, weight, italic);
+	f.setPointSizeF(ptSize);
 	f.setStyleHint(QFont::TypeWriter, QFont::StyleStrategy(QFont::PreferDefault | QFont::ForceIntegerMetrics));
 	f.setFixedPitch(true);
 	f.setKerning(false);

--- a/src/gui/shellwidget/shellwidget.h
+++ b/src/gui/shellwidget/shellwidget.h
@@ -17,7 +17,7 @@ class ShellWidget: public QWidget
 	Q_PROPERTY(QSize cellSize READ cellSize)
 public:
 	ShellWidget(QWidget *parent=0);
-	bool setShellFont(const QString& family, int ptSize, int weight = -1, bool italic = false, bool force = false);
+	bool setShellFont(const QString& family, qreal ptSize, int weight = -1, bool italic = false, bool force = false);
 
 	QColor background() const;
 	QColor foreground() const;


### PR DESCRIPTION
This adds support for setting GUI font sizes using floating-points. For
example, to use "Source Code Pro" at a size of 7.5 you'd run:

    GuiFont Source Code Pro:h7.5

This fixes #221.

## Examples

`Source Code Pro:h8:l`:

![8pt](https://user-images.githubusercontent.com/86065/54859151-2490ec80-4d0a-11e9-81c1-3511373fc4f8.png)

`Source Code Pro:h7.5:l`:

![7 5](https://user-images.githubusercontent.com/86065/54859154-2ce92780-4d0a-11e9-9f63-05a38ab09df5.png)

`Source Code Pro:h7:l` (ignore the window title, I forgot to change it):

![7](https://user-images.githubusercontent.com/86065/54859156-33779f00-4d0a-11e9-8ba0-aec2f9453d8e.png)
