### PR TITLE
Add Cut/Copy/Paste Context Menu

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -17,11 +17,6 @@ MainWindow::MainWindow(NeovimConnector *c, ShellOptions opts, QWidget *parent)
 			this, &MainWindow::reconnectNeovim);
 	setCentralWidget(&m_stack);
 
-	m_actCut = new QAction(QIcon::fromTheme("edit-cut"), "Cut");
-	m_actCopy = new QAction(QIcon::fromTheme("edit-copy"), "Copy");
-	m_actPaste = new QAction(QIcon::fromTheme("edit-paste"), "Paste");
-	m_actSelectAll = new QAction(QIcon::fromTheme("edit-select-all"), "Select All");
-
 	init(c);
 }
 
@@ -53,6 +48,18 @@ void MainWindow::init(NeovimConnector *c)
 
 	m_tabline_bar->addWidget(m_tabline);
 	m_tabline_bar->setVisible(m_shell_options.enable_ext_tabline);
+
+	// Context menu and actions for right-click
+	m_contextMenu = new QMenu();
+	m_actCut = new QAction(QIcon::fromTheme("edit-cut"), QString("Cut"));
+	m_actCopy = new QAction(QIcon::fromTheme("edit-copy"), QString("Copy"));
+	m_actPaste = new QAction(QIcon::fromTheme("edit-paste"), QString("Paste"));
+	m_actSelectAll = new QAction(QIcon::fromTheme("edit-select-all"), QString("Select All"));
+	m_contextMenu->addAction(m_actCut);
+	m_contextMenu->addAction(m_actCopy);
+	m_contextMenu->addAction(m_actPaste);
+	m_contextMenu->addSeparator();
+	m_contextMenu->addAction(m_actSelectAll);
 
 	m_nvim = c;
 
@@ -355,35 +362,27 @@ void MainWindow::neovimTablineUpdate(int64_t curtab, QList<Tab> tabs)
 
 void MainWindow::neovimShowContextMenu()
 {
-	QMenu rightClickMenu;
-
-	rightClickMenu.addAction(m_actCut);
-	rightClickMenu.addAction(m_actCopy);
-	rightClickMenu.addAction(m_actPaste);
-	rightClickMenu.addSeparator();
-	rightClickMenu.addAction(m_actSelectAll);
-
-	rightClickMenu.exec(QCursor::pos());
+	m_contextMenu->popup(QCursor::pos());
 }
 
 void MainWindow::neovimSendCut()
 {
-	m_nvim->api0()->vim_feedkeys(R"("+x)", "m", true);
+	m_nvim->api0()->vim_command_output(R"(normal! "+x)");
 }
 
 void MainWindow::neovimSendCopy()
 {
-	m_nvim->api0()->vim_feedkeys(R"("+y)", "m", true);
+	m_nvim->api0()->vim_command(R"(normal! "+y)");
 }
 
 void MainWindow::neovimSendPaste()
 {
-	m_nvim->api0()->vim_feedkeys(R"("+gP)", "m", true);
+	m_nvim->api0()->vim_command(R"(normal! "+gP)");
 }
 
 void MainWindow::neovimSendSelectAll()
 {
-	m_nvim->api0()->vim_feedkeys("ggVG", "m", true);
+	m_nvim->api0()->vim_command("normal! ggVG");
 }
 
 void MainWindow::changeTab(int index)

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -51,10 +51,11 @@ void MainWindow::init(NeovimConnector *c)
 
 	// Context menu and actions for right-click
 	m_contextMenu = new QMenu();
-	m_actCut = new QAction(QIcon::fromTheme("edit-cut"), QString("Cut"));
-	m_actCopy = new QAction(QIcon::fromTheme("edit-copy"), QString("Copy"));
-	m_actPaste = new QAction(QIcon::fromTheme("edit-paste"), QString("Paste"));
-	m_actSelectAll = new QAction(QIcon::fromTheme("edit-select-all"), QString("Select All"));
+	m_actCut = new QAction(QIcon::fromTheme("edit-cut"), QString("Cut"), nullptr /*parent*/);
+	m_actCopy = new QAction(QIcon::fromTheme("edit-copy"), QString("Copy"), nullptr /*parent*/);
+	m_actPaste = new QAction(QIcon::fromTheme("edit-paste"), QString("Paste"), nullptr /*parent*/);
+	m_actSelectAll = new QAction(QIcon::fromTheme("edit-select-all"), QString("Select All"),
+		nullptr /*parent*/);
 	m_contextMenu->addAction(m_actCut);
 	m_contextMenu->addAction(m_actCopy);
 	m_contextMenu->addAction(m_actPaste);

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -68,6 +68,7 @@ private:
 	QToolBar *m_tabline_bar;
 	ShellOptions m_shell_options;
 	bool m_neovim_requested_close;
+	QMenu *m_contextMenu;
 	QAction *m_actCut;
 	QAction *m_actCopy;
 	QAction *m_actPaste;

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -48,11 +48,16 @@ private slots:
 	void neovimIsUnsupported();
 	void neovimShowtablineSet(int);
 	void neovimTablineUpdate(int64_t curtab, QList<Tab> tabs);
+	void neovimShowContextMenu();
+	void neovimSendCut();
+	void neovimSendCopy();
+	void neovimSendPaste();
+	void neovimSendSelectAll();
 	void extTablineSet(bool);
 	void changeTab(int index);
 private:
 	void init(NeovimConnector *);
-        NeovimConnector *m_nvim;
+	NeovimConnector *m_nvim;
 	ErrorWidget *m_errorWidget;
 	QSplitter *m_window;
 	TreeView *m_tree;
