### PR TITLE
Issue 661: GuiScrollBar split change causes cursor jump

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -390,6 +390,11 @@ void MainWindow::setGuiScrollBarVisible(bool isEnabled)
 
 void MainWindow::neovimCursorMovedUpdateScrollBar(uint64_t minLineVisible, uint64_t bufferSize, uint64_t windowHeight)
 {
+	if (!m_rightScrollBar->isVisible())
+	{
+		return;
+	}
+
 	m_rightScrollBar->setMaximum(bufferSize);
 	m_rightScrollBar->setPageStep(windowHeight);
 
@@ -405,6 +410,11 @@ void MainWindow::neovimCursorMovedUpdateScrollBar(uint64_t minLineVisible, uint6
 
 void MainWindow::neovimScrollEvent(int64_t rows)
 {
+	if (!m_rightScrollBar->isVisible())
+	{
+		return;
+	}
+
 	// Prevent double-registration of scroll event. See m_scrollbarLastDelta for details.
 	if (rows == m_scrollbarLastDelta)
 	{


### PR DESCRIPTION
Fixes the issue for `:GuiScrollBar 0` events should not be sent when the feature is not enabled.

This does not resolve Issue 661, the buffer change is still incorrectly classified as a scroll event.