### PR TITLE
Version argument incorrect, stale at 0.2.14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,9 @@ if (POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)
 endif (POLICY CMP0048)
 
-project(neovim-qt VERSION 0.2.14.0)
+# Neovim-Qt Version, used by --version update before release
+# 9999 = Development Pre-Release
+project(neovim-qt VERSION 0.2.16.9999)
 
 INCLUDE(CPack)
 


### PR DESCRIPTION
The 0.2.15 release contained a stale version entry of 0.2.14.

I am updating the value now to 0.2.16. Since this is not a real release, I have added a 9999 to the least significant revision number to indicate this is the git `master` branch.

This `9999` will provide useful information when users give `--version` debug output.