### PR TITLE
Save window size and position

### DIFF
--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -107,6 +107,17 @@ void App::showUi(NeovimConnector *c, const QCommandLineParser& parser)
 	QObject::connect(instance(), SIGNAL(openFilesTriggered(const QList<QUrl>)),
 		win->shell(), SLOT(openFiles(const QList<QUrl>)));
 
+	// Window geometry should be restored only when the user does not specify
+	// one of the following command line arguments. Argument "maximized" can
+	// be safely ignored, as the loaded geometry only takes effect after the
+	// user un-maximizes the window; this behavior is desirable.
+	if (!parser.isSet("fullscreen") &&
+		!parser.isSet("geometry") &&
+		!parser.isSet("qwindowgeometry"))
+	{
+		win->restoreWindowGeometry();
+	}
+
 	if (parser.isSet("fullscreen")) {
 		win->delayedShow(NeovimQt::MainWindow::DelayedShow::FullScreen);
 	} else if (parser.isSet("maximized")) {

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -232,7 +232,11 @@ void MainWindow::reconnectNeovim()
 
 void MainWindow::closeEvent(QCloseEvent *ev)
 {
-	saveWindowGeometry();
+	// Do not save window geometry in '--fullscreen' mode. If saved, all
+	// subsequent Neovim-Qt sessions would default to fullscreen mode.
+	if (!isFullScreen()) {
+		saveWindowGeometry();
+	}
 
 	if (m_neovim_requested_close) {
 		// If this was requested by nvim, shutdown
@@ -276,9 +280,6 @@ void MainWindow::showIfDelayed()
 {
 	if (!isVisible()) {
 		if (m_delayedShow == DelayedShow::Normal) {
-			// Restore the last known window size/position.
-			loadWindowGeometry();
-
 			show();
 		} else if (m_delayedShow == DelayedShow::Maximized) {
 			showMaximized();
@@ -413,7 +414,7 @@ void MainWindow::saveWindowGeometry()
 	settings.setValue("window_state", saveState());
 }
 
-void MainWindow::loadWindowGeometry()
+void MainWindow::restoreWindowGeometry()
 {
 	QSettings settings{ "nvim-qt", "window-geometry" };
 	restoreGeometry(settings.value("window_geometry").toByteArray());

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -26,6 +26,7 @@ public:
 	MainWindow(NeovimConnector *, ShellOptions opts, QWidget *parent=0);
 	bool neovimAttached() const;
 	Shell* shell();
+	void restoreWindowGeometry();
 public slots:
 	void delayedShow(DelayedShow type=DelayedShow::Normal);
 signals:
@@ -56,7 +57,6 @@ private slots:
 	void extTablineSet(bool);
 	void changeTab(int index);
 	void saveWindowGeometry();
-	void loadWindowGeometry();
 private:
 	void init(NeovimConnector *);
 	NeovimConnector *m_nvim;

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -55,6 +55,8 @@ private slots:
 	void neovimSendSelectAll();
 	void extTablineSet(bool);
 	void changeTab(int index);
+	void saveWindowGeometry();
+	void loadWindowGeometry();
 private:
 	void init(NeovimConnector *);
 	NeovimConnector *m_nvim;


### PR DESCRIPTION
Adds support for the feature requested in issue #540.

When neovim-qt is restarted, the last known window size and position are restored.

The window state and geometry are stored via QSettings on each close event. Whenever a window is opened, QSettings is polled for the last known window geometry and state (if one exists).