### PR TITLE
Issue 650: Add font stretch option to GuiFont

### DIFF
--- a/src/gui/runtime/doc/nvim_gui_shim.txt
+++ b/src/gui/runtime/doc/nvim_gui_shim.txt
@@ -36,6 +36,7 @@ GuiFont		When called with no arguments this command display the
 
 			hXX - height is XX in points (can be floating-point)
 			b   - bold weight
+			sb  - semibold weight
 			l   - light weight
 			i   - italic
 

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -161,7 +161,7 @@ bool Shell::setGuiFont(const QString& fdesc, bool force, bool updateOption)
 			} else if (attr.size() >= 2 && attr[0] == 's') {
 				bool ok{ false };
 				int stretchPercent = attr.mid(1).toInt(&ok);
-				if (!ok || stretchPercent <= 0 || stretchPercent > 100) {
+				if (!ok || stretchPercent <= 0 || stretchPercent > 200) {
 					m_nvim->api0()->vim_report_error("Invalid font stretch");
 					return false;
 				}

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -76,10 +76,12 @@ void Shell::fontError(const QString& msg)
 QString Shell::fontDesc()
 {
 	QString fdesc = QString("%1:h%2").arg(fontFamily()).arg(fontSize());
-	if (font().bold()) {
+	if (font().weight() == QFont::Bold) {
 		fdesc += ":b";
 	} else if (font().weight() == QFont::Light) {
 		fdesc += ":l";
+	} else if (font().weight() == QFont::DemiBold) {
+		fdesc += ":sb";
 	}
 	if (font().italic()) {
 		fdesc += ":i";
@@ -137,6 +139,8 @@ bool Shell::setGuiFont(const QString& fdesc, bool force, bool updateOption)
 				weight = QFont::Bold;
 			} else if (attr == "l") {
 				weight = QFont::Light;
+			} else if (attr == "sb") {
+				weight = QFont::DemiBold;
 			} else if (attr == "i") {
 				italic = true;
 			}

--- a/src/gui/shellwidget/shellwidget.cpp
+++ b/src/gui/shellwidget/shellwidget.cpp
@@ -36,17 +36,35 @@ void ShellWidget::setDefaultFont()
 #else
 #  define DEFAULT_FONT "Monospace"
 #endif
-	setShellFont(DEFAULT_FONT, 11, -1, false, true);
+	setShellFont(DEFAULT_FONT, 11, -1, -1, -1, false, true);
 }
 
-bool ShellWidget::setShellFont(const QString& family, qreal ptSize, int weight, bool italic, bool force)
+bool ShellWidget::setShellFont(
+	const QString& family,
+	qreal ptSize,
+	int weight,
+	int pxSize,
+	int stretch,
+	bool italic,
+	bool force) noexcept
 {
 	QFont f(family, -1, weight, italic);
 	// Issue #575: Clear style name. The KDE/Plasma theme plugin may set this
 	// but we want to match the family name with the bold/italic attributes.
 	f.setStyleName(QStringLiteral(""));
 
-	f.setPointSizeF(ptSize);
+	// FIXME Ugly Code... Write this more eloquently!
+	if (pxSize > 0) {
+		f.setPixelSize(pxSize);
+	} else {
+		f.setPointSize(ptSize);
+	}
+
+	qDebug() << "Stretch:" << stretch;
+	if (stretch > 0 && stretch <= 200) {
+		f.setStretch(stretch);
+	}
+
 	f.setStyleHint(QFont::TypeWriter, QFont::StyleStrategy(QFont::PreferDefault | QFont::ForceIntegerMetrics));
 	f.setFixedPitch(true);
 	f.setKerning(false);

--- a/src/gui/shellwidget/shellwidget.h
+++ b/src/gui/shellwidget/shellwidget.h
@@ -27,7 +27,15 @@ public:
 		Light
 	};
 
-	bool setShellFont(const QString& family, qreal ptSize, int weight = -1, bool italic = false, bool force = false);
+	/// FIXME Doxygen comment!
+	bool setShellFont(
+		const QString& family,
+		qreal ptSize,
+		int weight,
+		int pxSize,
+		int stretch,
+		bool italic,
+		bool force) noexcept;
 
 	QColor background() const;
 	QColor foreground() const;


### PR DESCRIPTION
**NOT READY FOR CHECK-IN**

This Pull Request was opened to distribute a proof of concept build for Issue #650.

Adds an option `:sXX` to GuiFont for setting horizontal font stretch.

Adds an option `:pXX` to GuiFont to set font size based on pixel height.

Example:
`:GuiFont Liberation\ Mono:p20:h110`

The resulting font is 20px high with a horizontal stretch of 110%.
