### PR TITLE
Various Font Related Fixes

### DIFF
--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -527,6 +527,7 @@ void Shell::handleRedraw(const QByteArray& name, const QVariantList& opargs)
 		handleGridCursorGoto(opargs);
 	} else if (name == "grid_scroll") {
 		handleGridScroll(opargs);
+	} else if (name == "hl_group_set") {
 	}
 	else {
 		qDebug() << "Received unknown redraw notification" << name << opargs;

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -77,7 +77,7 @@ public slots:
 	void handleNeovimNotification(const QByteArray &name, const QVariantList& args);
 	void resizeNeovim(const QSize&);
 	void resizeNeovim(int n_cols, int n_rows);
-	bool setGuiFont(const QString& fdesc, bool force = false);
+	bool setGuiFont(const QString& fdesc, bool force, bool updateOption);
 	void updateGuiWindowState(Qt::WindowStates state);
 	void openFiles(const QList<QUrl> url);
 
@@ -131,6 +131,7 @@ protected:
 	virtual void handlePopupMenuShow(const QVariantList& opargs);
 	virtual void handlePopupMenuSelect(const QVariantList& opargs);
 	virtual void handleMouse(bool);
+	virtual void handleGuiFontFunction(const QVariantList& args);
 
 	// Modern 'ext_linegrid' Grid UI Events
 	virtual void handleGridResize(const QVariantList& opargs);


### PR DESCRIPTION
This PR contains a few font-related fixes/improvements :)

I modified the `bool Shell::setGuiFont(...)` logic so users can view font descriptions with either the `:GuiFont` or `:set guifont` commands. Before option guifont would update when set from itself, but not when set from GuiFont.

**Issue #585:** Error message "Unknown font:" displayed for recent versions of neovim (0.4.2).

**Issue #584:** Add QFontDialog similar to gVim for `:GuiFont *` and `:set guifont=*`

![image](https://user-images.githubusercontent.com/11207308/65117629-2f29f700-d9b8-11e9-85f5-c62de77e7588.png)

Also... I'm sneaking in an empty implementation for `hl_group_set`. This feature is rather noisy on startup for Debug builds.