### PR TITLE
Support exit status to differenciate `:q` and `:cq`

### DIFF
--- a/src/gui/app.h
+++ b/src/gui/app.h
@@ -33,6 +33,11 @@ private:
 
 	QCommandLineParser m_parser;
 	std::shared_ptr<NeovimConnector> m_connector;
+	int m_exitStatus = 0;
+
+public slots:
+	void mainWindowClosing(int);
+	void exitWithStatus();
 
 signals:
 	void openFilesTriggered(const QList<QUrl>);

--- a/src/gui/app.h
+++ b/src/gui/app.h
@@ -33,7 +33,7 @@ private:
 
 	QCommandLineParser m_parser;
 	std::shared_ptr<NeovimConnector> m_connector;
-	int m_exitStatus = 0;
+	int m_exitStatus{ 0 };
 
 public slots:
 	void mainWindowClosing(int);

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -239,9 +239,10 @@ void MainWindow::neovimFullScreen(bool set)
 	}
 }
 
-void MainWindow::neovimGuiCloseRequest()
+void MainWindow::neovimGuiCloseRequest(int status)
 {
 	m_neovim_requested_close = true;
+	m_exitStatus = status;
 	QMainWindow::close();
 	m_neovim_requested_close = false;
 }
@@ -264,10 +265,12 @@ void MainWindow::closeEvent(QCloseEvent *ev)
 
 	if (m_neovim_requested_close) {
 		// If this was requested by nvim, shutdown
-		QWidget::closeEvent(ev);
+		emit closing(m_exitStatus);
+		ev->accept();
 	} else if (m_shell->close()) {
 		// otherwise only if the Neovim shell closes too
-		QWidget::closeEvent(ev);
+		emit closing(m_exitStatus);
+		ev->accept();
 	} else {
 		ev->ignore();
 	}

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -90,7 +90,7 @@ private:
 	QAction* m_actPaste{ nullptr };
 	QAction* m_actSelectAll{ nullptr };
 	ScrollBar* m_scrollbar{ nullptr };
-	int m_exitStatus = 0;
+	int m_exitStatus{ 0 };
 
 	// GuiAdaptive Color/Font/Style
 	bool m_isAdaptiveColorEnabled{ false };

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -4,6 +4,7 @@
 #include <QMainWindow>
 #include <QPalette>
 #include <QSplitter>
+#include <QCloseEvent>
 #include <QStackedWidget>
 #include <QTabBar>
 
@@ -34,6 +35,7 @@ public slots:
 	void delayedShow(DelayedShow type=DelayedShow::Normal);
 signals:
 	void neovimAttached(bool);
+	void closing(int);
 protected:
 	virtual void closeEvent(QCloseEvent *ev) Q_DECL_OVERRIDE;
 	virtual void changeEvent(QEvent *ev) Q_DECL_OVERRIDE;
@@ -44,7 +46,7 @@ private slots:
 	void neovimForeground();
 	void neovimSuspend();
 	void neovimFullScreen(bool);
-	void neovimGuiCloseRequest();
+	void neovimGuiCloseRequest(int);
 	void neovimExited(int status);
 	void neovimError(NeovimConnector::NeovimError);
 	void reconnectNeovim();
@@ -88,6 +90,7 @@ private:
 	QAction* m_actPaste{ nullptr };
 	QAction* m_actSelectAll{ nullptr };
 	ScrollBar* m_scrollbar{ nullptr };
+	int m_exitStatus = 0;
 
 	// GuiAdaptive Color/Font/Style
 	bool m_isAdaptiveColorEnabled{ false };

--- a/src/gui/runtime/plugin/nvim_gui_shim.vim
+++ b/src/gui/runtime/plugin/nvim_gui_shim.vim
@@ -18,7 +18,7 @@ endfunction
 
 " Close the GUI
 function! GuiClose() abort
