### PR TITLE
Add support for 'ext_linegrid'

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,6 +8,7 @@ set(NEOVIM_QT_SOURCES
   auto/neovimapi2.cpp
   auto/neovimapi3.cpp
   auto/neovimapi4.cpp
+  auto/neovimapi5.cpp
   auto/neovimapi6.cpp
   function.cpp
   msgpackiodevice.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,7 +2,20 @@
 configure_file(version.h.in ${CMAKE_CURRENT_BINARY_DIR}/version.h)
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
-set(NEOVIM_QT_SOURCES util.cpp neovimconnector.cpp neovimconnectorhelper.cpp function.cpp msgpackrequest.cpp msgpackiodevice.cpp auto/neovimapi0.cpp auto/neovimapi1.cpp auto/neovimapi2.cpp auto/neovimapi3.cpp auto/neovimapi4.cpp auto/neovimapi6.cpp)
+set(NEOVIM_QT_SOURCES
+  auto/neovimapi0.cpp
+  auto/neovimapi1.cpp
+  auto/neovimapi2.cpp
+  auto/neovimapi3.cpp
+  auto/neovimapi4.cpp
+  auto/neovimapi6.cpp
+  function.cpp
+  msgpackiodevice.cpp
+  msgpackrequest.cpp
+  neovimconnector.cpp
+  neovimconnectorhelper.cpp
+  util.cpp)
+
 if(WIN32)
   list(APPEND NEOVIM_QT_SOURCES stdinreader.cpp)
 endif()

--- a/src/auto/neovimapi5.cpp
+++ b/src/auto/neovimapi5.cpp
@@ -1,0 +1,5135 @@
+// Auto generated 2019-06-08 16:53:42.502897 from nvim API level:5
+#include "auto/neovimapi5.h"
+#include "neovimconnector.h"
+#include "msgpackrequest.h"
+#include "msgpackiodevice.h"
+#include "util.h"
+
+namespace NeovimQt {
+/* Unpack Neovim EXT types Window, Buffer Tabpage which are all
+ * uint64_t see Neovim:msgpack_rpc_to_
+ */
+QVariant unpackBufferApi5(MsgpackIODevice *dev, const char* in, quint32 size)
+{
+	msgpack_unpacked result;
+	msgpack_unpacked_init(&result);
+	msgpack_unpack_return ret = msgpack_unpack_next(&result, in, size, NULL);
+
+	QVariant variant;
+
+	if (ret == MSGPACK_UNPACK_SUCCESS) {
+		switch (result.data.type) {
+			case MSGPACK_OBJECT_NEGATIVE_INTEGER:
+				variant = (qint64)result.data.via.i64;
+				break;
+			case MSGPACK_OBJECT_POSITIVE_INTEGER:
+				variant = (quint64)result.data.via.u64;
+				break;
+			default:
+				// TODO it would be nice if we could call back MsgpackIoDevice method or primitive types here
+				qWarning() << "Unsupported type found for EXT type" << result.data.type << result.data;
+		}
+	}
+
+	msgpack_unpacked_destroy(&result);
+	return variant;
+}
+#define unpackWindowApi5 unpackBufferApi5
+#define unpackTabpageApi5 unpackBufferApi5
+
+NeovimApi5::NeovimApi5(NeovimConnector *c)
+:m_c(c)
+{
+	// EXT types
+		m_c->m_dev->registerExtType(0, unpackBufferApi5);
+		m_c->m_dev->registerExtType(1, unpackWindowApi5);
+		m_c->m_dev->registerExtType(2, unpackTabpageApi5);
+		connect(m_c->m_dev, &MsgpackIODevice::notification,
+			this, &NeovimApi5::neovimNotification);
+}
+
+// Slots
+MsgpackRequest* NeovimApi5::nvim_buf_line_count(int64_t buffer)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_line_count", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_BUF_LINE_COUNT);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(buffer);
+	return r;
+}
+MsgpackRequest* NeovimApi5::buffer_get_line(int64_t buffer, int64_t index)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_line", 2);
+	r->setFunction(NeovimApi5::NEOVIM_FN_BUFFER_GET_LINE);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(buffer);
+	m_c->m_dev->send(index);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_buf_attach(int64_t buffer, bool send_buffer, QVariantMap opts)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_attach", 3);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_BUF_ATTACH);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(buffer);
+	m_c->m_dev->send(send_buffer);
+	m_c->m_dev->send(opts);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_buf_detach(int64_t buffer)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_detach", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_BUF_DETACH);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(buffer);
+	return r;
+}
+MsgpackRequest* NeovimApi5::buffer_set_line(int64_t buffer, int64_t index, QByteArray line)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_set_line", 3);
+	r->setFunction(NeovimApi5::NEOVIM_FN_BUFFER_SET_LINE);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(buffer);
+	m_c->m_dev->send(index);
+	m_c->m_dev->send(line);
+	return r;
+}
+MsgpackRequest* NeovimApi5::buffer_del_line(int64_t buffer, int64_t index)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_del_line", 2);
+	r->setFunction(NeovimApi5::NEOVIM_FN_BUFFER_DEL_LINE);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(buffer);
+	m_c->m_dev->send(index);
+	return r;
+}
+MsgpackRequest* NeovimApi5::buffer_get_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_line_slice", 5);
+	r->setFunction(NeovimApi5::NEOVIM_FN_BUFFER_GET_LINE_SLICE);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(buffer);
+	m_c->m_dev->send(start);
+	m_c->m_dev->send(end);
+	m_c->m_dev->send(include_start);
+	m_c->m_dev->send(include_end);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_buf_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_get_lines", 4);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_BUF_GET_LINES);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(buffer);
+	m_c->m_dev->send(start);
+	m_c->m_dev->send(end);
+	m_c->m_dev->send(strict_indexing);
+	return r;
+}
+MsgpackRequest* NeovimApi5::buffer_set_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end, QList<QByteArray> replacement)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_set_line_slice", 6);
+	r->setFunction(NeovimApi5::NEOVIM_FN_BUFFER_SET_LINE_SLICE);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(buffer);
+	m_c->m_dev->send(start);
+	m_c->m_dev->send(end);
+	m_c->m_dev->send(include_start);
+	m_c->m_dev->send(include_end);
+	m_c->m_dev->sendArrayOf(replacement);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_buf_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_set_lines", 5);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_BUF_SET_LINES);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(buffer);
+	m_c->m_dev->send(start);
+	m_c->m_dev->send(end);
+	m_c->m_dev->send(strict_indexing);
+	m_c->m_dev->sendArrayOf(replacement);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_buf_get_offset(int64_t buffer, int64_t index)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_get_offset", 2);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_BUF_GET_OFFSET);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(buffer);
+	m_c->m_dev->send(index);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_buf_get_var(int64_t buffer, QByteArray name)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_get_var", 2);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_BUF_GET_VAR);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(buffer);
+	m_c->m_dev->send(name);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_buf_get_changedtick(int64_t buffer)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_get_changedtick", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_BUF_GET_CHANGEDTICK);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(buffer);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_buf_get_keymap(int64_t buffer, QByteArray mode)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_get_keymap", 2);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_BUF_GET_KEYMAP);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(buffer);
+	m_c->m_dev->send(mode);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_buf_get_commands(int64_t buffer, QVariantMap opts)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_get_commands", 2);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_BUF_GET_COMMANDS);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(buffer);
+	m_c->m_dev->send(opts);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_buf_set_var(int64_t buffer, QByteArray name, QVariant value)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_set_var", 3);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_BUF_SET_VAR);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(buffer);
+	m_c->m_dev->send(name);
+	m_c->m_dev->send(value);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_buf_del_var(int64_t buffer, QByteArray name)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_del_var", 2);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_BUF_DEL_VAR);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(buffer);
+	m_c->m_dev->send(name);
+	return r;
+}
+MsgpackRequest* NeovimApi5::buffer_set_var(int64_t buffer, QByteArray name, QVariant value)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_set_var", 3);
+	r->setFunction(NeovimApi5::NEOVIM_FN_BUFFER_SET_VAR);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(buffer);
+	m_c->m_dev->send(name);
+	m_c->m_dev->send(value);
+	return r;
+}
+MsgpackRequest* NeovimApi5::buffer_del_var(int64_t buffer, QByteArray name)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_del_var", 2);
+	r->setFunction(NeovimApi5::NEOVIM_FN_BUFFER_DEL_VAR);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(buffer);
+	m_c->m_dev->send(name);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_buf_get_option(int64_t buffer, QByteArray name)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_get_option", 2);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_BUF_GET_OPTION);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(buffer);
+	m_c->m_dev->send(name);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_buf_set_option(int64_t buffer, QByteArray name, QVariant value)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_set_option", 3);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_BUF_SET_OPTION);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(buffer);
+	m_c->m_dev->send(name);
+	m_c->m_dev->send(value);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_buf_get_number(int64_t buffer)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_get_number", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_BUF_GET_NUMBER);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(buffer);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_buf_get_name(int64_t buffer)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_get_name", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_BUF_GET_NAME);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(buffer);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_buf_set_name(int64_t buffer, QByteArray name)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_set_name", 2);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_BUF_SET_NAME);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(buffer);
+	m_c->m_dev->send(name);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_buf_is_loaded(int64_t buffer)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_is_loaded", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_BUF_IS_LOADED);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(buffer);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_buf_is_valid(int64_t buffer)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_is_valid", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_BUF_IS_VALID);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(buffer);
+	return r;
+}
+MsgpackRequest* NeovimApi5::buffer_insert(int64_t buffer, int64_t lnum, QList<QByteArray> lines)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_insert", 3);
+	r->setFunction(NeovimApi5::NEOVIM_FN_BUFFER_INSERT);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(buffer);
+	m_c->m_dev->send(lnum);
+	m_c->m_dev->sendArrayOf(lines);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_buf_get_mark(int64_t buffer, QByteArray name)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_get_mark", 2);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_BUF_GET_MARK);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(buffer);
+	m_c->m_dev->send(name);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_buf_add_highlight(int64_t buffer, int64_t ns_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_add_highlight", 6);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_BUF_ADD_HIGHLIGHT);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(buffer);
+	m_c->m_dev->send(ns_id);
+	m_c->m_dev->send(hl_group);
+	m_c->m_dev->send(line);
+	m_c->m_dev->send(col_start);
+	m_c->m_dev->send(col_end);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_buf_clear_namespace(int64_t buffer, int64_t ns_id, int64_t line_start, int64_t line_end)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_clear_namespace", 4);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_BUF_CLEAR_NAMESPACE);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(buffer);
+	m_c->m_dev->send(ns_id);
+	m_c->m_dev->send(line_start);
+	m_c->m_dev->send(line_end);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_buf_clear_highlight(int64_t buffer, int64_t ns_id, int64_t line_start, int64_t line_end)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_clear_highlight", 4);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_BUF_CLEAR_HIGHLIGHT);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(buffer);
+	m_c->m_dev->send(ns_id);
+	m_c->m_dev->send(line_start);
+	m_c->m_dev->send(line_end);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_buf_set_virtual_text(int64_t buffer, int64_t ns_id, int64_t line, QVariantList chunks, QVariantMap opts)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_set_virtual_text", 5);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_BUF_SET_VIRTUAL_TEXT);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(buffer);
+	m_c->m_dev->send(ns_id);
+	m_c->m_dev->send(line);
+	m_c->m_dev->send(chunks);
+	m_c->m_dev->send(opts);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_tabpage_list_wins(int64_t tabpage)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_tabpage_list_wins", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_TABPAGE_LIST_WINS);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(tabpage);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_tabpage_get_var(int64_t tabpage, QByteArray name)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_tabpage_get_var", 2);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_TABPAGE_GET_VAR);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(tabpage);
+	m_c->m_dev->send(name);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_tabpage_set_var", 3);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_TABPAGE_SET_VAR);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(tabpage);
+	m_c->m_dev->send(name);
+	m_c->m_dev->send(value);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_tabpage_del_var(int64_t tabpage, QByteArray name)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_tabpage_del_var", 2);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_TABPAGE_DEL_VAR);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(tabpage);
+	m_c->m_dev->send(name);
+	return r;
+}
+MsgpackRequest* NeovimApi5::tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("tabpage_set_var", 3);
+	r->setFunction(NeovimApi5::NEOVIM_FN_TABPAGE_SET_VAR);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(tabpage);
+	m_c->m_dev->send(name);
+	m_c->m_dev->send(value);
+	return r;
+}
+MsgpackRequest* NeovimApi5::tabpage_del_var(int64_t tabpage, QByteArray name)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("tabpage_del_var", 2);
+	r->setFunction(NeovimApi5::NEOVIM_FN_TABPAGE_DEL_VAR);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(tabpage);
+	m_c->m_dev->send(name);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_tabpage_get_win(int64_t tabpage)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_tabpage_get_win", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_TABPAGE_GET_WIN);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(tabpage);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_tabpage_get_number(int64_t tabpage)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_tabpage_get_number", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_TABPAGE_GET_NUMBER);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(tabpage);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_tabpage_is_valid(int64_t tabpage)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_tabpage_is_valid", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_TABPAGE_IS_VALID);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(tabpage);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_ui_attach(int64_t width, int64_t height, QVariantMap options)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_ui_attach", 3);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_UI_ATTACH);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(width);
+	m_c->m_dev->send(height);
+	m_c->m_dev->send(options);
+	return r;
+}
+MsgpackRequest* NeovimApi5::ui_attach(int64_t width, int64_t height, bool enable_rgb)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("ui_attach", 3);
+	r->setFunction(NeovimApi5::NEOVIM_FN_UI_ATTACH);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(width);
+	m_c->m_dev->send(height);
+	m_c->m_dev->send(enable_rgb);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_ui_detach()
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_ui_detach", 0);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_UI_DETACH);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_ui_try_resize(int64_t width, int64_t height)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_ui_try_resize", 2);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_UI_TRY_RESIZE);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(width);
+	m_c->m_dev->send(height);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_ui_set_option(QByteArray name, QVariant value)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_ui_set_option", 2);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_UI_SET_OPTION);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(name);
+	m_c->m_dev->send(value);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_command(QByteArray command)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_command", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_COMMAND);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(command);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_get_hl_by_name(QByteArray name, bool rgb)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_hl_by_name", 2);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_GET_HL_BY_NAME);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(name);
+	m_c->m_dev->send(rgb);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_get_hl_by_id(int64_t hl_id, bool rgb)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_hl_by_id", 2);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_GET_HL_BY_ID);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(hl_id);
+	m_c->m_dev->send(rgb);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_feedkeys", 3);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_FEEDKEYS);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(keys);
+	m_c->m_dev->send(mode);
+	m_c->m_dev->send(escape_csi);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_input(QByteArray keys)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_input", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_INPUT);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(keys);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_replace_termcodes", 4);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_REPLACE_TERMCODES);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(str);
+	m_c->m_dev->send(from_part);
+	m_c->m_dev->send(do_lt);
+	m_c->m_dev->send(special);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_command_output(QByteArray command)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_command_output", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_COMMAND_OUTPUT);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(command);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_eval(QByteArray expr)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_eval", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_EVAL);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(expr);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_execute_lua(QByteArray code, QVariantList args)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_execute_lua", 2);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_EXECUTE_LUA);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(code);
+	m_c->m_dev->send(args);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_call_function(QByteArray fn, QVariantList args)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_call_function", 2);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_CALL_FUNCTION);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(fn);
+	m_c->m_dev->send(args);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_call_dict_function(QVariant dict, QByteArray fn, QVariantList args)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_call_dict_function", 3);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_CALL_DICT_FUNCTION);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(dict);
+	m_c->m_dev->send(fn);
+	m_c->m_dev->send(args);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_strwidth(QByteArray text)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_strwidth", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_STRWIDTH);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(text);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_list_runtime_paths()
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_list_runtime_paths", 0);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_LIST_RUNTIME_PATHS);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_set_current_dir(QByteArray dir)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_set_current_dir", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_SET_CURRENT_DIR);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(dir);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_get_current_line()
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_current_line", 0);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_GET_CURRENT_LINE);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_set_current_line(QByteArray line)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_set_current_line", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_SET_CURRENT_LINE);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(line);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_del_current_line()
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_del_current_line", 0);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_DEL_CURRENT_LINE);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_get_var(QByteArray name)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_var", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_GET_VAR);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(name);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_set_var(QByteArray name, QVariant value)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_set_var", 2);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_SET_VAR);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(name);
+	m_c->m_dev->send(value);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_del_var(QByteArray name)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_del_var", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_DEL_VAR);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(name);
+	return r;
+}
+MsgpackRequest* NeovimApi5::vim_set_var(QByteArray name, QVariant value)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_set_var", 2);
+	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_SET_VAR);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(name);
+	m_c->m_dev->send(value);
+	return r;
+}
+MsgpackRequest* NeovimApi5::vim_del_var(QByteArray name)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_del_var", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_DEL_VAR);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(name);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_get_vvar(QByteArray name)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_vvar", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_GET_VVAR);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(name);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_get_option(QByteArray name)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_option", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_GET_OPTION);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(name);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_set_option(QByteArray name, QVariant value)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_set_option", 2);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_SET_OPTION);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(name);
+	m_c->m_dev->send(value);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_out_write(QByteArray str)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_out_write", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_OUT_WRITE);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(str);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_err_write(QByteArray str)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_err_write", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_ERR_WRITE);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(str);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_err_writeln(QByteArray str)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_err_writeln", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_ERR_WRITELN);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(str);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_list_bufs()
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_list_bufs", 0);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_LIST_BUFS);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_get_current_buf()
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_current_buf", 0);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_GET_CURRENT_BUF);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_set_current_buf(int64_t buffer)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_set_current_buf", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_SET_CURRENT_BUF);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(buffer);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_list_wins()
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_list_wins", 0);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_LIST_WINS);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_get_current_win()
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_current_win", 0);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_GET_CURRENT_WIN);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_set_current_win(int64_t window)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_set_current_win", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_SET_CURRENT_WIN);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(window);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_list_tabpages()
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_list_tabpages", 0);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_LIST_TABPAGES);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_get_current_tabpage()
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_current_tabpage", 0);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_GET_CURRENT_TABPAGE);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_set_current_tabpage(int64_t tabpage)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_set_current_tabpage", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_SET_CURRENT_TABPAGE);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(tabpage);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_create_namespace(QByteArray name)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_create_namespace", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_CREATE_NAMESPACE);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(name);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_get_namespaces()
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_namespaces", 0);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_GET_NAMESPACES);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_subscribe(QByteArray event)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_subscribe", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_SUBSCRIBE);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(event);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_unsubscribe(QByteArray event)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_unsubscribe", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_UNSUBSCRIBE);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(event);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_get_color_by_name(QByteArray name)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_color_by_name", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_GET_COLOR_BY_NAME);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(name);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_get_color_map()
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_color_map", 0);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_GET_COLOR_MAP);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_get_mode()
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_mode", 0);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_GET_MODE);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_get_keymap(QByteArray mode)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_keymap", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_GET_KEYMAP);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(mode);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_get_commands(QVariantMap opts)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_commands", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_GET_COMMANDS);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(opts);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_get_api_info()
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_api_info", 0);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_GET_API_INFO);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_set_client_info(QByteArray name, QVariantMap version, QByteArray type, QVariantMap methods, QVariantMap attributes)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_set_client_info", 5);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_SET_CLIENT_INFO);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(name);
+	m_c->m_dev->send(version);
+	m_c->m_dev->send(type);
+	m_c->m_dev->send(methods);
+	m_c->m_dev->send(attributes);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_get_chan_info(int64_t chan)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_chan_info", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_GET_CHAN_INFO);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(chan);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_list_chans()
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_list_chans", 0);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_LIST_CHANS);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_call_atomic(QVariantList calls)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_call_atomic", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_CALL_ATOMIC);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(calls);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_parse_expression(QByteArray expr, QByteArray flags, bool highlight)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_parse_expression", 3);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_PARSE_EXPRESSION);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(expr);
+	m_c->m_dev->send(flags);
+	m_c->m_dev->send(highlight);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_list_uis()
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_list_uis", 0);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_LIST_UIS);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_get_proc_children(int64_t pid)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_proc_children", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_GET_PROC_CHILDREN);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(pid);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_get_proc(int64_t pid)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_proc", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_GET_PROC);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(pid);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_win_get_buf(int64_t window)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_buf", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_WIN_GET_BUF);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(window);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_win_set_buf(int64_t window, int64_t buffer)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_set_buf", 2);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_WIN_SET_BUF);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(window);
+	m_c->m_dev->send(buffer);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_win_get_cursor(int64_t window)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_cursor", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_WIN_GET_CURSOR);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(window);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_win_set_cursor(int64_t window, QPoint pos)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_set_cursor", 2);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_WIN_SET_CURSOR);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(window);
+	m_c->m_dev->send(pos);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_win_get_height(int64_t window)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_height", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_WIN_GET_HEIGHT);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(window);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_win_set_height(int64_t window, int64_t height)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_set_height", 2);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_WIN_SET_HEIGHT);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(window);
+	m_c->m_dev->send(height);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_win_get_width(int64_t window)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_width", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_WIN_GET_WIDTH);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(window);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_win_set_width(int64_t window, int64_t width)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_set_width", 2);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_WIN_SET_WIDTH);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(window);
+	m_c->m_dev->send(width);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_win_get_var(int64_t window, QByteArray name)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_var", 2);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_WIN_GET_VAR);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(window);
+	m_c->m_dev->send(name);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_win_set_var(int64_t window, QByteArray name, QVariant value)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_set_var", 3);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_WIN_SET_VAR);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(window);
+	m_c->m_dev->send(name);
+	m_c->m_dev->send(value);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_win_del_var(int64_t window, QByteArray name)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_del_var", 2);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_WIN_DEL_VAR);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(window);
+	m_c->m_dev->send(name);
+	return r;
+}
+MsgpackRequest* NeovimApi5::window_set_var(int64_t window, QByteArray name, QVariant value)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_set_var", 3);
+	r->setFunction(NeovimApi5::NEOVIM_FN_WINDOW_SET_VAR);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(window);
+	m_c->m_dev->send(name);
+	m_c->m_dev->send(value);
+	return r;
+}
+MsgpackRequest* NeovimApi5::window_del_var(int64_t window, QByteArray name)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_del_var", 2);
+	r->setFunction(NeovimApi5::NEOVIM_FN_WINDOW_DEL_VAR);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(window);
+	m_c->m_dev->send(name);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_win_get_option(int64_t window, QByteArray name)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_option", 2);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_WIN_GET_OPTION);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(window);
+	m_c->m_dev->send(name);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_win_set_option(int64_t window, QByteArray name, QVariant value)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_set_option", 3);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_WIN_SET_OPTION);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(window);
+	m_c->m_dev->send(name);
+	m_c->m_dev->send(value);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_win_get_position(int64_t window)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_position", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_WIN_GET_POSITION);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(window);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_win_get_tabpage(int64_t window)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_tabpage", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_WIN_GET_TABPAGE);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(window);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_win_get_number(int64_t window)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_number", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_WIN_GET_NUMBER);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(window);
+	return r;
+}
+MsgpackRequest* NeovimApi5::nvim_win_is_valid(int64_t window)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_is_valid", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_WIN_IS_VALID);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(window);
+	return r;
+}
+MsgpackRequest* NeovimApi5::buffer_line_count(int64_t buffer)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_line_count", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_BUFFER_LINE_COUNT);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(buffer);
+	return r;
+}
+MsgpackRequest* NeovimApi5::buffer_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_lines", 4);
+	r->setFunction(NeovimApi5::NEOVIM_FN_BUFFER_GET_LINES);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(buffer);
+	m_c->m_dev->send(start);
+	m_c->m_dev->send(end);
+	m_c->m_dev->send(strict_indexing);
+	return r;
+}
+MsgpackRequest* NeovimApi5::buffer_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_set_lines", 5);
+	r->setFunction(NeovimApi5::NEOVIM_FN_BUFFER_SET_LINES);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(buffer);
+	m_c->m_dev->send(start);
+	m_c->m_dev->send(end);
+	m_c->m_dev->send(strict_indexing);
+	m_c->m_dev->sendArrayOf(replacement);
+	return r;
+}
+MsgpackRequest* NeovimApi5::buffer_get_var(int64_t buffer, QByteArray name)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_var", 2);
+	r->setFunction(NeovimApi5::NEOVIM_FN_BUFFER_GET_VAR);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(buffer);
+	m_c->m_dev->send(name);
+	return r;
+}
+MsgpackRequest* NeovimApi5::buffer_get_option(int64_t buffer, QByteArray name)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_option", 2);
+	r->setFunction(NeovimApi5::NEOVIM_FN_BUFFER_GET_OPTION);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(buffer);
+	m_c->m_dev->send(name);
+	return r;
+}
+MsgpackRequest* NeovimApi5::buffer_set_option(int64_t buffer, QByteArray name, QVariant value)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_set_option", 3);
+	r->setFunction(NeovimApi5::NEOVIM_FN_BUFFER_SET_OPTION);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(buffer);
+	m_c->m_dev->send(name);
+	m_c->m_dev->send(value);
+	return r;
+}
+MsgpackRequest* NeovimApi5::buffer_get_number(int64_t buffer)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_number", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_BUFFER_GET_NUMBER);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(buffer);
+	return r;
+}
+MsgpackRequest* NeovimApi5::buffer_get_name(int64_t buffer)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_name", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_BUFFER_GET_NAME);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(buffer);
+	return r;
+}
+MsgpackRequest* NeovimApi5::buffer_set_name(int64_t buffer, QByteArray name)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_set_name", 2);
+	r->setFunction(NeovimApi5::NEOVIM_FN_BUFFER_SET_NAME);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(buffer);
+	m_c->m_dev->send(name);
+	return r;
+}
+MsgpackRequest* NeovimApi5::buffer_is_valid(int64_t buffer)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_is_valid", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_BUFFER_IS_VALID);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(buffer);
+	return r;
+}
+MsgpackRequest* NeovimApi5::buffer_get_mark(int64_t buffer, QByteArray name)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_mark", 2);
+	r->setFunction(NeovimApi5::NEOVIM_FN_BUFFER_GET_MARK);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(buffer);
+	m_c->m_dev->send(name);
+	return r;
+}
+MsgpackRequest* NeovimApi5::buffer_add_highlight(int64_t buffer, int64_t ns_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_add_highlight", 6);
+	r->setFunction(NeovimApi5::NEOVIM_FN_BUFFER_ADD_HIGHLIGHT);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(buffer);
+	m_c->m_dev->send(ns_id);
+	m_c->m_dev->send(hl_group);
+	m_c->m_dev->send(line);
+	m_c->m_dev->send(col_start);
+	m_c->m_dev->send(col_end);
+	return r;
+}
+MsgpackRequest* NeovimApi5::buffer_clear_highlight(int64_t buffer, int64_t ns_id, int64_t line_start, int64_t line_end)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_clear_highlight", 4);
+	r->setFunction(NeovimApi5::NEOVIM_FN_BUFFER_CLEAR_HIGHLIGHT);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(buffer);
+	m_c->m_dev->send(ns_id);
+	m_c->m_dev->send(line_start);
+	m_c->m_dev->send(line_end);
+	return r;
+}
+MsgpackRequest* NeovimApi5::tabpage_get_windows(int64_t tabpage)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("tabpage_get_windows", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_TABPAGE_GET_WINDOWS);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(tabpage);
+	return r;
+}
+MsgpackRequest* NeovimApi5::tabpage_get_var(int64_t tabpage, QByteArray name)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("tabpage_get_var", 2);
+	r->setFunction(NeovimApi5::NEOVIM_FN_TABPAGE_GET_VAR);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(tabpage);
+	m_c->m_dev->send(name);
+	return r;
+}
+MsgpackRequest* NeovimApi5::tabpage_get_window(int64_t tabpage)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("tabpage_get_window", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_TABPAGE_GET_WINDOW);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(tabpage);
+	return r;
+}
+MsgpackRequest* NeovimApi5::tabpage_is_valid(int64_t tabpage)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("tabpage_is_valid", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_TABPAGE_IS_VALID);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(tabpage);
+	return r;
+}
+MsgpackRequest* NeovimApi5::ui_detach()
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("ui_detach", 0);
+	r->setFunction(NeovimApi5::NEOVIM_FN_UI_DETACH);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	return r;
+}
+MsgpackRequest* NeovimApi5::ui_try_resize(int64_t width, int64_t height)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("ui_try_resize", 2);
+	r->setFunction(NeovimApi5::NEOVIM_FN_UI_TRY_RESIZE);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(width);
+	m_c->m_dev->send(height);
+	return r;
+}
+MsgpackRequest* NeovimApi5::vim_command(QByteArray command)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_command", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_COMMAND);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(command);
+	return r;
+}
+MsgpackRequest* NeovimApi5::vim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_feedkeys", 3);
+	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_FEEDKEYS);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(keys);
+	m_c->m_dev->send(mode);
+	m_c->m_dev->send(escape_csi);
+	return r;
+}
+MsgpackRequest* NeovimApi5::vim_input(QByteArray keys)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_input", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_INPUT);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(keys);
+	return r;
+}
+MsgpackRequest* NeovimApi5::vim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_replace_termcodes", 4);
+	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_REPLACE_TERMCODES);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(str);
+	m_c->m_dev->send(from_part);
+	m_c->m_dev->send(do_lt);
+	m_c->m_dev->send(special);
+	return r;
+}
+MsgpackRequest* NeovimApi5::vim_command_output(QByteArray command)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_command_output", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_COMMAND_OUTPUT);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(command);
+	return r;
+}
+MsgpackRequest* NeovimApi5::vim_eval(QByteArray expr)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_eval", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_EVAL);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(expr);
+	return r;
+}
+MsgpackRequest* NeovimApi5::vim_call_function(QByteArray fn, QVariantList args)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_call_function", 2);
+	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_CALL_FUNCTION);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(fn);
+	m_c->m_dev->send(args);
+	return r;
+}
+MsgpackRequest* NeovimApi5::vim_strwidth(QByteArray text)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_strwidth", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_STRWIDTH);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(text);
+	return r;
+}
+MsgpackRequest* NeovimApi5::vim_list_runtime_paths()
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_list_runtime_paths", 0);
+	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_LIST_RUNTIME_PATHS);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	return r;
+}
+MsgpackRequest* NeovimApi5::vim_change_directory(QByteArray dir)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_change_directory", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_CHANGE_DIRECTORY);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(dir);
+	return r;
+}
+MsgpackRequest* NeovimApi5::vim_get_current_line()
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_current_line", 0);
+	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_GET_CURRENT_LINE);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	return r;
+}
+MsgpackRequest* NeovimApi5::vim_set_current_line(QByteArray line)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_set_current_line", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_SET_CURRENT_LINE);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(line);
+	return r;
+}
+MsgpackRequest* NeovimApi5::vim_del_current_line()
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_del_current_line", 0);
+	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_DEL_CURRENT_LINE);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	return r;
+}
+MsgpackRequest* NeovimApi5::vim_get_var(QByteArray name)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_var", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_GET_VAR);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(name);
+	return r;
+}
+MsgpackRequest* NeovimApi5::vim_get_vvar(QByteArray name)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_vvar", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_GET_VVAR);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(name);
+	return r;
+}
+MsgpackRequest* NeovimApi5::vim_get_option(QByteArray name)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_option", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_GET_OPTION);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(name);
+	return r;
+}
+MsgpackRequest* NeovimApi5::vim_set_option(QByteArray name, QVariant value)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_set_option", 2);
+	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_SET_OPTION);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(name);
+	m_c->m_dev->send(value);
+	return r;
+}
+MsgpackRequest* NeovimApi5::vim_out_write(QByteArray str)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_out_write", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_OUT_WRITE);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(str);
+	return r;
+}
+MsgpackRequest* NeovimApi5::vim_err_write(QByteArray str)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_err_write", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_ERR_WRITE);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(str);
+	return r;
+}
+MsgpackRequest* NeovimApi5::vim_report_error(QByteArray str)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_report_error", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_REPORT_ERROR);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(str);
+	return r;
+}
+MsgpackRequest* NeovimApi5::vim_get_buffers()
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_buffers", 0);
+	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_GET_BUFFERS);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	return r;
+}
+MsgpackRequest* NeovimApi5::vim_get_current_buffer()
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_current_buffer", 0);
+	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_GET_CURRENT_BUFFER);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	return r;
+}
+MsgpackRequest* NeovimApi5::vim_set_current_buffer(int64_t buffer)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_set_current_buffer", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_SET_CURRENT_BUFFER);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(buffer);
+	return r;
+}
+MsgpackRequest* NeovimApi5::vim_get_windows()
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_windows", 0);
+	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_GET_WINDOWS);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	return r;
+}
+MsgpackRequest* NeovimApi5::vim_get_current_window()
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_current_window", 0);
+	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_GET_CURRENT_WINDOW);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	return r;
+}
+MsgpackRequest* NeovimApi5::vim_set_current_window(int64_t window)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_set_current_window", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_SET_CURRENT_WINDOW);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(window);
+	return r;
+}
+MsgpackRequest* NeovimApi5::vim_get_tabpages()
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_tabpages", 0);
+	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_GET_TABPAGES);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	return r;
+}
+MsgpackRequest* NeovimApi5::vim_get_current_tabpage()
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_current_tabpage", 0);
+	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_GET_CURRENT_TABPAGE);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	return r;
+}
+MsgpackRequest* NeovimApi5::vim_set_current_tabpage(int64_t tabpage)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_set_current_tabpage", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_SET_CURRENT_TABPAGE);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(tabpage);
+	return r;
+}
+MsgpackRequest* NeovimApi5::vim_subscribe(QByteArray event)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_subscribe", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_SUBSCRIBE);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(event);
+	return r;
+}
+MsgpackRequest* NeovimApi5::vim_unsubscribe(QByteArray event)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_unsubscribe", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_UNSUBSCRIBE);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(event);
+	return r;
+}
+MsgpackRequest* NeovimApi5::vim_name_to_color(QByteArray name)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_name_to_color", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_NAME_TO_COLOR);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(name);
+	return r;
+}
+MsgpackRequest* NeovimApi5::vim_get_color_map()
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_color_map", 0);
+	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_GET_COLOR_MAP);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	return r;
+}
+MsgpackRequest* NeovimApi5::window_get_buffer(int64_t window)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_buffer", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_WINDOW_GET_BUFFER);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(window);
+	return r;
+}
+MsgpackRequest* NeovimApi5::window_get_cursor(int64_t window)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_cursor", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_WINDOW_GET_CURSOR);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(window);
+	return r;
+}
+MsgpackRequest* NeovimApi5::window_set_cursor(int64_t window, QPoint pos)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_set_cursor", 2);
+	r->setFunction(NeovimApi5::NEOVIM_FN_WINDOW_SET_CURSOR);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(window);
+	m_c->m_dev->send(pos);
+	return r;
+}
+MsgpackRequest* NeovimApi5::window_get_height(int64_t window)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_height", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_WINDOW_GET_HEIGHT);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(window);
+	return r;
+}
+MsgpackRequest* NeovimApi5::window_set_height(int64_t window, int64_t height)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_set_height", 2);
+	r->setFunction(NeovimApi5::NEOVIM_FN_WINDOW_SET_HEIGHT);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(window);
+	m_c->m_dev->send(height);
+	return r;
+}
+MsgpackRequest* NeovimApi5::window_get_width(int64_t window)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_width", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_WINDOW_GET_WIDTH);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(window);
+	return r;
+}
+MsgpackRequest* NeovimApi5::window_set_width(int64_t window, int64_t width)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_set_width", 2);
+	r->setFunction(NeovimApi5::NEOVIM_FN_WINDOW_SET_WIDTH);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(window);
+	m_c->m_dev->send(width);
+	return r;
+}
+MsgpackRequest* NeovimApi5::window_get_var(int64_t window, QByteArray name)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_var", 2);
+	r->setFunction(NeovimApi5::NEOVIM_FN_WINDOW_GET_VAR);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(window);
+	m_c->m_dev->send(name);
+	return r;
+}
+MsgpackRequest* NeovimApi5::window_get_option(int64_t window, QByteArray name)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_option", 2);
+	r->setFunction(NeovimApi5::NEOVIM_FN_WINDOW_GET_OPTION);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(window);
+	m_c->m_dev->send(name);
+	return r;
+}
+MsgpackRequest* NeovimApi5::window_set_option(int64_t window, QByteArray name, QVariant value)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_set_option", 3);
+	r->setFunction(NeovimApi5::NEOVIM_FN_WINDOW_SET_OPTION);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(window);
+	m_c->m_dev->send(name);
+	m_c->m_dev->send(value);
+	return r;
+}
+MsgpackRequest* NeovimApi5::window_get_position(int64_t window)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_position", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_WINDOW_GET_POSITION);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(window);
+	return r;
+}
+MsgpackRequest* NeovimApi5::window_get_tabpage(int64_t window)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_tabpage", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_WINDOW_GET_TABPAGE);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(window);
+	return r;
+}
+MsgpackRequest* NeovimApi5::window_is_valid(int64_t window)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_is_valid", 1);
+	r->setFunction(NeovimApi5::NEOVIM_FN_WINDOW_IS_VALID);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
+	m_c->m_dev->send(window);
+	return r;
+}
+
+// Handlers
+
+void NeovimApi5::handleResponseError(quint32 msgid, quint64 fun, const QVariant& res)
+{
+
+	// TODO: support Neovim error types Exception/Validation/etc
+	QString errMsg;
+	const QVariantList asList = res.toList();
+	if (asList.size() >= 2) {
+		if (asList.at(1).canConvert<QByteArray>()) {
+			errMsg = m_c->m_dev->decode(asList.at(1).toByteArray());
+		} else {
+			errMsg = tr("Received unsupported Neovim error type");
+		}
+	}
+
+	switch(fun) {
+	case NeovimApi5::NEOVIM_FN_NVIM_BUF_LINE_COUNT:
+		emit err_nvim_buf_line_count(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_BUFFER_GET_LINE:
+		emit err_buffer_get_line(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_BUF_ATTACH:
+		emit err_nvim_buf_attach(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_BUF_DETACH:
+		emit err_nvim_buf_detach(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_BUFFER_SET_LINE:
+		emit err_buffer_set_line(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_BUFFER_DEL_LINE:
+		emit err_buffer_del_line(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_BUFFER_GET_LINE_SLICE:
+		emit err_buffer_get_line_slice(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_BUF_GET_LINES:
+		emit err_nvim_buf_get_lines(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_BUFFER_SET_LINE_SLICE:
+		emit err_buffer_set_line_slice(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_BUF_SET_LINES:
+		emit err_nvim_buf_set_lines(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_BUF_GET_OFFSET:
+		emit err_nvim_buf_get_offset(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_BUF_GET_VAR:
+		emit err_nvim_buf_get_var(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_BUF_GET_CHANGEDTICK:
+		emit err_nvim_buf_get_changedtick(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_BUF_GET_KEYMAP:
+		emit err_nvim_buf_get_keymap(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_BUF_GET_COMMANDS:
+		emit err_nvim_buf_get_commands(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_BUF_SET_VAR:
+		emit err_nvim_buf_set_var(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_BUF_DEL_VAR:
+		emit err_nvim_buf_del_var(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_BUFFER_SET_VAR:
+		emit err_buffer_set_var(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_BUFFER_DEL_VAR:
+		emit err_buffer_del_var(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_BUF_GET_OPTION:
+		emit err_nvim_buf_get_option(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_BUF_SET_OPTION:
+		emit err_nvim_buf_set_option(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_BUF_GET_NUMBER:
+		emit err_nvim_buf_get_number(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_BUF_GET_NAME:
+		emit err_nvim_buf_get_name(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_BUF_SET_NAME:
+		emit err_nvim_buf_set_name(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_BUF_IS_LOADED:
+		emit err_nvim_buf_is_loaded(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_BUF_IS_VALID:
+		emit err_nvim_buf_is_valid(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_BUFFER_INSERT:
+		emit err_buffer_insert(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_BUF_GET_MARK:
+		emit err_nvim_buf_get_mark(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_BUF_ADD_HIGHLIGHT:
+		emit err_nvim_buf_add_highlight(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_BUF_CLEAR_NAMESPACE:
+		emit err_nvim_buf_clear_namespace(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_BUF_CLEAR_HIGHLIGHT:
+		emit err_nvim_buf_clear_highlight(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_BUF_SET_VIRTUAL_TEXT:
+		emit err_nvim_buf_set_virtual_text(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_TABPAGE_LIST_WINS:
+		emit err_nvim_tabpage_list_wins(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_TABPAGE_GET_VAR:
+		emit err_nvim_tabpage_get_var(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_TABPAGE_SET_VAR:
+		emit err_nvim_tabpage_set_var(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_TABPAGE_DEL_VAR:
+		emit err_nvim_tabpage_del_var(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_TABPAGE_SET_VAR:
+		emit err_tabpage_set_var(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_TABPAGE_DEL_VAR:
+		emit err_tabpage_del_var(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_TABPAGE_GET_WIN:
+		emit err_nvim_tabpage_get_win(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_TABPAGE_GET_NUMBER:
+		emit err_nvim_tabpage_get_number(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_TABPAGE_IS_VALID:
+		emit err_nvim_tabpage_is_valid(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_UI_ATTACH:
+		emit err_nvim_ui_attach(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_UI_ATTACH:
+		emit err_ui_attach(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_UI_DETACH:
+		emit err_nvim_ui_detach(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_UI_TRY_RESIZE:
+		emit err_nvim_ui_try_resize(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_UI_SET_OPTION:
+		emit err_nvim_ui_set_option(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_COMMAND:
+		emit err_nvim_command(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_GET_HL_BY_NAME:
+		emit err_nvim_get_hl_by_name(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_GET_HL_BY_ID:
+		emit err_nvim_get_hl_by_id(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_FEEDKEYS:
+		emit err_nvim_feedkeys(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_INPUT:
+		emit err_nvim_input(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_REPLACE_TERMCODES:
+		emit err_nvim_replace_termcodes(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_COMMAND_OUTPUT:
+		emit err_nvim_command_output(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_EVAL:
+		emit err_nvim_eval(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_EXECUTE_LUA:
+		emit err_nvim_execute_lua(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_CALL_FUNCTION:
+		emit err_nvim_call_function(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_CALL_DICT_FUNCTION:
+		emit err_nvim_call_dict_function(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_STRWIDTH:
+		emit err_nvim_strwidth(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_LIST_RUNTIME_PATHS:
+		emit err_nvim_list_runtime_paths(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_SET_CURRENT_DIR:
+		emit err_nvim_set_current_dir(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_GET_CURRENT_LINE:
+		emit err_nvim_get_current_line(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_SET_CURRENT_LINE:
+		emit err_nvim_set_current_line(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_DEL_CURRENT_LINE:
+		emit err_nvim_del_current_line(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_GET_VAR:
+		emit err_nvim_get_var(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_SET_VAR:
+		emit err_nvim_set_var(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_DEL_VAR:
+		emit err_nvim_del_var(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_SET_VAR:
+		emit err_vim_set_var(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_DEL_VAR:
+		emit err_vim_del_var(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_GET_VVAR:
+		emit err_nvim_get_vvar(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_GET_OPTION:
+		emit err_nvim_get_option(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_SET_OPTION:
+		emit err_nvim_set_option(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_OUT_WRITE:
+		emit err_nvim_out_write(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_ERR_WRITE:
+		emit err_nvim_err_write(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_ERR_WRITELN:
+		emit err_nvim_err_writeln(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_LIST_BUFS:
+		emit err_nvim_list_bufs(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_GET_CURRENT_BUF:
+		emit err_nvim_get_current_buf(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_SET_CURRENT_BUF:
+		emit err_nvim_set_current_buf(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_LIST_WINS:
+		emit err_nvim_list_wins(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_GET_CURRENT_WIN:
+		emit err_nvim_get_current_win(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_SET_CURRENT_WIN:
+		emit err_nvim_set_current_win(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_LIST_TABPAGES:
+		emit err_nvim_list_tabpages(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_GET_CURRENT_TABPAGE:
+		emit err_nvim_get_current_tabpage(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_SET_CURRENT_TABPAGE:
+		emit err_nvim_set_current_tabpage(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_CREATE_NAMESPACE:
+		emit err_nvim_create_namespace(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_GET_NAMESPACES:
+		emit err_nvim_get_namespaces(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_SUBSCRIBE:
+		emit err_nvim_subscribe(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_UNSUBSCRIBE:
+		emit err_nvim_unsubscribe(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_GET_COLOR_BY_NAME:
+		emit err_nvim_get_color_by_name(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_GET_COLOR_MAP:
+		emit err_nvim_get_color_map(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_GET_MODE:
+		emit err_nvim_get_mode(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_GET_KEYMAP:
+		emit err_nvim_get_keymap(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_GET_COMMANDS:
+		emit err_nvim_get_commands(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_GET_API_INFO:
+		emit err_nvim_get_api_info(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_SET_CLIENT_INFO:
+		emit err_nvim_set_client_info(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_GET_CHAN_INFO:
+		emit err_nvim_get_chan_info(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_LIST_CHANS:
+		emit err_nvim_list_chans(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_CALL_ATOMIC:
+		emit err_nvim_call_atomic(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_PARSE_EXPRESSION:
+		emit err_nvim_parse_expression(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_LIST_UIS:
+		emit err_nvim_list_uis(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_GET_PROC_CHILDREN:
+		emit err_nvim_get_proc_children(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_GET_PROC:
+		emit err_nvim_get_proc(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_WIN_GET_BUF:
+		emit err_nvim_win_get_buf(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_WIN_SET_BUF:
+		emit err_nvim_win_set_buf(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_WIN_GET_CURSOR:
+		emit err_nvim_win_get_cursor(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_WIN_SET_CURSOR:
+		emit err_nvim_win_set_cursor(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_WIN_GET_HEIGHT:
+		emit err_nvim_win_get_height(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_WIN_SET_HEIGHT:
+		emit err_nvim_win_set_height(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_WIN_GET_WIDTH:
+		emit err_nvim_win_get_width(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_WIN_SET_WIDTH:
+		emit err_nvim_win_set_width(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_WIN_GET_VAR:
+		emit err_nvim_win_get_var(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_WIN_SET_VAR:
+		emit err_nvim_win_set_var(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_WIN_DEL_VAR:
+		emit err_nvim_win_del_var(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_WINDOW_SET_VAR:
+		emit err_window_set_var(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_WINDOW_DEL_VAR:
+		emit err_window_del_var(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_WIN_GET_OPTION:
+		emit err_nvim_win_get_option(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_WIN_SET_OPTION:
+		emit err_nvim_win_set_option(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_WIN_GET_POSITION:
+		emit err_nvim_win_get_position(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_WIN_GET_TABPAGE:
+		emit err_nvim_win_get_tabpage(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_WIN_GET_NUMBER:
+		emit err_nvim_win_get_number(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_WIN_IS_VALID:
+		emit err_nvim_win_is_valid(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_BUFFER_LINE_COUNT:
+		emit err_buffer_line_count(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_BUFFER_GET_LINES:
+		emit err_buffer_get_lines(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_BUFFER_SET_LINES:
+		emit err_buffer_set_lines(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_BUFFER_GET_VAR:
+		emit err_buffer_get_var(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_BUFFER_GET_OPTION:
+		emit err_buffer_get_option(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_BUFFER_SET_OPTION:
+		emit err_buffer_set_option(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_BUFFER_GET_NUMBER:
+		emit err_buffer_get_number(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_BUFFER_GET_NAME:
+		emit err_buffer_get_name(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_BUFFER_SET_NAME:
+		emit err_buffer_set_name(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_BUFFER_IS_VALID:
+		emit err_buffer_is_valid(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_BUFFER_GET_MARK:
+		emit err_buffer_get_mark(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_BUFFER_ADD_HIGHLIGHT:
+		emit err_buffer_add_highlight(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_BUFFER_CLEAR_HIGHLIGHT:
+		emit err_buffer_clear_highlight(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_TABPAGE_GET_WINDOWS:
+		emit err_tabpage_get_windows(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_TABPAGE_GET_VAR:
+		emit err_tabpage_get_var(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_TABPAGE_GET_WINDOW:
+		emit err_tabpage_get_window(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_TABPAGE_IS_VALID:
+		emit err_tabpage_is_valid(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_UI_DETACH:
+		emit err_ui_detach(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_UI_TRY_RESIZE:
+		emit err_ui_try_resize(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_COMMAND:
+		emit err_vim_command(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_FEEDKEYS:
+		emit err_vim_feedkeys(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_INPUT:
+		emit err_vim_input(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_REPLACE_TERMCODES:
+		emit err_vim_replace_termcodes(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_COMMAND_OUTPUT:
+		emit err_vim_command_output(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_EVAL:
+		emit err_vim_eval(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_CALL_FUNCTION:
+		emit err_vim_call_function(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_STRWIDTH:
+		emit err_vim_strwidth(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_LIST_RUNTIME_PATHS:
+		emit err_vim_list_runtime_paths(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_CHANGE_DIRECTORY:
+		emit err_vim_change_directory(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_GET_CURRENT_LINE:
+		emit err_vim_get_current_line(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_SET_CURRENT_LINE:
+		emit err_vim_set_current_line(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_DEL_CURRENT_LINE:
+		emit err_vim_del_current_line(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_GET_VAR:
+		emit err_vim_get_var(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_GET_VVAR:
+		emit err_vim_get_vvar(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_GET_OPTION:
+		emit err_vim_get_option(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_SET_OPTION:
+		emit err_vim_set_option(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_OUT_WRITE:
+		emit err_vim_out_write(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_ERR_WRITE:
+		emit err_vim_err_write(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_REPORT_ERROR:
+		emit err_vim_report_error(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_GET_BUFFERS:
+		emit err_vim_get_buffers(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_GET_CURRENT_BUFFER:
+		emit err_vim_get_current_buffer(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_SET_CURRENT_BUFFER:
+		emit err_vim_set_current_buffer(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_GET_WINDOWS:
+		emit err_vim_get_windows(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_GET_CURRENT_WINDOW:
+		emit err_vim_get_current_window(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_SET_CURRENT_WINDOW:
+		emit err_vim_set_current_window(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_GET_TABPAGES:
+		emit err_vim_get_tabpages(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_GET_CURRENT_TABPAGE:
+		emit err_vim_get_current_tabpage(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_SET_CURRENT_TABPAGE:
+		emit err_vim_set_current_tabpage(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_SUBSCRIBE:
+		emit err_vim_subscribe(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_UNSUBSCRIBE:
+		emit err_vim_unsubscribe(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_NAME_TO_COLOR:
+		emit err_vim_name_to_color(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_GET_COLOR_MAP:
+		emit err_vim_get_color_map(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_WINDOW_GET_BUFFER:
+		emit err_window_get_buffer(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_WINDOW_GET_CURSOR:
+		emit err_window_get_cursor(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_WINDOW_SET_CURSOR:
+		emit err_window_set_cursor(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_WINDOW_GET_HEIGHT:
+		emit err_window_get_height(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_WINDOW_SET_HEIGHT:
+		emit err_window_set_height(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_WINDOW_GET_WIDTH:
+		emit err_window_get_width(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_WINDOW_SET_WIDTH:
+		emit err_window_set_width(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_WINDOW_GET_VAR:
+		emit err_window_get_var(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_WINDOW_GET_OPTION:
+		emit err_window_get_option(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_WINDOW_SET_OPTION:
+		emit err_window_set_option(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_WINDOW_GET_POSITION:
+		emit err_window_get_position(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_WINDOW_GET_TABPAGE:
+		emit err_window_get_tabpage(errMsg, res);
+		break;
+	case NeovimApi5::NEOVIM_FN_WINDOW_IS_VALID:
+		emit err_window_is_valid(errMsg, res);
+		break;
+	default:
+		m_c->setError(NeovimConnector::RuntimeMsgpackError, QString("Received error for function that should not fail: %s").arg(fun));
+	}
+}
+
+void NeovimApi5::handleResponse(quint32 msgid, quint64 fun, const QVariant& res)
+{
+	switch(fun) {
+	case NeovimApi5::NEOVIM_FN_NVIM_BUF_LINE_COUNT:
+		{
+			int64_t data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_line_count");
+				return;
+			} else {
+				emit on_nvim_buf_line_count(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_BUFFER_GET_LINE:
+		{
+			QByteArray data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_line");
+				return;
+			} else {
+				emit on_buffer_get_line(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_BUF_ATTACH:
+		{
+			bool data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_attach");
+				return;
+			} else {
+				emit on_nvim_buf_attach(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_BUF_DETACH:
+		{
+			bool data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_detach");
+				return;
+			} else {
+				emit on_nvim_buf_detach(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_BUFFER_SET_LINE:
+		{
+			emit on_buffer_set_line();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_BUFFER_DEL_LINE:
+		{
+			emit on_buffer_del_line();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_BUFFER_GET_LINE_SLICE:
+		{
+			QList<QByteArray> data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_line_slice");
+				return;
+			} else {
+				emit on_buffer_get_line_slice(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_BUF_GET_LINES:
+		{
+			QList<QByteArray> data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_lines");
+				return;
+			} else {
+				emit on_nvim_buf_get_lines(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_BUFFER_SET_LINE_SLICE:
+		{
+			emit on_buffer_set_line_slice();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_BUF_SET_LINES:
+		{
+			emit on_nvim_buf_set_lines();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_BUF_GET_OFFSET:
+		{
+			int64_t data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_offset");
+				return;
+			} else {
+				emit on_nvim_buf_get_offset(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_BUF_GET_VAR:
+		{
+			QVariant data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_var");
+				return;
+			} else {
+				emit on_nvim_buf_get_var(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_BUF_GET_CHANGEDTICK:
+		{
+			int64_t data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_changedtick");
+				return;
+			} else {
+				emit on_nvim_buf_get_changedtick(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_BUF_GET_KEYMAP:
+		{
+			QList<QVariantMap> data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_keymap");
+				return;
+			} else {
+				emit on_nvim_buf_get_keymap(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_BUF_GET_COMMANDS:
+		{
+			QVariantMap data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_commands");
+				return;
+			} else {
+				emit on_nvim_buf_get_commands(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_BUF_SET_VAR:
+		{
+			emit on_nvim_buf_set_var();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_BUF_DEL_VAR:
+		{
+			emit on_nvim_buf_del_var();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_BUFFER_SET_VAR:
+		{
+			QVariant data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_set_var");
+				return;
+			} else {
+				emit on_buffer_set_var(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_BUFFER_DEL_VAR:
+		{
+			QVariant data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_del_var");
+				return;
+			} else {
+				emit on_buffer_del_var(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_BUF_GET_OPTION:
+		{
+			QVariant data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_option");
+				return;
+			} else {
+				emit on_nvim_buf_get_option(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_BUF_SET_OPTION:
+		{
+			emit on_nvim_buf_set_option();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_BUF_GET_NUMBER:
+		{
+			int64_t data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_number");
+				return;
+			} else {
+				emit on_nvim_buf_get_number(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_BUF_GET_NAME:
+		{
+			QByteArray data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_name");
+				return;
+			} else {
+				emit on_nvim_buf_get_name(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_BUF_SET_NAME:
+		{
+			emit on_nvim_buf_set_name();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_BUF_IS_LOADED:
+		{
+			bool data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_is_loaded");
+				return;
+			} else {
+				emit on_nvim_buf_is_loaded(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_BUF_IS_VALID:
+		{
+			bool data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_is_valid");
+				return;
+			} else {
+				emit on_nvim_buf_is_valid(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_BUFFER_INSERT:
+		{
+			emit on_buffer_insert();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_BUF_GET_MARK:
+		{
+			QPoint data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_mark");
+				return;
+			} else {
+				emit on_nvim_buf_get_mark(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_BUF_ADD_HIGHLIGHT:
+		{
+			int64_t data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_add_highlight");
+				return;
+			} else {
+				emit on_nvim_buf_add_highlight(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_BUF_CLEAR_NAMESPACE:
+		{
+			emit on_nvim_buf_clear_namespace();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_BUF_CLEAR_HIGHLIGHT:
+		{
+			emit on_nvim_buf_clear_highlight();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_BUF_SET_VIRTUAL_TEXT:
+		{
+			int64_t data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_set_virtual_text");
+				return;
+			} else {
+				emit on_nvim_buf_set_virtual_text(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_TABPAGE_LIST_WINS:
+		{
+			QList<int64_t> data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_list_wins");
+				return;
+			} else {
+				emit on_nvim_tabpage_list_wins(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_TABPAGE_GET_VAR:
+		{
+			QVariant data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_get_var");
+				return;
+			} else {
+				emit on_nvim_tabpage_get_var(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_TABPAGE_SET_VAR:
+		{
+			emit on_nvim_tabpage_set_var();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_TABPAGE_DEL_VAR:
+		{
+			emit on_nvim_tabpage_del_var();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_TABPAGE_SET_VAR:
+		{
+			QVariant data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_set_var");
+				return;
+			} else {
+				emit on_tabpage_set_var(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_TABPAGE_DEL_VAR:
+		{
+			QVariant data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_del_var");
+				return;
+			} else {
+				emit on_tabpage_del_var(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_TABPAGE_GET_WIN:
+		{
+			int64_t data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_get_win");
+				return;
+			} else {
+				emit on_nvim_tabpage_get_win(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_TABPAGE_GET_NUMBER:
+		{
+			int64_t data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_get_number");
+				return;
+			} else {
+				emit on_nvim_tabpage_get_number(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_TABPAGE_IS_VALID:
+		{
+			bool data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_is_valid");
+				return;
+			} else {
+				emit on_nvim_tabpage_is_valid(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_UI_ATTACH:
+		{
+			emit on_nvim_ui_attach();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_UI_ATTACH:
+		{
+			emit on_ui_attach();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_UI_DETACH:
+		{
+			emit on_nvim_ui_detach();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_UI_TRY_RESIZE:
+		{
+			emit on_nvim_ui_try_resize();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_UI_SET_OPTION:
+		{
+			emit on_nvim_ui_set_option();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_COMMAND:
+		{
+			emit on_nvim_command();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_GET_HL_BY_NAME:
+		{
+			QVariantMap data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_hl_by_name");
+				return;
+			} else {
+				emit on_nvim_get_hl_by_name(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_GET_HL_BY_ID:
+		{
+			QVariantMap data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_hl_by_id");
+				return;
+			} else {
+				emit on_nvim_get_hl_by_id(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_FEEDKEYS:
+		{
+			emit on_nvim_feedkeys();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_INPUT:
+		{
+			int64_t data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_input");
+				return;
+			} else {
+				emit on_nvim_input(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_REPLACE_TERMCODES:
+		{
+			QByteArray data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_replace_termcodes");
+				return;
+			} else {
+				emit on_nvim_replace_termcodes(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_COMMAND_OUTPUT:
+		{
+			QByteArray data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_command_output");
+				return;
+			} else {
+				emit on_nvim_command_output(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_EVAL:
+		{
+			QVariant data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_eval");
+				return;
+			} else {
+				emit on_nvim_eval(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_EXECUTE_LUA:
+		{
+			QVariant data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_execute_lua");
+				return;
+			} else {
+				emit on_nvim_execute_lua(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_CALL_FUNCTION:
+		{
+			QVariant data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_call_function");
+				return;
+			} else {
+				emit on_nvim_call_function(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_CALL_DICT_FUNCTION:
+		{
+			QVariant data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_call_dict_function");
+				return;
+			} else {
+				emit on_nvim_call_dict_function(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_STRWIDTH:
+		{
+			int64_t data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_strwidth");
+				return;
+			} else {
+				emit on_nvim_strwidth(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_LIST_RUNTIME_PATHS:
+		{
+			QList<QByteArray> data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_runtime_paths");
+				return;
+			} else {
+				emit on_nvim_list_runtime_paths(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_SET_CURRENT_DIR:
+		{
+			emit on_nvim_set_current_dir();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_GET_CURRENT_LINE:
+		{
+			QByteArray data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_current_line");
+				return;
+			} else {
+				emit on_nvim_get_current_line(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_SET_CURRENT_LINE:
+		{
+			emit on_nvim_set_current_line();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_DEL_CURRENT_LINE:
+		{
+			emit on_nvim_del_current_line();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_GET_VAR:
+		{
+			QVariant data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_var");
+				return;
+			} else {
+				emit on_nvim_get_var(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_SET_VAR:
+		{
+			emit on_nvim_set_var();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_DEL_VAR:
+		{
+			emit on_nvim_del_var();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_SET_VAR:
+		{
+			QVariant data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_set_var");
+				return;
+			} else {
+				emit on_vim_set_var(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_DEL_VAR:
+		{
+			QVariant data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_del_var");
+				return;
+			} else {
+				emit on_vim_del_var(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_GET_VVAR:
+		{
+			QVariant data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_vvar");
+				return;
+			} else {
+				emit on_nvim_get_vvar(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_GET_OPTION:
+		{
+			QVariant data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_option");
+				return;
+			} else {
+				emit on_nvim_get_option(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_SET_OPTION:
+		{
+			emit on_nvim_set_option();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_OUT_WRITE:
+		{
+			emit on_nvim_out_write();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_ERR_WRITE:
+		{
+			emit on_nvim_err_write();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_ERR_WRITELN:
+		{
+			emit on_nvim_err_writeln();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_LIST_BUFS:
+		{
+			QList<int64_t> data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_bufs");
+				return;
+			} else {
+				emit on_nvim_list_bufs(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_GET_CURRENT_BUF:
+		{
+			int64_t data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_current_buf");
+				return;
+			} else {
+				emit on_nvim_get_current_buf(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_SET_CURRENT_BUF:
+		{
+			emit on_nvim_set_current_buf();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_LIST_WINS:
+		{
+			QList<int64_t> data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_wins");
+				return;
+			} else {
+				emit on_nvim_list_wins(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_GET_CURRENT_WIN:
+		{
+			int64_t data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_current_win");
+				return;
+			} else {
+				emit on_nvim_get_current_win(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_SET_CURRENT_WIN:
+		{
+			emit on_nvim_set_current_win();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_LIST_TABPAGES:
+		{
+			QList<int64_t> data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_tabpages");
+				return;
+			} else {
+				emit on_nvim_list_tabpages(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_GET_CURRENT_TABPAGE:
+		{
+			int64_t data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_current_tabpage");
+				return;
+			} else {
+				emit on_nvim_get_current_tabpage(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_SET_CURRENT_TABPAGE:
+		{
+			emit on_nvim_set_current_tabpage();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_CREATE_NAMESPACE:
+		{
+			int64_t data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_create_namespace");
+				return;
+			} else {
+				emit on_nvim_create_namespace(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_GET_NAMESPACES:
+		{
+			QVariantMap data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_namespaces");
+				return;
+			} else {
+				emit on_nvim_get_namespaces(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_SUBSCRIBE:
+		{
+			emit on_nvim_subscribe();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_UNSUBSCRIBE:
+		{
+			emit on_nvim_unsubscribe();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_GET_COLOR_BY_NAME:
+		{
+			int64_t data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_color_by_name");
+				return;
+			} else {
+				emit on_nvim_get_color_by_name(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_GET_COLOR_MAP:
+		{
+			QVariantMap data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_color_map");
+				return;
+			} else {
+				emit on_nvim_get_color_map(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_GET_MODE:
+		{
+			QVariantMap data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_mode");
+				return;
+			} else {
+				emit on_nvim_get_mode(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_GET_KEYMAP:
+		{
+			QList<QVariantMap> data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_keymap");
+				return;
+			} else {
+				emit on_nvim_get_keymap(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_GET_COMMANDS:
+		{
+			QVariantMap data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_commands");
+				return;
+			} else {
+				emit on_nvim_get_commands(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_GET_API_INFO:
+		{
+			QVariantList data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_api_info");
+				return;
+			} else {
+				emit on_nvim_get_api_info(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_SET_CLIENT_INFO:
+		{
+			emit on_nvim_set_client_info();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_GET_CHAN_INFO:
+		{
+			QVariantMap data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_chan_info");
+				return;
+			} else {
+				emit on_nvim_get_chan_info(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_LIST_CHANS:
+		{
+			QVariantList data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_chans");
+				return;
+			} else {
+				emit on_nvim_list_chans(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_CALL_ATOMIC:
+		{
+			QVariantList data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_call_atomic");
+				return;
+			} else {
+				emit on_nvim_call_atomic(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_PARSE_EXPRESSION:
+		{
+			QVariantMap data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_parse_expression");
+				return;
+			} else {
+				emit on_nvim_parse_expression(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_LIST_UIS:
+		{
+			QVariantList data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_uis");
+				return;
+			} else {
+				emit on_nvim_list_uis(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_GET_PROC_CHILDREN:
+		{
+			QVariantList data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_proc_children");
+				return;
+			} else {
+				emit on_nvim_get_proc_children(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_GET_PROC:
+		{
+			QVariant data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_proc");
+				return;
+			} else {
+				emit on_nvim_get_proc(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_WIN_GET_BUF:
+		{
+			int64_t data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_buf");
+				return;
+			} else {
+				emit on_nvim_win_get_buf(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_WIN_SET_BUF:
+		{
+			emit on_nvim_win_set_buf();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_WIN_GET_CURSOR:
+		{
+			QPoint data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_cursor");
+				return;
+			} else {
+				emit on_nvim_win_get_cursor(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_WIN_SET_CURSOR:
+		{
+			emit on_nvim_win_set_cursor();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_WIN_GET_HEIGHT:
+		{
+			int64_t data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_height");
+				return;
+			} else {
+				emit on_nvim_win_get_height(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_WIN_SET_HEIGHT:
+		{
+			emit on_nvim_win_set_height();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_WIN_GET_WIDTH:
+		{
+			int64_t data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_width");
+				return;
+			} else {
+				emit on_nvim_win_get_width(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_WIN_SET_WIDTH:
+		{
+			emit on_nvim_win_set_width();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_WIN_GET_VAR:
+		{
+			QVariant data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_var");
+				return;
+			} else {
+				emit on_nvim_win_get_var(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_WIN_SET_VAR:
+		{
+			emit on_nvim_win_set_var();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_WIN_DEL_VAR:
+		{
+			emit on_nvim_win_del_var();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_WINDOW_SET_VAR:
+		{
+			QVariant data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_set_var");
+				return;
+			} else {
+				emit on_window_set_var(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_WINDOW_DEL_VAR:
+		{
+			QVariant data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_del_var");
+				return;
+			} else {
+				emit on_window_del_var(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_WIN_GET_OPTION:
+		{
+			QVariant data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_option");
+				return;
+			} else {
+				emit on_nvim_win_get_option(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_WIN_SET_OPTION:
+		{
+			emit on_nvim_win_set_option();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_WIN_GET_POSITION:
+		{
+			QPoint data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_position");
+				return;
+			} else {
+				emit on_nvim_win_get_position(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_WIN_GET_TABPAGE:
+		{
+			int64_t data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_tabpage");
+				return;
+			} else {
+				emit on_nvim_win_get_tabpage(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_WIN_GET_NUMBER:
+		{
+			int64_t data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_number");
+				return;
+			} else {
+				emit on_nvim_win_get_number(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_NVIM_WIN_IS_VALID:
+		{
+			bool data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_is_valid");
+				return;
+			} else {
+				emit on_nvim_win_is_valid(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_BUFFER_LINE_COUNT:
+		{
+			int64_t data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_line_count");
+				return;
+			} else {
+				emit on_buffer_line_count(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_BUFFER_GET_LINES:
+		{
+			QList<QByteArray> data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_lines");
+				return;
+			} else {
+				emit on_buffer_get_lines(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_BUFFER_SET_LINES:
+		{
+			emit on_buffer_set_lines();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_BUFFER_GET_VAR:
+		{
+			QVariant data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_var");
+				return;
+			} else {
+				emit on_buffer_get_var(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_BUFFER_GET_OPTION:
+		{
+			QVariant data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_option");
+				return;
+			} else {
+				emit on_buffer_get_option(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_BUFFER_SET_OPTION:
+		{
+			emit on_buffer_set_option();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_BUFFER_GET_NUMBER:
+		{
+			int64_t data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_number");
+				return;
+			} else {
+				emit on_buffer_get_number(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_BUFFER_GET_NAME:
+		{
+			QByteArray data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_name");
+				return;
+			} else {
+				emit on_buffer_get_name(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_BUFFER_SET_NAME:
+		{
+			emit on_buffer_set_name();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_BUFFER_IS_VALID:
+		{
+			bool data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_is_valid");
+				return;
+			} else {
+				emit on_buffer_is_valid(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_BUFFER_GET_MARK:
+		{
+			QPoint data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_mark");
+				return;
+			} else {
+				emit on_buffer_get_mark(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_BUFFER_ADD_HIGHLIGHT:
+		{
+			int64_t data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_add_highlight");
+				return;
+			} else {
+				emit on_buffer_add_highlight(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_BUFFER_CLEAR_HIGHLIGHT:
+		{
+			emit on_buffer_clear_highlight();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_TABPAGE_GET_WINDOWS:
+		{
+			QList<int64_t> data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_get_windows");
+				return;
+			} else {
+				emit on_tabpage_get_windows(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_TABPAGE_GET_VAR:
+		{
+			QVariant data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_get_var");
+				return;
+			} else {
+				emit on_tabpage_get_var(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_TABPAGE_GET_WINDOW:
+		{
+			int64_t data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_get_window");
+				return;
+			} else {
+				emit on_tabpage_get_window(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_TABPAGE_IS_VALID:
+		{
+			bool data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_is_valid");
+				return;
+			} else {
+				emit on_tabpage_is_valid(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_UI_DETACH:
+		{
+			emit on_ui_detach();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_UI_TRY_RESIZE:
+		{
+			QVariant data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for ui_try_resize");
+				return;
+			} else {
+				emit on_ui_try_resize(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_COMMAND:
+		{
+			emit on_vim_command();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_FEEDKEYS:
+		{
+			emit on_vim_feedkeys();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_INPUT:
+		{
+			int64_t data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_input");
+				return;
+			} else {
+				emit on_vim_input(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_REPLACE_TERMCODES:
+		{
+			QByteArray data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_replace_termcodes");
+				return;
+			} else {
+				emit on_vim_replace_termcodes(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_COMMAND_OUTPUT:
+		{
+			QByteArray data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_command_output");
+				return;
+			} else {
+				emit on_vim_command_output(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_EVAL:
+		{
+			QVariant data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_eval");
+				return;
+			} else {
+				emit on_vim_eval(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_CALL_FUNCTION:
+		{
+			QVariant data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_call_function");
+				return;
+			} else {
+				emit on_vim_call_function(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_STRWIDTH:
+		{
+			int64_t data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_strwidth");
+				return;
+			} else {
+				emit on_vim_strwidth(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_LIST_RUNTIME_PATHS:
+		{
+			QList<QByteArray> data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_list_runtime_paths");
+				return;
+			} else {
+				emit on_vim_list_runtime_paths(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_CHANGE_DIRECTORY:
+		{
+			emit on_vim_change_directory();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_GET_CURRENT_LINE:
+		{
+			QByteArray data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_current_line");
+				return;
+			} else {
+				emit on_vim_get_current_line(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_SET_CURRENT_LINE:
+		{
+			emit on_vim_set_current_line();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_DEL_CURRENT_LINE:
+		{
+			emit on_vim_del_current_line();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_GET_VAR:
+		{
+			QVariant data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_var");
+				return;
+			} else {
+				emit on_vim_get_var(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_GET_VVAR:
+		{
+			QVariant data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_vvar");
+				return;
+			} else {
+				emit on_vim_get_vvar(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_GET_OPTION:
+		{
+			QVariant data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_option");
+				return;
+			} else {
+				emit on_vim_get_option(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_SET_OPTION:
+		{
+			emit on_vim_set_option();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_OUT_WRITE:
+		{
+			emit on_vim_out_write();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_ERR_WRITE:
+		{
+			emit on_vim_err_write();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_REPORT_ERROR:
+		{
+			emit on_vim_report_error();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_GET_BUFFERS:
+		{
+			QList<int64_t> data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_buffers");
+				return;
+			} else {
+				emit on_vim_get_buffers(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_GET_CURRENT_BUFFER:
+		{
+			int64_t data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_current_buffer");
+				return;
+			} else {
+				emit on_vim_get_current_buffer(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_SET_CURRENT_BUFFER:
+		{
+			emit on_vim_set_current_buffer();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_GET_WINDOWS:
+		{
+			QList<int64_t> data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_windows");
+				return;
+			} else {
+				emit on_vim_get_windows(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_GET_CURRENT_WINDOW:
+		{
+			int64_t data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_current_window");
+				return;
+			} else {
+				emit on_vim_get_current_window(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_SET_CURRENT_WINDOW:
+		{
+			emit on_vim_set_current_window();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_GET_TABPAGES:
+		{
+			QList<int64_t> data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_tabpages");
+				return;
+			} else {
+				emit on_vim_get_tabpages(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_GET_CURRENT_TABPAGE:
+		{
+			int64_t data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_current_tabpage");
+				return;
+			} else {
+				emit on_vim_get_current_tabpage(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_SET_CURRENT_TABPAGE:
+		{
+			emit on_vim_set_current_tabpage();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_SUBSCRIBE:
+		{
+			emit on_vim_subscribe();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_UNSUBSCRIBE:
+		{
+			emit on_vim_unsubscribe();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_NAME_TO_COLOR:
+		{
+			int64_t data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_name_to_color");
+				return;
+			} else {
+				emit on_vim_name_to_color(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_VIM_GET_COLOR_MAP:
+		{
+			QVariantMap data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_color_map");
+				return;
+			} else {
+				emit on_vim_get_color_map(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_WINDOW_GET_BUFFER:
+		{
+			int64_t data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_buffer");
+				return;
+			} else {
+				emit on_window_get_buffer(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_WINDOW_GET_CURSOR:
+		{
+			QPoint data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_cursor");
+				return;
+			} else {
+				emit on_window_get_cursor(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_WINDOW_SET_CURSOR:
+		{
+			emit on_window_set_cursor();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_WINDOW_GET_HEIGHT:
+		{
+			int64_t data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_height");
+				return;
+			} else {
+				emit on_window_get_height(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_WINDOW_SET_HEIGHT:
+		{
+			emit on_window_set_height();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_WINDOW_GET_WIDTH:
+		{
+			int64_t data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_width");
+				return;
+			} else {
+				emit on_window_get_width(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_WINDOW_SET_WIDTH:
+		{
+			emit on_window_set_width();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_WINDOW_GET_VAR:
+		{
+			QVariant data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_var");
+				return;
+			} else {
+				emit on_window_get_var(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_WINDOW_GET_OPTION:
+		{
+			QVariant data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_option");
+				return;
+			} else {
+				emit on_window_get_option(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_WINDOW_SET_OPTION:
+		{
+			emit on_window_set_option();
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_WINDOW_GET_POSITION:
+		{
+			QPoint data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_position");
+				return;
+			} else {
+				emit on_window_get_position(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_WINDOW_GET_TABPAGE:
+		{
+			int64_t data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_tabpage");
+				return;
+			} else {
+				emit on_window_get_tabpage(data);
+			}
+
+		}
+		break;
+	case NeovimApi5::NEOVIM_FN_WINDOW_IS_VALID:
+		{
+			bool data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_is_valid");
+				return;
+			} else {
+				emit on_window_is_valid(data);
+			}
+
+		}
+		break;
+	default:
+		qWarning() << "Received unexpected response";
+	}
+}
+
+/**
+ * Check function table from api_metadata[1]
+ *
+ * This checks the API metadata build from the bindings against the metadata
+ * passed as argument.
+ *
+ * Returns false if there is an API mismatch
+ */
+bool NeovimApi5::checkFunctions(const QVariantList& ftable)
+{
+
+	QList<Function> required;
+	required
+		<< Function("Integer", "nvim_buf_line_count",
+			QList<QString>()
+						<< QString("Buffer")
+						, false)
+		<< Function("String", "buffer_get_line",
+			QList<QString>()
+						<< QString("Buffer")
+						<< QString("Integer")
+						, false)
+		<< Function("Boolean", "nvim_buf_attach",
+			QList<QString>()
+						<< QString("Buffer")
+						<< QString("Boolean")
+						<< QString("Dictionary")
+						, false)
+		<< Function("Boolean", "nvim_buf_detach",
+			QList<QString>()
+						<< QString("Buffer")
+						, false)
+		<< Function("void", "buffer_set_line",
+			QList<QString>()
+						<< QString("Buffer")
+						<< QString("Integer")
+						<< QString("String")
+						, false)
+		<< Function("void", "buffer_del_line",
+			QList<QString>()
+						<< QString("Buffer")
+						<< QString("Integer")
+						, false)
+		<< Function("ArrayOf(String)", "buffer_get_line_slice",
+			QList<QString>()
+						<< QString("Buffer")
+						<< QString("Integer")
+						<< QString("Integer")
+						<< QString("Boolean")
+						<< QString("Boolean")
+						, false)
+		<< Function("ArrayOf(String)", "nvim_buf_get_lines",
+			QList<QString>()
+						<< QString("Buffer")
+						<< QString("Integer")
+						<< QString("Integer")
+						<< QString("Boolean")
+						, false)
+		<< Function("void", "buffer_set_line_slice",
+			QList<QString>()
+						<< QString("Buffer")
+						<< QString("Integer")
+						<< QString("Integer")
+						<< QString("Boolean")
+						<< QString("Boolean")
+						<< QString("ArrayOf(String)")
+						, false)
+		<< Function("void", "nvim_buf_set_lines",
+			QList<QString>()
+						<< QString("Buffer")
+						<< QString("Integer")
+						<< QString("Integer")
+						<< QString("Boolean")
+						<< QString("ArrayOf(String)")
+						, false)
+		<< Function("Integer", "nvim_buf_get_offset",
+			QList<QString>()
+						<< QString("Buffer")
+						<< QString("Integer")
+						, false)
+		<< Function("Object", "nvim_buf_get_var",
+			QList<QString>()
+						<< QString("Buffer")
+						<< QString("String")
+						, false)
+		<< Function("Integer", "nvim_buf_get_changedtick",
+			QList<QString>()
+						<< QString("Buffer")
+						, false)
+		<< Function("ArrayOf(Dictionary)", "nvim_buf_get_keymap",
+			QList<QString>()
+						<< QString("Buffer")
+						<< QString("String")
+						, false)
+		<< Function("Dictionary", "nvim_buf_get_commands",
+			QList<QString>()
+						<< QString("Buffer")
+						<< QString("Dictionary")
+						, false)
+		<< Function("void", "nvim_buf_set_var",
+			QList<QString>()
+						<< QString("Buffer")
+						<< QString("String")
+						<< QString("Object")
+						, false)
+		<< Function("void", "nvim_buf_del_var",
+			QList<QString>()
+						<< QString("Buffer")
+						<< QString("String")
+						, false)
+		<< Function("Object", "buffer_set_var",
+			QList<QString>()
+						<< QString("Buffer")
+						<< QString("String")
+						<< QString("Object")
+						, false)
+		<< Function("Object", "buffer_del_var",
+			QList<QString>()
+						<< QString("Buffer")
+						<< QString("String")
+						, false)
+		<< Function("Object", "nvim_buf_get_option",
+			QList<QString>()
+						<< QString("Buffer")
+						<< QString("String")
+						, false)
+		<< Function("void", "nvim_buf_set_option",
+			QList<QString>()
+						<< QString("Buffer")
+						<< QString("String")
+						<< QString("Object")
+						, false)
+		<< Function("Integer", "nvim_buf_get_number",
+			QList<QString>()
+						<< QString("Buffer")
+						, false)
+		<< Function("String", "nvim_buf_get_name",
+			QList<QString>()
+						<< QString("Buffer")
+						, false)
+		<< Function("void", "nvim_buf_set_name",
+			QList<QString>()
+						<< QString("Buffer")
+						<< QString("String")
+						, false)
+		<< Function("Boolean", "nvim_buf_is_loaded",
+			QList<QString>()
+						<< QString("Buffer")
+						, false)
+		<< Function("Boolean", "nvim_buf_is_valid",
+			QList<QString>()
+						<< QString("Buffer")
+						, false)
+		<< Function("void", "buffer_insert",
+			QList<QString>()
+						<< QString("Buffer")
+						<< QString("Integer")
+						<< QString("ArrayOf(String)")
+						, false)
+		<< Function("ArrayOf(Integer, 2)", "nvim_buf_get_mark",
+			QList<QString>()
+						<< QString("Buffer")
+						<< QString("String")
+						, false)
+		<< Function("Integer", "nvim_buf_add_highlight",
+			QList<QString>()
+						<< QString("Buffer")
+						<< QString("Integer")
+						<< QString("String")
+						<< QString("Integer")
+						<< QString("Integer")
+						<< QString("Integer")
+						, false)
+		<< Function("void", "nvim_buf_clear_namespace",
+			QList<QString>()
+						<< QString("Buffer")
+						<< QString("Integer")
+						<< QString("Integer")
+						<< QString("Integer")
+						, false)
+		<< Function("void", "nvim_buf_clear_highlight",
+			QList<QString>()
+						<< QString("Buffer")
+						<< QString("Integer")
+						<< QString("Integer")
+						<< QString("Integer")
+						, false)
+		<< Function("Integer", "nvim_buf_set_virtual_text",
+			QList<QString>()
+						<< QString("Buffer")
+						<< QString("Integer")
+						<< QString("Integer")
+						<< QString("Array")
+						<< QString("Dictionary")
+						, false)
+		<< Function("ArrayOf(Window)", "nvim_tabpage_list_wins",
+			QList<QString>()
+						<< QString("Tabpage")
+						, false)
+		<< Function("Object", "nvim_tabpage_get_var",
+			QList<QString>()
+						<< QString("Tabpage")
+						<< QString("String")
+						, false)
+		<< Function("void", "nvim_tabpage_set_var",
+			QList<QString>()
+						<< QString("Tabpage")
+						<< QString("String")
+						<< QString("Object")
+						, false)
+		<< Function("void", "nvim_tabpage_del_var",
+			QList<QString>()
+						<< QString("Tabpage")
+						<< QString("String")
+						, false)
+		<< Function("Object", "tabpage_set_var",
+			QList<QString>()
+						<< QString("Tabpage")
+						<< QString("String")
+						<< QString("Object")
+						, false)
+		<< Function("Object", "tabpage_del_var",
+			QList<QString>()
+						<< QString("Tabpage")
+						<< QString("String")
+						, false)
+		<< Function("Window", "nvim_tabpage_get_win",
+			QList<QString>()
+						<< QString("Tabpage")
+						, false)
+		<< Function("Integer", "nvim_tabpage_get_number",
+			QList<QString>()
+						<< QString("Tabpage")
+						, false)
+		<< Function("Boolean", "nvim_tabpage_is_valid",
+			QList<QString>()
+						<< QString("Tabpage")
+						, false)
+		<< Function("void", "nvim_ui_attach",
+			QList<QString>()
+						<< QString("Integer")
+						<< QString("Integer")
+						<< QString("Dictionary")
+						, false)
+		<< Function("void", "ui_attach",
+			QList<QString>()
+						<< QString("Integer")
+						<< QString("Integer")
+						<< QString("Boolean")
+						, false)
+		<< Function("void", "nvim_ui_detach",
+			QList<QString>()
+						, false)
+		<< Function("void", "nvim_ui_try_resize",
+			QList<QString>()
+						<< QString("Integer")
+						<< QString("Integer")
+						, false)
+		<< Function("void", "nvim_ui_set_option",
+			QList<QString>()
+						<< QString("String")
+						<< QString("Object")
+						, false)
+		<< Function("void", "nvim_command",
+			QList<QString>()
+						<< QString("String")
+						, false)
+		<< Function("Dictionary", "nvim_get_hl_by_name",
+			QList<QString>()
+						<< QString("String")
+						<< QString("Boolean")
+						, false)
+		<< Function("Dictionary", "nvim_get_hl_by_id",
+			QList<QString>()
+						<< QString("Integer")
+						<< QString("Boolean")
+						, false)
+		<< Function("void", "nvim_feedkeys",
+			QList<QString>()
+						<< QString("String")
+						<< QString("String")
+						<< QString("Boolean")
+						, false)
+		<< Function("Integer", "nvim_input",
+			QList<QString>()
+						<< QString("String")
+						, false)
+		<< Function("String", "nvim_replace_termcodes",
+			QList<QString>()
+						<< QString("String")
+						<< QString("Boolean")
+						<< QString("Boolean")
+						<< QString("Boolean")
+						, false)
+		<< Function("String", "nvim_command_output",
+			QList<QString>()
+						<< QString("String")
+						, false)
+		<< Function("Object", "nvim_eval",
+			QList<QString>()
+						<< QString("String")
+						, false)
+		<< Function("Object", "nvim_execute_lua",
+			QList<QString>()
+						<< QString("String")
+						<< QString("Array")
+						, false)
+		<< Function("Object", "nvim_call_function",
+			QList<QString>()
+						<< QString("String")
+						<< QString("Array")
+						, false)
+		<< Function("Object", "nvim_call_dict_function",
+			QList<QString>()
+						<< QString("Object")
+						<< QString("String")
+						<< QString("Array")
+						, false)
+		<< Function("Integer", "nvim_strwidth",
+			QList<QString>()
+						<< QString("String")
+						, false)
+		<< Function("ArrayOf(String)", "nvim_list_runtime_paths",
+			QList<QString>()
+						, false)
+		<< Function("void", "nvim_set_current_dir",
+			QList<QString>()
+						<< QString("String")
+						, false)
+		<< Function("String", "nvim_get_current_line",
+			QList<QString>()
+						, false)
+		<< Function("void", "nvim_set_current_line",
+			QList<QString>()
+						<< QString("String")
+						, false)
+		<< Function("void", "nvim_del_current_line",
+			QList<QString>()
+						, false)
+		<< Function("Object", "nvim_get_var",
+			QList<QString>()
+						<< QString("String")
+						, false)
+		<< Function("void", "nvim_set_var",
+			QList<QString>()
+						<< QString("String")
+						<< QString("Object")
+						, false)
+		<< Function("void", "nvim_del_var",
+			QList<QString>()
+						<< QString("String")
+						, false)
+		<< Function("Object", "vim_set_var",
+			QList<QString>()
+						<< QString("String")
+						<< QString("Object")
+						, false)
+		<< Function("Object", "vim_del_var",
+			QList<QString>()
+						<< QString("String")
+						, false)
+		<< Function("Object", "nvim_get_vvar",
+			QList<QString>()
+						<< QString("String")
+						, false)
+		<< Function("Object", "nvim_get_option",
+			QList<QString>()
+						<< QString("String")
+						, false)
+		<< Function("void", "nvim_set_option",
+			QList<QString>()
+						<< QString("String")
+						<< QString("Object")
+						, false)
+		<< Function("void", "nvim_out_write",
+			QList<QString>()
+						<< QString("String")
+						, false)
+		<< Function("void", "nvim_err_write",
+			QList<QString>()
+						<< QString("String")
+						, false)
+		<< Function("void", "nvim_err_writeln",
+			QList<QString>()
+						<< QString("String")
+						, false)
+		<< Function("ArrayOf(Buffer)", "nvim_list_bufs",
+			QList<QString>()
+						, false)
+		<< Function("Buffer", "nvim_get_current_buf",
+			QList<QString>()
+						, false)
+		<< Function("void", "nvim_set_current_buf",
+			QList<QString>()
+						<< QString("Buffer")
+						, false)
+		<< Function("ArrayOf(Window)", "nvim_list_wins",
+			QList<QString>()
+						, false)
+		<< Function("Window", "nvim_get_current_win",
+			QList<QString>()
+						, false)
+		<< Function("void", "nvim_set_current_win",
+			QList<QString>()
+						<< QString("Window")
+						, false)
+		<< Function("ArrayOf(Tabpage)", "nvim_list_tabpages",
+			QList<QString>()
+						, false)
+		<< Function("Tabpage", "nvim_get_current_tabpage",
+			QList<QString>()
+						, false)
+		<< Function("void", "nvim_set_current_tabpage",
+			QList<QString>()
+						<< QString("Tabpage")
+						, false)
+		<< Function("Integer", "nvim_create_namespace",
+			QList<QString>()
+						<< QString("String")
+						, false)
+		<< Function("Dictionary", "nvim_get_namespaces",
+			QList<QString>()
+						, false)
+		<< Function("void", "nvim_subscribe",
+			QList<QString>()
+						<< QString("String")
+						, false)
+		<< Function("void", "nvim_unsubscribe",
+			QList<QString>()
+						<< QString("String")
+						, false)
+		<< Function("Integer", "nvim_get_color_by_name",
+			QList<QString>()
+						<< QString("String")
+						, false)
+		<< Function("Dictionary", "nvim_get_color_map",
+			QList<QString>()
+						, false)
+		<< Function("Dictionary", "nvim_get_mode",
+			QList<QString>()
+						, false)
+		<< Function("ArrayOf(Dictionary)", "nvim_get_keymap",
+			QList<QString>()
+						<< QString("String")
+						, false)
+		<< Function("Dictionary", "nvim_get_commands",
+			QList<QString>()
+						<< QString("Dictionary")
+						, false)
+		<< Function("Array", "nvim_get_api_info",
+			QList<QString>()
+						, false)
+		<< Function("void", "nvim_set_client_info",
+			QList<QString>()
+						<< QString("String")
+						<< QString("Dictionary")
+						<< QString("String")
+						<< QString("Dictionary")
+						<< QString("Dictionary")
+						, false)
+		<< Function("Dictionary", "nvim_get_chan_info",
+			QList<QString>()
+						<< QString("Integer")
+						, false)
+		<< Function("Array", "nvim_list_chans",
+			QList<QString>()
+						, false)
+		<< Function("Array", "nvim_call_atomic",
+			QList<QString>()
+						<< QString("Array")
+						, false)
+		<< Function("Dictionary", "nvim_parse_expression",
+			QList<QString>()
+						<< QString("String")
+						<< QString("String")
+						<< QString("Boolean")
+						, false)
+		<< Function("Array", "nvim_list_uis",
+			QList<QString>()
+						, false)
+		<< Function("Array", "nvim_get_proc_children",
+			QList<QString>()
+						<< QString("Integer")
+						, false)
+		<< Function("Object", "nvim_get_proc",
+			QList<QString>()
+						<< QString("Integer")
+						, false)
+		<< Function("Buffer", "nvim_win_get_buf",
+			QList<QString>()
+						<< QString("Window")
+						, false)
+		<< Function("void", "nvim_win_set_buf",
+			QList<QString>()
+						<< QString("Window")
+						<< QString("Buffer")
+						, false)
+		<< Function("ArrayOf(Integer, 2)", "nvim_win_get_cursor",
+			QList<QString>()
+						<< QString("Window")
+						, false)
+		<< Function("void", "nvim_win_set_cursor",
+			QList<QString>()
+						<< QString("Window")
+						<< QString("ArrayOf(Integer, 2)")
+						, false)
+		<< Function("Integer", "nvim_win_get_height",
+			QList<QString>()
+						<< QString("Window")
+						, false)
+		<< Function("void", "nvim_win_set_height",
+			QList<QString>()
+						<< QString("Window")
+						<< QString("Integer")
+						, false)
+		<< Function("Integer", "nvim_win_get_width",
+			QList<QString>()
+						<< QString("Window")
+						, false)
+		<< Function("void", "nvim_win_set_width",
+			QList<QString>()
+						<< QString("Window")
+						<< QString("Integer")
+						, false)
+		<< Function("Object", "nvim_win_get_var",
+			QList<QString>()
+						<< QString("Window")
+						<< QString("String")
+						, false)
+		<< Function("void", "nvim_win_set_var",
+			QList<QString>()
+						<< QString("Window")
+						<< QString("String")
+						<< QString("Object")
+						, false)
+		<< Function("void", "nvim_win_del_var",
+			QList<QString>()
+						<< QString("Window")
+						<< QString("String")
+						, false)
+		<< Function("Object", "window_set_var",
+			QList<QString>()
+						<< QString("Window")
+						<< QString("String")
+						<< QString("Object")
+						, false)
+		<< Function("Object", "window_del_var",
+			QList<QString>()
+						<< QString("Window")
+						<< QString("String")
+						, false)
+		<< Function("Object", "nvim_win_get_option",
+			QList<QString>()
+						<< QString("Window")
+						<< QString("String")
+						, false)
+		<< Function("void", "nvim_win_set_option",
+			QList<QString>()
+						<< QString("Window")
+						<< QString("String")
+						<< QString("Object")
+						, false)
+		<< Function("ArrayOf(Integer, 2)", "nvim_win_get_position",
+			QList<QString>()
+						<< QString("Window")
+						, false)
+		<< Function("Tabpage", "nvim_win_get_tabpage",
+			QList<QString>()
+						<< QString("Window")
+						, false)
+		<< Function("Integer", "nvim_win_get_number",
+			QList<QString>()
+						<< QString("Window")
+						, false)
+		<< Function("Boolean", "nvim_win_is_valid",
+			QList<QString>()
+						<< QString("Window")
+						, false)
+		<< Function("Integer", "buffer_line_count",
+			QList<QString>()
+						<< QString("Buffer")
+						, false)
+		<< Function("ArrayOf(String)", "buffer_get_lines",
+			QList<QString>()
+						<< QString("Buffer")
+						<< QString("Integer")
+						<< QString("Integer")
+						<< QString("Boolean")
+						, false)
+		<< Function("void", "buffer_set_lines",
+			QList<QString>()
+						<< QString("Buffer")
+						<< QString("Integer")
+						<< QString("Integer")
+						<< QString("Boolean")
+						<< QString("ArrayOf(String)")
+						, false)
+		<< Function("Object", "buffer_get_var",
+			QList<QString>()
+						<< QString("Buffer")
+						<< QString("String")
+						, false)
+		<< Function("Object", "buffer_get_option",
+			QList<QString>()
+						<< QString("Buffer")
+						<< QString("String")
+						, false)
+		<< Function("void", "buffer_set_option",
+			QList<QString>()
+						<< QString("Buffer")
+						<< QString("String")
+						<< QString("Object")
+						, false)
+		<< Function("Integer", "buffer_get_number",
+			QList<QString>()
+						<< QString("Buffer")
+						, false)
+		<< Function("String", "buffer_get_name",
+			QList<QString>()
+						<< QString("Buffer")
+						, false)
+		<< Function("void", "buffer_set_name",
+			QList<QString>()
+						<< QString("Buffer")
+						<< QString("String")
+						, false)
+		<< Function("Boolean", "buffer_is_valid",
+			QList<QString>()
+						<< QString("Buffer")
+						, false)
+		<< Function("ArrayOf(Integer, 2)", "buffer_get_mark",
+			QList<QString>()
+						<< QString("Buffer")
+						<< QString("String")
+						, false)
+		<< Function("Integer", "buffer_add_highlight",
+			QList<QString>()
+						<< QString("Buffer")
+						<< QString("Integer")
+						<< QString("String")
+						<< QString("Integer")
+						<< QString("Integer")
+						<< QString("Integer")
+						, false)
+		<< Function("void", "buffer_clear_highlight",
+			QList<QString>()
+						<< QString("Buffer")
+						<< QString("Integer")
+						<< QString("Integer")
+						<< QString("Integer")
+						, false)
+		<< Function("ArrayOf(Window)", "tabpage_get_windows",
+			QList<QString>()
+						<< QString("Tabpage")
+						, false)
+		<< Function("Object", "tabpage_get_var",
+			QList<QString>()
+						<< QString("Tabpage")
+						<< QString("String")
+						, false)
+		<< Function("Window", "tabpage_get_window",
+			QList<QString>()
+						<< QString("Tabpage")
+						, false)
+		<< Function("Boolean", "tabpage_is_valid",
+			QList<QString>()
+						<< QString("Tabpage")
+						, false)
+		<< Function("void", "ui_detach",
+			QList<QString>()
+						, false)
+		<< Function("Object", "ui_try_resize",
+			QList<QString>()
+						<< QString("Integer")
+						<< QString("Integer")
+						, false)
+		<< Function("void", "vim_command",
+			QList<QString>()
+						<< QString("String")
+						, false)
+		<< Function("void", "vim_feedkeys",
+			QList<QString>()
+						<< QString("String")
+						<< QString("String")
+						<< QString("Boolean")
+						, false)
+		<< Function("Integer", "vim_input",
+			QList<QString>()
+						<< QString("String")
+						, false)
+		<< Function("String", "vim_replace_termcodes",
+			QList<QString>()
+						<< QString("String")
+						<< QString("Boolean")
+						<< QString("Boolean")
+						<< QString("Boolean")
+						, false)
+		<< Function("String", "vim_command_output",
+			QList<QString>()
+						<< QString("String")
+						, false)
+		<< Function("Object", "vim_eval",
+			QList<QString>()
+						<< QString("String")
+						, false)
+		<< Function("Object", "vim_call_function",
+			QList<QString>()
+						<< QString("String")
+						<< QString("Array")
+						, false)
+		<< Function("Integer", "vim_strwidth",
+			QList<QString>()
+						<< QString("String")
+						, false)
+		<< Function("ArrayOf(String)", "vim_list_runtime_paths",
+			QList<QString>()
+						, false)
+		<< Function("void", "vim_change_directory",
+			QList<QString>()
+						<< QString("String")
+						, false)
+		<< Function("String", "vim_get_current_line",
+			QList<QString>()
+						, false)
+		<< Function("void", "vim_set_current_line",
+			QList<QString>()
+						<< QString("String")
+						, false)
+		<< Function("void", "vim_del_current_line",
+			QList<QString>()
+						, false)
+		<< Function("Object", "vim_get_var",
+			QList<QString>()
+						<< QString("String")
+						, false)
+		<< Function("Object", "vim_get_vvar",
+			QList<QString>()
+						<< QString("String")
+						, false)
+		<< Function("Object", "vim_get_option",
+			QList<QString>()
+						<< QString("String")
+						, false)
+		<< Function("void", "vim_set_option",
+			QList<QString>()
+						<< QString("String")
+						<< QString("Object")
+						, false)
+		<< Function("void", "vim_out_write",
+			QList<QString>()
+						<< QString("String")
+						, false)
+		<< Function("void", "vim_err_write",
+			QList<QString>()
+						<< QString("String")
+						, false)
+		<< Function("void", "vim_report_error",
+			QList<QString>()
+						<< QString("String")
+						, false)
+		<< Function("ArrayOf(Buffer)", "vim_get_buffers",
+			QList<QString>()
+						, false)
+		<< Function("Buffer", "vim_get_current_buffer",
+			QList<QString>()
+						, false)
+		<< Function("void", "vim_set_current_buffer",
+			QList<QString>()
+						<< QString("Buffer")
+						, false)
+		<< Function("ArrayOf(Window)", "vim_get_windows",
+			QList<QString>()
+						, false)
+		<< Function("Window", "vim_get_current_window",
+			QList<QString>()
+						, false)
+		<< Function("void", "vim_set_current_window",
+			QList<QString>()
+						<< QString("Window")
+						, false)
+		<< Function("ArrayOf(Tabpage)", "vim_get_tabpages",
+			QList<QString>()
+						, false)
+		<< Function("Tabpage", "vim_get_current_tabpage",
+			QList<QString>()
+						, false)
+		<< Function("void", "vim_set_current_tabpage",
+			QList<QString>()
+						<< QString("Tabpage")
+						, false)
+		<< Function("void", "vim_subscribe",
+			QList<QString>()
+						<< QString("String")
+						, false)
+		<< Function("void", "vim_unsubscribe",
+			QList<QString>()
+						<< QString("String")
+						, false)
+		<< Function("Integer", "vim_name_to_color",
+			QList<QString>()
+						<< QString("String")
+						, false)
+		<< Function("Dictionary", "vim_get_color_map",
+			QList<QString>()
+						, false)
+		<< Function("Buffer", "window_get_buffer",
+			QList<QString>()
+						<< QString("Window")
+						, false)
+		<< Function("ArrayOf(Integer, 2)", "window_get_cursor",
+			QList<QString>()
+						<< QString("Window")
+						, false)
+		<< Function("void", "window_set_cursor",
+			QList<QString>()
+						<< QString("Window")
+						<< QString("ArrayOf(Integer, 2)")
+						, false)
+		<< Function("Integer", "window_get_height",
+			QList<QString>()
+						<< QString("Window")
+						, false)
+		<< Function("void", "window_set_height",
+			QList<QString>()
+						<< QString("Window")
+						<< QString("Integer")
+						, false)
+		<< Function("Integer", "window_get_width",
+			QList<QString>()
+						<< QString("Window")
+						, false)
+		<< Function("void", "window_set_width",
+			QList<QString>()
+						<< QString("Window")
+						<< QString("Integer")
+						, false)
+		<< Function("Object", "window_get_var",
+			QList<QString>()
+						<< QString("Window")
+						<< QString("String")
+						, false)
+		<< Function("Object", "window_get_option",
+			QList<QString>()
+						<< QString("Window")
+						<< QString("String")
+						, false)
+		<< Function("void", "window_set_option",
+			QList<QString>()
+						<< QString("Window")
+						<< QString("String")
+						<< QString("Object")
+						, false)
+		<< Function("ArrayOf(Integer, 2)", "window_get_position",
+			QList<QString>()
+						<< QString("Window")
+						, false)
+		<< Function("Tabpage", "window_get_tabpage",
+			QList<QString>()
+						<< QString("Window")
+						, false)
+		<< Function("Boolean", "window_is_valid",
+			QList<QString>()
+						<< QString("Window")
+						, false)
+		;
+
+
+	QList<Function> supported;
+	foreach(const QVariant& val, ftable) {
+		auto f = Function::fromVariant(val);
+		if (!f.isValid()) {
+			qDebug() << "Invalid function in metadata" << f;
+			continue;
+		}
+		supported.append(f);
+
+		if (!required.contains(f)) {
+			qDebug() << "Unknown function(api 5)" << f;
+		}
+	}
+
+	bool ok = true;
+	foreach(const Function& f, required) {
+		if (!supported.contains(f)) {
+			qDebug() << "- instance DOES NOT support API5:" << f;
+			ok = false;
+		}
+	}
+	return ok;
+}
+
+} // Namespace

--- a/src/auto/neovimapi5.h
+++ b/src/auto/neovimapi5.h
@@ -1,0 +1,1233 @@
+// Auto generated 2019-06-08 16:53:42.519531 from nvim API level:5
+#ifndef NEOVIM_QT_NEOVIMAPI5
+#define NEOVIM_QT_NEOVIMAPI5
+#include "msgpack.h"
+#include <QObject>
+#include <QVariant>
+#include <QPoint>
+#include "function.h"
+
+namespace NeovimQt {
+class NeovimConnector;
+class MsgpackRequest;
+
+class NeovimApi5: public QObject
+{
+	Q_OBJECT
+	Q_ENUMS(FunctionId)
+
+public:
+
+	enum FunctionId {
+		NEOVIM_FN_NULL=0,
+				NEOVIM_FN_NVIM_BUF_LINE_COUNT,
+				NEOVIM_FN_BUFFER_GET_LINE,
+				NEOVIM_FN_NVIM_BUF_ATTACH,
+				NEOVIM_FN_NVIM_BUF_DETACH,
+				NEOVIM_FN_BUFFER_SET_LINE,
+				NEOVIM_FN_BUFFER_DEL_LINE,
+				NEOVIM_FN_BUFFER_GET_LINE_SLICE,
+				NEOVIM_FN_NVIM_BUF_GET_LINES,
+				NEOVIM_FN_BUFFER_SET_LINE_SLICE,
+				NEOVIM_FN_NVIM_BUF_SET_LINES,
+				NEOVIM_FN_NVIM_BUF_GET_OFFSET,
+				NEOVIM_FN_NVIM_BUF_GET_VAR,
+				NEOVIM_FN_NVIM_BUF_GET_CHANGEDTICK,
+				NEOVIM_FN_NVIM_BUF_GET_KEYMAP,
+				NEOVIM_FN_NVIM_BUF_GET_COMMANDS,
+				NEOVIM_FN_NVIM_BUF_SET_VAR,
+				NEOVIM_FN_NVIM_BUF_DEL_VAR,
+				NEOVIM_FN_BUFFER_SET_VAR,
+				NEOVIM_FN_BUFFER_DEL_VAR,
+				NEOVIM_FN_NVIM_BUF_GET_OPTION,
+				NEOVIM_FN_NVIM_BUF_SET_OPTION,
+				NEOVIM_FN_NVIM_BUF_GET_NUMBER,
+				NEOVIM_FN_NVIM_BUF_GET_NAME,
+				NEOVIM_FN_NVIM_BUF_SET_NAME,
+				NEOVIM_FN_NVIM_BUF_IS_LOADED,
+				NEOVIM_FN_NVIM_BUF_IS_VALID,
+				NEOVIM_FN_BUFFER_INSERT,
+				NEOVIM_FN_NVIM_BUF_GET_MARK,
+				NEOVIM_FN_NVIM_BUF_ADD_HIGHLIGHT,
+				NEOVIM_FN_NVIM_BUF_CLEAR_NAMESPACE,
+				NEOVIM_FN_NVIM_BUF_CLEAR_HIGHLIGHT,
+				NEOVIM_FN_NVIM_BUF_SET_VIRTUAL_TEXT,
+				NEOVIM_FN_NVIM_TABPAGE_LIST_WINS,
+				NEOVIM_FN_NVIM_TABPAGE_GET_VAR,
+				NEOVIM_FN_NVIM_TABPAGE_SET_VAR,
+				NEOVIM_FN_NVIM_TABPAGE_DEL_VAR,
+				NEOVIM_FN_TABPAGE_SET_VAR,
+				NEOVIM_FN_TABPAGE_DEL_VAR,
+				NEOVIM_FN_NVIM_TABPAGE_GET_WIN,
+				NEOVIM_FN_NVIM_TABPAGE_GET_NUMBER,
+				NEOVIM_FN_NVIM_TABPAGE_IS_VALID,
+				NEOVIM_FN_NVIM_UI_ATTACH,
+				NEOVIM_FN_UI_ATTACH,
+				NEOVIM_FN_NVIM_UI_DETACH,
+				NEOVIM_FN_NVIM_UI_TRY_RESIZE,
+				NEOVIM_FN_NVIM_UI_SET_OPTION,
+				NEOVIM_FN_NVIM_COMMAND,
+				NEOVIM_FN_NVIM_GET_HL_BY_NAME,
+				NEOVIM_FN_NVIM_GET_HL_BY_ID,
+				NEOVIM_FN_NVIM_FEEDKEYS,
+				NEOVIM_FN_NVIM_INPUT,
+				NEOVIM_FN_NVIM_REPLACE_TERMCODES,
+				NEOVIM_FN_NVIM_COMMAND_OUTPUT,
+				NEOVIM_FN_NVIM_EVAL,
+				NEOVIM_FN_NVIM_EXECUTE_LUA,
+				NEOVIM_FN_NVIM_CALL_FUNCTION,
+				NEOVIM_FN_NVIM_CALL_DICT_FUNCTION,
+				NEOVIM_FN_NVIM_STRWIDTH,
+				NEOVIM_FN_NVIM_LIST_RUNTIME_PATHS,
+				NEOVIM_FN_NVIM_SET_CURRENT_DIR,
+				NEOVIM_FN_NVIM_GET_CURRENT_LINE,
+				NEOVIM_FN_NVIM_SET_CURRENT_LINE,
+				NEOVIM_FN_NVIM_DEL_CURRENT_LINE,
+				NEOVIM_FN_NVIM_GET_VAR,
+				NEOVIM_FN_NVIM_SET_VAR,
+				NEOVIM_FN_NVIM_DEL_VAR,
+				NEOVIM_FN_VIM_SET_VAR,
+				NEOVIM_FN_VIM_DEL_VAR,
+				NEOVIM_FN_NVIM_GET_VVAR,
+				NEOVIM_FN_NVIM_GET_OPTION,
+				NEOVIM_FN_NVIM_SET_OPTION,
+				NEOVIM_FN_NVIM_OUT_WRITE,
+				NEOVIM_FN_NVIM_ERR_WRITE,
+				NEOVIM_FN_NVIM_ERR_WRITELN,
+				NEOVIM_FN_NVIM_LIST_BUFS,
+				NEOVIM_FN_NVIM_GET_CURRENT_BUF,
+				NEOVIM_FN_NVIM_SET_CURRENT_BUF,
+				NEOVIM_FN_NVIM_LIST_WINS,
+				NEOVIM_FN_NVIM_GET_CURRENT_WIN,
+				NEOVIM_FN_NVIM_SET_CURRENT_WIN,
+				NEOVIM_FN_NVIM_LIST_TABPAGES,
+				NEOVIM_FN_NVIM_GET_CURRENT_TABPAGE,
+				NEOVIM_FN_NVIM_SET_CURRENT_TABPAGE,
+				NEOVIM_FN_NVIM_CREATE_NAMESPACE,
+				NEOVIM_FN_NVIM_GET_NAMESPACES,
+				NEOVIM_FN_NVIM_SUBSCRIBE,
+				NEOVIM_FN_NVIM_UNSUBSCRIBE,
+				NEOVIM_FN_NVIM_GET_COLOR_BY_NAME,
+				NEOVIM_FN_NVIM_GET_COLOR_MAP,
+				NEOVIM_FN_NVIM_GET_MODE,
+				NEOVIM_FN_NVIM_GET_KEYMAP,
+				NEOVIM_FN_NVIM_GET_COMMANDS,
+				NEOVIM_FN_NVIM_GET_API_INFO,
+				NEOVIM_FN_NVIM_SET_CLIENT_INFO,
+				NEOVIM_FN_NVIM_GET_CHAN_INFO,
+				NEOVIM_FN_NVIM_LIST_CHANS,
+				NEOVIM_FN_NVIM_CALL_ATOMIC,
+				NEOVIM_FN_NVIM_PARSE_EXPRESSION,
+				NEOVIM_FN_NVIM_LIST_UIS,
+				NEOVIM_FN_NVIM_GET_PROC_CHILDREN,
+				NEOVIM_FN_NVIM_GET_PROC,
+				NEOVIM_FN_NVIM_WIN_GET_BUF,
+				NEOVIM_FN_NVIM_WIN_SET_BUF,
+				NEOVIM_FN_NVIM_WIN_GET_CURSOR,
+				NEOVIM_FN_NVIM_WIN_SET_CURSOR,
+				NEOVIM_FN_NVIM_WIN_GET_HEIGHT,
+				NEOVIM_FN_NVIM_WIN_SET_HEIGHT,
+				NEOVIM_FN_NVIM_WIN_GET_WIDTH,
+				NEOVIM_FN_NVIM_WIN_SET_WIDTH,
+				NEOVIM_FN_NVIM_WIN_GET_VAR,
+				NEOVIM_FN_NVIM_WIN_SET_VAR,
+				NEOVIM_FN_NVIM_WIN_DEL_VAR,
+				NEOVIM_FN_WINDOW_SET_VAR,
+				NEOVIM_FN_WINDOW_DEL_VAR,
+				NEOVIM_FN_NVIM_WIN_GET_OPTION,
+				NEOVIM_FN_NVIM_WIN_SET_OPTION,
+				NEOVIM_FN_NVIM_WIN_GET_POSITION,
+				NEOVIM_FN_NVIM_WIN_GET_TABPAGE,
+				NEOVIM_FN_NVIM_WIN_GET_NUMBER,
+				NEOVIM_FN_NVIM_WIN_IS_VALID,
+				NEOVIM_FN_BUFFER_LINE_COUNT,
+				NEOVIM_FN_BUFFER_GET_LINES,
+				NEOVIM_FN_BUFFER_SET_LINES,
+				NEOVIM_FN_BUFFER_GET_VAR,
+				NEOVIM_FN_BUFFER_GET_OPTION,
+				NEOVIM_FN_BUFFER_SET_OPTION,
+				NEOVIM_FN_BUFFER_GET_NUMBER,
+				NEOVIM_FN_BUFFER_GET_NAME,
+				NEOVIM_FN_BUFFER_SET_NAME,
+				NEOVIM_FN_BUFFER_IS_VALID,
+				NEOVIM_FN_BUFFER_GET_MARK,
+				NEOVIM_FN_BUFFER_ADD_HIGHLIGHT,
+				NEOVIM_FN_BUFFER_CLEAR_HIGHLIGHT,
+				NEOVIM_FN_TABPAGE_GET_WINDOWS,
+				NEOVIM_FN_TABPAGE_GET_VAR,
+				NEOVIM_FN_TABPAGE_GET_WINDOW,
+				NEOVIM_FN_TABPAGE_IS_VALID,
+				NEOVIM_FN_UI_DETACH,
+				NEOVIM_FN_UI_TRY_RESIZE,
+				NEOVIM_FN_VIM_COMMAND,
+				NEOVIM_FN_VIM_FEEDKEYS,
+				NEOVIM_FN_VIM_INPUT,
+				NEOVIM_FN_VIM_REPLACE_TERMCODES,
+				NEOVIM_FN_VIM_COMMAND_OUTPUT,
+				NEOVIM_FN_VIM_EVAL,
+				NEOVIM_FN_VIM_CALL_FUNCTION,
+				NEOVIM_FN_VIM_STRWIDTH,
+				NEOVIM_FN_VIM_LIST_RUNTIME_PATHS,
+				NEOVIM_FN_VIM_CHANGE_DIRECTORY,
+				NEOVIM_FN_VIM_GET_CURRENT_LINE,
+				NEOVIM_FN_VIM_SET_CURRENT_LINE,
+				NEOVIM_FN_VIM_DEL_CURRENT_LINE,
+				NEOVIM_FN_VIM_GET_VAR,
+				NEOVIM_FN_VIM_GET_VVAR,
+				NEOVIM_FN_VIM_GET_OPTION,
+				NEOVIM_FN_VIM_SET_OPTION,
+				NEOVIM_FN_VIM_OUT_WRITE,
+				NEOVIM_FN_VIM_ERR_WRITE,
+				NEOVIM_FN_VIM_REPORT_ERROR,
+				NEOVIM_FN_VIM_GET_BUFFERS,
+				NEOVIM_FN_VIM_GET_CURRENT_BUFFER,
+				NEOVIM_FN_VIM_SET_CURRENT_BUFFER,
+				NEOVIM_FN_VIM_GET_WINDOWS,
+				NEOVIM_FN_VIM_GET_CURRENT_WINDOW,
+				NEOVIM_FN_VIM_SET_CURRENT_WINDOW,
+				NEOVIM_FN_VIM_GET_TABPAGES,
+				NEOVIM_FN_VIM_GET_CURRENT_TABPAGE,
+				NEOVIM_FN_VIM_SET_CURRENT_TABPAGE,
+				NEOVIM_FN_VIM_SUBSCRIBE,
+				NEOVIM_FN_VIM_UNSUBSCRIBE,
+				NEOVIM_FN_VIM_NAME_TO_COLOR,
+				NEOVIM_FN_VIM_GET_COLOR_MAP,
+				NEOVIM_FN_WINDOW_GET_BUFFER,
+				NEOVIM_FN_WINDOW_GET_CURSOR,
+				NEOVIM_FN_WINDOW_SET_CURSOR,
+				NEOVIM_FN_WINDOW_GET_HEIGHT,
+				NEOVIM_FN_WINDOW_SET_HEIGHT,
+				NEOVIM_FN_WINDOW_GET_WIDTH,
+				NEOVIM_FN_WINDOW_SET_WIDTH,
+				NEOVIM_FN_WINDOW_GET_VAR,
+				NEOVIM_FN_WINDOW_GET_OPTION,
+				NEOVIM_FN_WINDOW_SET_OPTION,
+				NEOVIM_FN_WINDOW_GET_POSITION,
+				NEOVIM_FN_WINDOW_GET_TABPAGE,
+				NEOVIM_FN_WINDOW_IS_VALID,
+			};
+
+	static bool checkFunctions(const QVariantList& ftable);
+	static FunctionId functionId(const Function& f);
+
+	NeovimApi5(NeovimConnector *);
+protected slots:
+	void handleResponse(quint32 id, quint64 fun, const QVariant&);
+	void handleResponseError(quint32 id, quint64 fun, const QVariant&);
+signals:
+	void error(const QString& errmsg, const QVariant& errObj);
+	void neovimNotification(const QByteArray &name, const QVariantList& args);
+private:
+	NeovimConnector *m_c;
+public slots:
+	// Integer nvim_buf_line_count(Buffer buffer, ) 
+	MsgpackRequest* nvim_buf_line_count(int64_t buffer);
+	// DEPRECATED
+	// String buffer_get_line(Buffer buffer, Integer index, ) 
+	MsgpackRequest* buffer_get_line(int64_t buffer, int64_t index);
+	// Boolean nvim_buf_attach(Buffer buffer, Boolean send_buffer, Dictionary opts, ) 
+	MsgpackRequest* nvim_buf_attach(int64_t buffer, bool send_buffer, QVariantMap opts);
+	// Boolean nvim_buf_detach(Buffer buffer, ) 
+	MsgpackRequest* nvim_buf_detach(int64_t buffer);
+	// DEPRECATED
+	// void buffer_set_line(Buffer buffer, Integer index, String line, ) 
+	MsgpackRequest* buffer_set_line(int64_t buffer, int64_t index, QByteArray line);
+	// DEPRECATED
+	// void buffer_del_line(Buffer buffer, Integer index, ) 
+	MsgpackRequest* buffer_del_line(int64_t buffer, int64_t index);
+	// DEPRECATED
+	// ArrayOf(String) buffer_get_line_slice(Buffer buffer, Integer start, Integer end, Boolean include_start, Boolean include_end, ) 
+	MsgpackRequest* buffer_get_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end);
+	// ArrayOf(String) nvim_buf_get_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ) 
+	MsgpackRequest* nvim_buf_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing);
+	// DEPRECATED
+	// void buffer_set_line_slice(Buffer buffer, Integer start, Integer end, Boolean include_start, Boolean include_end, ArrayOf(String) replacement, ) 
+	MsgpackRequest* buffer_set_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end, QList<QByteArray> replacement);
+	// void nvim_buf_set_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ArrayOf(String) replacement, ) 
+	MsgpackRequest* nvim_buf_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement);
+	// Integer nvim_buf_get_offset(Buffer buffer, Integer index, ) 
+	MsgpackRequest* nvim_buf_get_offset(int64_t buffer, int64_t index);
+	// Object nvim_buf_get_var(Buffer buffer, String name, ) 
+	MsgpackRequest* nvim_buf_get_var(int64_t buffer, QByteArray name);
+	// Integer nvim_buf_get_changedtick(Buffer buffer, ) 
+	MsgpackRequest* nvim_buf_get_changedtick(int64_t buffer);
+	// ArrayOf(Dictionary) nvim_buf_get_keymap(Buffer buffer, String mode, ) 
+	MsgpackRequest* nvim_buf_get_keymap(int64_t buffer, QByteArray mode);
+	// Dictionary nvim_buf_get_commands(Buffer buffer, Dictionary opts, ) 
+	MsgpackRequest* nvim_buf_get_commands(int64_t buffer, QVariantMap opts);
+	// void nvim_buf_set_var(Buffer buffer, String name, Object value, ) 
+	MsgpackRequest* nvim_buf_set_var(int64_t buffer, QByteArray name, QVariant value);
+	// void nvim_buf_del_var(Buffer buffer, String name, ) 
+	MsgpackRequest* nvim_buf_del_var(int64_t buffer, QByteArray name);
+	// DEPRECATED
+	// Object buffer_set_var(Buffer buffer, String name, Object value, ) 
+	MsgpackRequest* buffer_set_var(int64_t buffer, QByteArray name, QVariant value);
+	// DEPRECATED
+	// Object buffer_del_var(Buffer buffer, String name, ) 
+	MsgpackRequest* buffer_del_var(int64_t buffer, QByteArray name);
+	// Object nvim_buf_get_option(Buffer buffer, String name, ) 
+	MsgpackRequest* nvim_buf_get_option(int64_t buffer, QByteArray name);
+	// void nvim_buf_set_option(Buffer buffer, String name, Object value, ) 
+	MsgpackRequest* nvim_buf_set_option(int64_t buffer, QByteArray name, QVariant value);
+	// DEPRECATED
+	// Integer nvim_buf_get_number(Buffer buffer, ) 
+	MsgpackRequest* nvim_buf_get_number(int64_t buffer);
+	// String nvim_buf_get_name(Buffer buffer, ) 
+	MsgpackRequest* nvim_buf_get_name(int64_t buffer);
+	// void nvim_buf_set_name(Buffer buffer, String name, ) 
+	MsgpackRequest* nvim_buf_set_name(int64_t buffer, QByteArray name);
+	// Boolean nvim_buf_is_loaded(Buffer buffer, ) 
+	MsgpackRequest* nvim_buf_is_loaded(int64_t buffer);
+	// Boolean nvim_buf_is_valid(Buffer buffer, ) 
+	MsgpackRequest* nvim_buf_is_valid(int64_t buffer);
+	// DEPRECATED
+	// void buffer_insert(Buffer buffer, Integer lnum, ArrayOf(String) lines, ) 
+	MsgpackRequest* buffer_insert(int64_t buffer, int64_t lnum, QList<QByteArray> lines);
+	// ArrayOf(Integer, 2) nvim_buf_get_mark(Buffer buffer, String name, ) 
+	MsgpackRequest* nvim_buf_get_mark(int64_t buffer, QByteArray name);
+	// Integer nvim_buf_add_highlight(Buffer buffer, Integer ns_id, String hl_group, Integer line, Integer col_start, Integer col_end, ) 
+	MsgpackRequest* nvim_buf_add_highlight(int64_t buffer, int64_t ns_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end);
+	// void nvim_buf_clear_namespace(Buffer buffer, Integer ns_id, Integer line_start, Integer line_end, ) 
+	MsgpackRequest* nvim_buf_clear_namespace(int64_t buffer, int64_t ns_id, int64_t line_start, int64_t line_end);
+	// void nvim_buf_clear_highlight(Buffer buffer, Integer ns_id, Integer line_start, Integer line_end, ) 
+	MsgpackRequest* nvim_buf_clear_highlight(int64_t buffer, int64_t ns_id, int64_t line_start, int64_t line_end);
+	// Integer nvim_buf_set_virtual_text(Buffer buffer, Integer ns_id, Integer line, Array chunks, Dictionary opts, ) 
+	MsgpackRequest* nvim_buf_set_virtual_text(int64_t buffer, int64_t ns_id, int64_t line, QVariantList chunks, QVariantMap opts);
+	// ArrayOf(Window) nvim_tabpage_list_wins(Tabpage tabpage, ) 
+	MsgpackRequest* nvim_tabpage_list_wins(int64_t tabpage);
+	// Object nvim_tabpage_get_var(Tabpage tabpage, String name, ) 
+	MsgpackRequest* nvim_tabpage_get_var(int64_t tabpage, QByteArray name);
+	// void nvim_tabpage_set_var(Tabpage tabpage, String name, Object value, ) 
+	MsgpackRequest* nvim_tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value);
+	// void nvim_tabpage_del_var(Tabpage tabpage, String name, ) 
+	MsgpackRequest* nvim_tabpage_del_var(int64_t tabpage, QByteArray name);
+	// DEPRECATED
+	// Object tabpage_set_var(Tabpage tabpage, String name, Object value, ) 
+	MsgpackRequest* tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value);
+	// DEPRECATED
+	// Object tabpage_del_var(Tabpage tabpage, String name, ) 
+	MsgpackRequest* tabpage_del_var(int64_t tabpage, QByteArray name);
+	// Window nvim_tabpage_get_win(Tabpage tabpage, ) 
+	MsgpackRequest* nvim_tabpage_get_win(int64_t tabpage);
+	// Integer nvim_tabpage_get_number(Tabpage tabpage, ) 
+	MsgpackRequest* nvim_tabpage_get_number(int64_t tabpage);
+	// Boolean nvim_tabpage_is_valid(Tabpage tabpage, ) 
+	MsgpackRequest* nvim_tabpage_is_valid(int64_t tabpage);
+	// void nvim_ui_attach(Integer width, Integer height, Dictionary options, ) 
+	MsgpackRequest* nvim_ui_attach(int64_t width, int64_t height, QVariantMap options);
+	// DEPRECATED
+	// void ui_attach(Integer width, Integer height, Boolean enable_rgb, ) 
+	MsgpackRequest* ui_attach(int64_t width, int64_t height, bool enable_rgb);
+	// void nvim_ui_detach() 
+	MsgpackRequest* nvim_ui_detach();
+	// void nvim_ui_try_resize(Integer width, Integer height, ) 
+	MsgpackRequest* nvim_ui_try_resize(int64_t width, int64_t height);
+	// void nvim_ui_set_option(String name, Object value, ) 
+	MsgpackRequest* nvim_ui_set_option(QByteArray name, QVariant value);
+	// void nvim_command(String command, ) 
+	MsgpackRequest* nvim_command(QByteArray command);
+	// Dictionary nvim_get_hl_by_name(String name, Boolean rgb, ) 
+	MsgpackRequest* nvim_get_hl_by_name(QByteArray name, bool rgb);
+	// Dictionary nvim_get_hl_by_id(Integer hl_id, Boolean rgb, ) 
+	MsgpackRequest* nvim_get_hl_by_id(int64_t hl_id, bool rgb);
+	// void nvim_feedkeys(String keys, String mode, Boolean escape_csi, ) 
+	MsgpackRequest* nvim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi);
+	// Integer nvim_input(String keys, ) 
+	MsgpackRequest* nvim_input(QByteArray keys);
+	// String nvim_replace_termcodes(String str, Boolean from_part, Boolean do_lt, Boolean special, ) 
+	MsgpackRequest* nvim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special);
+	// String nvim_command_output(String command, ) 
+	MsgpackRequest* nvim_command_output(QByteArray command);
+	// Object nvim_eval(String expr, ) 
+	MsgpackRequest* nvim_eval(QByteArray expr);
+	// Object nvim_execute_lua(String code, Array args, ) 
+	MsgpackRequest* nvim_execute_lua(QByteArray code, QVariantList args);
+	// Object nvim_call_function(String fn, Array args, ) 
+	MsgpackRequest* nvim_call_function(QByteArray fn, QVariantList args);
+	// Object nvim_call_dict_function(Object dict, String fn, Array args, ) 
+	MsgpackRequest* nvim_call_dict_function(QVariant dict, QByteArray fn, QVariantList args);
+	// Integer nvim_strwidth(String text, ) 
+	MsgpackRequest* nvim_strwidth(QByteArray text);
+	// ArrayOf(String) nvim_list_runtime_paths() 
+	MsgpackRequest* nvim_list_runtime_paths();
+	// void nvim_set_current_dir(String dir, ) 
+	MsgpackRequest* nvim_set_current_dir(QByteArray dir);
+	// String nvim_get_current_line() 
+	MsgpackRequest* nvim_get_current_line();
+	// void nvim_set_current_line(String line, ) 
+	MsgpackRequest* nvim_set_current_line(QByteArray line);
+	// void nvim_del_current_line() 
+	MsgpackRequest* nvim_del_current_line();
+	// Object nvim_get_var(String name, ) 
+	MsgpackRequest* nvim_get_var(QByteArray name);
+	// void nvim_set_var(String name, Object value, ) 
+	MsgpackRequest* nvim_set_var(QByteArray name, QVariant value);
+	// void nvim_del_var(String name, ) 
+	MsgpackRequest* nvim_del_var(QByteArray name);
+	// DEPRECATED
+	// Object vim_set_var(String name, Object value, ) 
+	MsgpackRequest* vim_set_var(QByteArray name, QVariant value);
+	// DEPRECATED
+	// Object vim_del_var(String name, ) 
+	MsgpackRequest* vim_del_var(QByteArray name);
+	// Object nvim_get_vvar(String name, ) 
+	MsgpackRequest* nvim_get_vvar(QByteArray name);
+	// Object nvim_get_option(String name, ) 
+	MsgpackRequest* nvim_get_option(QByteArray name);
+	// void nvim_set_option(String name, Object value, ) 
+	MsgpackRequest* nvim_set_option(QByteArray name, QVariant value);
+	// void nvim_out_write(String str, ) 
+	MsgpackRequest* nvim_out_write(QByteArray str);
+	// void nvim_err_write(String str, ) 
+	MsgpackRequest* nvim_err_write(QByteArray str);
+	// void nvim_err_writeln(String str, ) 
+	MsgpackRequest* nvim_err_writeln(QByteArray str);
+	// ArrayOf(Buffer) nvim_list_bufs() 
+	MsgpackRequest* nvim_list_bufs();
+	// Buffer nvim_get_current_buf() 
+	MsgpackRequest* nvim_get_current_buf();
+	// void nvim_set_current_buf(Buffer buffer, ) 
+	MsgpackRequest* nvim_set_current_buf(int64_t buffer);
+	// ArrayOf(Window) nvim_list_wins() 
+	MsgpackRequest* nvim_list_wins();
+	// Window nvim_get_current_win() 
+	MsgpackRequest* nvim_get_current_win();
+	// void nvim_set_current_win(Window window, ) 
+	MsgpackRequest* nvim_set_current_win(int64_t window);
+	// ArrayOf(Tabpage) nvim_list_tabpages() 
+	MsgpackRequest* nvim_list_tabpages();
+	// Tabpage nvim_get_current_tabpage() 
+	MsgpackRequest* nvim_get_current_tabpage();
+	// void nvim_set_current_tabpage(Tabpage tabpage, ) 
+	MsgpackRequest* nvim_set_current_tabpage(int64_t tabpage);
+	// Integer nvim_create_namespace(String name, ) 
+	MsgpackRequest* nvim_create_namespace(QByteArray name);
+	// Dictionary nvim_get_namespaces() 
+	MsgpackRequest* nvim_get_namespaces();
+	// void nvim_subscribe(String event, ) 
+	MsgpackRequest* nvim_subscribe(QByteArray event);
+	// void nvim_unsubscribe(String event, ) 
+	MsgpackRequest* nvim_unsubscribe(QByteArray event);
+	// Integer nvim_get_color_by_name(String name, ) 
+	MsgpackRequest* nvim_get_color_by_name(QByteArray name);
+	// Dictionary nvim_get_color_map() 
+	MsgpackRequest* nvim_get_color_map();
+	// Dictionary nvim_get_mode() 
+	MsgpackRequest* nvim_get_mode();
+	// ArrayOf(Dictionary) nvim_get_keymap(String mode, ) 
+	MsgpackRequest* nvim_get_keymap(QByteArray mode);
+	// Dictionary nvim_get_commands(Dictionary opts, ) 
+	MsgpackRequest* nvim_get_commands(QVariantMap opts);
+	// Array nvim_get_api_info() 
+	MsgpackRequest* nvim_get_api_info();
+	// void nvim_set_client_info(String name, Dictionary version, String type, Dictionary methods, Dictionary attributes, ) 
+	MsgpackRequest* nvim_set_client_info(QByteArray name, QVariantMap version, QByteArray type, QVariantMap methods, QVariantMap attributes);
+	// Dictionary nvim_get_chan_info(Integer chan, ) 
+	MsgpackRequest* nvim_get_chan_info(int64_t chan);
+	// Array nvim_list_chans() 
+	MsgpackRequest* nvim_list_chans();
+	// Array nvim_call_atomic(Array calls, ) 
+	MsgpackRequest* nvim_call_atomic(QVariantList calls);
+	// Dictionary nvim_parse_expression(String expr, String flags, Boolean highlight, ) 
+	MsgpackRequest* nvim_parse_expression(QByteArray expr, QByteArray flags, bool highlight);
+	// Array nvim_list_uis() 
+	MsgpackRequest* nvim_list_uis();
+	// Array nvim_get_proc_children(Integer pid, ) 
+	MsgpackRequest* nvim_get_proc_children(int64_t pid);
+	// Object nvim_get_proc(Integer pid, ) 
+	MsgpackRequest* nvim_get_proc(int64_t pid);
+	// Buffer nvim_win_get_buf(Window window, ) 
+	MsgpackRequest* nvim_win_get_buf(int64_t window);
+	// void nvim_win_set_buf(Window window, Buffer buffer, ) 
+	MsgpackRequest* nvim_win_set_buf(int64_t window, int64_t buffer);
+	// ArrayOf(Integer, 2) nvim_win_get_cursor(Window window, ) 
+	MsgpackRequest* nvim_win_get_cursor(int64_t window);
+	// void nvim_win_set_cursor(Window window, ArrayOf(Integer, 2) pos, ) 
+	MsgpackRequest* nvim_win_set_cursor(int64_t window, QPoint pos);
+	// Integer nvim_win_get_height(Window window, ) 
+	MsgpackRequest* nvim_win_get_height(int64_t window);
+	// void nvim_win_set_height(Window window, Integer height, ) 
+	MsgpackRequest* nvim_win_set_height(int64_t window, int64_t height);
+	// Integer nvim_win_get_width(Window window, ) 
+	MsgpackRequest* nvim_win_get_width(int64_t window);
+	// void nvim_win_set_width(Window window, Integer width, ) 
+	MsgpackRequest* nvim_win_set_width(int64_t window, int64_t width);
+	// Object nvim_win_get_var(Window window, String name, ) 
+	MsgpackRequest* nvim_win_get_var(int64_t window, QByteArray name);
+	// void nvim_win_set_var(Window window, String name, Object value, ) 
+	MsgpackRequest* nvim_win_set_var(int64_t window, QByteArray name, QVariant value);
+	// void nvim_win_del_var(Window window, String name, ) 
+	MsgpackRequest* nvim_win_del_var(int64_t window, QByteArray name);
+	// DEPRECATED
+	// Object window_set_var(Window window, String name, Object value, ) 
+	MsgpackRequest* window_set_var(int64_t window, QByteArray name, QVariant value);
+	// DEPRECATED
+	// Object window_del_var(Window window, String name, ) 
+	MsgpackRequest* window_del_var(int64_t window, QByteArray name);
+	// Object nvim_win_get_option(Window window, String name, ) 
+	MsgpackRequest* nvim_win_get_option(int64_t window, QByteArray name);
+	// void nvim_win_set_option(Window window, String name, Object value, ) 
+	MsgpackRequest* nvim_win_set_option(int64_t window, QByteArray name, QVariant value);
+	// ArrayOf(Integer, 2) nvim_win_get_position(Window window, ) 
+	MsgpackRequest* nvim_win_get_position(int64_t window);
+	// Tabpage nvim_win_get_tabpage(Window window, ) 
+	MsgpackRequest* nvim_win_get_tabpage(int64_t window);
+	// Integer nvim_win_get_number(Window window, ) 
+	MsgpackRequest* nvim_win_get_number(int64_t window);
+	// Boolean nvim_win_is_valid(Window window, ) 
+	MsgpackRequest* nvim_win_is_valid(int64_t window);
+	// DEPRECATED
+	// Integer buffer_line_count(Buffer buffer, ) 
+	MsgpackRequest* buffer_line_count(int64_t buffer);
+	// DEPRECATED
+	// ArrayOf(String) buffer_get_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ) 
+	MsgpackRequest* buffer_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing);
+	// DEPRECATED
+	// void buffer_set_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ArrayOf(String) replacement, ) 
+	MsgpackRequest* buffer_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement);
+	// DEPRECATED
+	// Object buffer_get_var(Buffer buffer, String name, ) 
+	MsgpackRequest* buffer_get_var(int64_t buffer, QByteArray name);
+	// DEPRECATED
+	// Object buffer_get_option(Buffer buffer, String name, ) 
+	MsgpackRequest* buffer_get_option(int64_t buffer, QByteArray name);
+	// DEPRECATED
+	// void buffer_set_option(Buffer buffer, String name, Object value, ) 
+	MsgpackRequest* buffer_set_option(int64_t buffer, QByteArray name, QVariant value);
+	// DEPRECATED
+	// Integer buffer_get_number(Buffer buffer, ) 
+	MsgpackRequest* buffer_get_number(int64_t buffer);
+	// DEPRECATED
+	// String buffer_get_name(Buffer buffer, ) 
+	MsgpackRequest* buffer_get_name(int64_t buffer);
+	// DEPRECATED
+	// void buffer_set_name(Buffer buffer, String name, ) 
+	MsgpackRequest* buffer_set_name(int64_t buffer, QByteArray name);
+	// DEPRECATED
+	// Boolean buffer_is_valid(Buffer buffer, ) 
+	MsgpackRequest* buffer_is_valid(int64_t buffer);
+	// DEPRECATED
+	// ArrayOf(Integer, 2) buffer_get_mark(Buffer buffer, String name, ) 
+	MsgpackRequest* buffer_get_mark(int64_t buffer, QByteArray name);
+	// DEPRECATED
+	// Integer buffer_add_highlight(Buffer buffer, Integer ns_id, String hl_group, Integer line, Integer col_start, Integer col_end, ) 
+	MsgpackRequest* buffer_add_highlight(int64_t buffer, int64_t ns_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end);
+	// DEPRECATED
+	// void buffer_clear_highlight(Buffer buffer, Integer ns_id, Integer line_start, Integer line_end, ) 
+	MsgpackRequest* buffer_clear_highlight(int64_t buffer, int64_t ns_id, int64_t line_start, int64_t line_end);
+	// DEPRECATED
+	// ArrayOf(Window) tabpage_get_windows(Tabpage tabpage, ) 
+	MsgpackRequest* tabpage_get_windows(int64_t tabpage);
+	// DEPRECATED
+	// Object tabpage_get_var(Tabpage tabpage, String name, ) 
+	MsgpackRequest* tabpage_get_var(int64_t tabpage, QByteArray name);
+	// DEPRECATED
+	// Window tabpage_get_window(Tabpage tabpage, ) 
+	MsgpackRequest* tabpage_get_window(int64_t tabpage);
+	// DEPRECATED
+	// Boolean tabpage_is_valid(Tabpage tabpage, ) 
+	MsgpackRequest* tabpage_is_valid(int64_t tabpage);
+	// DEPRECATED
+	// void ui_detach() 
+	MsgpackRequest* ui_detach();
+	// DEPRECATED
+	// Object ui_try_resize(Integer width, Integer height, ) 
+	MsgpackRequest* ui_try_resize(int64_t width, int64_t height);
+	// DEPRECATED
+	// void vim_command(String command, ) 
+	MsgpackRequest* vim_command(QByteArray command);
+	// DEPRECATED
+	// void vim_feedkeys(String keys, String mode, Boolean escape_csi, ) 
+	MsgpackRequest* vim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi);
+	// DEPRECATED
+	// Integer vim_input(String keys, ) 
+	MsgpackRequest* vim_input(QByteArray keys);
+	// DEPRECATED
+	// String vim_replace_termcodes(String str, Boolean from_part, Boolean do_lt, Boolean special, ) 
+	MsgpackRequest* vim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special);
+	// DEPRECATED
+	// String vim_command_output(String command, ) 
+	MsgpackRequest* vim_command_output(QByteArray command);
+	// DEPRECATED
+	// Object vim_eval(String expr, ) 
+	MsgpackRequest* vim_eval(QByteArray expr);
+	// DEPRECATED
+	// Object vim_call_function(String fn, Array args, ) 
+	MsgpackRequest* vim_call_function(QByteArray fn, QVariantList args);
+	// DEPRECATED
+	// Integer vim_strwidth(String text, ) 
+	MsgpackRequest* vim_strwidth(QByteArray text);
+	// DEPRECATED
+	// ArrayOf(String) vim_list_runtime_paths() 
+	MsgpackRequest* vim_list_runtime_paths();
+	// DEPRECATED
+	// void vim_change_directory(String dir, ) 
+	MsgpackRequest* vim_change_directory(QByteArray dir);
+	// DEPRECATED
+	// String vim_get_current_line() 
+	MsgpackRequest* vim_get_current_line();
+	// DEPRECATED
+	// void vim_set_current_line(String line, ) 
+	MsgpackRequest* vim_set_current_line(QByteArray line);
+	// DEPRECATED
+	// void vim_del_current_line() 
+	MsgpackRequest* vim_del_current_line();
+	// DEPRECATED
+	// Object vim_get_var(String name, ) 
+	MsgpackRequest* vim_get_var(QByteArray name);
+	// DEPRECATED
+	// Object vim_get_vvar(String name, ) 
+	MsgpackRequest* vim_get_vvar(QByteArray name);
+	// DEPRECATED
+	// Object vim_get_option(String name, ) 
+	MsgpackRequest* vim_get_option(QByteArray name);
+	// DEPRECATED
+	// void vim_set_option(String name, Object value, ) 
+	MsgpackRequest* vim_set_option(QByteArray name, QVariant value);
+	// DEPRECATED
+	// void vim_out_write(String str, ) 
+	MsgpackRequest* vim_out_write(QByteArray str);
+	// DEPRECATED
+	// void vim_err_write(String str, ) 
+	MsgpackRequest* vim_err_write(QByteArray str);
+	// DEPRECATED
+	// void vim_report_error(String str, ) 
+	MsgpackRequest* vim_report_error(QByteArray str);
+	// DEPRECATED
+	// ArrayOf(Buffer) vim_get_buffers() 
+	MsgpackRequest* vim_get_buffers();
+	// DEPRECATED
+	// Buffer vim_get_current_buffer() 
+	MsgpackRequest* vim_get_current_buffer();
+	// DEPRECATED
+	// void vim_set_current_buffer(Buffer buffer, ) 
+	MsgpackRequest* vim_set_current_buffer(int64_t buffer);
+	// DEPRECATED
+	// ArrayOf(Window) vim_get_windows() 
+	MsgpackRequest* vim_get_windows();
+	// DEPRECATED
+	// Window vim_get_current_window() 
+	MsgpackRequest* vim_get_current_window();
+	// DEPRECATED
+	// void vim_set_current_window(Window window, ) 
+	MsgpackRequest* vim_set_current_window(int64_t window);
+	// DEPRECATED
+	// ArrayOf(Tabpage) vim_get_tabpages() 
+	MsgpackRequest* vim_get_tabpages();
+	// DEPRECATED
+	// Tabpage vim_get_current_tabpage() 
+	MsgpackRequest* vim_get_current_tabpage();
+	// DEPRECATED
+	// void vim_set_current_tabpage(Tabpage tabpage, ) 
+	MsgpackRequest* vim_set_current_tabpage(int64_t tabpage);
+	// DEPRECATED
+	// void vim_subscribe(String event, ) 
+	MsgpackRequest* vim_subscribe(QByteArray event);
+	// DEPRECATED
+	// void vim_unsubscribe(String event, ) 
+	MsgpackRequest* vim_unsubscribe(QByteArray event);
+	// DEPRECATED
+	// Integer vim_name_to_color(String name, ) 
+	MsgpackRequest* vim_name_to_color(QByteArray name);
+	// DEPRECATED
+	// Dictionary vim_get_color_map() 
+	MsgpackRequest* vim_get_color_map();
+	// DEPRECATED
+	// Buffer window_get_buffer(Window window, ) 
+	MsgpackRequest* window_get_buffer(int64_t window);
+	// DEPRECATED
+	// ArrayOf(Integer, 2) window_get_cursor(Window window, ) 
+	MsgpackRequest* window_get_cursor(int64_t window);
+	// DEPRECATED
+	// void window_set_cursor(Window window, ArrayOf(Integer, 2) pos, ) 
+	MsgpackRequest* window_set_cursor(int64_t window, QPoint pos);
+	// DEPRECATED
+	// Integer window_get_height(Window window, ) 
+	MsgpackRequest* window_get_height(int64_t window);
+	// DEPRECATED
+	// void window_set_height(Window window, Integer height, ) 
+	MsgpackRequest* window_set_height(int64_t window, int64_t height);
+	// DEPRECATED
+	// Integer window_get_width(Window window, ) 
+	MsgpackRequest* window_get_width(int64_t window);
+	// DEPRECATED
+	// void window_set_width(Window window, Integer width, ) 
+	MsgpackRequest* window_set_width(int64_t window, int64_t width);
+	// DEPRECATED
+	// Object window_get_var(Window window, String name, ) 
+	MsgpackRequest* window_get_var(int64_t window, QByteArray name);
+	// DEPRECATED
+	// Object window_get_option(Window window, String name, ) 
+	MsgpackRequest* window_get_option(int64_t window, QByteArray name);
+	// DEPRECATED
+	// void window_set_option(Window window, String name, Object value, ) 
+	MsgpackRequest* window_set_option(int64_t window, QByteArray name, QVariant value);
+	// DEPRECATED
+	// ArrayOf(Integer, 2) window_get_position(Window window, ) 
+	MsgpackRequest* window_get_position(int64_t window);
+	// DEPRECATED
+	// Tabpage window_get_tabpage(Window window, ) 
+	MsgpackRequest* window_get_tabpage(int64_t window);
+	// DEPRECATED
+	// Boolean window_is_valid(Window window, ) 
+	MsgpackRequest* window_is_valid(int64_t window);
+
+signals:
+	void on_nvim_buf_line_count(int64_t);
+	void err_nvim_buf_line_count(const QString&, const QVariant&);
+
+	void on_buffer_get_line(QByteArray);
+	void err_buffer_get_line(const QString&, const QVariant&);
+
+	void on_nvim_buf_attach(bool);
+	void err_nvim_buf_attach(const QString&, const QVariant&);
+
+	void on_nvim_buf_detach(bool);
+	void err_nvim_buf_detach(const QString&, const QVariant&);
+
+	void on_buffer_set_line(void);
+	void err_buffer_set_line(const QString&, const QVariant&);
+
+	void on_buffer_del_line(void);
+	void err_buffer_del_line(const QString&, const QVariant&);
+
+	void on_buffer_get_line_slice(QList<QByteArray>);
+	void err_buffer_get_line_slice(const QString&, const QVariant&);
+
+	void on_nvim_buf_get_lines(QList<QByteArray>);
+	void err_nvim_buf_get_lines(const QString&, const QVariant&);
+
+	void on_buffer_set_line_slice(void);
+	void err_buffer_set_line_slice(const QString&, const QVariant&);
+
+	void on_nvim_buf_set_lines(void);
+	void err_nvim_buf_set_lines(const QString&, const QVariant&);
+
+	void on_nvim_buf_get_offset(int64_t);
+	void err_nvim_buf_get_offset(const QString&, const QVariant&);
+
+	void on_nvim_buf_get_var(QVariant);
+	void err_nvim_buf_get_var(const QString&, const QVariant&);
+
+	void on_nvim_buf_get_changedtick(int64_t);
+	void err_nvim_buf_get_changedtick(const QString&, const QVariant&);
+
+	void on_nvim_buf_get_keymap(QList<QVariantMap>);
+	void err_nvim_buf_get_keymap(const QString&, const QVariant&);
+
+	void on_nvim_buf_get_commands(QVariantMap);
+	void err_nvim_buf_get_commands(const QString&, const QVariant&);
+
+	void on_nvim_buf_set_var(void);
+	void err_nvim_buf_set_var(const QString&, const QVariant&);
+
+	void on_nvim_buf_del_var(void);
+	void err_nvim_buf_del_var(const QString&, const QVariant&);
+
+	void on_buffer_set_var(QVariant);
+	void err_buffer_set_var(const QString&, const QVariant&);
+
+	void on_buffer_del_var(QVariant);
+	void err_buffer_del_var(const QString&, const QVariant&);
+
+	void on_nvim_buf_get_option(QVariant);
+	void err_nvim_buf_get_option(const QString&, const QVariant&);
+
+	void on_nvim_buf_set_option(void);
+	void err_nvim_buf_set_option(const QString&, const QVariant&);
+
+	void on_nvim_buf_get_number(int64_t);
+	void err_nvim_buf_get_number(const QString&, const QVariant&);
+
+	void on_nvim_buf_get_name(QByteArray);
+	void err_nvim_buf_get_name(const QString&, const QVariant&);
+
+	void on_nvim_buf_set_name(void);
+	void err_nvim_buf_set_name(const QString&, const QVariant&);
+
+	void on_nvim_buf_is_loaded(bool);
+	void err_nvim_buf_is_loaded(const QString&, const QVariant&);
+
+	void on_nvim_buf_is_valid(bool);
+	void err_nvim_buf_is_valid(const QString&, const QVariant&);
+
+	void on_buffer_insert(void);
+	void err_buffer_insert(const QString&, const QVariant&);
+
+	void on_nvim_buf_get_mark(QPoint);
+	void err_nvim_buf_get_mark(const QString&, const QVariant&);
+
+	void on_nvim_buf_add_highlight(int64_t);
+	void err_nvim_buf_add_highlight(const QString&, const QVariant&);
+
+	void on_nvim_buf_clear_namespace(void);
+	void err_nvim_buf_clear_namespace(const QString&, const QVariant&);
+
+	void on_nvim_buf_clear_highlight(void);
+	void err_nvim_buf_clear_highlight(const QString&, const QVariant&);
+
+	void on_nvim_buf_set_virtual_text(int64_t);
+	void err_nvim_buf_set_virtual_text(const QString&, const QVariant&);
+
+	void on_nvim_tabpage_list_wins(QList<int64_t>);
+	void err_nvim_tabpage_list_wins(const QString&, const QVariant&);
+
+	void on_nvim_tabpage_get_var(QVariant);
+	void err_nvim_tabpage_get_var(const QString&, const QVariant&);
+
+	void on_nvim_tabpage_set_var(void);
+	void err_nvim_tabpage_set_var(const QString&, const QVariant&);
+
+	void on_nvim_tabpage_del_var(void);
+	void err_nvim_tabpage_del_var(const QString&, const QVariant&);
+
+	void on_tabpage_set_var(QVariant);
+	void err_tabpage_set_var(const QString&, const QVariant&);
+
+	void on_tabpage_del_var(QVariant);
+	void err_tabpage_del_var(const QString&, const QVariant&);
+
+	void on_nvim_tabpage_get_win(int64_t);
+	void err_nvim_tabpage_get_win(const QString&, const QVariant&);
+
+	void on_nvim_tabpage_get_number(int64_t);
+	void err_nvim_tabpage_get_number(const QString&, const QVariant&);
+
+	void on_nvim_tabpage_is_valid(bool);
+	void err_nvim_tabpage_is_valid(const QString&, const QVariant&);
+
+	void on_nvim_ui_attach(void);
+	void err_nvim_ui_attach(const QString&, const QVariant&);
+
+	void on_ui_attach(void);
+	void err_ui_attach(const QString&, const QVariant&);
+
+	void on_nvim_ui_detach(void);
+	void err_nvim_ui_detach(const QString&, const QVariant&);
+
+	void on_nvim_ui_try_resize(void);
+	void err_nvim_ui_try_resize(const QString&, const QVariant&);
+
+	void on_nvim_ui_set_option(void);
+	void err_nvim_ui_set_option(const QString&, const QVariant&);
+
+	void on_nvim_command(void);
+	void err_nvim_command(const QString&, const QVariant&);
+
+	void on_nvim_get_hl_by_name(QVariantMap);
+	void err_nvim_get_hl_by_name(const QString&, const QVariant&);
+
+	void on_nvim_get_hl_by_id(QVariantMap);
+	void err_nvim_get_hl_by_id(const QString&, const QVariant&);
+
+	void on_nvim_feedkeys(void);
+	void err_nvim_feedkeys(const QString&, const QVariant&);
+
+	void on_nvim_input(int64_t);
+	void err_nvim_input(const QString&, const QVariant&);
+
+	void on_nvim_replace_termcodes(QByteArray);
+	void err_nvim_replace_termcodes(const QString&, const QVariant&);
+
+	void on_nvim_command_output(QByteArray);
+	void err_nvim_command_output(const QString&, const QVariant&);
+
+	void on_nvim_eval(QVariant);
+	void err_nvim_eval(const QString&, const QVariant&);
+
+	void on_nvim_execute_lua(QVariant);
+	void err_nvim_execute_lua(const QString&, const QVariant&);
+
+	void on_nvim_call_function(QVariant);
+	void err_nvim_call_function(const QString&, const QVariant&);
+
+	void on_nvim_call_dict_function(QVariant);
+	void err_nvim_call_dict_function(const QString&, const QVariant&);
+
+	void on_nvim_strwidth(int64_t);
+	void err_nvim_strwidth(const QString&, const QVariant&);
+
+	void on_nvim_list_runtime_paths(QList<QByteArray>);
+	void err_nvim_list_runtime_paths(const QString&, const QVariant&);
+
+	void on_nvim_set_current_dir(void);
+	void err_nvim_set_current_dir(const QString&, const QVariant&);
+
+	void on_nvim_get_current_line(QByteArray);
+	void err_nvim_get_current_line(const QString&, const QVariant&);
+
+	void on_nvim_set_current_line(void);
+	void err_nvim_set_current_line(const QString&, const QVariant&);
+
+	void on_nvim_del_current_line(void);
+	void err_nvim_del_current_line(const QString&, const QVariant&);
+
+	void on_nvim_get_var(QVariant);
+	void err_nvim_get_var(const QString&, const QVariant&);
+
+	void on_nvim_set_var(void);
+	void err_nvim_set_var(const QString&, const QVariant&);
+
+	void on_nvim_del_var(void);
+	void err_nvim_del_var(const QString&, const QVariant&);
+
+	void on_vim_set_var(QVariant);
+	void err_vim_set_var(const QString&, const QVariant&);
+
+	void on_vim_del_var(QVariant);
+	void err_vim_del_var(const QString&, const QVariant&);
+
+	void on_nvim_get_vvar(QVariant);
+	void err_nvim_get_vvar(const QString&, const QVariant&);
+
+	void on_nvim_get_option(QVariant);
+	void err_nvim_get_option(const QString&, const QVariant&);
+
+	void on_nvim_set_option(void);
+	void err_nvim_set_option(const QString&, const QVariant&);
+
+	void on_nvim_out_write(void);
+	void err_nvim_out_write(const QString&, const QVariant&);
+
+	void on_nvim_err_write(void);
+	void err_nvim_err_write(const QString&, const QVariant&);
+
+	void on_nvim_err_writeln(void);
+	void err_nvim_err_writeln(const QString&, const QVariant&);
+
+	void on_nvim_list_bufs(QList<int64_t>);
+	void err_nvim_list_bufs(const QString&, const QVariant&);
+
+	void on_nvim_get_current_buf(int64_t);
+	void err_nvim_get_current_buf(const QString&, const QVariant&);
+
+	void on_nvim_set_current_buf(void);
+	void err_nvim_set_current_buf(const QString&, const QVariant&);
+
+	void on_nvim_list_wins(QList<int64_t>);
+	void err_nvim_list_wins(const QString&, const QVariant&);
+
+	void on_nvim_get_current_win(int64_t);
+	void err_nvim_get_current_win(const QString&, const QVariant&);
+
+	void on_nvim_set_current_win(void);
+	void err_nvim_set_current_win(const QString&, const QVariant&);
+
+	void on_nvim_list_tabpages(QList<int64_t>);
+	void err_nvim_list_tabpages(const QString&, const QVariant&);
+
+	void on_nvim_get_current_tabpage(int64_t);
+	void err_nvim_get_current_tabpage(const QString&, const QVariant&);
+
+	void on_nvim_set_current_tabpage(void);
+	void err_nvim_set_current_tabpage(const QString&, const QVariant&);
+
+	void on_nvim_create_namespace(int64_t);
+	void err_nvim_create_namespace(const QString&, const QVariant&);
+
+	void on_nvim_get_namespaces(QVariantMap);
+	void err_nvim_get_namespaces(const QString&, const QVariant&);
+
+	void on_nvim_subscribe(void);
+	void err_nvim_subscribe(const QString&, const QVariant&);
+
+	void on_nvim_unsubscribe(void);
+	void err_nvim_unsubscribe(const QString&, const QVariant&);
+
+	void on_nvim_get_color_by_name(int64_t);
+	void err_nvim_get_color_by_name(const QString&, const QVariant&);
+
+	void on_nvim_get_color_map(QVariantMap);
+	void err_nvim_get_color_map(const QString&, const QVariant&);
+
+	void on_nvim_get_mode(QVariantMap);
+	void err_nvim_get_mode(const QString&, const QVariant&);
+
+	void on_nvim_get_keymap(QList<QVariantMap>);
+	void err_nvim_get_keymap(const QString&, const QVariant&);
+
+	void on_nvim_get_commands(QVariantMap);
+	void err_nvim_get_commands(const QString&, const QVariant&);
+
+	void on_nvim_get_api_info(QVariantList);
+	void err_nvim_get_api_info(const QString&, const QVariant&);
+
+	void on_nvim_set_client_info(void);
+	void err_nvim_set_client_info(const QString&, const QVariant&);
+
+	void on_nvim_get_chan_info(QVariantMap);
+	void err_nvim_get_chan_info(const QString&, const QVariant&);
+
+	void on_nvim_list_chans(QVariantList);
+	void err_nvim_list_chans(const QString&, const QVariant&);
+
+	void on_nvim_call_atomic(QVariantList);
+	void err_nvim_call_atomic(const QString&, const QVariant&);
+
+	void on_nvim_parse_expression(QVariantMap);
+	void err_nvim_parse_expression(const QString&, const QVariant&);
+
+	void on_nvim_list_uis(QVariantList);
+	void err_nvim_list_uis(const QString&, const QVariant&);
+
+	void on_nvim_get_proc_children(QVariantList);
+	void err_nvim_get_proc_children(const QString&, const QVariant&);
+
+	void on_nvim_get_proc(QVariant);
+	void err_nvim_get_proc(const QString&, const QVariant&);
+
+	void on_nvim_win_get_buf(int64_t);
+	void err_nvim_win_get_buf(const QString&, const QVariant&);
+
+	void on_nvim_win_set_buf(void);
+	void err_nvim_win_set_buf(const QString&, const QVariant&);
+
+	void on_nvim_win_get_cursor(QPoint);
+	void err_nvim_win_get_cursor(const QString&, const QVariant&);
+
+	void on_nvim_win_set_cursor(void);
+	void err_nvim_win_set_cursor(const QString&, const QVariant&);
+
+	void on_nvim_win_get_height(int64_t);
+	void err_nvim_win_get_height(const QString&, const QVariant&);
+
+	void on_nvim_win_set_height(void);
+	void err_nvim_win_set_height(const QString&, const QVariant&);
+
+	void on_nvim_win_get_width(int64_t);
+	void err_nvim_win_get_width(const QString&, const QVariant&);
+
+	void on_nvim_win_set_width(void);
+	void err_nvim_win_set_width(const QString&, const QVariant&);
+
+	void on_nvim_win_get_var(QVariant);
+	void err_nvim_win_get_var(const QString&, const QVariant&);
+
+	void on_nvim_win_set_var(void);
+	void err_nvim_win_set_var(const QString&, const QVariant&);
+
+	void on_nvim_win_del_var(void);
+	void err_nvim_win_del_var(const QString&, const QVariant&);
+
+	void on_window_set_var(QVariant);
+	void err_window_set_var(const QString&, const QVariant&);
+
+	void on_window_del_var(QVariant);
+	void err_window_del_var(const QString&, const QVariant&);
+
+	void on_nvim_win_get_option(QVariant);
+	void err_nvim_win_get_option(const QString&, const QVariant&);
+
+	void on_nvim_win_set_option(void);
+	void err_nvim_win_set_option(const QString&, const QVariant&);
+
+	void on_nvim_win_get_position(QPoint);
+	void err_nvim_win_get_position(const QString&, const QVariant&);
+
+	void on_nvim_win_get_tabpage(int64_t);
+	void err_nvim_win_get_tabpage(const QString&, const QVariant&);
+
+	void on_nvim_win_get_number(int64_t);
+	void err_nvim_win_get_number(const QString&, const QVariant&);
+
+	void on_nvim_win_is_valid(bool);
+	void err_nvim_win_is_valid(const QString&, const QVariant&);
+
+	void on_buffer_line_count(int64_t);
+	void err_buffer_line_count(const QString&, const QVariant&);
+
+	void on_buffer_get_lines(QList<QByteArray>);
+	void err_buffer_get_lines(const QString&, const QVariant&);
+
+	void on_buffer_set_lines(void);
+	void err_buffer_set_lines(const QString&, const QVariant&);
+
+	void on_buffer_get_var(QVariant);
+	void err_buffer_get_var(const QString&, const QVariant&);
+
+	void on_buffer_get_option(QVariant);
+	void err_buffer_get_option(const QString&, const QVariant&);
+
+	void on_buffer_set_option(void);
+	void err_buffer_set_option(const QString&, const QVariant&);
+
+	void on_buffer_get_number(int64_t);
+	void err_buffer_get_number(const QString&, const QVariant&);
+
+	void on_buffer_get_name(QByteArray);
+	void err_buffer_get_name(const QString&, const QVariant&);
+
+	void on_buffer_set_name(void);
+	void err_buffer_set_name(const QString&, const QVariant&);
+
+	void on_buffer_is_valid(bool);
+	void err_buffer_is_valid(const QString&, const QVariant&);
+
+	void on_buffer_get_mark(QPoint);
+	void err_buffer_get_mark(const QString&, const QVariant&);
+
+	void on_buffer_add_highlight(int64_t);
+	void err_buffer_add_highlight(const QString&, const QVariant&);
+
+	void on_buffer_clear_highlight(void);
+	void err_buffer_clear_highlight(const QString&, const QVariant&);
+
+	void on_tabpage_get_windows(QList<int64_t>);
+	void err_tabpage_get_windows(const QString&, const QVariant&);
+
+	void on_tabpage_get_var(QVariant);
+	void err_tabpage_get_var(const QString&, const QVariant&);
+
+	void on_tabpage_get_window(int64_t);
+	void err_tabpage_get_window(const QString&, const QVariant&);
+
+	void on_tabpage_is_valid(bool);
+	void err_tabpage_is_valid(const QString&, const QVariant&);
+
+	void on_ui_detach(void);
+	void err_ui_detach(const QString&, const QVariant&);
+
+	void on_ui_try_resize(QVariant);
+	void err_ui_try_resize(const QString&, const QVariant&);
+
+	void on_vim_command(void);
+	void err_vim_command(const QString&, const QVariant&);
+
+	void on_vim_feedkeys(void);
+	void err_vim_feedkeys(const QString&, const QVariant&);
+
+	void on_vim_input(int64_t);
+	void err_vim_input(const QString&, const QVariant&);
+
+	void on_vim_replace_termcodes(QByteArray);
+	void err_vim_replace_termcodes(const QString&, const QVariant&);
+
+	void on_vim_command_output(QByteArray);
+	void err_vim_command_output(const QString&, const QVariant&);
+
+	void on_vim_eval(QVariant);
+	void err_vim_eval(const QString&, const QVariant&);
+
+	void on_vim_call_function(QVariant);
+	void err_vim_call_function(const QString&, const QVariant&);
+
+	void on_vim_strwidth(int64_t);
+	void err_vim_strwidth(const QString&, const QVariant&);
+
+	void on_vim_list_runtime_paths(QList<QByteArray>);
+	void err_vim_list_runtime_paths(const QString&, const QVariant&);
+
+	void on_vim_change_directory(void);
+	void err_vim_change_directory(const QString&, const QVariant&);
+
+	void on_vim_get_current_line(QByteArray);
+	void err_vim_get_current_line(const QString&, const QVariant&);
+
+	void on_vim_set_current_line(void);
+	void err_vim_set_current_line(const QString&, const QVariant&);
+
+	void on_vim_del_current_line(void);
+	void err_vim_del_current_line(const QString&, const QVariant&);
+
+	void on_vim_get_var(QVariant);
+	void err_vim_get_var(const QString&, const QVariant&);
+
+	void on_vim_get_vvar(QVariant);
+	void err_vim_get_vvar(const QString&, const QVariant&);
+
+	void on_vim_get_option(QVariant);
+	void err_vim_get_option(const QString&, const QVariant&);
+
+	void on_vim_set_option(void);
+	void err_vim_set_option(const QString&, const QVariant&);
+
+	void on_vim_out_write(void);
+	void err_vim_out_write(const QString&, const QVariant&);
+
+	void on_vim_err_write(void);
+	void err_vim_err_write(const QString&, const QVariant&);
+
+	void on_vim_report_error(void);
+	void err_vim_report_error(const QString&, const QVariant&);
+
+	void on_vim_get_buffers(QList<int64_t>);
+	void err_vim_get_buffers(const QString&, const QVariant&);
+
+	void on_vim_get_current_buffer(int64_t);
+	void err_vim_get_current_buffer(const QString&, const QVariant&);
+
+	void on_vim_set_current_buffer(void);
+	void err_vim_set_current_buffer(const QString&, const QVariant&);
+
+	void on_vim_get_windows(QList<int64_t>);
+	void err_vim_get_windows(const QString&, const QVariant&);
+
+	void on_vim_get_current_window(int64_t);
+	void err_vim_get_current_window(const QString&, const QVariant&);
+
+	void on_vim_set_current_window(void);
+	void err_vim_set_current_window(const QString&, const QVariant&);
+
+	void on_vim_get_tabpages(QList<int64_t>);
+	void err_vim_get_tabpages(const QString&, const QVariant&);
+
+	void on_vim_get_current_tabpage(int64_t);
+	void err_vim_get_current_tabpage(const QString&, const QVariant&);
+
+	void on_vim_set_current_tabpage(void);
+	void err_vim_set_current_tabpage(const QString&, const QVariant&);
+
+	void on_vim_subscribe(void);
+	void err_vim_subscribe(const QString&, const QVariant&);
+
+	void on_vim_unsubscribe(void);
+	void err_vim_unsubscribe(const QString&, const QVariant&);
+
+	void on_vim_name_to_color(int64_t);
+	void err_vim_name_to_color(const QString&, const QVariant&);
+
+	void on_vim_get_color_map(QVariantMap);
+	void err_vim_get_color_map(const QString&, const QVariant&);
+
+	void on_window_get_buffer(int64_t);
+	void err_window_get_buffer(const QString&, const QVariant&);
+
+	void on_window_get_cursor(QPoint);
+	void err_window_get_cursor(const QString&, const QVariant&);
+
+	void on_window_set_cursor(void);
+	void err_window_set_cursor(const QString&, const QVariant&);
+
+	void on_window_get_height(int64_t);
+	void err_window_get_height(const QString&, const QVariant&);
+
+	void on_window_set_height(void);
+	void err_window_set_height(const QString&, const QVariant&);
+
+	void on_window_get_width(int64_t);
+	void err_window_get_width(const QString&, const QVariant&);
+
+	void on_window_set_width(void);
+	void err_window_set_width(const QString&, const QVariant&);
+
+	void on_window_get_var(QVariant);
+	void err_window_get_var(const QString&, const QVariant&);
+
+	void on_window_get_option(QVariant);
+	void err_window_get_option(const QString&, const QVariant&);
+
+	void on_window_set_option(void);
+	void err_window_set_option(const QString&, const QVariant&);
+
+	void on_window_get_position(QPoint);
+	void err_window_get_position(const QString&, const QVariant&);
+
+	void on_window_get_tabpage(int64_t);
+	void err_window_get_tabpage(const QString&, const QVariant&);
+
+	void on_window_is_valid(bool);
+	void err_window_is_valid(const QString&, const QVariant&);
+
+};
+} // namespace
+#endif

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -22,6 +22,7 @@ add_subdirectory(shellwidget)
 include(GNUInstallDirs)
 set(RUNTIME_PATH )
 add_library(neovim-qt-gui shell.cpp input.cpp treeview.cpp errorwidget.cpp mainwindow.cpp app.cpp
+	highlight.cpp
 	popupmenumodel.cpp
 	popupmenu.cpp
 	${CMAKE_SOURCE_DIR}/third-party/konsole_wcwidth.cpp

--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -91,6 +91,10 @@ void App::showUi(NeovimConnector *c, const QCommandLineParser& parser)
 		opts.enable_ext_tabline = false;
 	}
 
+	if (parser.isSet("ext-linegrid")) {
+		opts.enable_ext_linegrid = true;
+	}
+
 #ifdef NEOVIMQT_GUI_WIDGET
 	NeovimQt::Shell *win = new NeovimQt::Shell(c);
 	win->show();
@@ -142,6 +146,8 @@ void App::processCliOptions(QCommandLineParser &parser, const QStringList& argum
 				QCoreApplication::translate("main", "Maximize the window on startup")));
 	parser.addOption(QCommandLineOption("no-ext-tabline",
 				QCoreApplication::translate("main", "Disable the external GUI tabline")));
+	parser.addOption(QCommandLineOption("ext-linegrid",
+				QCoreApplication::translate("main", "Enable the modern 'ext_linegrid' Neovim GUI API")));
 	parser.addOption(QCommandLineOption("fullscreen",
 				QCoreApplication::translate("main", "Open the window in fullscreen on startup")));
 	parser.addOption(QCommandLineOption("embed",

--- a/src/gui/app.h
+++ b/src/gui/app.h
@@ -6,6 +6,7 @@
 #include <QUrl>
 #include <QList>
 #include <QCommandLineParser>
+#include "shell.h"
 
 namespace NeovimQt {
 
@@ -19,6 +20,9 @@ public:
 	void showUi(NeovimConnector *c, const QCommandLineParser&);
 	static void processCliOptions(QCommandLineParser& p, const QStringList& arguments);
 	static NeovimConnector* createConnector(const QCommandLineParser& p);
+
+private:
+	static ShellOptions GetShellOptionsFromQSettings();
 
 signals:
 	void openFilesTriggered(const QList<QUrl>);

--- a/src/gui/highlight.cpp
+++ b/src/gui/highlight.cpp
@@ -3,10 +3,6 @@
 namespace NeovimQt {
 
 QColor HighlightAttribute::GetForegroundColor() const {
-	if (m_foreground == QColor::Invalid) {
-		return m_defaultForeground;
-	}
-
 	if (IsReverse()) {
 		return m_background;
 	}
@@ -15,29 +11,11 @@ QColor HighlightAttribute::GetForegroundColor() const {
 }
 
 QColor HighlightAttribute::GetBackgroundColor() const {
-	if (m_background == QColor::Invalid) {
-		return m_defaultBackground;
-	}
-
 	if (IsReverse()) {
 		return m_foreground;
 	}
 
 	return m_background;
 }
-
-QColor HighlightAttribute::GetSpecialColor() const {
-	if (m_special == QColor::Invalid) {
-		return m_defaultSpecial;
-	}
-
-	return m_special;
-}
-
-/*static*/ QColor HighlightAttribute::m_defaultForeground{ Qt::black };
-
-/*static*/ QColor HighlightAttribute::m_defaultBackground{ Qt::white };
-
-/*static*/ QColor HighlightAttribute::m_defaultSpecial{ Qt::black };
 
 } // namespace NeovimQt

--- a/src/gui/highlight.cpp
+++ b/src/gui/highlight.cpp
@@ -1,0 +1,43 @@
+#include "highlight.h"
+
+namespace NeovimQt {
+
+QColor HighlightAttribute::GetForegroundColor() const {
+	if (m_foreground == QColor::Invalid) {
+		return m_defaultForeground;
+	}
+
+	if (IsReverse()) {
+		return m_background;
+	}
+
+	return m_foreground;
+}
+
+QColor HighlightAttribute::GetBackgroundColor() const {
+	if (m_background == QColor::Invalid) {
+		return m_defaultBackground;
+	}
+
+	if (IsReverse()) {
+		return m_foreground;
+	}
+
+	return m_background;
+}
+
+QColor HighlightAttribute::GetSpecialColor() const {
+	if (m_special == QColor::Invalid) {
+		return m_defaultSpecial;
+	}
+
+	return m_special;
+}
+
+/*static*/ QColor HighlightAttribute::m_defaultForeground{ Qt::black };
+
+/*static*/ QColor HighlightAttribute::m_defaultBackground{ Qt::white };
+
+/*static*/ QColor HighlightAttribute::m_defaultSpecial{ Qt::black };
+
+} // namespace NeovimQt

--- a/src/gui/highlight.h
+++ b/src/gui/highlight.h
@@ -1,0 +1,85 @@
+#ifndef NEOVIM_QT_HIGHLIGHT
+#define NEOVIM_QT_HIGHLIGHT
+
+#include <QColor>
+
+namespace NeovimQt {
+
+class HighlightAttribute {
+public:
+	HighlightAttribute(
+		QColor foreground,
+		QColor background,
+		QColor special,
+		bool reverse,
+		bool italic,
+		bool bold,
+		bool underline,
+		bool undercurl) :
+		m_foreground{ foreground },
+		m_background{ background },
+		m_special{ special },
+		m_reverse{ reverse },
+		m_italic{ italic },
+		m_bold{ bold },
+		m_underline{ underline },
+		m_undercurl{ undercurl }
+	{
+	}
+
+	/// Creates safe object with default highlight/style, required for QMap.
+	HighlightAttribute() {};
+
+	static void SetDefaultForegroundColor(QColor foreground) {
+		m_defaultForeground = foreground;
+	}
+
+	static void SetDefaultBackgroundColor(QColor background) {
+		m_defaultBackground = background;
+	}
+
+	static void SetDefaultSpecialColor(QColor special) {
+		m_defaultSpecial = special;
+	}
+
+	static QColor GetDefaultForegroundColor() { return m_defaultForeground; }
+
+	static QColor GetDefaultBackgroundColor() { return m_defaultBackground; }
+
+	static QColor GetDefaultSpecialColor() { return m_defaultSpecial; }
+
+	QColor GetForegroundColor() const;
+
+	QColor GetBackgroundColor() const;
+
+	QColor GetSpecialColor() const;
+
+	bool IsReverse() const { return m_reverse; }
+
+	bool IsItalic() const { return m_italic; }
+
+	bool IsBold() const { return m_bold; }
+
+	bool IsUnderline() const { return m_underline; }
+
+	bool IsUndercurl() const { return m_undercurl; }
+
+private:
+	static QColor m_defaultForeground;
+	static QColor m_defaultBackground;
+	static QColor m_defaultSpecial;
+
+	QColor m_foreground{ QColor::Invalid };
+	QColor m_background{ QColor::Invalid };
+	QColor m_special{ QColor::Invalid };
+
+	bool m_reverse{ false };
+	bool m_italic{ false };
+	bool m_bold{ false };
+	bool m_underline{ false };
+	bool m_undercurl{ false };
+};
+
+} // namespace NeovimQt
+
+#endif // NEOVIM_QT_HIGHLIGHT

--- a/src/gui/highlight.h
+++ b/src/gui/highlight.h
@@ -30,29 +30,11 @@ public:
 	/// Creates safe object with default highlight/style, required for QMap.
 	HighlightAttribute() {};
 
-	static void SetDefaultForegroundColor(QColor foreground) {
-		m_defaultForeground = foreground;
-	}
-
-	static void SetDefaultBackgroundColor(QColor background) {
-		m_defaultBackground = background;
-	}
-
-	static void SetDefaultSpecialColor(QColor special) {
-		m_defaultSpecial = special;
-	}
-
-	static QColor GetDefaultForegroundColor() { return m_defaultForeground; }
-
-	static QColor GetDefaultBackgroundColor() { return m_defaultBackground; }
-
-	static QColor GetDefaultSpecialColor() { return m_defaultSpecial; }
-
 	QColor GetForegroundColor() const;
 
 	QColor GetBackgroundColor() const;
 
-	QColor GetSpecialColor() const;
+	QColor GetSpecialColor() const { return m_special; }
 
 	bool IsReverse() const { return m_reverse; }
 
@@ -65,10 +47,6 @@ public:
 	bool IsUndercurl() const { return m_undercurl; }
 
 private:
-	static QColor m_defaultForeground;
-	static QColor m_defaultBackground;
-	static QColor m_defaultSpecial;
-
 	QColor m_foreground{ QColor::Invalid };
 	QColor m_background{ QColor::Invalid };
 	QColor m_special{ QColor::Invalid };

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -538,7 +538,7 @@ void Shell::handleRedraw(const QByteArray& name, const QVariantList& opargs)
 	} else if (name == "grid_line") {
 		handleGridLine(opargs);
 	} else if (name == "grid_clear") {
-		clearShell(HighlightAttribute::GetDefaultBackgroundColor());
+		clearShell();
 	} else if (name == "grid_destroy") {
 		qDebug() << "Not implemented grid_destroy:" << opargs;
 	} else if (name == "grid_cursor_goto") {
@@ -882,15 +882,13 @@ void Shell::handleDefaultColorsSet(const QVariantList& opargs)
 	const QColor backgroundColor = color(rgb_bg, QColor::Invalid);
 	const QColor specialColor = color(rgb_sp, QColor::Invalid);
 
-	// Set default background/foreground colors for "hl_attr_define"
-	HighlightAttribute::SetDefaultForegroundColor(foregroundColor);
-	HighlightAttribute::SetDefaultBackgroundColor(backgroundColor);
-	HighlightAttribute::SetDefaultSpecialColor(specialColor);
-
 	// Update shellwidget default colors
 	setForeground(foregroundColor);
 	setBackground(backgroundColor);
 	setSpecial(specialColor);
+
+	// Cells drawn with the default colors require a re-paint
+	update();
 }
 
 void Shell::handleHighlightAttributeDefine(const QVariantList& opargs)

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -222,7 +222,8 @@ void Shell::init()
 	if (m_options.enable_ext_popupmenu) {
 		options.insert("ext_popupmenu", true);
 	}
-	if (m_options.enable_ext_linegrid) {
+	if (m_options.enable_ext_linegrid
+		&& m_nvim->hasUIOption("ext_linegrid")) {
 		// Modern Grid UI API is optionally enabled via cmdline
 		options.insert("ext_linegrid", true);
 	}

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -12,6 +12,7 @@
 #include <QMenu>
 #include "neovimconnector.h"
 #include "shellwidget/shellwidget.h"
+#include "highlight.h"
 #include "popupmenu.h"
 #include "popupmenumodel.h"
 
@@ -30,14 +31,10 @@ public:
 
 class ShellOptions {
 public:
-	ShellOptions() {
-		enable_ext_tabline = true;
-		enable_ext_popupmenu = true;
-		nvim_show_tabline = 1;
-	}
-	bool enable_ext_tabline;
-	int nvim_show_tabline;
-	bool enable_ext_popupmenu;
+	bool enable_ext_tabline{ true };
+	bool enable_ext_popupmenu{ true };
+	bool enable_ext_linegrid{ false };
+	int nvim_show_tabline{ 1 };
 };
 
 class Shell: public ShellWidget
@@ -135,6 +132,14 @@ protected:
 	void handlePopupMenuSelect(int64_t selected);
 	virtual void handleMouse(bool);
 
+	// Modern 'ext_linegrid' Grid UI Events
+	virtual void handleGridResize(const QVariantList& opargs);
+	virtual void handleDefaultColorsSet(const QVariantList& opargs);
+	virtual void handleHighlightAttributeDefine(const QVariantList& opargs);
+	virtual void handleGridLine(const QVariantList& opargs);
+	virtual void handleGridCursorGoto(const QVariantList& opargs);
+	virtual void handleGridScroll(const QVariantList& opargs);
+
 	void neovimMouseEvent(QMouseEvent *ev);
 	virtual void mousePressEvent(QMouseEvent *ev) Q_DECL_OVERRIDE;
 	virtual void mouseReleaseEvent(QMouseEvent *ev) Q_DECL_OVERRIDE;
@@ -161,6 +166,9 @@ private:
 	// use the values from above
 	QColor m_hg_foreground, m_hg_background, m_hg_special;
 	QColor m_cursor_color;
+
+	/// Modern 'ext_linegrid' highlight definition map
+	QMap<uint64_t, HighlightAttribute> m_highlightMap;
 
 	/// Cursor position in shell coordinates
 	QPoint m_cursor_pos;

--- a/src/gui/shellwidget/cell.h
+++ b/src/gui/shellwidget/cell.h
@@ -8,30 +8,52 @@
 struct Cell {
 public:
 
-
-	inline Cell(QChar c, QColor fgColor, QColor bgColor, QColor spColor, bool bold,
-			bool italic, bool underline, bool undercurl)
-	:foregroundColor(fgColor), backgroundColor(bgColor), specialColor(spColor),
-	bold(bold), italic(italic), underline(underline), undercurl(undercurl),
-	valid(true), doubleWidth(false) {
+	inline Cell(
+		QChar c,
+		QColor fgColor,
+		QColor bgColor,
+		QColor spColor,
+		bool bold,
+		bool italic,
+		bool underline,
+		bool undercurl) :
+		foregroundColor{ fgColor },
+		backgroundColor{ bgColor },
+		specialColor{ spColor },
+		bold{ bold },
+		italic{ italic },
+		underline{ underline },
+		undercurl{ undercurl },
+		valid{ true },
+		doubleWidth{ false } {
 		setChar(c);
-	}
+	};
 
 	/// Default cells are space characters using invalid colors
-	inline Cell()
-	:c(' '), foregroundColor(QColor()), backgroundColor(QColor()), specialColor(QColor()),
-	bold(false), italic(false), underline(false), undercurl(false),
-	valid(true), doubleWidth(false) {}
+	inline Cell() :
+		c(' '),
+		foregroundColor{ QColor::Invalid },
+		backgroundColor{ QColor::Invalid },
+		specialColor{ QColor::Invalid },
+		bold{ false },
+		italic{ false },
+		underline{ false },
+		undercurl{ false },
+		valid{ true },
+		doubleWidth{ false } {}
 
 	inline void reset() {
 		c = ' ';
-		foregroundColor = QColor();
-		backgroundColor = foregroundColor;
-		specialColor = foregroundColor;
-		bold = italic = underline = undercurl = doubleWidth = false;
+		foregroundColor = QColor::Invalid;
+		backgroundColor = QColor::Invalid;
+		specialColor = QColor::Invalid;
+		bold = false;
+		italic = false;
+		underline = false;
+		undercurl = false;
+		doubleWidth = false;
 		valid = true;
 	}
-
 
 	/// Create an empty Cell with a background color
 	static Cell bg(QColor bg) {

--- a/src/gui/shellwidget/shellwidget.cpp
+++ b/src/gui/shellwidget/shellwidget.cpp
@@ -283,15 +283,6 @@ int ShellWidget::put(const QString& text, int row, int column,
 		QColor fg, QColor bg, QColor sp, bool bold, bool italic,
 		bool underline, bool undercurl)
 {
-	if (!fg.isValid()) {
-		fg = m_fgColor;
-	}
-	if (!bg.isValid()) {
-		bg = m_bgColor;
-	}
-	if (!sp.isValid()) {
-		sp = m_spColor;
-	}
 	int cols_changed = m_contents.put(text, row, column, fg, bg, sp,
 				bold, italic, underline, undercurl);
 	if (cols_changed > 0) {

--- a/src/gui/shellwidget/shellwidget.h
+++ b/src/gui/shellwidget/shellwidget.h
@@ -45,7 +45,7 @@ public slots:
 			bool bold=false, bool italic=false,
 			bool underline=false, bool undercurl=false);
 	void clearRow(int row);
-	void clearShell(QColor bg);
+	void clearShell(QColor bg = QColor::Invalid);
 	void clearRegion(int row0, int col0, int row1, int col1);
 	void scrollShell(int rows);
 	void scrollShellRegion(int row0, int row1, int col0,

--- a/src/neovimconnector.cpp
+++ b/src/neovimconnector.cpp
@@ -223,6 +223,22 @@ NeovimApi4* NeovimConnector::api4()
  * @warning Do not call this before NeovimConnector::ready as been signaled
  * @see NeovimConnector::isReady
  */
+NeovimApi5* NeovimConnector::api5()
+{
+	if ( !m_api5 ) {
+		if (m_api_compat <= 5 && 5 <= m_api_supported) {
+			m_api5 = new NeovimApi5(this);
+		} else {
+			qWarning() << "This instance of neovim not support api level 5";
+		}
+	}
+	return m_api5;
+}
+
+/**
+ * @warning Do not call this before NeovimConnector::ready as been signaled
+ * @see NeovimConnector::isReady
+ */
 NeovimApi6* NeovimConnector::api6()
 {
 	if ( !m_api6 ) {

--- a/src/neovimconnector.cpp
+++ b/src/neovimconnector.cpp
@@ -461,10 +461,17 @@ quint64 NeovimConnector::apiCompatibility()
 {
 	return m_api_compat;
 }
+
 /** The maximum API level supported by this instance */
 quint64 NeovimConnector::apiLevel()
 {
 	return m_api_supported;
+}
+
+/** Inspect Neovim metadata for ui_option support */
+bool NeovimConnector::hasUIOption(const QByteArray &option)
+{
+	return m_uiOptions.contains(option);
 }
 
 /**

--- a/src/neovimconnector.cpp
+++ b/src/neovimconnector.cpp
@@ -25,9 +25,7 @@ NeovimConnector::NeovimConnector(QIODevice *dev)
 }
 
 NeovimConnector::NeovimConnector(MsgpackIODevice *dev)
-:QObject(), m_dev(dev), m_helper(0), m_error(NoError), m_api0(NULL), m_api1(NULL), m_api2(NULL), m_api3(NULL),
-	m_api4(NULL), m_api6(NULL), m_channel(0), m_api_compat(0), m_api_supported(0), m_ctype(OtherConnection),
-    m_ready(false), m_timeout(20000)
+:QObject(), m_dev(dev)
 {
 	m_helper = new NeovimConnectorHelper(this);
 	qRegisterMetaType<NeovimError>("NeovimError");

--- a/src/neovimconnector.h
+++ b/src/neovimconnector.h
@@ -116,29 +116,29 @@ protected slots:
 	void msgpackError();
 
 private:
-	MsgpackIODevice *m_dev;
-	NeovimConnectorHelper *m_helper;
+	MsgpackIODevice *m_dev{ nullptr };
+	NeovimConnectorHelper *m_helper{ nullptr };
 	QString m_errorString;
-	NeovimError m_error;
+	NeovimError m_error{ NoError };
 
-	NeovimApi0 *m_api0;
-	NeovimApi1 *m_api1;
-	NeovimApi2 *m_api2;
-	NeovimApi3 *m_api3;
-	NeovimApi4 *m_api4;
-	NeovimApi6 *m_api6;
-	quint64 m_channel;
-	quint64 m_api_compat;
-	quint64 m_api_supported;
+	NeovimApi0 *m_api0{ nullptr };
+	NeovimApi1 *m_api1{ nullptr };
+	NeovimApi2 *m_api2{ nullptr };
+	NeovimApi3 *m_api3{ nullptr };
+	NeovimApi4 *m_api4{ nullptr };
+	NeovimApi6 *m_api6{ nullptr };
+	quint64 m_channel{ 0 };
+	quint64 m_api_compat{ 0 };
+	quint64 m_api_supported{ 0 };
 
 	// Store connection arguments for reconnect()
-	NeovimConnectionType m_ctype;
+	NeovimConnectionType m_ctype{ OtherConnection };
 	QStringList m_spawnArgs;
 	QString m_spawnExe;
 	QString m_connSocket, m_connHost;
 	int m_connPort;
-	bool m_ready;
-	int m_timeout;
+	bool m_ready{ false };
+	int m_timeout{ 20000 };
 };
 } // namespace NeovimQt
 Q_DECLARE_METATYPE(NeovimQt::NeovimConnector::NeovimError)

--- a/src/neovimconnector.h
+++ b/src/neovimconnector.h
@@ -11,6 +11,7 @@
 #include "auto/neovimapi2.h"
 #include "auto/neovimapi3.h"
 #include "auto/neovimapi4.h"
+#include "auto/neovimapi5.h"
 #include "auto/neovimapi6.h"
 
 namespace NeovimQt {
@@ -25,6 +26,7 @@ class NeovimConnector: public QObject
 	friend class NeovimApi2;
 	friend class NeovimApi3;
 	friend class NeovimApi4;
+	friend class NeovimApi5;
 	friend class NeovimApi6;
 	friend class NeovimConnectorHelper;
 	Q_OBJECT
@@ -83,6 +85,7 @@ public:
 	NeovimApi2 * api2();
 	NeovimApi3 * api3();
 	NeovimApi4 * api4();
+	NeovimApi5 * api5();
 	NeovimApi6 * api6();
 	uint64_t channel();
 	QString decode(const QByteArray&);
@@ -126,6 +129,7 @@ private:
 	NeovimApi2 *m_api2{ nullptr };
 	NeovimApi3 *m_api3{ nullptr };
 	NeovimApi4 *m_api4{ nullptr };
+	NeovimApi5 *m_api5{ nullptr };
 	NeovimApi6 *m_api6{ nullptr };
 	quint64 m_channel{ 0 };
 	quint64 m_api_compat{ 0 };

--- a/src/neovimconnector.h
+++ b/src/neovimconnector.h
@@ -98,6 +98,7 @@ public:
 
 	quint64 apiCompatibility();
 	quint64 apiLevel();
+	bool hasUIOption(const QByteArray& option);
 
 signals:
 	/** Emitted when Neovim is ready @see ready */
@@ -140,6 +141,7 @@ private:
 	QStringList m_spawnArgs;
 	QString m_spawnExe;
 	QString m_connSocket, m_connHost;
+	QVariantList m_uiOptions;
 	int m_connPort;
 	bool m_ready{ false };
 	int m_timeout{ 20000 };

--- a/src/neovimconnectorhelper.cpp
+++ b/src/neovimconnectorhelper.cpp
@@ -38,19 +38,20 @@ void NeovimConnectorHelper::handleMetadataError(quint32 msgid, quint64, const QV
 void NeovimConnectorHelper::handleMetadata(quint32 msgid, quint64, const QVariant& result)
 {
 	const QVariantList asList = result.toList();
-	if (asList.size() != 2 || 
-			!asList.at(0).canConvert<quint64>() ||
-			!asList.at(1).canConvert<QVariantMap>()) {
+	if (asList.size() != 2
+		|| !asList.at(0).canConvert<quint64>()
+		|| !asList.at(1).canConvert<QVariantMap>()) {
 		m_c->setError(NeovimConnector::UnexpectedMsg,
-				tr("Unable to unpack metadata response description, unexpected data type"));
+			tr("Unable to unpack metadata response description, unexpected data type"));
 	}
 
 	m_c->m_channel = asList.at(0).toUInt();
 	const QVariantMap metadata = asList.at(1).toMap();
 
-	int api_compat = metadata.value("version").toMap().value("api_compatible").toUInt();
-	int api_level = metadata.value("version").toMap().value("api_level").toUInt();
+	const int api_compat = metadata.value("version").toMap().value("api_compatible").toUInt();
+	const int api_level = metadata.value("version").toMap().value("api_level").toUInt();
 	qDebug() << "Neovim API version compatible with" << api_compat << "supported" << api_level;
+	m_c->m_uiOptions = metadata.value("ui_options").toList();
 	m_c->m_api_compat = api_compat;
 	m_c->m_api_supported = api_level;
 


### PR DESCRIPTION
This change adds support for the`ext_linegrid` UI protocol.

This change is motivated by a desire to add support form modal confirm dialogs in Neovim-Qt (close, save, open, etc). In the past, there wasn't a good way to do this. NeoVim does not emit events for `:confirm(...)`. However, `ext_messages` was added recently to address this (and to make the command-bar extensible).

Unfortunately for Neovim-Qt, `ext_messages` is only supported when `ext_linegrid` is enabled. Currently, Neovim-Qt only supports the legacy cell-based API.

The `ext_linegrid` API is off by default, and can be enabled via command-line:
        `neovim-qt --ext-linegrid`

The API renders most things correctly but is not yet 100%.

**Outstanding Issues:**
1. ext-linegrid cannot be enabled 'on-the-fly'
2. 'default_colors_set' do not update previously-painted cells.

**Issue 1**
I am not sure if this is a limitation of Neovim's API or a short-coming in my implementation. The map for "hl_attr" is not re-sent for styles that have already been painted with the cell-based API. The default style is then used in places where it should not be.

I addressed this by setting 'ext_linegrid' at ui_attach time with a command-line argument.

**Issue 2**
To see the issues with default color update, try changing your color scheme.

The new API leaves default color changes for the client to handle. The client must now decide what should be re-painted given the new default colors. This is a departure from the old API behavior, which guarantees stale default colors are overwritten.

I think this can be addressed via `ShellWidget` in a future commit. A function which re-paints any cells using the default colors must be added. Such a function could be called from within `handleDefaultColorsSet(...)`.