### PR TITLE
Default colorscheme is broken

### DIFF
--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -852,6 +852,11 @@ void Shell::handleDefaultColorsSet(const QVariantList& opargs)
 	const uint64_t rgb_bg = opargs.at(1).toULongLong();
 	const uint64_t rgb_sp = opargs.at(2).toULongLong();
 
+	MsgpackRequest* getBackgroundMode{
+		m_nvim->api0()->vim_get_option(QString{ "background" }.toLatin1()) };
+
+	connect(getBackgroundMode, &MsgpackRequest::finished, this, &Shell::handleGetBackgroundOption);
+
 	const QColor foregroundColor = color(rgb_fg, QColor::Invalid);
 	const QColor backgroundColor = color(rgb_bg, QColor::Invalid);
 	const QColor specialColor = color(rgb_sp, QColor::Invalid);
@@ -1653,4 +1658,18 @@ void Shell::handleShimError(quint32 msgid, quint64 fun, const QVariant& err)
 	qDebug() << "GUI shim error " << err;
 }
 
-} // Namespace
+void Shell::handleGetBackgroundOption(quint32 msgid, quint64 fun, const QVariant& val)
+{
+	const QString mode{ val.toString() };
+
+	if (mode == "dark" && getBackgroundType() != Background::Dark) {
+		setBackgroundType(Background::Dark);
+		update();
+	}
+	else if (mode == "light" && getBackgroundType() != Background::Light) {
+		setBackgroundType(Background::Light);
+		update();
+	}
+}
+
+} // namespace NeovimQt

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -93,6 +93,7 @@ protected slots:
 	void updateClientInfo();
 	void handleGinitError(quint32 msgid, quint64 fun, const QVariant& err);
 	void handleShimError(quint32 msgid, quint64 fun, const QVariant& err);
+	void handleGetBackgroundOption(quint32 msgid, quint64 fun, const QVariant& val);
 
 protected:
 	void tooltip(const QString& text);

--- a/src/gui/shellwidget/shellwidget.cpp
+++ b/src/gui/shellwidget/shellwidget.cpp
@@ -138,7 +138,7 @@ void ShellWidget::paintEvent(QPaintEvent *ev)
 					if (cell.backgroundColor.isValid()) {
 						p.fillRect(r, cell.backgroundColor);
 					} else {
-						p.fillRect(r, m_bgColor);
+						p.fillRect(r, background());
 					}
 
 					if (cell.c == ' ') {
@@ -148,7 +148,7 @@ void ShellWidget::paintEvent(QPaintEvent *ev)
 					if (cell.foregroundColor.isValid()) {
 						p.setPen(cell.foregroundColor);
 					} else {
-						p.setPen(m_fgColor);
+						p.setPen(foreground());
 					}
 
 					if (cell.bold || cell.italic) {
@@ -171,18 +171,18 @@ void ShellWidget::paintEvent(QPaintEvent *ev)
 					if (cell.undercurl) {
 						if (cell.specialColor.isValid()) {
 							pen.setColor(cell.specialColor);
-						} else if (m_spColor.isValid()) {
-							pen.setColor(m_spColor);
+						} else if (special().isValid()) {
+							pen.setColor(special());
 						} else if (cell.foregroundColor.isValid()) {
 							pen.setColor(cell.foregroundColor);
 						} else {
-							pen.setColor(m_fgColor);
+							pen.setColor(foreground());
 						}
 					} else if (cell.underline) {
 						if (cell.foregroundColor.isValid()) {
 							pen.setColor(cell.foregroundColor);
 						} else {
-							pen.setColor(m_fgColor);
+							pen.setColor(foreground());
 						}
 					}
 
@@ -212,7 +212,7 @@ void ShellWidget::paintEvent(QPaintEvent *ev)
 				m_contents.rows(), m_contents.columns());
 	QRegion margins = QRegion(rect()).subtracted(shellArea);
 	foreach(QRect margin, margins.intersected(ev->region()).rects()) {
-		p.fillRect(margin, m_bgColor);
+		p.fillRect(margin, background());
 	}
 
 #if 0
@@ -267,6 +267,24 @@ void ShellWidget::setBackground(const QColor& color)
 
 QColor ShellWidget::background() const
 {
+	// See 'default_colors_set' in Neovim ':help ui-linegrid'.
+	// QColor::Invalid indicates the default color (-1), which should be
+	// rendered as white or black based on Neovim 'background'.
+	if (!m_bgColor.isValid())
+	{
+		switch (m_background)
+		{
+			case Background::Light:
+				return Qt::white;
+
+			case Background::Dark:
+				return Qt::black;
+
+			default:
+				return Qt::black;
+		}
+	}
+
 	return m_bgColor;
 }
 
@@ -277,6 +295,22 @@ void ShellWidget::setForeground(const QColor& color)
 
 QColor ShellWidget::foreground() const
 {
+	// See ShellWidget::background() for more details.
+	if (!m_bgColor.isValid())
+	{
+		switch (m_background)
+		{
+			case Background::Light:
+				return Qt::black;
+
+			case Background::Dark:
+				return Qt::white;
+
+			default:
+				return Qt::white;
+		}
+	}
+
 	return m_fgColor;
 }
 

--- a/src/gui/shellwidget/shellwidget.h
+++ b/src/gui/shellwidget/shellwidget.h
@@ -17,6 +17,15 @@ class ShellWidget: public QWidget
 	Q_PROPERTY(QSize cellSize READ cellSize)
 public:
 	ShellWidget(QWidget *parent=0);
+
+	/// Represents Neovim 'background' option. Used for rendering default theme colors (-1).
+	/// See 'default_colors_set' in Neovim ':help ui-linegrid' for more details.
+	enum class Background : int
+	{
+		Dark,
+		Light
+	};
+
 	bool setShellFont(const QString& family, qreal ptSize, int weight = -1, bool italic = false, bool force = false);
 
 	QColor background() const;
@@ -31,6 +40,11 @@ public:
 	QSize cellSize() const;
 	const ShellContents& contents() const;
 	QSize sizeHint() const Q_DECL_OVERRIDE;
+
+	Background getBackgroundType() const { return m_background; }
+
+	void setBackgroundType(Background type) { m_background = type; }
+
 signals:
 	void shellFontChanged();
 	void fontError(const QString& msg);
@@ -66,6 +80,8 @@ private:
 	int m_ascent;
 	QColor m_bgColor, m_fgColor, m_spColor;
 	int m_lineSpace;
+
+	Background m_background{ Background::Dark };
 };
 
 #endif


### PR DESCRIPTION
Issue #568 
Issue #390 

Neovim can send color -1 for "default_colors_set", and this is not handled properly. This value should default to black or white based on the value of Neovim setting `background`.

A background setting was added to ShellWidget, which defaults to `dark`. On every call to `default_colors_set` an async `vim_get_option` lookup is performed. Everything renders using the last known (or default) value of background. When a change to this setting is observed, the screen is updated with the new default color settings.