### PR TITLE
Issue 199: Control + CapsLock inserts $

### DIFF
--- a/src/gui/input.cpp
+++ b/src/gui/input.cpp
@@ -181,9 +181,11 @@ QString convertKey(const QKeyEvent& ev) noexcept
 
 	if (text.isEmpty()) {
 		// Ignore all modifier-only key events.
-		//   Issue #344: Ignore Ctrl-Shift, C-S- being treated as C-Space
+		//   Issue#344: Ignore Ctrl-Shift, C-S- being treated as C-Space
 		//   Issue#593: Pressing Control + Super inserts ^S
+		//   Issue#199: Pressing Control + CapsLock inserts $
 		if (key == Qt::Key::Key_Alt
+			|| key == Qt::Key::Key_CapsLock
 			|| key == Qt::Key::Key_Control
 			|| key == Qt::Key::Key_Meta
 			|| key == Qt::Key::Key_Shift

--- a/test/tst_input_common.cpp
+++ b/test/tst_input_common.cpp
@@ -10,6 +10,7 @@ private slots:
 	void LessThanKey() noexcept;
 	void ModifierOnlyKeyEventsIgnored() noexcept;
 	void ShiftKeyEventWellFormed() noexcept;
+	void CapsLockIgnored() noexcept;
 };
 
 void TestInputCommon::LessThanKey() noexcept
@@ -82,6 +83,19 @@ void TestInputCommon::ShiftKeyEventWellFormed() noexcept
 
 	QKeyEvent evShiftC{ QEvent::KeyPress, Qt::Key_C, Qt::ShiftModifier, "C" };
 	QCOMPARE(NeovimQt::Input::convertKey(evShiftC), QString{ "C" });
+}
+
+void TestInputCommon::CapsLockIgnored() noexcept
+{
+	// Issue#199: Pressing Control + CapsLock inserts $
+	QKeyEvent evCapsLock{ QEvent::KeyPress, Qt::Key_CapsLock, Qt::NoModifier};
+	QCOMPARE(NeovimQt::Input::convertKey(evCapsLock), QString{ "" });
+
+	QKeyEvent evCtrlCapsLock{ QEvent::KeyPress, Qt::Key_CapsLock, Qt::ControlModifier };
+	QCOMPARE(NeovimQt::Input::convertKey(evCtrlCapsLock), QString{ "" });
+
+	QKeyEvent evMetaCapsLock{ QEvent::KeyPress, Qt::Key_CapsLock, Qt::MetaModifier};
+	QCOMPARE(NeovimQt::Input::convertKey(evMetaCapsLock), QString{ "" });
 }
 
 #include "tst_input_common.moc"


### PR DESCRIPTION
Issue #199 

When CapsLock is pressed Qt sends events such as:
	`QKeyEvent(KeyPress, Qt::Key_CapsLock, Qt::NoModifier, "")`

These key events do not get rejected as special keys, and the lack of a text
field triggers the conversion to '$'. These events should be ignored.