### PR TITLE
Issue 326: Add Basic GuiScrollBar Support

### DIFF
--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -4,6 +4,7 @@
 #include <QMainWindow>
 #include <QStackedWidget>
 #include <QTabBar>
+#include <QScrollBar>
 #include <QSplitter>
 #include "treeview.h"
 #include "neovimconnector.h"
@@ -57,6 +58,11 @@ private slots:
 	void extTablineSet(bool);
 	void changeTab(int index);
 	void saveWindowGeometry();
+	void setGuiScrollBarVisible(bool isVisible);
+	void neovimCursorMovedUpdateScrollBar(
+		uint64_t minLineVisible, uint64_t bufferSize, uint64_t windowHeigt);
+	void neovimScrollEvent(int64_t rows);
+
 private:
 	void init(NeovimConnector *);
 	NeovimConnector *m_nvim;
@@ -75,6 +81,12 @@ private:
 	QAction *m_actCopy;
 	QAction *m_actPaste;
 	QAction *m_actSelectAll;
+	QScrollBar *m_rightScrollBar;
+
+	/// The scrollbar updates on cursor movement and GUI paint/scroll events.
+	/// In cases where the scroll event triggers cursor movement, this can result
+	/// in double registration. Detect and ignore this double registration.
+	int m_scrollbarLastDelta{ 0 };
 };
 
 } // Namespace

--- a/src/gui/runtime/doc/nvim_gui_shim.txt
+++ b/src/gui/runtime/doc/nvim_gui_shim.txt
@@ -49,6 +49,9 @@ GuiLinespace	When called with no arguments this command displays the
 		linespace, the number of extra pixels each line will have.
                 A single argument is accepted as the new linespace height.
 
+								*GuiScrollBar*
+GuiScrollBar	Enable or disable the external GUI scrollbar
+
 								*GuiTabline*
 GuiTabline	Enable or disable the external GUI tabline
 

--- a/src/gui/runtime/plugin/nvim_gui_shim.vim
+++ b/src/gui/runtime/plugin/nvim_gui_shim.vim
@@ -210,3 +210,20 @@ anoremenu <script> Gui.Treeview.Toggle :call <SID>TreeViewShowToggle()
 function GuiShowContextMenu() range
 	call rpcnotify(0, 'Gui', 'ShowContextMenu')
 endfunction
+
+" Notify Gui of any cursor movement, used by GuiScrollBar
+function s:GuiCursorMovedUpdateScrollBar()
+	let l:minLineVisible = line('w0')
+	let l:bufferSize = line('$')
+	let l:windowHeight = winheight(winnr())
+	call rpcnotify(0, 'Gui', 'CursorMovedUpdateScrollBar', l:minLineVisible, l:bufferSize, l:windowHeight)
+endfunction
+
+autocmd CursorMoved,CursorMovedI,VimResized * call <SID>GuiCursorMovedUpdateScrollBar()
+
+" Show/Hide the Gui ScrollBar
+function! s:GuiScrollBar(enable) abort
+	call rpcnotify(0, 'Gui', 'SetScrollBarVisible', a:enable)
+endfunction
+
+command! -nargs=1 GuiScrollBar call s:GuiScrollBar(<args>)

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -76,6 +76,12 @@ signals:
 	void neovimShowContextMenu();
 	void fontChanged();
 
+	// GuiScrollBar Signals
+	void neovimCursorMovedUpdateScrollBar(
+		uint64_t minLineVisible, uint64_t bufferSize, uint64_t windowHeight);
+	void neovimScrollEvent(int64_t rows);
+	void setGuiScrollBarVisible(bool isVisible);
+
 public slots:
 	void handleNeovimNotification(const QByteArray &name, const QVariantList& args);
 	void resizeNeovim(const QSize&);
@@ -83,6 +89,9 @@ public slots:
 	bool setGuiFont(const QString& fdesc, bool force, bool updateOption);
 	void updateGuiWindowState(Qt::WindowStates state);
 	void openFiles(const QList<QUrl> url);
+
+	/// Update the Neovim buffer position after a gui-triggered scrollbar event
+	void handleScrollBarChanged(int position);
 
 protected slots:
 	void neovimError(NeovimConnector::NeovimError);
@@ -140,6 +149,10 @@ protected:
 	virtual void handleGridCursorGoto(const QVariantList& opargs);
 	virtual void handleGridScroll(const QVariantList& opargs);
 
+	// GuiScrollBar Slots
+	virtual void handleCursorMovedUpdateScrollBar(const QVariantList& opargs) noexcept;
+	virtual void handleSetScrollBarVisible(const QVariantList& opargs) noexcept;
+
 	void neovimMouseEvent(QMouseEvent *ev);
 	virtual void mousePressEvent(QMouseEvent *ev) Q_DECL_OVERRIDE;
 	virtual void mouseReleaseEvent(QMouseEvent *ev) Q_DECL_OVERRIDE;
@@ -194,6 +207,9 @@ private:
 	ShellOptions m_options;
 	PopupMenu m_pum{ this };
 	bool m_mouseEnabled{ true };
+
+	/// GuiScrollBar last known position: used to compute scroll line delta.
+	int m_lastScrollBarPosition{ 0 };
 };
 
 class ShellRequestHandler: public QObject, public MsgpackRequestHandler


### PR DESCRIPTION
This change adds a primitive GUI `QScrollBar` to interact with the active buffer.

![image](https://user-images.githubusercontent.com/11207308/73988077-a03e5c80-490f-11ea-9d08-36bf9bc58fc2.png)

The feature can be enabled with:
`:GuiScrollBar 1`

**Design:**
The scrollbar position for the active buffer is computed by attaching to autocmds `CursorMoved`, `CursorMovedI`, and `VimResized`. Whenever one of these events is triggered, we can compute the scrollbar position with the following data:
1. `line('w0')`: Minimum visible line number in active buffer
2. `line('$')`: Current line number of cursor in active buffer
3. `winheight(winnr())`: Size of the active buffer.

These events alone are not enough to keep the scrollbar synchronized. I have also connected the `scroll` and `grid_scroll` events to determine when the buffer scrolls and the cursor does not move.

When a scroll event is triggered from the GUI (user adjusts QScrollBarPosition), `nvim-qt` computes a scroll delta between the last-stored position and the current position. This delta is then used to send an input event `X<C-E>` or `X<C-Y>`, where X is the number of lines to scroll.

I am not particularly fond of the `<C-E>`/`<C-Y>` approach... But I haven't come up with anything better yet. The use of `scroll` and `grid_scroll` also seems a little hack-y.

**Related Issues**:
Issue #326

Scrolling seems like a basic feature that has been missing for too long :)