### PR TITLE
Enable Neovim ext_linegrid by default

### DIFF
--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -33,7 +33,7 @@ class ShellOptions {
 public:
 	bool enable_ext_tabline{ true };
 	bool enable_ext_popupmenu{ true };
-	bool enable_ext_linegrid{ false };
+	bool enable_ext_linegrid{ true };
 	int nvim_show_tabline{ 1 };
 };
 


### PR DESCRIPTION
No issues have been reported relating to this feature. Since this is the modern rendering engine for neovim, it should be enabled by default (when supported).

The old API will still be used for unsupported clients, and can still be manually disabled via QSettings.

On Linux `~/.config/nvim-qt/nvim-qt.conf`:
```
[General]
ext_linegrid=false
```