### PR TITLE
Fix bold fonts not displaying in KDE (#575)

### DIFF
--- a/src/gui/shellwidget/shellwidget.cpp
+++ b/src/gui/shellwidget/shellwidget.cpp
@@ -151,10 +151,20 @@ void ShellWidget::paintEvent(QPaintEvent *ev)
 						p.setPen(foreground());
 					}
 
+					// We must specify the style to force bold/italic fonts
 					if (cell.bold || cell.italic) {
 						QFont f = p.font();
-						f.setBold(cell.bold);
-						f.setItalic(cell.italic);
+						if (cell.bold && cell.italic) {
+							f.setBold(true);
+							f.setItalic(true);
+							f.setStyleName(QStringLiteral("BoldItalic"));
+						} else if (cell.bold) {
+							f.setBold(true);
+							f.setStyleName(QStringLiteral("Bold"));
+						} else /* cell.italic */ {
+							f.setItalic(true);
+							f.setStyleName(QStringLiteral("Italic"));
+						}
 						p.setFont(f);
 					} else {
 						p.setFont(font());


### PR DESCRIPTION
I explained the purpose of this tiny PR in the related issue (#575). This fixes it completely for me.