### PR TITLE
GuiPopupMenu modify size logic to mimic Terminal UI

### DIFF
--- a/src/gui/popupmenu.cpp
+++ b/src/gui/popupmenu.cpp
@@ -1,12 +1,14 @@
 #include "popupmenu.h"
 #include "popupwidgetitem.h"
 
+#include <QDebug>
 #include <QScrollBar>
 
 namespace NeovimQt {
 
-PopupMenu::PopupMenu(QWidget *parent)
-:QListView(parent)
+PopupMenu::PopupMenu(ShellWidget* parent) :
+	QListView(parent),
+	m_parentShellWidget{ parent }
 {
 	setFocusPolicy(Qt::NoFocus);
 	setAttribute(Qt::WA_TransparentForMouseEvents);
@@ -15,12 +17,107 @@ PopupMenu::PopupMenu(QWidget *parent)
 }
 
 QSize PopupMenu::sizeHint() const {
+	if (!model()) {
+		return {};
+	}
+
 	int height = 0;
 	for (int i=0; i<model()->rowCount(); i++) {
 		height += sizeHintForRow(i);
 	}
 	return QSize(sizeHintForColumn(0) + 2*frameWidth(),
 			height + 2*frameWidth());
+}
+
+void PopupMenu::setAnchor(int64_t row, int64_t col)
+{
+	m_anchorRow = row;
+	m_anchorCol = col;
+}
+
+void PopupMenu::setSelectedIndex(int64_t index)
+{
+	if (!model()) {
+		return;
+	}
+
+	QModelIndex idx = model()->index(index, 0);
+	setCurrentIndex(idx);
+	scrollTo(idx);
+}
+
+void PopupMenu::updateGeometry()
+{
+	setGeometry(m_anchorRow, m_anchorCol);
+	QListView::updateGeometry();
+}
+
+void PopupMenu::setGeometry(int64_t row, int64_t col)
+{
+	const QSize sizeHintContent = sizeHint();
+
+	if (!m_parentShellWidget) {
+		const int width = sizeHintContent.width();
+		const int height = sizeHintContent.height();
+
+		qDebug() << "Fallback: PUM anchored to 0,0 without parent shell_widget!";
+		return QListView::setGeometry(0, 0, width, height);
+	}
+
+	const int cell_width = m_parentShellWidget->cellSize().width();
+	const int min_width = 20 * cell_width;
+	const int total_width = m_parentShellWidget->columns() * cell_width;
+
+	// Compute default width properties (anchor_x, width)
+	int width = sizeHintContent.width();
+	int anchor_x = col * cell_width;
+
+	// PUM must fit within available space to the right of anchor_x
+	if (anchor_x + width > total_width)
+	{
+		width = total_width - anchor_x;
+
+		// PUM should never go below minimum width
+		if (width < min_width)
+		{
+			anchor_x = 0;
+			width = qMin(total_width, sizeHintContent.width());
+		}
+	}
+
+	const int cell_height = m_parentShellWidget->cellSize().height();
+	const int min_height = 15 * cell_height;
+	const int space_above_row = row * cell_height + 1;
+	const int space_below_row =
+		(m_parentShellWidget->rows() - row - 2) * cell_height + 1;
+
+	// Compute default height properties (anchor_y, height)
+	int height = sizeHintContent.height();
+	int anchor_y = (row + 1) * cell_height;
+
+	if (height < space_below_row) {
+		// PUM defaults work fine. Keep this case.
+	}
+	else if (space_below_row >= min_height) {
+		// Truncate PUM to space available below anchor.
+		height = space_below_row;
+	}
+	else if (height < space_above_row) {
+		// Space available for PUM above anchor.
+		anchor_y = (row - 1) * cell_height - height;
+	}
+	else if (space_above_row > space_below_row) {
+		// Not enough space for min_height, more space above.
+		anchor_y = 0;
+		height = space_above_row;
+	}
+	else {
+		// Not enough space for min_height, more space below.
+		height = space_below_row;
+		anchor_y = (row + 1) * cell_height;
+	}
+
+	return QListView::setGeometry(anchor_x, anchor_y, width, height);
 }
 
 } // Namespace

--- a/src/gui/popupmenu.h
+++ b/src/gui/popupmenu.h
@@ -2,13 +2,24 @@
 #define NEOVIM_QT_POPUPMENU
 
 #include <QListWidget>
