### PR TITLE
Issue 648: IncSearch not rendered properly with ext_linegrid.

### DIFF
--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -1053,7 +1053,8 @@ void Shell::handleGridLine(const QVariantList& opargs)
 				hl_attr.IsBold(),
 				hl_attr.IsItalic(),
 				hl_attr.IsUnderline(),
-				hl_attr.IsUndercurl());
+				hl_attr.IsUndercurl(),
+				hl_attr.IsReverse());
 
 			col_next++;
 		}

--- a/src/gui/shellwidget/cell.cpp
+++ b/src/gui/shellwidget/cell.cpp
@@ -8,9 +8,9 @@ Cell::Cell(
 	bool bold,
 	bool italic,
 	bool underline,
-	bool undercurl)
-	: m_highlight{ fgColor, bgColor, spColor, false /*reverse*/,
-		italic, bold, underline, undercurl }
+	bool undercurl,
+	bool reverse)
+	: m_highlight{ fgColor, bgColor, spColor, reverse, italic, bold, underline, undercurl }
 {
 	SetCharacter(character);
 };

--- a/src/gui/shellwidget/cell.h
+++ b/src/gui/shellwidget/cell.h
@@ -15,7 +15,8 @@ public:
 		bool bold,
 		bool italic,
 		bool underline,
-		bool undercurl);
+		bool undercurl,
+		bool reverse);
 
 	/// Create an empty Cell with a background color
 	Cell(QColor bgColor)

--- a/src/gui/shellwidget/shellcontents.cpp
+++ b/src/gui/shellwidget/shellcontents.cpp
@@ -221,25 +221,35 @@ const Cell& ShellContents::constValue(int row, int column) const
 }
 
 /// Writes content to the shell, returns the number of columns written
