### PR TITLE
Add detailed build instructions in Build.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ The binaries will be under build/bin/. The GUI binary is called nvim-qt. Run mak
 
 	$ NVIM_QT_RUNTIME_PATH=../src/gui/runtime bin/nvim-qt
 
+See the [wiki](https://github.com/equalsraf/neovim-qt/wiki/Build) for detailed build instructions.
+
 ## Using the GUI
 
 Run **nvim-qt**, the **nvim** binary must be in your $PATH. Check `nvim-qt --help` for additional options.


### PR DESCRIPTION
These instructions explain how to build neovim-qt on Ubuntu 18.04 and
Windows 10 using MinWG and Visual Studio 2019.