### PR TITLE
QCommandLineParser geometry argument improvements

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -3,6 +3,9 @@ set(QTLIBS Qt5::Network Qt5::Widgets)
 include_directories(.. shellwidget)
 qt5_add_resources(NEOVIM_RCC_SOURCES data.qrc)
 if(WIN32)
+	set(SRCS_PLATFORM
+		arguments_qwindowgeometry.cpp
+		)
 	if (USE_STATIC_QT)
 		add_definitions(-DUSE_STATIC_QT)
 		link_directories(${CMAKE_PREFIX_PATH}/share/qt5/plugins/platforms)
@@ -11,21 +14,37 @@ if(WIN32)
 	set(RES_FILE "data.rc")
 	enable_language(RC)
 elseif(APPLE)
+	set(SRCS_PLATFORM
+		arguments_qwindowgeometry.cpp
+		)
 	set(ICON_PATH ${PROJECT_SOURCE_DIR}/third-party/neovim.icns)
 	set_source_files_properties(${ICON_PATH} PROPERTIES MACOSX_PACKAGE_LOCATION "Resources")
 
 	set(MACOSX_BUNDLE_INFO_PLIST ${PROJECT_SOURCE_DIR}/cmake/MacOSXBundleInfo.plist.in)
+else()
+	set(SRCS_PLATFORM
+		arguments_geometry.cpp
+		)
 endif()
 
 add_subdirectory(shellwidget)
 
 include(GNUInstallDirs)
 set(RUNTIME_PATH )
-add_library(neovim-qt-gui shell.cpp input.cpp treeview.cpp errorwidget.cpp mainwindow.cpp app.cpp
+
+add_library(neovim-qt-gui
+	app.cpp
+	errorwidget.cpp
 	highlight.cpp
-	popupmenumodel.cpp
+	input.cpp
+	mainwindow.cpp
 	popupmenu.cpp
+	popupmenumodel.cpp
+	shell.cpp
+	treeview.cpp
+	${SRCS_PLATFORM}
 	${NEOVIM_RCC_SOURCES})
+
 target_link_libraries(neovim-qt-gui qshellwidget neovim-qt)
 
 if(NOT APPLE)

--- a/src/gui/arguments.h
+++ b/src/gui/arguments.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <QCommandLineParser>
+
+namespace NeovimQt {
+
+/// Checks for commandline argument --geometry support.
+bool hasGeometryArg();
+
+/// Checks for commandline argument --qwindowgeometry support.
+bool hasQWindowGeometryArg();
+
+} // namespace NeovimQt

--- a/src/gui/arguments_geometry.cpp
+++ b/src/gui/arguments_geometry.cpp
@@ -1,0 +1,15 @@
+#include "arguments.h"
+
+namespace NeovimQt {
+
+bool hasGeometryArg()
+{
+	return true;
+}
+
+bool hasQWindowGeometryArg()
+{
+	return false;
+}
+
+} // namespace NeovimQt

--- a/src/gui/arguments_qwindowgeometry.cpp
+++ b/src/gui/arguments_qwindowgeometry.cpp
@@ -1,0 +1,15 @@
+#include "arguments.h"
+
+namespace NeovimQt {
+
+bool hasGeometryArg()
+{
+	return false;
+}
+
+bool hasQWindowGeometryArg()
+{
+	return true;
+}
+
+} // namespace NeovimQt


### PR DESCRIPTION
**Issue #587:** QCommandLineParser issues a qWarning when isSet is called for an
argument that has not been defined. This is fixed by adding platform specific
logic to only check the argument which exists --geometry or --qwindowgeometry.

**Issue #565:** The help message on some platforms displays the wrong --geometry
argument on Windows/Apple platforms. The fix for Issue 587 is used to add the
correct help message.