-int ShellContents::put(const QString& str, int row, int column,
-		QColor fg, QColor bg, QColor sp, bool bold, bool italic,
-		bool underline, bool undercurl)
+int ShellContents::put(
+	const QString& str,
+	int row,
+	int column,
+	QColor fg,
+	QColor bg,
+	QColor sp,
+	bool bold,
+	bool italic,
+	bool underline,
+	bool undercurl,
+	bool reverse) noexcept
 {
 	if (row < 0 || row >= _rows || column < 0 || column >= _columns) {
 		return 0;
 	}
 
-	auto vec = str.toUcs4();
+	const QVector<uint> vec{ str.toUcs4() };
 
 	int pos = column;
-	foreach(const uint chr, vec) {
-		Cell& c = value(row, pos);
-		c = Cell(chr, fg, bg, sp, bold, italic, underline, undercurl);
-		if (c.IsDoubleWidth()) {
-			value(row, pos+1) = Cell();
-			pos += 2;
-		} else {
-			pos += 1;
+	for(const uint chr : vec) {
+		Cell& cell{ value(row, pos) };
+		cell = { chr, fg, bg, sp, bold, italic, underline, undercurl, reverse };
+		pos++;
+
+		// Clear neighboring character for double-width cell.
+		if (cell.IsDoubleWidth()) {
+			value(row, pos) = {};
+			pos++;
 		}
 	}
 	return pos - column;

--- a/src/gui/shellwidget/shellcontents.h
+++ b/src/gui/shellwidget/shellcontents.h
@@ -24,10 +24,20 @@ public:
 	const Cell* data();
 	Cell& value(int row, int column);
 	const Cell& constValue(int row, int column) const;
-	int put(const QString&, int row, int column,
-			QColor fg=Qt::black, QColor bg=Qt::white, QColor sp=QColor(),
-			bool bold=false, bool italic=false,
-			bool underline=false, bool undercurl=false);
+
+	/// Insert string `str` into cell grid.
+	int put(
+		const QString& str,
+		int row,
+		int column,
+		QColor fg = {},
+		QColor bg = {},
+		QColor sp = {},
+		bool bold = false,
+		bool italic = false,
+		bool underline = false,
+		bool undercurl = false,
+		bool reverse = false) noexcept;
 
 	void clearAll(QColor bg=QColor());
 	void clearRow(int r, int startCol=0);

--- a/src/gui/shellwidget/shellwidget.cpp
+++ b/src/gui/shellwidget/shellwidget.cpp
@@ -241,7 +241,7 @@ void ShellWidget::paintEvent(QPaintEvent *ev)
 					// of a wide char
 					QColor bgColor{ cell.GetBackgroundColor() };
 					if (!bgColor.isValid()) {
-						bgColor = background();
+						bgColor = (cell.IsReverse()) ? foreground() : background();
 					}
 					p.fillRect(r, bgColor);
 
@@ -255,7 +255,7 @@ void ShellWidget::paintEvent(QPaintEvent *ev)
 					if (cell.GetCharacter() != ' ') {
 						QColor fgColor{ cell.GetForegroundColor() };
 						if (!fgColor.isValid()) {
-							fgColor = foreground();
+							fgColor = (cell.IsReverse()) ? background() : foreground();
 						}
 						p.setPen(fgColor);
 
@@ -436,12 +436,21 @@ const ShellContents& ShellWidget::contents() const
 }
 
 /// Put text in position, returns the amount of colums used
-int ShellWidget::put(const QString& text, int row, int column,
-		QColor fg, QColor bg, QColor sp, bool bold, bool italic,
-		bool underline, bool undercurl)
+int ShellWidget::put(
+	const QString& text,
+	int row,
+	int column,
+	QColor fg,
+	QColor bg,
+	QColor sp,
+	bool bold,
+	bool italic,
+	bool underline,
+	bool undercurl,
+	bool reverse)
 {
 	int cols_changed = m_contents.put(text, row, column, fg, bg, sp,
-				bold, italic, underline, undercurl);
+				bold, italic, underline, undercurl, reverse);
 	if (cols_changed > 0) {
 		QRect rect = absoluteShellRect(row, column, 1, cols_changed);
 		update(rect);

--- a/src/gui/shellwidget/shellwidget.h
+++ b/src/gui/shellwidget/shellwidget.h
@@ -55,10 +55,20 @@ public slots:
 	void setBackground(const QColor& color);
 	void setForeground(const QColor& color);
 	void setDefaultFont();
-	int put(const QString&, int row, int column,
-			QColor fg=QColor(), QColor bg=QColor(), QColor sp=QColor(),
-			bool bold=false, bool italic=false,
-			bool underline=false, bool undercurl=false);
+
+	int put(
+		const QString& text,
+		int row,
+		int column,
+		QColor fg = {},
+		QColor bg = {},
+		QColor sp = {},
+		bool bold = false,
+		bool italic = false,
+		bool underline = false,
+		bool undercurl = false,
+		bool reverse = false);
+
 	void clearRow(int row);
 	void clearShell(QColor bg = QColor::Invalid);
 	void clearRegion(int row0, int col0, int row1, int col1);

--- a/src/gui/shellwidget/test/bench_cell.cpp
+++ b/src/gui/shellwidget/test/bench_cell.cpp
@@ -12,7 +12,7 @@ class Test: public QObject
 private slots:
 	void benchCell() {
 		QBENCHMARK {
-			Cell c('1', Qt::red, Qt::blue, QColor(), false, false, false, false);
+			Cell c('1', Qt::red, Qt::blue, QColor(), false, false, false, false, false);
 		}
 	}
 };

--- a/src/gui/shellwidget/test/test_cell.cpp
+++ b/src/gui/shellwidget/test/test_cell.cpp
@@ -29,13 +29,13 @@ private slots:
 	void cellValue() {
 		QBENCHMARK {
 			Cell c('z', Qt::black, Qt::white, QColor(),
-					false, false, false, false);
+					false, false, false, false, false);
 		}
 	}
 	void cellValueRgb() {
 		QBENCHMARK {
 			Cell c('z', QRgb(33), QRgb(66), QColor(),
-					false, false, false, false);
+					false, false, false, false, false);
 		}
 	}
 


### PR DESCRIPTION
**Fixes Issue #648: Incremental search misbehaving**

With `ext_linegrid` some highlights do not render properly:
QMap(("reverse", QVariant(bool, true)))

Any highlight that uses the default colors and "reverse" does not render in
reverse.

This occurs because the reverse parameter is not actually passed to the
rendering layer in ShellWidget.

Adds the "reverse" flag, so default colors can be determined at render time.
This is necessary to support `set background`.