-  call rpcnotify(0, 'Gui', 'Close')
+  call rpcnotify(0, 'Gui', 'Close', v:exiting)
 endfunction
 
 " Notify the GUI when exiting Neovim

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -970,15 +970,12 @@ void Shell::handleLineSpace(const QVariant& value) noexcept
 
 void Shell::handleCloseEvent(const QVariantList &args) noexcept
 {
-	if (args.size() == 2 && !args.at(1).canConvert<int>()) {
+	qDebug() << "Neovim requested a GUI close";
+
+	if (args.size() >= 2 && !args.at(1).canConvert<int>()) {
 		qWarning() << "Unexpected exit status for close:" << args.at(1);
 		return;
-	} else if (args.size() >= 3) {
-		qWarning() << "Unexpected arguments for close:" << args;
-		return;
 	}
-
-	qDebug() << "Neovim requested a GUI close";
 
 	// Decide exit status.  If there is an argument, the exit status is
 	// specified by the argument.

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -968,7 +968,7 @@ void Shell::handleLineSpace(const QVariant& value) noexcept
 	resizeNeovim(size());
 }
 
-void Shell::handleCloseEvent(const QVariantList &args) noexcept
+void Shell::handleCloseEvent(const QVariantList& args) noexcept
 {
 	qDebug() << "Neovim requested a GUI close";
 

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -808,12 +808,22 @@ void Shell::handleNeovimNotification(const QByteArray &name, const QVariantList&
 			m_mouseHide = variant_not_zero(args.at(1));
 			int val = m_mouseHide ? 1 : 0;
 			m_nvim->api0()->vim_set_var("GuiMousehide", val);
-		} else if (guiEvName == "Close" && args.size() == 2) {
+		} else if (guiEvName == "Close" && (args.size() == 1 || args.size() == 2)) {
 			qDebug() << "Neovim requested a GUI close";
-			// retrieve current exit status
-			bool ok;
-			int status = args.at(1).toInt(&ok);
-			if (!ok) status = 1;
+
+			// Decide which exit status Neovim-qt should exit with.
+			int status;
+			if (args.size() == 1) {
+				// If there are no arguments, then the exit status is zero.
+				status = 0;
+			} if (args.size() == 2) {
+				// Or, if there is an argument, then the exit status is
+				// specified in the argument.
+				bool ok;
+				status = args.at(1).toInt(&ok);
+				if (!ok) status = 1;
+			}
+
 			emit neovimGuiCloseRequest(status);
 		} else if (guiEvName == "Option" && args.size() >= 3) {
 			QString option = m_nvim->decode(args.at(1).toByteArray());

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -808,9 +808,13 @@ void Shell::handleNeovimNotification(const QByteArray &name, const QVariantList&
 			m_mouseHide = variant_not_zero(args.at(1));
 			int val = m_mouseHide ? 1 : 0;
 			m_nvim->api0()->vim_set_var("GuiMousehide", val);
-		} else if (guiEvName == "Close" && args.size() == 1) {
+		} else if (guiEvName == "Close" && args.size() == 2) {
 			qDebug() << "Neovim requested a GUI close";
-			emit neovimGuiCloseRequest();
+			// retrieve current exit status
+			bool ok;
+			int status = args.at(1).toInt(&ok);
+			if (!ok) status = 1;
+			emit neovimGuiCloseRequest(status);
 		} else if (guiEvName == "Option" && args.size() >= 3) {
 			QString option = m_nvim->decode(args.at(1).toByteArray());
 			handleExtGuiOption(option, args.at(2));

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -979,7 +979,7 @@ void Shell::handleCloseEvent(const QVariantList& args) noexcept
 
 	// Decide exit status.  If there is an argument, the exit status is
 	// specified by the argument.
-	int status = 0;
+	int status{ 0 };
 	if (args.size() == 2) {
 		status = args.at(1).toInt();
 	}

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -167,6 +167,7 @@ protected:
 	virtual void handleGuiFontFunction(const QVariantList& args);
 	virtual void handleGuiFontWide(const QVariant& value) noexcept;
 	virtual void handleLineSpace(const QVariant& value) noexcept;
+	virtual void handleCloseEvent(const QVariantList &args) noexcept;
 
 	// Modern 'ext_linegrid' Grid UI Events
 	virtual void handleGridResize(const QVariantList& opargs);

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -90,7 +90,7 @@ signals:
 	void neovimOpacity(double);
 	void neovimSuspend();
 	void neovimFullScreen(bool);
-	void neovimGuiCloseRequest(int);
+	void neovimGuiCloseRequest(int status = 0);
 	/// This signal is emmited if the running neovim version is unsupported by the GUI
 	void neovimIsUnsupported();
 	void neovimExtTablineSet(bool);

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -90,7 +90,7 @@ signals:
 	void neovimOpacity(double);
 	void neovimSuspend();
 	void neovimFullScreen(bool);
-	void neovimGuiCloseRequest();
+	void neovimGuiCloseRequest(int);
 	/// This signal is emmited if the running neovim version is unsupported by the GUI
 	void neovimIsUnsupported();
 	void neovimExtTablineSet(bool);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,6 +9,18 @@ endif ()
 
 add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND})
 
+# Place all platform-specific test definitions here
+if(WIN32)
+	set(SRC_SHELL_PLATFORM tst_shell_win32.cpp)
+	set(SRC_INPUT_PLATFORM ${CMAKE_SOURCE_DIR}/src/gui/input_win32.cpp)
+elseif(APPLE)
+	set(SRC_SHELL_PLATFORM tst_shell_mac.cpp)
+	set(SRC_INPUT_PLATFORM ${CMAKE_SOURCE_DIR}/src/gui/input_mac.cpp)
+else()
+	set(SRC_SHELL_PLATFORM tst_shell_unix.cpp)
+	set(SRC_INPUT_PLATFORM ${CMAKE_SOURCE_DIR}/src/gui/input_unix.cpp)
+endif()
+
 function(add_xtest SOURCE_NAME)
 	add_executable(${SOURCE_NAME} ${SOURCE_NAME}.cpp ${ARGV1} ${ARGV2})
 	target_link_libraries(${SOURCE_NAME} ${QTLIBS} ${MSGPACK_LIBRARIES} neovim-qt)
@@ -17,7 +29,7 @@ function(add_xtest SOURCE_NAME)
 endfunction()
 
 function(add_xtest_gui SOURCE_NAME)
-	add_executable(${SOURCE_NAME} ${SOURCE_NAME}.cpp)
+	add_executable(${SOURCE_NAME} ${SOURCE_NAME}.cpp ${ARGV1} ${ARGV2})
 	target_link_libraries(${SOURCE_NAME} ${QTLIBS} ${MSGPACK_LIBRARIES} neovim-qt Qt5::Widgets neovim-qt-gui)
 	add_test(NAME ${SOURCE_NAME} COMMAND ${SOURCE_NAME}
 		# Run GUI tests from source dir, they depend on src files
@@ -37,7 +49,7 @@ add_xtest(tst_neovimconnector)
 add_xtest(tst_callallmethods)
 add_xtest(tst_encoding)
 add_xtest(tst_msgpackiodevice)
-add_xtest_gui(tst_shell)
+add_xtest_gui(tst_shell ${SRC_SHELL_PLATFORM})
 add_xtest_gui(tst_main)
 
 # Platform Specific Input Tests
@@ -55,12 +67,12 @@ add_xtest(tst_input_win32
 add_shared_test(tst_input_common_mac
 	tst_input_common.cpp
 	${CMAKE_SOURCE_DIR}/src/gui/input.cpp
-	${CMAKE_SOURCE_DIR}/src/gui/input_mac.cpp)
+	${SRC_INPUT_PLATFORM})
 add_shared_test(tst_input_common_unix
 	tst_input_common.cpp
 	${CMAKE_SOURCE_DIR}/src/gui/input.cpp
-	${CMAKE_SOURCE_DIR}/src/gui/input_unix.cpp)
+	${SRC_INPUT_PLATFORM})
 add_shared_test(tst_input_common_win32
 	tst_input_common.cpp
 	${CMAKE_SOURCE_DIR}/src/gui/input.cpp
-	${CMAKE_SOURCE_DIR}/src/gui/input_win32.cpp)
+	${SRC_INPUT_PLATFORM})

--- a/test/tst_shell.cpp
+++ b/test/tst_shell.cpp
@@ -252,11 +252,21 @@ private slots:
 		QCOMPARE(onWindowClosing.takeFirst().at(0).toInt(), event_status);
 
 		// and finally a call to nvim-qt
+		QProcess p;
+		p.setProgram(NVIM_QT_BINARY);
+		QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
+		env.insert("NVIM_QT_RUNTIME_PATH", path_to_src_runtime);
+		p.setProcessEnvironment(env);
 #if defined(Q_OS_WIN32)
-		int actual_exit_status = QProcess::execute(NVIM_QT_BINARY, {NVIM_QT_BINARY, "--",  "-c", command});
+		p.setArguments({NVIM_QT_BINARY, "--",  "-c", command});
 #else
-		int actual_exit_status = QProcess::execute(NVIM_QT_BINARY, {NVIM_QT_BINARY, "--nofork", "--",  "-c", command});
+		p.setArguments({NVIM_QT_BINARY, "--nofork", "--",  "-c", command});
 #endif
+		p.start();
+		p.waitForFinished(-1);
+		QCOMPARE(p.exitStatus(), QProcess::NormalExit);
+		int actual_exit_status = p.exitCode();
+
 		QCOMPARE(actual_exit_status, exit_status);
 	}
 

