### PR TITLE
Issue 626: GuiTreeview empty on startup

### DIFF
--- a/src/gui/runtime/plugin/nvim_gui_shim.vim
+++ b/src/gui/runtime/plugin/nvim_gui_shim.vim
@@ -178,15 +178,12 @@ function GuiClipboard()
 endfunction
 
 " Directory autocommands for Treeview
-" TODO : for the time being, the chdir events are broadcasted to all
-"        UIs. Being able to select a "correct" UI would be an improvement.
-"        But what is "the correct UI" ?
 augroup guiDirEvents
     autocmd!
     autocmd DirChanged * call rpcnotify(0, 'Dir', getcwd())
     autocmd WinEnter * call rpcnotify(0, 'Dir', getcwd())
+    autocmd VimEnter * call rpcnotify(0, 'Dir', getcwd())
 augroup END
-
 
 " Notifies the TreeView widget of a Show or Hide event
 function! s:TreeViewShowHide(show)


### PR DESCRIPTION
Fixes Issue #626 

The `autocmd WinEnter` does not trigger for the first window.

We can add an `autocmd VimEnter` to trigger the first initialization for the first window.