### PR TITLE
Use SVG icon for better high-dpi scaling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
           command: sudo apt-get update
       - run:
           name: Install dependencies
-          command: sudo apt-get install -y neovim python3-pip python3-dev python3-msgpack python3-jinja2 cmake qt5-default
+          command: sudo apt-get install -y cmake libqt5svg5 libqt5svg5-dev neovim python3-dev python3-jinja2 python3-msgpack python3-pip qt5-default
       - run:
           name: build
           command: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,9 +38,10 @@ include(MacOSXPaths)
 # Qt
 set(CMAKE_AUTOMOC ON)
 find_package(Qt5Core REQUIRED)
-find_package(Qt5Widgets REQUIRED)
 find_package(Qt5Network REQUIRED)
+find_package(Qt5Svg REQUIRED)
 find_package(Qt5Test REQUIRED)
+find_package(Qt5Widgets REQUIRED)
 
 # msgpack
 option(USE_SYSTEM_MSGPACK "Use system msgpack libraries " OFF)

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -52,8 +52,7 @@ add_library(neovim-qt-gui
 	treeview.cpp
 	${SRCS_PLATFORM}
 	${NEOVIM_RCC_SOURCES})
-
-target_link_libraries(neovim-qt-gui qshellwidget neovim-qt)
+target_link_libraries(neovim-qt-gui ${QTLIBS} qshellwidget neovim-qt)
 
 if(NOT APPLE)
 	set_property(SOURCE app_runtime.cpp PROPERTY COMPILE_DEFINITIONS

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(QTLIBS Qt5::Network Qt5::Widgets)
+set(QTLIBS Qt5::Network Qt5::Svg Qt5::Widgets)
 
 include_directories(.. shellwidget)
 qt5_add_resources(NEOVIM_RCC_SOURCES data.qrc)

--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -55,7 +55,7 @@ bool getLoginEnvironment(const QString& path)
 App::App(int &argc, char ** argv) noexcept
 :QApplication(argc, argv)
 {
-	setWindowIcon(QIcon(":/neovim.png"));
+	setWindowIcon(QIcon(":/neovim.svg"));
 	setApplicationDisplayName("Neovim");
 
 #ifdef Q_OS_MAC

--- a/src/gui/data.qrc
+++ b/src/gui/data.qrc
@@ -1,6 +1,7 @@
 <!DOCTYPE RCC><RCC VERSION="1.0">
 <qresource>
   <file alias="neovim.png">../../third-party/neovim.png</file>
+  <file alias="neovim.svg">../../third-party/neovim.svg</file>
   <file alias="icons/unknown.png">../../third-party/oxygen/unknown.png</file>
   <file alias="icons/inode-directory.png">../../third-party/oxygen/inode-directory.png</file>
   <file alias="icons/document-open-recent.png">../../third-party/oxygen/document-open-recent.png</file>

--- a/src/gui/errorwidget.cpp
+++ b/src/gui/errorwidget.cpp
@@ -11,8 +11,8 @@ ErrorWidget::ErrorWidget(QWidget *parent)
 	m_errorLabel = new QLabel();
 	m_closeButton = new QPushButton(tr("Retry"));
 
-	m_image = new QLabel();
-	m_image->setPixmap(QPixmap(":/neovim.png").scaled(64, 64, Qt::KeepAspectRatio));
+	m_image = new QSvgWidget(":/neovim.svg");
+	m_image->setFixedSize(64, 64);
 
 	connect(m_closeButton, &QPushButton::clicked,
 			this, &ErrorWidget::reconnectNeovim);

--- a/src/gui/errorwidget.h
+++ b/src/gui/errorwidget.h
@@ -1,16 +1,17 @@
 #ifndef NEOVIM_QT_ERRORWIDGET
 #define NEOVIM_QT_ERRORWIDGET
 
-#include <QWidget>
-#include <QPushButton>
 #include <QLabel>
+#include <QPushButton>
+#include <QtSvg/QSvgWidget>
+#include <QWidget>
 
 namespace NeovimQt {
 
 class ErrorWidget: public QWidget {
 	Q_OBJECT
 public:
-	ErrorWidget(QWidget *parent=0);
+	ErrorWidget(QWidget *parent = nullptr);
 public slots:
 	void setText(const QString& text);
 	void showReconnect(bool);
@@ -19,7 +20,7 @@ signals:
 
 private:
 	QLabel *m_errorLabel;
-	QLabel *m_image;
+	QSvgWidget *m_image;
 	QPushButton *m_closeButton;
 };
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,3 +1,5 @@
+set(QTLIBS Qt5::Network Qt5::Svg Qt5::Test)
+
 include_directories(${CMAKE_SOURCE_DIR}/src)
 add_definitions(-DCMAKE_SOURCE_DIR=\"${CMAKE_SOURCE_DIR}\")
 if (WIN32 AND USE_STATIC_QT)
@@ -8,14 +10,14 @@ add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND})
 
 function(add_xtest SOURCE_NAME)
 	add_executable(${SOURCE_NAME} ${SOURCE_NAME}.cpp ${ARGV1} ${ARGV2})
-	target_link_libraries(${SOURCE_NAME} Qt5::Network Qt5::Test Qt5::Widgets ${MSGPACK_LIBRARIES} neovim-qt)
+	target_link_libraries(${SOURCE_NAME} ${QTLIBS} ${MSGPACK_LIBRARIES} neovim-qt)
 	add_test(NAME ${SOURCE_NAME} COMMAND ${SOURCE_NAME})
 	add_dependencies(check ${SOURCE_NAME})
 endfunction()
 
 function(add_xtest_gui SOURCE_NAME)
 	add_executable(${SOURCE_NAME} ${SOURCE_NAME}.cpp)
-	target_link_libraries(${SOURCE_NAME} Qt5::Network Qt5::Test ${MSGPACK_LIBRARIES} neovim-qt Qt5::Widgets neovim-qt-gui)
+	target_link_libraries(${SOURCE_NAME} ${QTLIBS} ${MSGPACK_LIBRARIES} neovim-qt Qt5::Widgets neovim-qt-gui)
 	add_test(NAME ${SOURCE_NAME} COMMAND ${SOURCE_NAME}
 		# Run GUI tests from source dir, they depend on src files
 		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})

--- a/third-party/neovim.svg
+++ b/third-party/neovim.svg
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:sketch="http://www.bohemiancoding.com/sketch/ns"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="256"
+   height="256"
+   viewBox="0 0 256 256"
+   version="1.1"
+   id="svg4612"
+   sodipodi:docname="neovim.svg"
+   inkscape:version="0.92.4 5da689c313, 2019-01-14">
+  <metadata
+     id="metadata4616">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>neovim-mark@2x</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1333"
+     id="namedview4614"
+     showgrid="false"
+     inkscape:zoom="2.1945358"
+     inkscape:cx="132.84232"
+     inkscape:cy="196.34741"
+     inkscape:window-x="0"
+     inkscape:window-y="34"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4612" />
+  <title
+     id="title4587">neovim-mark@2x</title>
+  <description>Created with Sketch (http://www.bohemiancoding.com/sketch)</description>
+  <defs
+     id="defs4604">
+    <linearGradient
+       x1="167.95833"
+       y1="-0.46142399"
+       x2="167.95833"
+       y2="335.45523"
+       id="linearGradient-1"
+       gradientTransform="scale(0.46142398,2.1672042)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         stop-color="#16B0ED"
+         stop-opacity="0.800235524"
+         offset="0%"
+         id="stop4589" />
+      <stop
+         stop-color="#0F59B2"
+         stop-opacity="0.83700023"
+         offset="100%"
+         id="stop4591" />
+    </linearGradient>
+    <linearGradient
+       x1="1118.3427"
+       y1="-0.46586797"
+       x2="1118.3427"
+       y2="338.68604"
+       id="linearGradient-2"
+       gradientTransform="scale(0.46586797,2.1465309)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         stop-color="#7DB643"
+         offset="0%"
+         id="stop4594" />
+      <stop
+         stop-color="#367533"
+         offset="100%"
+         id="stop4596" />
+    </linearGradient>
+    <linearGradient
+       x1="356.33795"
+       y1="0"
+       x2="356.33795"
+       y2="612.90131"
+       id="linearGradient-3"
+       gradientTransform="scale(0.84189739,1.1877932)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         stop-color="#88C649"
+         stop-opacity="0.8"
+         offset="0%"
+         id="stop4599" />
+      <stop
+         stop-color="#439240"
+         stop-opacity="0.84"
+         offset="100%"
+         id="stop4601" />
+    </linearGradient>
+  </defs>
+  <g
+     id="Page-1"
+     sketch:type="MSPage"
+     style="fill:none;fill-rule:evenodd;stroke:none;stroke-width:1"
+     transform="matrix(0.34367476,0,0,0.34367476,25.312651,1.7737533)">
+    <g
+       id="mark-copy"
+       sketch:type="MSLayerGroup"
+       transform="translate(2,3)">
+      <path
+         d="M 0,155.5704 155,-1 V 727 L 0,572.23792 Z"
+         id="Left---green"
+         sketch:type="MSShapeGroup"
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient-1)" />
+      <path
+         d="M 443.0604,156.9824 600,-1 596.81879,727 442,572.21994 Z"
+         id="Right---blue"
+         sketch:type="MSShapeGroup"
+         transform="matrix(-1,0,0,1,1042,0)"
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient-2)" />
+      <path
+         d="M 154.98629,0 558,615.1897 445.2246,728 42,114.17202 Z"
+         id="Cross---blue"
+         sketch:type="MSShapeGroup"
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient-3)" />
+      <path
+         d="M 155,283.83232 154.78675,308 31,124.71061 42.461949,113 Z"
+         id="Shadow"
+         sketch:type="MSShapeGroup"
+         inkscape:connector-curvature="0"
+         style="fill:#000000;fill-opacity:0.12999998" />
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
The ErrorWidget has scaling artifacts for High DPI displays. Converting from PNG to SVG, allows Qt to better render/scale icons images.

**Before:**
![image](https://user-images.githubusercontent.com/11207308/63214436-1e027780-c0e6-11e9-860c-1694af881f56.png)

**After:**
![image](https://user-images.githubusercontent.com/11207308/63214455-6c177b00-c0e6-11e9-9102-1cd61c4a0f9a.png)