--- a/test/tst_shell.cpp
+++ b/test/tst_shell.cpp
@@ -211,7 +211,8 @@ private slots:
 		QTest::newRow("Exit with Invalid Code: -1cq")
 			<< -1 << 0 << QByteArray("-1cq");
 
-		// Some exit-status scenarios are platform dependent. Ex) Overflow on Windows
+		// Some exit-status scenarios are platform dependent.
+		// Ex) Overflow on UNIX-like operating systems.
 		AddPlatformSpecificExitCodeCases();
 	}
 

--- a/test/tst_shell.cpp
+++ b/test/tst_shell.cpp
@@ -245,10 +245,10 @@ private slots:
 		c->api0()->vim_command(c->encode(command));
 
 		QVERIFY(SPYWAIT(onClose));
-		QCOMPARE(onClose.takeFirst().at(0), event_status);
+		QCOMPARE(onClose.takeFirst().at(0).toInt(), event_status);
 
 		QVERIFY(SPYWAIT(onWindowClosing));
-		QCOMPARE(onWindowClosing.takeFirst().at(0), event_status);
+		QCOMPARE(onWindowClosing.takeFirst().at(0).toInt(), event_status);
 
 		// and finally a call to nvim-qt
 #if defined(Q_OS_WIN32)

--- a/test/tst_shell.cpp
+++ b/test/tst_shell.cpp
@@ -207,10 +207,6 @@ private slots:
 		QTest::newRow("Exit with Code 255: 255cq")
 			<< 255 << 255 << QByteArray("255cq");
 
