### PR TITLE
Make the window title match the current tab text

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -353,6 +353,7 @@ void MainWindow::neovimTablineUpdate(int64_t curtab, QList<Tab> tabs)
 
 		if (curtab == tabs[index].tab) {
 			m_tabline->setCurrentIndex(index);
+			setWindowTitle(m_tabline->tabText(index));
 		}
 	}
 
@@ -364,6 +365,7 @@ void MainWindow::neovimTablineUpdate(int64_t curtab, QList<Tab> tabs)
 	} else {
 		m_tabline_bar->setVisible(tabs.size() > 1);
 	}
+
 
 	Q_ASSERT(tabs.size() == m_tabline->count());
 }
@@ -405,6 +407,8 @@ void MainWindow::changeTab(int index)
 
 	int64_t tab = m_tabline->tabData(index).toInt();
 	m_nvim->api2()->nvim_set_current_tabpage(tab);
+
+	setWindowTitle(m_tabline->tabText(index));
 }
 
 void MainWindow::saveWindowGeometry()


### PR DESCRIPTION
Presently the Neovim-qt window title does not contain the name of the file open in the active tab. If there are multiple Neovim windows open at once it is very difficult to tell them apart because of this. This tiny patch sets with window title to match the tab text.