### PR TITLE
Avoid printing Char when AltGr is pressed

### DIFF
--- a/src/gui/input.cpp
+++ b/src/gui/input.cpp
@@ -185,6 +185,7 @@ QString convertKey(const QKeyEvent& ev) noexcept
 		//   Issue#593: Pressing Control + Super inserts ^S
 		//   Issue#199: Pressing Control + CapsLock inserts $
 		if (key == Qt::Key::Key_Alt
+			|| key == Qt::Key::Key_AltGr
 			|| key == Qt::Key::Key_CapsLock
 			|| key == Qt::Key::Key_Control
 			|| key == Qt::Key::Key_Meta

--- a/test/tst_input_common.cpp
+++ b/test/tst_input_common.cpp
@@ -11,6 +11,8 @@ private slots:
 	void ModifierOnlyKeyEventsIgnored() noexcept;
 	void ShiftKeyEventWellFormed() noexcept;
 	void CapsLockIgnored() noexcept;
+	void AltGrAloneIgnored() noexcept;
+	void AltGrKeyEventWellFormed() noexcept;
 };
 
 void TestInputCommon::LessThanKey() noexcept
@@ -33,6 +35,7 @@ void TestInputCommon::ModifierOnlyKeyEventsIgnored() noexcept
 
 	const QList<Qt::Key> modifierKeyList {
 		Qt::Key::Key_Alt,
+		Qt::Key::Key_AltGr,
 		Qt::Key::Key_Control,
 		Qt::Key::Key_Meta,
 		Qt::Key::Key_Shift,
@@ -46,6 +49,7 @@ void TestInputCommon::ModifierOnlyKeyEventsIgnored() noexcept
 		Qt::KeyboardModifier::ControlModifier,
 		Qt::KeyboardModifier::MetaModifier,
 		Qt::KeyboardModifier::ShiftModifier,
+		Qt::KeyboardModifier::GroupSwitchModifier,
 	};
 
 	for (const auto& key : modifierKeyList) {
@@ -62,6 +66,19 @@ void TestInputCommon::ModifierOnlyKeyEventsIgnored() noexcept
 	// Issue#593: Pressing Control + Super inserts ^S
 	QKeyEvent evIssue593{ QEvent::KeyPress, Qt::Key::Key_Super_L, Qt::KeyboardModifier::ControlModifier};
 	QCOMPARE(NeovimQt::Input::convertKey(evIssue593), QString{});
+}
+
+void TestInputCommon::AltGrAloneIgnored() noexcept
+{
+	// Issue#510: Pressing AltGr inserts weird char
+	QKeyEvent event{ QEvent::KeyPress, Qt::Key::Key_AltGr, Qt::KeyboardModifier::GroupSwitchModifier};
+	QCOMPARE(NeovimQt::Input::convertKey(event), QString{});
+}
+
+void TestInputCommon::AltGrKeyEventWellFormed() noexcept
+{
+	QKeyEvent event{ QEvent::KeyPress, Qt::Key::Key_AsciiTilde, Qt::KeyboardModifier::GroupSwitchModifier};
+	QCOMPARE(NeovimQt::Input::convertKey(event), QString{ "~" });
 }
 
 void TestInputCommon::ShiftKeyEventWellFormed() noexcept


### PR DESCRIPTION
# System specs
Debian 9
QMake version 3.0
Using Qt version 5.7.1 in /usr/lib/x86_64-linux-gnu
Input source: Italian
 
# Problem
Every time I press `AltGr` a weird character is immediately inserted. This behaviour only happens when using nvim-qt, nvim in terminal properly handles this case.

The debug output is:
```
QKeyEvent ev: QKeyEvent(KeyPress, Key_AltGr, GroupSwitchModifier)
   "ᄃ"
QKeyEvent ev: QKeyEvent(KeyPress, Key_AsciiTilde, GroupSwitchModifier, text="~")
   "~"
```
The key combination for tilde is `AltGr+ì` where `ì` is a button on the left of backspace.