-		// FIXME This probably requires a comment... Also expected value is 0 (not -1)?
-		QTest::newRow("Exit with Invalid Code: -1cq")
-			<< -1 << 0 << QByteArray("-1cq");
-
 		// Some exit-status scenarios are platform dependent.
 		// Ex) Overflow on UNIX-like operating systems.
 		AddPlatformSpecificExitCodeCases();

--- a/test/tst_shell.cpp
+++ b/test/tst_shell.cpp
@@ -188,6 +188,77 @@ private slots:
 		QVERIFY(onOptionSet.isValid());
 	}
 
+	void CloseEvent_data() {
+		// The status code as carried via msgpack
+		QTest::addColumn<int>("event_status");
+		// The expected process exit status
+		QTest::addColumn<int>("exit_status");
+		// q/cq command
+		QTest::addColumn<QByteArray>("command");
+
+		QTest::newRow("q")
+			<< 0 << 0 << QByteArray("q");
+		QTest::newRow("cq")
+			<< 1 << 1 << QByteArray("cq");
+		QTest::newRow("2cq")
+			<< 2 << 2 << QByteArray("2cq");
+		QTest::newRow("255cq")
+			<< 255 << 255 << QByteArray("255cq");
+		// Overflow, this generates an exit code 0, but the
+		// original count is passed to us
+		QTest::newRow("256cq")
+			<< 256 << 0 << QByteArray("256cq");
+		// a bit of corner case, but nvim exits with
+		// status 0 and provides us count 0 - calling it with nvim -c
+		// actually causes an error with an invalid range, so it can not run
+//		QTest::newRow("-1cq")
+//			<< 0 << QByteArray("-1cq");
+	}
+
+	void CloseEvent() {
+		QFETCH(int, event_status);
+		QFETCH(int, exit_status);
+		QFETCH(QByteArray, command);
+
+		QString path_to_src_runtime(CMAKE_SOURCE_DIR);
+		path_to_src_runtime.append("/src/gui/runtime");
+		QFileInfo fi = QFileInfo(path_to_src_runtime);
+		QVERIFY2(fi.exists(), "Unable to find GUI runtime");
+		QStringList args = {"-u", "NONE",
+			"--cmd", "set rtp+=" + fi.absoluteFilePath()};
+
+		NeovimConnector *c = NeovimConnector::spawn(args);
+		MainWindow *s = new MainWindow(c);
+		s->show();
+		QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
+		QVERIFY(onAttached.isValid());
+		QVERIFY(SPYWAIT(onAttached));
+		QVERIFY(s->neovimAttached());
+
+		// GUI shim Close event
+		QSignalSpy onClose(s->shell(), &Shell::neovimGuiCloseRequest);
+		QVERIFY(onClose.isValid());
+
+		QSignalSpy onWindowClosing(s, &MainWindow::closing);
+		QVERIFY(onWindowClosing.isValid());
+
+		c->api0()->vim_command(c->encode(command));
+
+		QVERIFY(SPYWAIT(onClose));
+		QCOMPARE(onClose.takeFirst().at(0), event_status);
+
+		QVERIFY(SPYWAIT(onWindowClosing));
+		QCOMPARE(onWindowClosing.takeFirst().at(0), event_status);
+
+		// and finally a call to nvim-qt
+#if defined(Q_OS_WIN32)
+		int actual_exit_status = QProcess::execute(NVIM_QT_BINARY, {NVIM_QT_BINARY, "--",  "-c", command});
+#else
+		int actual_exit_status = QProcess::execute(NVIM_QT_BINARY, {NVIM_QT_BINARY, "--nofork", "--",  "-c", command});
+#endif
+		QCOMPARE(actual_exit_status, exit_status);
+	}
+
 	void GetClipboard_data() {
 		// * or +
 		QTest::addColumn<char>("reg");

--- a/test/tst_shell.cpp
+++ b/test/tst_shell.cpp
@@ -204,10 +204,11 @@ private slots:
 			<< 2 << 2 << QByteArray("2cq");
 		QTest::newRow("255cq")
 			<< 255 << 255 << QByteArray("255cq");
-		// Overflow, this generates an exit code 0, but the
+		// Overflow except Windows, this generates an exit code 0, but the
 		// original count is passed to us
-		QTest::newRow("256cq")
-			<< 256 << 0 << QByteArray("256cq");
+		// Commented out as this test doesn't pass on Windows
+//		QTest::newRow("256cq")
+//			<< 256 << 0 << QByteArray("256cq");
 		// a bit of corner case, but nvim exits with
 		// status 0 and provides us count 0 - calling it with nvim -c
 		// actually causes an error with an invalid range, so it can not run

--- a/test/tst_shell.h
+++ b/test/tst_shell.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <QStringList>
+
+namespace NeovimQt {
+
+QStringList BinaryAndArgumentsNoForkWithCommand(const QString& command) noexcept;
+
+void AddPlatformSpecificExitCodeCases() noexcept;
+
+class Test;
+
+} // Namespace NeovimQt

--- a/test/tst_shell_mac.cpp
+++ b/test/tst_shell_mac.cpp
@@ -1,0 +1,20 @@
+#include "tst_shell.h"
+
+#include <QStringList>
+#include <QTest>
+
+namespace NeovimQt {
+
+QStringList BinaryAndArgumentsNoForkWithCommand(const QString& command) noexcept
+{
+	return { NVIM_QT_BINARY, "--nofork", "--",  "-c", command };
+}
+
+void AddPlatformSpecificExitCodeCases() noexcept
+{
+	// FIXME Add comment
+	QTest::newRow("Exit Code Overflow: 256cq")
+		<< 256 << 0 << QByteArray("256cq");
+}
+
+} // namespace NeovimQt

--- a/test/tst_shell_mac.cpp
+++ b/test/tst_shell_mac.cpp
@@ -12,7 +12,9 @@ QStringList BinaryAndArgumentsNoForkWithCommand(const QString& command) noexcept
 
 void AddPlatformSpecificExitCodeCases() noexcept
 {
-	// FIXME Add comment
+	// On UNIX-like operating systems, the child exit code is represented as a
+	// 8-bit integer. Therefore 256 overflows and becomes 0.
+	// Reference: man for wait(2).
 	QTest::newRow("Exit Code Overflow: 256cq")
 		<< 256 << 0 << QByteArray("256cq");
 }

--- a/test/tst_shell_unix.cpp
+++ b/test/tst_shell_unix.cpp
@@ -1,0 +1,20 @@
+#include "tst_shell.h"
+
+#include <QStringList>
+#include <QTest>
+
+namespace NeovimQt {
+
+QStringList BinaryAndArgumentsNoForkWithCommand(const QString& command) noexcept
+{
+	return { NVIM_QT_BINARY, "--nofork", "--",  "-c", command };
+}
+
+void AddPlatformSpecificExitCodeCases() noexcept
+{
+	// FIXME Add comment
+	QTest::newRow("Exit Code Overflow: 256cq")
+		<< 256 << 0 << QByteArray("256cq");
+}
+
+} // namespace NeovimQt

--- a/test/tst_shell_unix.cpp
+++ b/test/tst_shell_unix.cpp
@@ -12,7 +12,9 @@ QStringList BinaryAndArgumentsNoForkWithCommand(const QString& command) noexcept
 
 void AddPlatformSpecificExitCodeCases() noexcept
 {
-	// FIXME Add comment
+	// On UNIX-like operating systems, the child exit code is represented as a
+	// 8-bit integer. Therefore 256 overflows and becomes 0.
+	// Reference: man for wait(2).
 	QTest::newRow("Exit Code Overflow: 256cq")
 		<< 256 << 0 << QByteArray("256cq");
 }

--- a/test/tst_shell_win32.cpp
+++ b/test/tst_shell_win32.cpp
@@ -1,0 +1,20 @@
+#include "tst_shell.h"
+
+#include <QStringList>
+#include <QTest>
+
+namespace NeovimQt {
+
+QStringList BinaryAndArgumentsNoForkWithCommand(const QString& command) noexcept
+{
+	return { NVIM_QT_BINARY, "--",  "-c", command };
+}
+
+void AddPlatformSpecificExitCodeCases() noexcept
+{
+	// FIXME Add comment
+	QTest::newRow("Exit Code Overflow: 256cq")
+		<< 256 << 0 << QByteArray("256cq");
+}
+
+} // namespace NeovimQt

--- a/test/tst_shell_win32.cpp
+++ b/test/tst_shell_win32.cpp
@@ -12,9 +12,11 @@ QStringList BinaryAndArgumentsNoForkWithCommand(const QString& command) noexcept
 
 void AddPlatformSpecificExitCodeCases() noexcept
 {
-	// FIXME Add comment
-	QTest::newRow("Exit Code Overflow: 256cq")
-		<< 256 << 0 << QByteArray("256cq");
+	// Unlike UNIX-like operating systems, Windows represents the exit code as
+	// a signed 32-bit integer. 256 doesn't overflows hence :256cq returns
+	// 256.
+	QTest::newRow("Exit with Code 256: 256cq")
+		<< 256 << 256 << QByteArray("256cq");
 }
 
 } // namespace NeovimQt


### PR DESCRIPTION
In terminal Neovim, we can use `:cq` to indicate that the editor failed to do something.  For example, we can use `:cq` to abort `git commit -v --amend`.  However Neovim-qt always returns 0 whether `:q` or `:cq` is used.  This PR makes the exit status of Neovim-qt to be the same with the inner Neovim's exit status.