### PR TITLE
Add NVIM_QT_RUNTIME_PATH and Neovim Arguments to Version

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -4,8 +4,9 @@ include_directories(.. shellwidget)
 qt5_add_resources(NEOVIM_RCC_SOURCES data.qrc)
 if(WIN32)
 	set(SRCS_PLATFORM
-		arguments_qwindowgeometry.cpp
 		app_runtime.cpp
+		arguments_qwindowgeometry.cpp
+		printinfo_msgbox.cpp
 		)
 	if (USE_STATIC_QT)
 		add_definitions(-DUSE_STATIC_QT)
@@ -16,8 +17,9 @@ if(WIN32)
 	enable_language(RC)
 elseif(APPLE)
 	set(SRCS_PLATFORM
-		arguments_qwindowgeometry.cpp
 		app_runtime_mac.cpp
+		arguments_qwindowgeometry.cpp
+		printinfo_stdout.cpp
 		)
 	set(ICON_PATH ${PROJECT_SOURCE_DIR}/third-party/neovim.icns)
 	set_source_files_properties(${ICON_PATH} PROPERTIES MACOSX_PACKAGE_LOCATION "Resources")
@@ -25,8 +27,9 @@ elseif(APPLE)
 	set(MACOSX_BUNDLE_INFO_PLIST ${PROJECT_SOURCE_DIR}/cmake/MacOSXBundleInfo.plist.in)
 else()
 	set(SRCS_PLATFORM
-		arguments_geometry.cpp
 		app_runtime.cpp
+		arguments_geometry.cpp
+		printinfo_stdout.cpp
 		)
 endif()
 

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -5,6 +5,7 @@ qt5_add_resources(NEOVIM_RCC_SOURCES data.qrc)
 if(WIN32)
 	set(SRCS_PLATFORM
 		arguments_qwindowgeometry.cpp
+		app_runtime.cpp
 		)
 	if (USE_STATIC_QT)
 		add_definitions(-DUSE_STATIC_QT)
@@ -16,6 +17,7 @@ if(WIN32)
 elseif(APPLE)
 	set(SRCS_PLATFORM
 		arguments_qwindowgeometry.cpp
+		app_runtime_mac.cpp
 		)
 	set(ICON_PATH ${PROJECT_SOURCE_DIR}/third-party/neovim.icns)
 	set_source_files_properties(${ICON_PATH} PROPERTIES MACOSX_PACKAGE_LOCATION "Resources")
@@ -24,6 +26,7 @@ elseif(APPLE)
 else()
 	set(SRCS_PLATFORM
 		arguments_geometry.cpp
+		app_runtime.cpp
 		)
 endif()
 
