### PR TITLE
Issue 659: Add custom GuiDrop handler

### DIFF
--- a/src/gui/runtime/doc/nvim_gui_shim.txt
+++ b/src/gui/runtime/doc/nvim_gui_shim.txt
@@ -131,7 +131,10 @@ Replaces |'linespace'|.
 							*GuiDrop()*
 GuiDrop(...) is a wrapper around |:drop| it escapes all given arguments
 using |fnameescape()| and then passes them to :drop. This is useful if
-the GUI is requesting Neovim to open additional files.
+the GUI is requesting Neovim to open additional files. A custom implementation
+may be provided to override the default behavior, GuiDropCustom.
+GuiDropCustomHandler should accept an arbitrary number of file paths as arguments.
+Each argument should be processed, escaped, and passed to :drop.
 
 							*GuiMousehide()*
 GuiMousehide(enabled) enables mouse hiding while typing. If enabled is

--- a/src/gui/runtime/plugin/nvim_gui_shim.vim
+++ b/src/gui/runtime/plugin/nvim_gui_shim.vim
@@ -99,6 +99,11 @@ command! -nargs=1 GuiPopupmenu call s:GuiPopupmenu(<args>)
 " GuiDrop('file1', 'file2', ...) is similar to :drop file1 file2 ...
 " but it calls fnameescape() over all arguments
 function GuiDrop(...)
+	" Check for user defined handler function
+	if exists('*GuiDropCustomHandler')
+		return call("GuiDropCustomHandler", a:000)
+	endif
+
 	let l:fnames = deepcopy(a:000)
 	let l:args = map(l:fnames, 'fnameescape(v:val)')
 	exec 'drop '.join(l:args, ' ')


### PR DESCRIPTION
**Issue #659**

Adds an easy entry point `:GuiDropCustom` for the user to override the default `:GuiDrop` behavior. This is useful for altering the open behavior of nvim-qt.

Example:
```
" Echos the full path of any file opened in TreeView or DragDrop,
function! GuiDropCustom(...)
	let l:fnames = deepcopy(a:000)
	let l:args = map(l:fnames, 'fnameescape(v:val)')

	for l:file in l:args
		echo "You just opened: " . l:file
		exec 'drop '.join(l:file, ' ')
	endfor
endfunction
```