### PR TITLE
Report the right font size in GuiFont

### DIFF
--- a/src/gui/shellwidget/shellwidget.cpp
+++ b/src/gui/shellwidget/shellwidget.cpp
@@ -355,9 +355,9 @@ QString ShellWidget::fontFamily() const
 {
 	return QFontInfo(font()).family();
 }
-int ShellWidget::fontSize() const
+qreal ShellWidget::fontSize() const
 {
-	return font().pointSize();
+	return font().pointSizeF();
 }
 
 int ShellWidget::rows() const

--- a/src/gui/shellwidget/shellwidget.h
+++ b/src/gui/shellwidget/shellwidget.h
@@ -23,7 +23,7 @@ public:
 	QColor foreground() const;
 	QColor special() const;
 	QString fontFamily() const;
-	int fontSize() const;
+	qreal fontSize() const;
 	static ShellWidget* fromFile(const QString& path);
 
 	int rows() const;


### PR DESCRIPTION
This ensures that when floating-point font sizes are used they are
reported as floats, and not as rounded integers. Previously, setting a
font size of 7.5 would result in `GuiFont` reporting it as a size of 8.