### PR TITLE
Issue 674: Render `gui=reverse` color correctly

### DIFF
--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -1056,16 +1056,7 @@ void Shell::handleGridLine(const QVariantList& opargs)
 		// Send GUI updates to 'ShellWidget'.
 		for (uint64_t i=0;i<repeat;i++)
 		{
-			put(text, row, col_next,
-				hl_attr.GetForegroundColor(),
-				hl_attr.GetBackgroundColor(),
-				hl_attr.GetSpecialColor(),
-				hl_attr.IsBold(),
-				hl_attr.IsItalic(),
-				hl_attr.IsUnderline(),
-				hl_attr.IsUndercurl(),
-				hl_attr.IsReverse());
-
+			put(text, row, col_next, hl_attr);
 			col_next++;
 		}
 	}

--- a/src/gui/shellwidget/cell.cpp
+++ b/src/gui/shellwidget/cell.cpp
@@ -1,20 +1,5 @@
 #include "cell.h"
 
-Cell::Cell(
-	uint character,
-	QColor fgColor,
-	QColor bgColor,
-	QColor spColor,
-	bool bold,
-	bool italic,
-	bool underline,
-	bool undercurl,
-	bool reverse)
-	: m_highlight{ fgColor, bgColor, spColor, reverse, italic, bold, underline, undercurl }
-{
-	SetCharacter(character);
-};
-
 /*static*/ Cell Cell::MakeInvalidCell()
 {
 	Cell invalidCell;

--- a/src/gui/shellwidget/cell.h
+++ b/src/gui/shellwidget/cell.h
@@ -7,6 +7,13 @@
 
 class Cell {
 public:
+	/// Create a cell having a specified HighlightAttribute
+	Cell(uint character, const HighlightAttribute& attribute) noexcept :
+		m_highlight(attribute)
+	{
+		SetCharacter(character);
+	}
+
 	Cell(
 		uint character,
 		QColor fgColor,
@@ -16,12 +23,18 @@ public:
 		bool italic,
 		bool underline,
 		bool undercurl,
-		bool reverse);
+		bool reverse) noexcept :
+		Cell{
+			character,
+			{ fgColor, bgColor, spColor, reverse, italic, bold, underline, undercurl } }
+	{
+	}
 
 	/// Create an empty Cell with a background color
-	Cell(QColor bgColor)
-		: m_highlight{ QColor::Invalid, bgColor, QColor::Invalid,
-			false, false, false, false, false }
+	Cell(QColor bgColor) noexcept :
+		Cell{
+			' ',
+			{ QColor::Invalid, bgColor, QColor::Invalid, false, false, false, false, false } }
 	{
 	}
 

--- a/src/gui/shellwidget/shellcontents.cpp
+++ b/src/gui/shellwidget/shellcontents.cpp
@@ -225,14 +225,7 @@ int ShellContents::put(
 	const QString& str,
 	int row,
 	int column,
-	QColor fg,
-	QColor bg,
-	QColor sp,
-	bool bold,
-	bool italic,
-	bool underline,
-	bool undercurl,
-	bool reverse) noexcept
+	const HighlightAttribute& hl_attr) noexcept
 {
 	if (row < 0 || row >= _rows || column < 0 || column >= _columns) {
 		return 0;
@@ -243,7 +236,7 @@ int ShellContents::put(
 	int pos = column;
 	for(const uint chr : vec) {
 		Cell& cell{ value(row, pos) };
-		cell = { chr, fg, bg, sp, bold, italic, underline, undercurl, reverse };
+		cell = { chr, hl_attr };
 		pos++;
 
 		// Clear neighboring character for double-width cell.

--- a/src/gui/shellwidget/shellcontents.h
+++ b/src/gui/shellwidget/shellcontents.h
@@ -30,14 +30,7 @@ public:
 		const QString& str,
 		int row,
 		int column,
-		QColor fg = {},
-		QColor bg = {},
-		QColor sp = {},
-		bool bold = false,
-		bool italic = false,
-		bool underline = false,
-		bool undercurl = false,
-		bool reverse = false) noexcept;
+		const HighlightAttribute& hl_attr = {}) noexcept;
 
 	void clearAll(QColor bg=QColor());
 	void clearRow(int r, int startCol=0);

--- a/src/gui/shellwidget/shellwidget.cpp
+++ b/src/gui/shellwidget/shellwidget.cpp
@@ -450,8 +450,18 @@ int ShellWidget::put(
 	bool undercurl,
 	bool reverse)
 {
-	int cols_changed = m_contents.put(text, row, column, fg, bg, sp,
-				bold, italic, underline, undercurl, reverse);
+	HighlightAttribute hl_attr = { fg, bg, sp,
+		reverse, italic, bold, underline, undercurl };
+	return put(text, row, column, hl_attr);
+}
+
+int ShellWidget::put(
+	const QString& text,
+	int row,
+	int column,
+	const HighlightAttribute& hl_attr)
+{
+	int cols_changed = m_contents.put(text, row, column, hl_attr);
 	if (cols_changed > 0) {
 		QRect rect = absoluteShellRect(row, column, 1, cols_changed);
 		update(rect);

--- a/src/gui/shellwidget/shellwidget.h
+++ b/src/gui/shellwidget/shellwidget.h
@@ -69,6 +69,12 @@ public slots:
 		bool undercurl = false,
 		bool reverse = false);
 
+	int put(
+		const QString& text,
+		int row,
+		int column,
+		const HighlightAttribute& hl_attr);
+
 	void clearRow(int row);
 	void clearShell(QColor bg = QColor::Invalid);
 	void clearRegion(int row0, int col0, int row1, int col1);


### PR DESCRIPTION
**Issue #674**
To fix the issue, I added other variants of the related functions which takes a HighlightAttribute and pass the highlight attribute directly instead of reconstructing one. I'd be happy to change the implementation if I should solve this issue in a different way.