### PR TITLE
Fixed bundle identifier and version values in the mac build

### DIFF
--- a/cmake/MacOSXBundleInfo.plist.in
+++ b/cmake/MacOSXBundleInfo.plist.in
@@ -15,17 +15,17 @@
 	<key>NSHighResolutionCapable</key>
 	<true/>
 	<key>CFBundleIdentifier</key>
-	<string>${APPLE_GUI_IDENTIFIER}</string>
+	<string>${CMAKE_PROJECT_NAME}</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleLongVersionString</key>
-	<string>${APPLE_GUI_LONG_VERSION_STRING}</string>
+	<string>${CMAKE_PROJECT_VERSION}</string>
 	<key>CFBundleName</key>
 	<string>Neovim</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>${APPLE_GUI_SHORT_VERSION_STRING}</string>
+	<string>${CMAKE_PROJECT_VERSION}</string>
 	<key>CFBundleVersion</key>
 	<string>${APPLE_GUI_BUNDLE_VERSION}</string>
 	<key>CSResourcesFileMapped</key>


### PR DESCRIPTION
This fixes the values for 'version' and 'bundle identifier' to be filled in correctly for the mac build