### PR TITLE
Add GuiCursor Support

### DIFF
--- a/src/gui/input.cpp
+++ b/src/gui/input.cpp
@@ -57,7 +57,7 @@ const QMap<int, QString>& GetSpecialKeysMap() noexcept
 
 static QVariant GetButtonName(
 	Qt::MouseButton bt,
-	int clickCount) noexcept
+	uint8_t clickCount) noexcept
 {
 	// NOTE: In practice Neovim only supports the clickcount for Left
 	// mouse presses, even if our shell can support other buttons
@@ -109,7 +109,7 @@ QString convertMouse(
 	QEvent::Type type,
 	Qt::KeyboardModifiers mod,
 	QPoint pos,
-	int clickCount) noexcept
+	uint8_t clickCount) noexcept
 {
 	const QVariant varButtonName{ GetButtonName(bt, clickCount) };
 	if (!varButtonName.isValid() || !varButtonName.canConvert<QString>()) {

--- a/src/gui/input.h
+++ b/src/gui/input.h
@@ -34,7 +34,7 @@ QString convertMouse(
 	QEvent::Type type,
 	Qt::KeyboardModifiers mod,
 	QPoint pos,
-	int clicksCount) noexcept;
+	uint8_t clicksCount) noexcept;
 
 /// Platform specific Qt key modifier bitmask for 'Control'.
 Qt::KeyboardModifiers ControlModifier() noexcept;

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -216,20 +216,13 @@ QPoint Shell::neovimCursorTopLeft() const
 /// Get the area filled by the cursor
 QRect Shell::neovimCursorRect() const
 {
-	return neovimCursorRect(m_cursor_pos);
-}
+	const Cell& cell{ contents().constValue(m_cursor_pos.y(), m_cursor_pos.x()) };
 
-/// Get the area filled by the cursor at an arbitrary
-/// position
-QRect Shell::neovimCursorRect(QPoint at) const
-{
-	const Cell& c = contents().constValue(at.y(), at.x());
-	bool wide = c.IsDoubleWidth();
-	QRect r(neovimCursorTopLeft(), cellSize());
-	if (wide) {
-		r.setWidth(r.width()*2);
+	QRect cursor{ neovimCursorTopLeft(), cellSize() };
+	if (cell.IsDoubleWidth()) {
+		cursor.setWidth(cursor.width() * 2);
 	}
-	return r;
+	return cursor;
 }
 
 void Shell::init()

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -206,25 +206,6 @@ void Shell::setAttached(bool attached)
 	update();
 }
 
-/// The top left corner position (pixel) for the cursor
-QPoint Shell::neovimCursorTopLeft() const
-{
-	return QPoint(m_cursor_pos.x()*cellSize().width(),
-			m_cursor_pos.y()*cellSize().height());
-}
-
-/// Get the area filled by the cursor
-QRect Shell::neovimCursorRect() const
-{
-	const Cell& cell{ contents().constValue(m_cursor_pos.y(), m_cursor_pos.x()) };
-
-	QRect cursor{ neovimCursorTopLeft(), cellSize() };
-	if (cell.IsDoubleWidth()) {
-		cursor.setWidth(cursor.width() * 2);
-	}
-	return cursor;
-}
-
 void Shell::init()
 {
 	// Make sure the connector provides us with an api object
@@ -624,13 +605,6 @@ void Shell::handlePopupMenuSelect(const QVariantList& opargs)
 
 	// Neovim and Qt both use -1 for 'no selection'.
 	m_pum.setSelectedIndex(opargs.at(0).toLongLong());
-}
-
-void Shell::setNeovimCursor(quint64 row, quint64 col)
-{
-	update(neovimCursorRect());
-	m_cursor_pos = QPoint(col, row);
-	update(neovimCursorRect());
 }
 
 void Shell::handleModeChange(const QString& mode)

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -18,16 +18,9 @@
 namespace NeovimQt {
 
 Shell::Shell(NeovimConnector *nvim, ShellOptions opts, QWidget *parent)
-:ShellWidget(parent), m_attached(false), m_nvim(nvim),
-	m_font_bold(false), m_font_italic(false), m_font_underline(false), m_font_undercurl(false),
-	m_mouseHide(true),
-	m_hg_foreground(Qt::black), m_hg_background(Qt::white), m_hg_special(QColor()),
-	m_cursor_color(Qt::white), m_cursor_pos(0,0), m_insertMode(false),
-	m_resizing(false),
-	m_mouse_wheel_delta_fraction(0, 0),
-	m_neovimBusy(false),
-	m_options(opts),
-	m_mouseEnabled(true)
+	: ShellWidget{ parent }
+	, m_nvim{ nvim }
+	, m_options{ opts }
 {
 	setAttribute(Qt::WA_KeyCompression, false);
 
@@ -50,7 +43,7 @@ Shell::Shell(NeovimConnector *nvim, ShellOptions opts, QWidget *parent)
 	m_pum.setParent(this);
 	m_pum.hide();
 
-	if (m_nvim == NULL) {
+	if (!m_nvim) {
 		qWarning() << "Received NULL as Neovim Connector";
 		return;
 	}

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -898,30 +898,9 @@ void Shell::handleHighlightAttributeDefine(const QVariantList& opargs)
 	//     "cterm_attr" = opargs.at(2).toMap()
 
 	const uint64_t id = opargs.at(0).toULongLong();
-	const auto& rgb_attr = opargs.at(1).toMap();
+	const QVariantMap rgb_attr = opargs.at(1).toMap();
 
-	const QColor foregroundColor = (rgb_attr.contains("foreground")) ?
-		color(rgb_attr.value("foreground").toLongLong(), QColor::Invalid) :
-		QColor::Invalid;
-
-	const QColor backgroundColor = (rgb_attr.contains("background")) ?
-		color(rgb_attr.value("background").toLongLong(), QColor::Invalid) :
-		QColor::Invalid;
-
-	const QColor specialColor = rgb_attr.contains(("special")) ?
-		color(rgb_attr.value("special").toLongLong(), QColor::Invalid) :
-		QColor::Invalid;
-
-	HighlightAttribute hl_attr {
-		foregroundColor,
-		backgroundColor,
-		specialColor,
-		rgb_attr.contains("reverse"),
-		rgb_attr.contains("italic"),
-		rgb_attr.contains("bold"),
-		rgb_attr.contains("underline"),
-		rgb_attr.contains("undercurl") };
-
+	HighlightAttribute hl_attr{ rgb_attr };
 	m_highlightMap.insert(id, hl_attr);
 }
 

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -9,10 +9,13 @@
 #include <QTimer>
 #include <QUrl>
 #include <QList>
+#include <QMap>
 #include <QMenu>
+
 #include "neovimconnector.h"
 #include "shellwidget/highlight.h"
 #include "shellwidget/shellwidget.h"
+#include "shellwidget/cursor.h"
 #include "popupmenu.h"
 #include "popupmenumodel.h"
 
@@ -117,7 +120,8 @@ protected:
 	virtual void handleHighlightSet(const QVariantMap& args);
 	virtual void handleRedraw(const QByteArray& name, const QVariantList& args);
 	virtual void handleScroll(const QVariantList& args);
-	virtual void handleModeChange(const QString& mode);
+	virtual void handleModeChange(const QVariantList& opargs);
+	virtual void handleModeInfoSet(const QVariantList& opargs);
 	virtual void handleSetTitle(const QVariantList& opargs);
 	virtual void handleSetScrollRegion(const QVariantList& opargs);
 	virtual void handleBusy(bool);
@@ -169,6 +173,9 @@ private:
 
 	/// Modern 'ext_linegrid' highlight definition map
 	QMap<uint64_t, HighlightAttribute> m_highlightMap;
+
+	/// Neovim mode descriptions from "mode_change", used by guicursor
+	QVariantList m_modeInfo;
 
 	bool m_insertMode{ false };
 	bool m_resizing{ false };

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -103,7 +103,6 @@ protected:
 
 	QPoint neovimCursorTopLeft() const;
 	QRect neovimCursorRect() const;
-	QRect neovimCursorRect(QPoint at) const;
 	void setNeovimCursor(quint64 col, quint64 row);
 
 	virtual void resizeEvent(QResizeEvent *ev) Q_DECL_OVERRIDE;

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -173,7 +173,6 @@ private:
 
 	/// Cursor position in shell coordinates
 	QPoint m_cursor_pos;
-	bool m_cursor;
 	bool m_insertMode;
 	bool m_resizing;
 	QSize m_resize_neovim_pending;

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -153,43 +153,47 @@ private slots:
         void setAttached(bool attached=true);
 
 private:
-	bool m_attached;
-
-	NeovimConnector *m_nvim;
+	bool m_attached{ false };
+	NeovimConnector* m_nvim{ nullptr };
 
 	QList<QUrl> m_deferredOpen;
 
 	QRect m_scroll_region;
-	bool m_font_bold, m_font_italic, m_font_underline, m_font_undercurl;
-	bool m_mouseHide;
+	bool m_font_bold{ false };
+	bool m_font_italic{ false };
+	bool m_font_underline{ false };
+	bool m_font_undercurl{ false };
+	bool m_mouseHide{ true };
 
 	// highlight fg/bg - from redraw:highlightset - by default we
 	// use the values from above
-	QColor m_hg_foreground, m_hg_background, m_hg_special;
-	QColor m_cursor_color;
+	QColor m_hg_foreground{ Qt::black };
+	QColor m_hg_background{ Qt:: white };
+	QColor m_hg_special;
+	QColor m_cursor_color{ Qt::white };
 
 	/// Modern 'ext_linegrid' highlight definition map
 	QMap<uint64_t, HighlightAttribute> m_highlightMap;
 
 	/// Cursor position in shell coordinates
 	QPoint m_cursor_pos;
-	bool m_insertMode;
-	bool m_resizing;
+	bool m_insertMode{ false };
+	bool m_resizing{ false };
 	QSize m_resize_neovim_pending;
-	QLabel *m_tooltip;
+	QLabel* m_tooltip{ nullptr };
 	QPoint m_mouse_pos;
 	// 2/3/4 mouse click tracking
 	QTimer m_mouseclick_timer;
-	short m_mouseclick_count;
+	uint8_t m_mouseclick_count{ 0 };
 	Qt::MouseButton m_mouseclick_pending;
 	// Accumulates remainder of steppy scroll
 	QPoint m_mouse_wheel_delta_fraction;
 
 	// Properties
-	bool m_neovimBusy;
+	bool m_neovimBusy{ false };
 	ShellOptions m_options;
 	PopupMenu m_pum{ this };
-	bool m_mouseEnabled;
+	bool m_mouseEnabled{ true };
 };
 
 class ShellRequestHandler: public QObject, public MsgpackRequestHandler

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -101,10 +101,6 @@ protected:
 	virtual void wheelEvent(QWheelEvent *event) Q_DECL_OVERRIDE;
 	virtual bool event(QEvent *event) Q_DECL_OVERRIDE;
 
-	QPoint neovimCursorTopLeft() const;
-	QRect neovimCursorRect() const;
-	void setNeovimCursor(quint64 col, quint64 row);
-
 	virtual void resizeEvent(QResizeEvent *ev) Q_DECL_OVERRIDE;
 	virtual void keyPressEvent(QKeyEvent *ev) Q_DECL_OVERRIDE;
         void paintLogo(QPainter&);
@@ -174,8 +170,6 @@ private:
 	/// Modern 'ext_linegrid' highlight definition map
 	QMap<uint64_t, HighlightAttribute> m_highlightMap;
 
-	/// Cursor position in shell coordinates
-	QPoint m_cursor_pos;
 	bool m_insertMode{ false };
 	bool m_resizing{ false };
 	QSize m_resize_neovim_pending;

--- a/src/gui/shellwidget/CMakeLists.txt
+++ b/src/gui/shellwidget/CMakeLists.txt
@@ -17,6 +17,7 @@ endif ()
 
 set(SOURCES
   cell.cpp
+  cursor.cpp
   highlight.cpp
   helpers.cpp
   konsole_wcwidth.cpp

--- a/src/gui/shellwidget/cursor.cpp
+++ b/src/gui/shellwidget/cursor.cpp
@@ -1,0 +1,73 @@
+#include "cursor.h"
+#include "msgpackrequest.h"
+
+Cursor::Cursor() noexcept
+{
+	connect(&m_timer, &QTimer::timeout, this, &Cursor::TimerInterrupt);
+}
+
+void Cursor::TimerInterrupt() noexcept
+{
+	switch (m_blinkState) {
+		case BlinkState::Wait:
+		{
+			m_blinkState = BlinkState::Off;
+			m_timer.setInterval(m_blinkOffTime);
+		}
+		break;
+
+		case BlinkState::Off:
+		{
+			m_blinkState = BlinkState::On;
+			m_timer.setInterval(m_blinkOnTime);
+		}
+		break;
+
+		case BlinkState::On:
+		{
+			m_blinkState = BlinkState::Off;
+			m_timer.setInterval(m_blinkOffTime);
+		}
+		break;
+
+		case BlinkState::Disabled:
+		{
+		}
+		break;
+	}
+
+	emit CursorChanged();
+}
+
+void Cursor::StopTimer() noexcept
+{
+	m_blinkState = BlinkState::Disabled;
+	m_timer.stop();
+}
+
+void Cursor::StartTimer() noexcept
+{
+	m_blinkState = BlinkState::Wait;
+
+	if (m_blinkOnTime > 0 && m_blinkOffTime > 0)
+	{
+		m_timer.start();
+	}
+}
+
+void Cursor::ResetTimer() noexcept
+{
+	m_timer.setInterval(m_blinkWaitTime);
+	m_blinkState = BlinkState::Wait;
+}
+
+void Cursor::SetTimer(uint64_t blinkWaitTime, uint64_t blinkOnTime, uint64_t blinkOffTime) noexcept
+{
+	StopTimer();
+
+	m_blinkWaitTime = blinkWaitTime;
+	m_blinkOnTime = blinkOnTime;
+	m_blinkOffTime = blinkOffTime;
+
+	StartTimer();
+}

--- a/src/gui/shellwidget/cursor.h
+++ b/src/gui/shellwidget/cursor.h
@@ -1,0 +1,109 @@
+#pragma once
+
+#include <QPaintEvent>
+#include <QColor>
+#include <QObject>
+#include <QTimer>
+
+#include "highlight.h"
+
+class Cursor : public QObject
+{
+	Q_OBJECT
+
+signals:
+	void CursorChanged();
+
+public:
+
+	enum class Shape : uint8_t
+	{
+		Block,
+		Horizontal,
+		Vertical,
+	};
+
+	Cursor() noexcept;
+
+	void ResetTimer() noexcept;
+
+	void SetTimer(uint64_t blinkWaitTime, uint64_t blinkOnTime, uint64_t blinkOffTime) noexcept;
+
+	void SetColor(const HighlightAttribute& highlight) noexcept
+	{
+		m_background = highlight.GetBackgroundColor();
+		m_foreground = highlight.GetForegroundColor();
+	}
+
+	void SetStyle(Shape cursorShape, uint8_t cellPercentage) noexcept
+	{
+		m_shape = cursorShape;
+		m_percentage = cellPercentage;
+	}
+
+	void SetIsEnabled(bool isStyleEnabled) noexcept
+	{
+		m_styleEnabled = isStyleEnabled;
+	}
+
+	bool IsEnabled() const noexcept
+	{
+		return m_styleEnabled;
+	}
+
+	bool IsVisible() const noexcept
+	{
+		return m_styleEnabled && (m_blinkState != BlinkState::Off);
+	}
+
+	QColor GetBackgroundColor() const noexcept
+	{
+		return m_background;
+	}
+
+	QColor GetForegroundColor() const noexcept
+	{
+		return m_foreground;
+	}
+
+	uint8_t GetPercentage() const noexcept
+	{
+		return m_percentage;
+	}
+
+	Shape GetShape() const noexcept
+	{
+		return m_shape;
+	}
+
+private:
+	void TimerInterrupt() noexcept;
+
+	void StartTimer() noexcept;
+
+	void StopTimer() noexcept;
+
+	enum class BlinkState : uint8_t
+	{
+		Disabled,
+		On,
+		Off,
+		Wait,
+	};
+
+	QColor m_background;
+	QColor m_foreground;
+
+	Shape m_shape{ Shape::Block };
+	QVariantList m_modeInfo;
+	QTimer m_timer;
+	BlinkState m_blinkState{ BlinkState::Disabled };
+
+	bool m_styleEnabled{ false };
+
+	uint8_t m_percentage{ 100 };
+
+	uint64_t m_blinkWaitTime{ 0 };
+	uint64_t m_blinkOnTime{ 0 };
+	uint64_t m_blinkOffTime{ 0 };
+};

--- a/src/gui/shellwidget/highlight.cpp
+++ b/src/gui/shellwidget/highlight.cpp
@@ -1,5 +1,31 @@
 #include "highlight.h"
 
+static QColor GetQColorFromVariant(const QVariant& color) noexcept
+{
+	if (color.isNull()) {
+		return QColor{};
+	}
+
+	if (!color.canConvert<uint32_t>()) {
+		return QColor{};
+	}
+
+	return QColor{ color.toUInt() };
+}
+
+HighlightAttribute::HighlightAttribute(const QVariantMap& rgb_attr) noexcept
+{
+	m_foreground = GetQColorFromVariant(rgb_attr.value("foreground"));
+	m_background = GetQColorFromVariant(rgb_attr.value("background"));
+	m_special = GetQColorFromVariant(rgb_attr.value("special"));
+
+	m_reverse = rgb_attr.contains("reverse");
+	m_italic = rgb_attr.contains("italic");
+	m_bold = rgb_attr.contains("bold");
+	m_underline = rgb_attr.contains("underline");
+	m_undercurl = rgb_attr.contains("undercurl");
+}
+
 QColor HighlightAttribute::GetForegroundColor() const noexcept {
 	if (IsReverse()) {
 		return m_background;

--- a/src/gui/shellwidget/highlight.cpp
+++ b/src/gui/shellwidget/highlight.cpp
@@ -1,6 +1,6 @@
 #include "highlight.h"
 
-QColor HighlightAttribute::GetForegroundColor() const {
+QColor HighlightAttribute::GetForegroundColor() const noexcept {
 	if (IsReverse()) {
 		return m_background;
 	}
@@ -8,7 +8,7 @@ QColor HighlightAttribute::GetForegroundColor() const {
 	return m_foreground;
 }
 
-QColor HighlightAttribute::GetBackgroundColor() const {
+QColor HighlightAttribute::GetBackgroundColor() const noexcept {
 	if (IsReverse()) {
 		return m_foreground;
 	}
@@ -16,7 +16,7 @@ QColor HighlightAttribute::GetBackgroundColor() const {
 	return m_background;
 }
 
-bool HighlightAttribute::operator==(const HighlightAttribute& other) const {
+bool HighlightAttribute::operator==(const HighlightAttribute& other) const noexcept {
 	return
 		m_foreground == other.m_foreground &&
 		m_background == other.m_background &&

--- a/src/gui/shellwidget/highlight.h
+++ b/src/gui/shellwidget/highlight.h
@@ -12,7 +12,7 @@ public:
 		bool italic,
 		bool bold,
 		bool underline,
-		bool undercurl) :
+		bool undercurl) noexcept :
 		m_foreground{ foreground },
 		m_background{ background },
 		m_special{ special },
@@ -25,25 +25,25 @@ public:
 	}
 
 	/// Creates safe object with default highlight/style, required for QMap.
-	HighlightAttribute() {};
+	HighlightAttribute() noexcept {};
 
-	QColor GetForegroundColor() const;
+	QColor GetForegroundColor() const noexcept;
 
-	QColor GetBackgroundColor() const;
+	QColor GetBackgroundColor() const noexcept;
 
-	QColor GetSpecialColor() const { return m_special; }
+	QColor GetSpecialColor() const noexcept { return m_special; }
 
-	bool IsReverse() const { return m_reverse; }
+	bool IsReverse() const noexcept { return m_reverse; }
 
-	bool IsItalic() const { return m_italic; }
+	bool IsItalic() const noexcept { return m_italic; }
 
-	bool IsBold() const { return m_bold; }
+	bool IsBold() const noexcept { return m_bold; }
 
-	bool IsUnderline() const { return m_underline; }
+	bool IsUnderline() const noexcept { return m_underline; }
 
-	bool IsUndercurl() const { return m_undercurl; }
+	bool IsUndercurl() const noexcept { return m_undercurl; }
 
-	bool operator==(const HighlightAttribute& other) const;
+	bool operator==(const HighlightAttribute& other) const noexcept;
 
 private:
 	QColor m_foreground{ QColor::Invalid };

--- a/src/gui/shellwidget/highlight.h
+++ b/src/gui/shellwidget/highlight.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QColor>
+#include <QVariantMap>
 
 class HighlightAttribute {
 public:
@@ -23,6 +24,9 @@ public:
 		m_undercurl{ undercurl }
 	{
 	}
+
+	/// Creates a HighlightAttribute from the Neovim-MsgPack-Map format.
+	HighlightAttribute(const QVariantMap& map) noexcept;
 
 	/// Creates safe object with default highlight/style, required for QMap.
 	HighlightAttribute() noexcept {};

--- a/src/gui/shellwidget/shellwidget.cpp
+++ b/src/gui/shellwidget/shellwidget.cpp
@@ -406,7 +406,34 @@ int ShellWidget::rows() const
 {
 	return m_contents.rows();
 }
+
 int ShellWidget::columns() const
 {
 	return m_contents.columns();
 }
+
+void ShellWidget::setNeovimCursor(uint64_t row, uint64_t col)
+{
+	update(neovimCursorRect());
+	m_cursor_pos = QPoint(col, row);
+	update(neovimCursorRect());
+}
+
+QPoint ShellWidget::neovimCursorTopLeft() const
+{
+	const int xPixels{ m_cursor_pos.x() * cellSize().width() };
+	const int yPixels{ m_cursor_pos.y() * cellSize().height() };
+	return { xPixels, yPixels };
+}
+
+QRect ShellWidget::neovimCursorRect() const
+{
+	const Cell& cell{ contents().constValue(m_cursor_pos.y(), m_cursor_pos.x()) };
+
+	QRect cursor{ neovimCursorTopLeft(), cellSize() };
+	if (cell.IsDoubleWidth()) {
+		cursor.setWidth(cursor.width() * 2);
+	}
+	return cursor;
+}
+

--- a/src/gui/shellwidget/shellwidget.cpp
+++ b/src/gui/shellwidget/shellwidget.cpp
@@ -4,9 +4,8 @@
 #include "shellwidget.h"
 #include "helpers.h"
 
-ShellWidget::ShellWidget(QWidget *parent)
-:QWidget(parent), m_contents(0,0), m_bgColor(Qt::white),
-	m_fgColor(Qt::black), m_spColor(QColor()), m_lineSpace(0)
+ShellWidget::ShellWidget(QWidget* parent)
+	: QWidget(parent)
 {
 	setAttribute(Qt::WA_OpaquePaintEvent);
 	setAttribute(Qt::WA_KeyCompression, false);

--- a/src/gui/shellwidget/shellwidget.h
+++ b/src/gui/shellwidget/shellwidget.h
@@ -75,11 +75,13 @@ protected:
 private:
 	void setFont(const QFont&);
 
-	ShellContents m_contents;
+	ShellContents m_contents{ 0, 0 };
 	QSize m_cellSize;
 	int m_ascent;
-	QColor m_bgColor, m_fgColor, m_spColor;
-	int m_lineSpace;
+	QColor m_bgColor{ Qt::white };
+	QColor m_fgColor{ Qt::black };
+	QColor m_spColor;
+	int m_lineSpace{ 0 };
 
 	Background m_background{ Background::Dark };
 };

--- a/src/gui/shellwidget/shellwidget.h
+++ b/src/gui/shellwidget/shellwidget.h
@@ -66,6 +66,18 @@ public slots:
 			int col1, int rows);
 	void setLineSpace(int height);
 protected:
+	/// Cursor position in shell coordinates
+	QPoint m_cursor_pos;
+
+	/// The top left corner position (pixel) for the cursor
+	QPoint neovimCursorTopLeft() const;
+
+	/// Get the area filled by the cursor
+	QRect neovimCursorRect() const;
+
+	/// Move the neovim cursor for text insertion and display
+	void setNeovimCursor(uint64_t col, uint64_t row);
+
 	virtual void paintEvent(QPaintEvent *ev) Q_DECL_OVERRIDE;
 	virtual void resizeEvent(QResizeEvent *ev) Q_DECL_OVERRIDE;
 

--- a/src/gui/shellwidget/shellwidget.h
+++ b/src/gui/shellwidget/shellwidget.h
@@ -4,6 +4,7 @@
 #include <QWidget>
 
 #include "shellcontents.h"
+#include "cursor.h"
 
 class ShellWidget: public QWidget
 {
@@ -69,14 +70,17 @@ protected:
 	/// Cursor position in shell coordinates
 	QPoint m_cursor_pos;
 
+	/// Abstraction for guicursor options and styles
+	Cursor m_cursor;
+
 	/// The top left corner position (pixel) for the cursor
-	QPoint neovimCursorTopLeft() const;
+	QPoint neovimCursorTopLeft() const noexcept;
 
 	/// Get the area filled by the cursor
-	QRect neovimCursorRect() const;
+	QRect neovimCursorRect() const noexcept;
 
 	/// Move the neovim cursor for text insertion and display
-	void setNeovimCursor(uint64_t col, uint64_t row);
+	void setNeovimCursor(uint64_t col, uint64_t row) noexcept;
 
 	virtual void paintEvent(QPaintEvent *ev) Q_DECL_OVERRIDE;
 	virtual void resizeEvent(QResizeEvent *ev) Q_DECL_OVERRIDE;
@@ -86,6 +90,10 @@ protected:
 
 private:
 	void setFont(const QFont&);
+	void handleCursorChanged();
+	QRect getNeovimCursorRect(QRect cellRect) noexcept;
+	void paintNeovimCursorBackground(QPainter& p, QRect cellRect) noexcept;
+	void paintNeovimCursorForeground(QPainter& p, QRect cellRect, QPoint pos, QChar character) noexcept;
 
 	ShellContents m_contents{ 0, 0 };
 	QSize m_cellSize;


### PR DESCRIPTION
Based on #520

Thanks @b-r-o-c-k, your Pull Request was instrumental in putting this together and understanding the various guicursor options. :smile: 

I have moved some of the cursor code from `Shell` into `ShellWidget`, so we can have a clean abstraction. Moving the cursor there allows us to keep `Cell` immutable, and avoid `const_cast`.  I have also integrated guicursor styling with the new `HighlightAttribute` map from work on ext_linegrid.

I think this still needs a minimum neovim API version, I am not yet sure which one we should use due to the highlight map and `hl_id` vs `attr_id`. I will investigate...