### PR TITLE
Issue 663: Option guicursor does not respect busy state

### DIFF
--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -736,6 +736,8 @@ void Shell::handleSetTitle(const QVariantList& opargs)
 
 void Shell::handleBusy(bool busy)
 {
+	m_cursor.SetIsBusy(busy);
+
 	if (busy != m_neovimBusy) {
 		update(neovimCursorRect());
 	}

--- a/src/gui/shellwidget/cursor.h
+++ b/src/gui/shellwidget/cursor.h
@@ -46,14 +46,19 @@ public:
 		m_styleEnabled = isStyleEnabled;
 	}
 
+	void SetIsBusy(bool isBusy) noexcept
+	{
+		m_isBusy = isBusy;
+	}
+
 	bool IsEnabled() const noexcept
 	{
-		return m_styleEnabled;
+		return m_styleEnabled && !m_isBusy;
 	}
 
 	bool IsVisible() const noexcept
 	{
-		return m_styleEnabled && (m_blinkState != BlinkState::Off);
+		return IsEnabled() && (m_blinkState != BlinkState::Off);
 	}
 
 	QColor GetBackgroundColor() const noexcept
@@ -100,6 +105,7 @@ private:
 	BlinkState m_blinkState{ BlinkState::Disabled };
 
 	bool m_styleEnabled{ false };
+	bool m_isBusy{ false };
 
 	uint8_t m_percentage{ 100 };
 


### PR DESCRIPTION
**Issue #663**

The cursor should not be painted when neovim is busy.

Adds logic to mark the cursor for busy_start and busy_stop.