### PR TITLE
shell: fix duplicate cursors in terminal mode

### DIFF
--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -613,6 +613,9 @@ void Shell::handleSetTitle(const QVariantList& opargs)
 
 void Shell::handleBusy(bool busy)
 {
+	if (busy != m_neovimBusy) {
+		update(neovimCursorRect());
+	}
 	m_neovimBusy = busy;
 	if (busy) {
 		this->setCursor(Qt::WaitCursor);
@@ -799,7 +802,7 @@ void Shell::paintEvent(QPaintEvent *ev)
 
 	// paint cursor - we are not actually using Neovim colors yet,
 	// just invert the shell colors by painting white with XoR
-	if (ev->region().contains(neovimCursorTopLeft())) {
+	if (!m_neovimBusy && ev->region().contains(neovimCursorTopLeft())) {
 		bool wide = contents().constValue(m_cursor_pos.y(),
 						m_cursor_pos.x()).doubleWidth;
 		QRect cursorRect(neovimCursorTopLeft(), cellSize());


### PR DESCRIPTION
Fixes issue #541 

In terminal mode, nvim draws the cursor itself by writing space characters with the "reverse" attribute.  The only apparent signal to the UI is that "busy" is turned on until terminal mode is left.  The UI API documentation recommends not drawing the cursor while nvim is busy, which is how double cursors are avoided by other UIs.  Do the same thing.

I kept setting the mouse to a busy icon, but it stays that way for the entirety of terminal mode despite nvim being responsive.  Maybe it should be disabled until the busy state is not semantically overloaded.