### PR TITLE
Issue 649: Improper cursor redraw for grid_scroll

### DIFF
--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -1114,13 +1114,16 @@ void Shell::handleGridScroll(const QVariantList& opargs)
 
 	m_scroll_region = QRect(QPoint(left, top), QPoint(right, bot));
 
+	// Remove old cursor
 	if (m_scroll_region.contains(m_cursor_pos)) {
-		// Schedule cursor region to be repainted
 		update(neovimCursorRect());
 	}
 
 	scrollShellRegion(m_scroll_region.top(), m_scroll_region.bottom(),
 		m_scroll_region.left(), m_scroll_region.right(), rows);
+
+	// Draw new cursor
+	update(neovimCursorRect());
 
 	emit neovimScrollEvent(rows);
 }


### PR DESCRIPTION
**Issue #649**

The cursor should be updated both before and after scroll events. One will
remove the old cursor and the other will draw the new cursor.

Without both draw events, the `scrolloff` setting can cause artifacts.