+#include "shellwidget/shellwidget.h"
 
 namespace NeovimQt {
 
 class PopupMenu: public QListView {
 public:
-	PopupMenu(QWidget *parent=0);
+	PopupMenu(ShellWidget* parent = nullptr);
 	QSize sizeHint() const Q_DECL_OVERRIDE;
+	void setAnchor(int64_t row, int64_t col);
+	void setSelectedIndex(int64_t index);
+	void updateGeometry();
+
+private:
+	int64_t m_anchorRow{ 0 };
+	int64_t m_anchorCol{ 0 };
+	ShellWidget* m_parentShellWidget{ nullptr };
+
+	void setGeometry(int64_t row, int64_t col);
 };
 
 } // Namespace

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -497,28 +497,9 @@ void Shell::handleRedraw(const QByteArray& name, const QVariantList& opargs)
 			emit neovimSuspend();
 		}
 	} else if (name == "popupmenu_show") {
-    // The 5th argument was added to popupmenu_show in neovim/neovim@16c3337.
-    // Since neovim-qt does not use this argument, it checks that the argument
-    // is 4 or more.
-    if (opargs.size() < 4
-				|| !opargs.at(1).canConvert<qint64>()
-				|| !opargs.at(2).canConvert<qint64>()
-				|| !opargs.at(3).canConvert<qint64>()) {
-			qWarning() << "Unexpected arguments for redraw:" << name << opargs;
-			return;
-		}
-
-		handlePopupMenuShow(opargs.at(0).toList(),
-				opargs.at(1).toLongLong(),
-				opargs.at(2).toLongLong(),
-				opargs.at(3).toLongLong());
+		handlePopupMenuShow(opargs);
 	} else if (name == "popupmenu_select") {
-		if (opargs.size() != 1 || !opargs.at(0).canConvert<qint64>()) {
-			qWarning() << "Unexpected arguments for redraw:" << name << opargs;
-			return;
-		}
-		// Neovim uses -1 for 'no selection' and so does Qt
-		handlePopupMenuSelect(opargs.at(0).toLongLong());
+		handlePopupMenuSelect(opargs);
 	} else if (name == "popupmenu_hide") {
 		m_pum.hide();
 	} else if (name == "mode_info_set") {
@@ -531,80 +512,64 @@ void Shell::handleRedraw(const QByteArray& name, const QVariantList& opargs)
 
 }
 