@@ -47,7 +50,7 @@ add_library(neovim-qt-gui
 target_link_libraries(neovim-qt-gui qshellwidget neovim-qt)
 
 if(NOT APPLE)
-	set_property(SOURCE app.cpp PROPERTY COMPILE_DEFINITIONS
+	set_property(SOURCE app_runtime.cpp PROPERTY COMPILE_DEFINITIONS
 		NVIM_QT_RUNTIME_PATH="${CMAKE_INSTALL_FULL_DATADIR}/nvim-qt/runtime")
 endif()
 

--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -8,6 +8,7 @@
 
 #include "arguments.h"
 #include "mainwindow.h"
+#include "printinfo.h"
 #include "version.h"
 
 namespace NeovimQt {
@@ -338,7 +339,8 @@ static QString GetNeovimVersionInfo(const QString& nvim) noexcept
 
 void App::showVersionInfo() noexcept
 {
-	QTextStream out{ stdout };
+	QString versionInfo;
+	QTextStream out{ &versionInfo };
 
 	const QString nvimExecutable { (m_parser.isSet("nvim")) ?
 		m_parser.value("nvim") : "nvim" };
@@ -354,6 +356,8 @@ void App::showVersionInfo() noexcept
 	out << endl;
 
 	out << GetNeovimVersionInfo(nvimExecutable) << endl;
+
+	PrintInfo(versionInfo);
 }
 
 } // namespace NeovimQt

--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -348,6 +348,7 @@ void App::showVersionInfo() noexcept
 	out << "NVIM-QT v" << PROJECT_VERSION << endl;
 	out << "Build type: " << CMAKE_BUILD_TYPE << endl;
 	out << "Compilation:" << CMAKE_CXX_FLAGS << endl;
+	out << "Qt Version: " << QT_VERSION_STR << endl;
 	out << "Environment: " << endl;
 	out << "  nvim: " << nvimExecutable << endl;
 	out << "  args: " << getNeovimArgs().join(" ") << endl;

--- a/src/gui/app.h
+++ b/src/gui/app.h
@@ -24,6 +24,8 @@ public:
 	void checkArgumentsMayTerminate() noexcept;
 
 private:
+	QString getRuntimePath() noexcept;
+	QStringList getNeovimArgs() noexcept;
 	void processCommandlineOptions() noexcept;
 	void setupRequestTimeout() noexcept;
 	void showVersionInfo() noexcept;

--- a/src/gui/app.h
+++ b/src/gui/app.h
@@ -1,11 +1,13 @@
 #ifndef NEOVIM_QT_APP
 #define NEOVIM_QT_APP
 
+#include <memory>
 #include <QApplication>
-#include <QEvent>
-#include <QUrl>
-#include <QList>
 #include <QCommandLineParser>
+#include <QEvent>
+#include <QList>
+#include <QUrl>
+
 #include "shell.h"
 
 namespace NeovimQt {
@@ -15,20 +17,24 @@ class App: public QApplication
 {
 	Q_OBJECT
 public:
-	App(int &argc, char ** argv);
-	bool event(QEvent *event);
-	void showUi(NeovimConnector *c, const QCommandLineParser&);
-	static void processCliOptions(QCommandLineParser& p, const QStringList& arguments);
-	static NeovimConnector* createConnector(const QCommandLineParser& p);
-	static void showVersionInfo(const QCommandLineParser& parser) noexcept;
+	App(int &argc, char ** argv) noexcept;
+	bool event(QEvent *event) noexcept;
+	void showUi() noexcept;
+	void connectToRemoteNeovim() noexcept;
+	void checkArgumentsMayTerminate() noexcept;
 
 private:
-	static ShellOptions GetShellOptionsFromQSettings();
+	void processCommandlineOptions() noexcept;
+	void setupRequestTimeout() noexcept;
+	void showVersionInfo() noexcept;
+
+	QCommandLineParser m_parser;
+	std::shared_ptr<NeovimConnector> m_connector;
 
 signals:
 	void openFilesTriggered(const QList<QUrl>);
 };
 
-} // Namespace
+} // Namespace NeovimQt
 
 #endif

--- a/src/gui/app_runtime.cpp
+++ b/src/gui/app_runtime.cpp
@@ -1,0 +1,30 @@
+#include "app.h"
+
+#include <QDir>
+#include <QFileInfo>
+
+namespace NeovimQt {
+
+QString App::getRuntimePath() noexcept
+{
+	QString path{ QString::fromLocal8Bit(qgetenv("NVIM_QT_RUNTIME_PATH")) };
+
+	if (QFileInfo(path).isDir()) {
+		return path;
+	}
+
+	if (QFileInfo(NVIM_QT_RUNTIME_PATH).isDir()) {
+		return QStringLiteral(NVIM_QT_RUNTIME_PATH);
+	}
+
+	// Look for the runtime relative to the nvim-qt binary
+	const QDir d = QDir{ applicationDirPath() }.filePath("../share/nvim-qt/runtime");
+
+	if (d.exists()) {
+		return d.path();
+	}
+
+	return {};
+}
+
+} // namespace NeovimQt

--- a/src/gui/app_runtime_mac.cpp
+++ b/src/gui/app_runtime_mac.cpp
@@ -1,0 +1,26 @@
+#include "app.h"
+
+#include <QDir>
+#include <QFileInfo>
+
+namespace NeovimQt {
+
+QString App::getRuntimePath() noexcept
+{
+	QString path{ QString::fromLocal8Bit(qgetenv("NVIM_QT_RUNTIME_PATH")) };
+
+	if (QFileInfo(path).isDir()) {
+		return path;
+	}
+
+	// Look for the runtime relative to the nvim-qt binary
+	const QDir d = QDir{ applicationDirPath() }.filePath("../Resources/runtime");
+
+	if (d.exists()) {
+		return d.path();
+	}
+
+	return {};
+}
+
+} // namespace NeovimQt

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -30,31 +30,30 @@ int ui_main(int argc, char **argv)
 
 	NeovimQt::App app(argc, argv);
 
-	QCommandLineParser parser;
-	NeovimQt::App::processCliOptions(parser, app.arguments());
+	app.checkArgumentsMayTerminate();
 
-	int timeout = parser.value("timeout").toInt();
-	auto c = app.createConnector(parser);
-	c->setRequestTimeout(timeout);
-	app.showUi(c, parser);
+	app.connectToRemoteNeovim();
+
+	app.showUi();
 	return app.exec();
 }
 
 int cli_main(int argc, char **argv)
 {
-	QCoreApplication app(argc, argv);
+	NeovimQt::App app(argc, argv);
 
-	QCommandLineParser parser;
-	NeovimQt::App::processCliOptions(parser, app.arguments());
+	app.checkArgumentsMayTerminate();
 
-	QStringList new_args = app.arguments().mid(1);
+	// Get existing arguments, drop executable, append --nofork.
+	QStringList new_args{ app.arguments().mid(1) };
 	new_args.insert(0, "--nofork");
-	if (QProcess::startDetached(app.applicationFilePath(), new_args)) {
-		return 0;
-	} else {
+
+	if (!QProcess::startDetached(app.applicationFilePath(), new_args)) {
 		qWarning() << "Unable to fork into background";
 		return -1;
 	}
+
+	return 0;
 }
 
 int main(int argc, char **argv)

--- a/src/gui/printinfo.h
+++ b/src/gui/printinfo.h
@@ -1,0 +1,18 @@
+#ifndef NEOVIM_QT_PRINTINFO
+#define NEOVIM_QT_PRINTINFO
+
+#include <QString>
+
+namespace NeovimQt {
+
+/// Performs a cross-platform display of information to the user.
+/// MacOS: Prints to stdout
+/// Unix/Linux: Prints to stdout
+/// Windows: Displays a messagebox
+///
+/// Intended to behave the same way as QCommandLineParser's '--help' option.
+void PrintInfo(const QString& message) noexcept;
+
+} // Namespace NeovimQt
+
+#endif // NEOVIM_QT_PRINTINFO

--- a/src/gui/printinfo_msgbox.cpp
+++ b/src/gui/printinfo_msgbox.cpp
@@ -1,0 +1,25 @@
+#include "printinfo.h"
+
+#include <QCoreApplication>
+#include <qt_windows.h>
+#include <QVariant>
+
+namespace NeovimQt {
+
+void PrintInfo(const QString& message) noexcept
+{
+	QString title;
+	if (QCoreApplication::instance()) {
+		title = QCoreApplication::instance()->property("applicationDisplayName").toString();
+	}
+	if (title.isEmpty()) {
+		title = QCoreApplication::applicationName();
+	}
+
+	constexpr UINT flags{ MB_OK | MB_TOPMOST | MB_SETFOREGROUND | MB_ICONINFORMATION };
+
+	MessageBoxW(0, reinterpret_cast<const wchar_t *>(message.utf16()),
+		reinterpret_cast<const wchar_t *>(title.utf16()), flags);
+}
+
+} // namespace NeovimQt

--- a/src/gui/printinfo_stdout.cpp
+++ b/src/gui/printinfo_stdout.cpp
@@ -1,0 +1,13 @@
+#include "printinfo.h"
+
+#include <QTextStream>
+
+namespace NeovimQt {
+
+void PrintInfo(const QString& message) noexcept
+{
+	QTextStream out{ stdout };
+	out << message;
+}
+
+} // namespace NeovimQt


### PR DESCRIPTION
Here are some modifications to add `nvim` information to `nvim-qt --version`.

I moved some of the `NVIM_QT_RUNTIME_PATH` lookup code into functions so that it can be re-used. I also made modifications to `App` to remove a few outparams and store state inside of the class.

Sample Output:
```
> nvim-qt --version
NVIM-QT v0.2.14.0
Build type: Debug
Compilation: -Wall -Wextra -Wno-unused-parameter -std=c++11 -Wfatal-errors
Environment: 
  nvim: nvim
  args: --cmd let &rtp.=',/usr/local/share/nvim-qt/runtime' --cmd set termguicolors
  runtime: /home/jgehrig/Development/neovim-qt/src/gui/runtime

NVIM v0.3.7
Build type: Release
LuaJIT 2.0.5
Compilation: /usr/bin/x86_64-pc-linux-gnu-gcc -march=native -O2 -pipe -Wconversion -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1 -DMIN_LOG_LEVEL=3 -Wall -Wextra -pedantic -Wno-unused-parameter -Wstrict-prototypes -std=gnu99 -Wimplicit-fallthrough -Wvla -fstack-protector-strong -fdiagnostics-color=auto -Wno-array-bounds -DINCLUDE_GENERATED_DECLARATIONS -D_GNU_SOURCE -DNVIM_MSGPACK_HAS_FLOAT32 -DNVIM_UNIBI_HAS_VAR_FROM -I/tmp/portage/app-editors/neovim-0.3.7/work/neovim-0.3.7_build/config -I/tmp/portage/app-editors/neovim-0.3.7/work/neovim-0.3.7/src -I/usr/include -I/tmp/portage/app-editors/neovim-0.3.7/work/neovim-0.3.7_build/src/nvim/auto -I/tmp/portage/app-editors/neovim-0.3.7/work/neovim-0.3.7_build/include
Compiled by portage@jgehrig-x1y

Features: +acl +iconv +jemalloc +tui 
See ":help feature-compile"

   system vimrc file: "/etc/vim/sysinit.vim"
  fall-back for $VIM: "/usr/share/nvim"

Run :checkhealth for more info
```