### PR TITLE
Issue 671: Ignore volume keys

### DIFF
--- a/src/gui/input.cpp
+++ b/src/gui/input.cpp
@@ -195,6 +195,14 @@ QString convertKey(const QKeyEvent& ev) noexcept
 			return {};
 		}
 
+		// Ignore special keys
+		//   Issue#671: `q`/`p`/`r` key is sent by Mute/Volume DOWN/Volume UP
+		if (key == Qt::Key::Key_VolumeDown
+			|| key == Qt::Key::Key_VolumeMute
+			|| key == Qt::Key::Key_VolumeUp) {
+			return {};
+		}
+
 		// If QKeyEvent does not provide text, then use the value of key
 		//   Issue#579: Cannot map <A-...> on MacOS
 		text = QChar{ key };

--- a/test/tst_input_common.cpp
+++ b/test/tst_input_common.cpp
@@ -9,6 +9,7 @@ class TestInputCommon : public QObject
 private slots:
 	void LessThanKey() noexcept;
 	void ModifierOnlyKeyEventsIgnored() noexcept;
+	void VolumeKeysIgnored() noexcept;
 	void ShiftKeyEventWellFormed() noexcept;
 	void CapsLockIgnored() noexcept;
 	void AltGrAloneIgnored() noexcept;
@@ -66,6 +67,19 @@ void TestInputCommon::ModifierOnlyKeyEventsIgnored() noexcept
 	// Issue#593: Pressing Control + Super inserts ^S
 	QKeyEvent evIssue593{ QEvent::KeyPress, Qt::Key::Key_Super_L, Qt::KeyboardModifier::ControlModifier};
 	QCOMPARE(NeovimQt::Input::convertKey(evIssue593), QString{});
+}
+
+void TestInputCommon::VolumeKeysIgnored() noexcept
+{
+	const QList<Qt::Key> volumeKeysList {
+		Qt::Key::Key_VolumeDown,
+		Qt::Key::Key_VolumeMute,
+		Qt::Key::Key_VolumeUp,
+	};
+	for (const auto &key : volumeKeysList) {
+		QKeyEvent keyEvent{ QEvent::KeyPress, key, Qt::KeyboardModifier::NoModifier };
+		QCOMPARE(NeovimQt::Input::convertKey(keyEvent), QString{});
+	}
 }
 
 void TestInputCommon::AltGrAloneIgnored() noexcept


### PR DESCRIPTION
**Issue #671**
Fix the issue that pressing volume keys produces `p`, `q` or `r` key event. For now just ignore volume keys. I checked there are no other keys causing this kind of problem in my keyboard (mute mic, brightness down/up) but there might be other keys causing this problem.