-/// Show the pum, with the given items, selecting the given item (idx)
-/// and place the pum at the given row/col
-void Shell::handlePopupMenuShow(const QVariantList& items,
-			int64_t selected, int64_t row, int64_t col)
+void Shell::handlePopupMenuShow(const QVariantList& opargs)
 {
+	if (opargs.size() < 5
+		|| static_cast<QMetaType::Type>(opargs.at(0).type()) != QMetaType::QVariantList
+		|| !opargs.at(1).canConvert<int64_t>()
+		|| !opargs.at(2).canConvert<int64_t>()
+		|| !opargs.at(3).canConvert<int64_t>()
+		|| !opargs.at(4).canConvert<int64_t>()) {
+		qWarning() << "Unexpected arguments for popupmenu_show:" << opargs;
+		return;
+	}
+
+	const QVariantList items = opargs.at(0).toList();
+	const int64_t selected = opargs.at(1).toULongLong();
+	const int64_t row = opargs.at(2).toULongLong();
+	const int64_t col = opargs.at(3).toULongLong();
+	//const int64_t grid = opargs.at(4).toULongLong();
+
 	QList<PopupMenuItem> model;
-	foreach(const QVariant& v, items) {
+	for (const auto& v : items) {
 		QVariantList item = v.toList();
-		/// Item is (text, kind, extra, info)
+		// Item is (text, kind, extra, info)
 		QString text = item.value(0).toString();
-		if (item.isEmpty() || item.value(0).toString().isEmpty()
-				|| item.size() != 4) {
-			model.append({"", "", "", ""
-					});
-		} else {
-			model.append({
-					item.value(0).toString(),
-					item.value(1).toString(),
-					item.value(2).toString(),
-					item.value(3).toString()
-					});
+		if (item.size() < 4
+			|| item.isEmpty()
+			|| item.value(0).toString().isEmpty()) {
+
+			// Usually faster/smaller to init strings with {} instead of ""
+			model.append({ QString{}, QString{}, QString{}, QString{} });
+			continue;
 		}
+
+		model.append({
+			item.value(0).toString(),
+			item.value(1).toString(),
+			item.value(2).toString(),
+			item.value(3).toString() });
 	}
 
 	m_pum.setModel(new PopupMenuModel(model));
 
-	handlePopupMenuSelect(selected);
+	m_pum.setSelectedIndex(selected);
 
-	// By default the menu is as large as needed to fit all entries
-	int pum_width = m_pum.sizeHint().width();
-	int anchor_x = col*cellSize().width();
-
-	// If the menu width is larger than half the shell, make it half width
-	if (pum_width >= width()/2) {
-		pum_width = columns()/2*cellSize().width();
-		anchor_x = (columns()-1)/2*cellSize().width();
-	}
-
-	// If the menu still does not fit move the anchor to the left
-	if (pum_width > (columns()*cellSize().width()-anchor_x)) {
-		anchor_x = columns()*cellSize().width() - pum_width;
-	}
-
-	int pum_height = m_pum.sizeHint().height();
-	// By default the menu goes bellow the row
-	int anchor_y = (row+1)*cellSize().height();
-	if (row > rows() / 2) {
-		// TODO: leave a couple lines above/below?
-		if (pum_height > row*cellSize().height()) {
-			// The pum height is too large, move it to the top
-			anchor_y = 0;
-			pum_height = row*cellSize().height()-1;
-		} else {
-			// Display menu above the anchor row
-			anchor_y = row*cellSize().height()-pum_height-1;
-		}
-	} else {
-		// Display menu below anchor
-		if (pum_height > (rows()-row-1)*cellSize().height()) {
-			// Resize popupmenu to fit
-			pum_height = height() - anchor_y;
-		}
-	}
-
-	m_pum.setGeometry(anchor_x, anchor_y, pum_width, pum_height);
+	m_pum.setAnchor(row, col);
 	m_pum.updateGeometry();
 	m_pum.show();
 }
 
-void Shell::handlePopupMenuSelect(int64_t selected)
+void Shell::handlePopupMenuSelect(const QVariantList& opargs)
 {
-	auto idx = m_pum.model()->index(selected, 0);
-	m_pum.setCurrentIndex(idx);
-	m_pum.scrollTo(idx);
+	if (opargs.size() < 1
+		|| !opargs.at(0).canConvert<int64_t>()) {
+		qWarning() << "Unexpected arguments for popupmenu_select:" << opargs;
+		return;
+	}
+
+	// Neovim and Qt both use -1 for 'no selection'.
+	m_pum.setSelectedIndex(opargs.at(0).toLongLong());
 }
 
 void Shell::setNeovimCursor(quint64 row, quint64 col)

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -514,13 +514,18 @@ void Shell::handleRedraw(const QByteArray& name, const QVariantList& opargs)
 
 void Shell::handlePopupMenuShow(const QVariantList& opargs)
 {
-	if (opargs.size() < 5
+	// The 'popupmenu_show' API is not consistent across NeoVim versions!
+	// A 5th argument was introduced in neovim/neovim@16c3337
+	if (opargs.size() < 4
 		|| static_cast<QMetaType::Type>(opargs.at(0).type()) != QMetaType::QVariantList
 		|| !opargs.at(1).canConvert<int64_t>()
 		|| !opargs.at(2).canConvert<int64_t>()
-		|| !opargs.at(3).canConvert<int64_t>()
-		|| !opargs.at(4).canConvert<int64_t>()) {
+		|| !opargs.at(3).canConvert<int64_t>()) {
 		qWarning() << "Unexpected arguments for popupmenu_show:" << opargs;
+		return;
+	}
+	else if (opargs.size() >= 5 && !opargs.at(4).canConvert<int64_t>()) {
+		qWarning() << "Unexpected 5th argument for popupmenu_show:" << opargs.at(4);
 		return;
 	}
 
@@ -528,7 +533,7 @@ void Shell::handlePopupMenuShow(const QVariantList& opargs)
 	const int64_t selected = opargs.at(1).toULongLong();
 	const int64_t row = opargs.at(2).toULongLong();
 	const int64_t col = opargs.at(3).toULongLong();
-	//const int64_t grid = opargs.at(4).toULongLong();
+	//const int64_t grid = (opargs.size() < 5) ? 0 : opargs.at(4).toULongLong();
 
 	QList<PopupMenuItem> model;
 	for (const auto& v : items) {

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -130,9 +130,8 @@ protected:
 	virtual void handleBusy(bool);
 	virtual void handleSetOption(const QString& name, const QVariant& value);
 	void handleExtGuiOption(const QString& name, const QVariant& value);
-	virtual void handlePopupMenuShow(const QVariantList& items, int64_t selected,
-			int64_t row, int64_t col);
-	void handlePopupMenuSelect(int64_t selected);
+	virtual void handlePopupMenuShow(const QVariantList& opargs);
+	virtual void handlePopupMenuSelect(const QVariantList& opargs);
 	virtual void handleMouse(bool);
 
 	void neovimMouseEvent(QMouseEvent *ev);
@@ -180,7 +179,7 @@ private:
 	// Properties
 	bool m_neovimBusy;
 	ShellOptions m_options;
-	PopupMenu m_pum;
+	PopupMenu m_pum{ this };
 	bool m_mouseEnabled;
 };
 


### PR DESCRIPTION
The behavior between PopupMenus for NeoVim TUI and NeoVim-Qt are different.

Based on user feedback from Issue #524 the current logic is confusing some users. This change modifies the NeoVim-Qt size logic so that it is similar to the TUI. I tried to keep the logic simple and easy to follow.

While I was here, I also cleaned up and modularized some of the PUM code.