### PR TITLE
Draw undercurl properly under whitespace ` `

### DIFF
--- a/src/gui/shellwidget/shellwidget.cpp
+++ b/src/gui/shellwidget/shellwidget.cpp
@@ -153,29 +153,27 @@ void ShellWidget::paintEvent(QPaintEvent *ev)
 						p.fillRect(r, background());
 					}
 
-					if (cell.GetCharacter() == ' ') {
-						continue;
-					}
+					if (cell.GetCharacter() != ' ') {
+						if (cell.GetForegroundColor().isValid()) {
+							p.setPen(cell.GetForegroundColor());
+						} else {
+							p.setPen(foreground());
+						}
 
-					if (cell.GetForegroundColor().isValid()) {
-						p.setPen(cell.GetForegroundColor());
-					} else {
-						p.setPen(foreground());
-					}
+						if (cell.IsBold() || cell.IsItalic()) {
+							QFont f = p.font();
+							f.setBold(cell.IsBold());
+							f.setItalic(cell.IsItalic());
+							p.setFont(f);
+						} else {
+							p.setFont(font());
+						}
 
-					if (cell.IsBold() || cell.IsItalic()) {
-						QFont f = p.font();
-						f.setBold(cell.IsBold());
-						f.setItalic(cell.IsItalic());
-						p.setFont(f);
-					} else {
-						p.setFont(font());
+						// Draw chars at the baseline
+						QPoint pos(r.left(), r.top()+m_ascent+(m_lineSpace / 2));
+						uint character = cell.GetCharacter();
+						p.drawText(pos, QString::fromUcs4(&character, 1));
 					}
-
-					// Draw chars at the baseline
-					QPoint pos(r.left(), r.top()+m_ascent+(m_lineSpace / 2));
-					uint character = cell.GetCharacter();
-					p.drawText(pos, QString::fromUcs4(&character, 1));
 				}
 
 				// Draw "undercurl" at the bottom of the cell


### PR DESCRIPTION
Fixes issue that undercurl is not rendered if it is over whitespace characters.

Before:

![broken_undercurl](https://user-images.githubusercontent.com/20490597/74600790-b6030d00-50d9-11ea-884b-1ea5097c2d13.png)

After:

![fixed_undercurl](https://user-images.githubusercontent.com/20490597/74600791-b7ccd080-50d9-11ea-951a-5cf66e1e9f22.png)

