### PR TITLE
Fix build with Qt 5.15

### DIFF
--- a/src/gui/shellwidget/shellwidget.cpp
+++ b/src/gui/shellwidget/shellwidget.cpp
@@ -1,4 +1,5 @@
 #include <QPainter>
+#include <QPainterPath>
 #include <QPaintEvent>
 #include <QDebug>
 #include "shellwidget.h"


### PR DESCRIPTION
QPainterPath is no longer included via qtransform.h (since
5.15.0-beta2, 50d2acdc93b4de2ba56eb67787e2bdcb21dd4bea in qtbase.git).