@@ -63,6 +68,10 @@ private:
 	QToolBar *m_tabline_bar;
 	ShellOptions m_shell_options;
 	bool m_neovim_requested_close;
+	QAction *m_actCut;
+	QAction *m_actCopy;
+	QAction *m_actPaste;
+	QAction *m_actSelectAll;
 };
 
 } // Namespace

--- a/src/gui/runtime/doc/nvim_gui_shim.txt
+++ b/src/gui/runtime/doc/nvim_gui_shim.txt
@@ -149,6 +149,14 @@ This can be used to check for a specific GUI in ginit.vim, e.g.
 
 This is a wrapper around |nvim_get_chan_info()|.
 
+							*GuiShowContextMenu()*
+Displays a Cut-Copy-Paste context menu at the current cursor position. This
+menu can be mapped to right click events in ginit.vim, e.g.
+>
+	nnoremap <silent><RightMouse> :call GuiShowContextMenu()<CR>
+	inoremap <silent><RightMouse> <Esc>:call GuiShowContextMenu()<CR>
+	vnoremap <silent><RightMouse> :call GuiShowContextMenu()<CR>gv
+
 ==============================================================================
 4. Internals
 

--- a/src/gui/runtime/plugin/nvim_gui_shim.vim
+++ b/src/gui/runtime/plugin/nvim_gui_shim.vim
@@ -206,3 +206,13 @@ endfunction
 command! GuiTreeviewToggle call <SID>TreeViewToggle()
 noremap <script> <Plug>GuiTreeviewToggle :call <SID>TreeViewToggle()
 anoremenu <script> Gui.Treeview.Toggle :call <SID>TreeViewShowToggle()
+
+" Show Right-Click ContextMenu
+function s:GuiShowContextMenu() range
+	call rpcnotify(0, 'Gui', 'ShowContextMenu')
+endfunction
+
+command! -range GuiShowContextMenu call s:GuiShowContextMenu()
+nnoremap <silent><RightMouse> :GuiShowContextMenu<CR>
+inoremap <silent><RightMouse> :GuiShowContextMenu<CR>
+vnoremap <silent><RightMouse> :GuiShowContextMenu<CR>gv

--- a/src/gui/runtime/plugin/nvim_gui_shim.vim
+++ b/src/gui/runtime/plugin/nvim_gui_shim.vim
@@ -208,11 +208,6 @@ noremap <script> <Plug>GuiTreeviewToggle :call <SID>TreeViewToggle()
 anoremenu <script> Gui.Treeview.Toggle :call <SID>TreeViewShowToggle()
 
 " Show Right-Click ContextMenu
-function s:GuiShowContextMenu() range
+function GuiShowContextMenu() range
 	call rpcnotify(0, 'Gui', 'ShowContextMenu')
 endfunction
-
-command! -range GuiShowContextMenu call s:GuiShowContextMenu()
-nnoremap <silent><RightMouse> :GuiShowContextMenu<CR>
-inoremap <silent><RightMouse> :GuiShowContextMenu<CR>
-vnoremap <silent><RightMouse> :GuiShowContextMenu<CR>gv

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -734,6 +734,8 @@ void Shell::handleNeovimNotification(const QByteArray &name, const QVariantList&
 
 			qDebug() << "Neovim changed clipboard" << data << type << reg_name << clipboard;
 			QGuiApplication::clipboard()->setMimeData(clipData, clipboard);
+		} else if (guiEvName == "ShowContextMenu") {
+			emit neovimShowContextMenu();
 		}
 		return;
 	} else if (name != "redraw") {
@@ -873,19 +875,6 @@ void Shell::keyPressEvent(QKeyEvent *ev)
 void Shell::neovimMouseEvent(QMouseEvent *ev)
 {
 	if (!m_attached || !m_mouseEnabled) {
-		return;
-	}
-
-	static bool isRightButtonDown = false;
-	if (ev->buttons() & Qt::RightButton)
-	{
-		isRightButtonDown = true;
-		return;
-	}
-	else if (isRightButtonDown && ev->type() == QEvent::MouseButtonRelease)
-	{
-		isRightButtonDown = false;
-		emit neovimShowContextMenu();
 		return;
 	}
 

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -876,6 +876,19 @@ void Shell::neovimMouseEvent(QMouseEvent *ev)
 		return;
 	}
 
+	static bool isRightButtonDown = false;
+	if (ev->buttons() & Qt::RightButton)
+	{
+		isRightButtonDown = true;
+		return;
+	}
+	else if (isRightButtonDown && ev->type() == QEvent::MouseButtonRelease)
+	{
+		isRightButtonDown = false;
+		emit neovimShowContextMenu();
+		return;
+	}
+
 	QPoint pos(ev->x()/cellSize().width(),
 			ev->y()/cellSize().height());
 	QString inp;

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -73,6 +73,7 @@ signals:
 	/// as seen in Tab::tab.
 	void neovimTablineUpdate(int64_t curtab, QList<Tab> tabs);
 	void neovimShowtablineSet(int);
+	void neovimShowContextMenu();
 	void fontChanged();
 
 public slots:


### PR DESCRIPTION
I would like to see support in neovim-qt for a basic context menu. It is a feature supported by other vim front-ends (gVim, neovim-gtk, etc) and it makes the occasional mouse operation quicker/easier.

I have extended MainWindow to include fixed QActions for all context menu entries. I did change the mouse handling routine in shell.cpp, so right click events will no longer be passed to NeoVim. Click events occur on right mouse button release. Each time an event is detected by shell.cpp, an new QMenu is painted at the cursor position.

Any feedback you have as to how this could be better-implemented or modularized is welcome :)