### PR TITLE
Use cmake's Python package to find the interperter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,13 +14,14 @@ jobs:
           command: sudo apt-get update
       - run:
           name: Install dependencies
-          command: sudo apt-get install -y neovim python-pip python-dev cmake qt5-default
+          command: sudo apt-get install -y neovim python3-pip python3-dev python3-jinja2 python3-msgpack cmake qt5-default
       - run:
           name: build
           command: |
             mkdir build
             cd build
             cmake -DCMAKE_BUILD_TYPE=Debug -DUSE_GCOV=ON ..
+            cmake --build . --target bindings -- VERBOSE=1
             cmake --build . -- VERBOSE=1
       - run:
           name: test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,17 +82,18 @@ if(ENABLE_TESTS)
 endif()
 
 # Bindings
-find_package(PythonInterp)
-if (PYTHONINTERP_FOUND)
+include(FindPython)
+find_package(Python)
+if (Python_FOUND)
 	set(NVIM "nvim" CACHE STRING "Path to nvim executable")
 	add_custom_target(bindings
-		COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/bindings/generate_bindings.py ${NVIM} ${CMAKE_SOURCE_DIR}/src/auto
+		COMMAND ${Python_EXECUTABLE} ${CMAKE_SOURCE_DIR}/bindings/generate_bindings.py ${NVIM} ${CMAKE_SOURCE_DIR}/src/auto
 		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
 		COMMENT "Generating bindings"
 		)
 
 	add_custom_target(bindings-preview
-		COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/bindings/generate_bindings.py ${NVIM}
+		COMMAND ${Python_EXECUTABLE} ${CMAKE_SOURCE_DIR}/bindings/generate_bindings.py ${NVIM}
 		)
 endif()
 


### PR DESCRIPTION
As of cmake 3.12, the PythonInterp package is deprecated in favor of the Python package.

The Python package has existed for a long time, so this shouldn't affect cmake compatibility.