### PR TITLE
<A-lt> key could not be mapped

### DIFF
--- a/src/gui/input.cpp
+++ b/src/gui/input.cpp
@@ -214,7 +214,7 @@ QString InputConv::convertKey(const QString& text, int k, Qt::KeyboardModifiers 
 	QChar c;
 	// Escape < and backslash
 	if (text == "<") {
-		return QString("<lt>");
+		return QString("<%1%2>").arg(modPrefix(mod)).arg("lt");
 	} else if (text == "\\") {
 		return QString("<%1%2>").arg(modPrefix(mod)).arg("Bslash");
 	} else if (text.isEmpty()) {


### PR DESCRIPTION
The < (<lt>) key could not be mapped because it was not setting
modifiers (<C-lt>, <M-lt>, etc).

Fixes #533, for `<M-lt>` ad `<C-lt>`, but not `<S-lt>`.