### PR TITLE
Add win_viewport support for GuiScrollBar

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -48,6 +48,7 @@ add_library(neovim-qt-gui
 	mainwindow.cpp
 	popupmenu.cpp
 	popupmenumodel.cpp
+	scrollbar.cpp
 	shell.cpp
 	treeview.cpp
 	${SRCS_PLATFORM}

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -4,11 +4,11 @@
 #include <QMainWindow>
 #include <QStackedWidget>
 #include <QTabBar>
-#include <QScrollBar>
 #include <QSplitter>
 #include "treeview.h"
 #include "neovimconnector.h"
 #include "errorwidget.h"
+#include "scrollbar.h"
 #include "shell.h"
 
 namespace NeovimQt {
@@ -58,10 +58,6 @@ private slots:
 	void extTablineSet(bool);
 	void changeTab(int index);
 	void saveWindowGeometry();
-	void setGuiScrollBarVisible(bool isVisible);
-	void neovimCursorMovedUpdateScrollBar(
-		uint64_t minLineVisible, uint64_t bufferSize, uint64_t windowHeigt);
-	void neovimScrollEvent(int64_t rows);
 
 private:
 	void init(NeovimConnector *);
@@ -81,12 +77,7 @@ private:
 	QAction *m_actCopy;
 	QAction *m_actPaste;
 	QAction *m_actSelectAll;
-	QScrollBar *m_rightScrollBar;
-
-	/// The scrollbar updates on cursor movement and GUI paint/scroll events.
-	/// In cases where the scroll event triggers cursor movement, this can result
-	/// in double registration. Detect and ignore this double registration.
-	int m_scrollbarLastDelta{ 0 };
+	ScrollBar *m_scrollbar;
 };
 
 } // Namespace

--- a/src/gui/runtime/plugin/nvim_gui_shim.vim
+++ b/src/gui/runtime/plugin/nvim_gui_shim.vim
@@ -217,14 +217,14 @@ function GuiShowContextMenu() range
 endfunction
 
 " Notify Gui of any cursor movement, used by GuiScrollBar
-function s:GuiCursorMovedUpdateScrollBar()
+function s:GuiCursorMoved()
 	let l:minLineVisible = line('w0')
 	let l:bufferSize = line('$')
 	let l:windowHeight = winheight(winnr())
-	call rpcnotify(0, 'Gui', 'CursorMovedUpdateScrollBar', l:minLineVisible, l:bufferSize, l:windowHeight)
+	call rpcnotify(0, 'Gui', 'CursorMoved', l:minLineVisible, l:bufferSize, l:windowHeight)
 endfunction
 
-autocmd CursorMoved,CursorMovedI,VimResized * call <SID>GuiCursorMovedUpdateScrollBar()
+autocmd CursorMoved,CursorMovedI,VimResized * call <SID>GuiCursorMoved()
 
 " Show/Hide the Gui ScrollBar
 function! s:GuiScrollBar(enable) abort

--- a/src/gui/scrollbar.cpp
+++ b/src/gui/scrollbar.cpp
@@ -1,0 +1,224 @@
+#include "scrollbar.h"
+
+#include "shell.h"
+
+namespace NeovimQt {
+
+ScrollBar::ScrollBar(NeovimConnector* nvim, QWidget* parent) noexcept
+	: QScrollBar{ parent }
+	, m_nvim{ nvim }
+{
+	if (!m_nvim) {
+		qFatal("Fatal Error: ScrollBar must have a valid NeovimConnector!");
+	}
+
+	connect(m_nvim, &NeovimConnector::ready, this, &ScrollBar::neovimConnectorReady);
+	connect(this, &QScrollBar::valueChanged, this, &ScrollBar::handleValueChanged);
+
+	setVisible(false);
+	setMinimum(1);
+}
+
+void ScrollBar::neovimConnectorReady() noexcept
+{
+	connect(m_nvim->api0(), &NeovimApi0::neovimNotification,
+		this, &ScrollBar::handleNeovimNotification);
+
+	m_nvim->api0()->vim_subscribe("Gui");
+}
+
+bool ScrollBar::IsWinViewportSupported() const noexcept
+{
+	static const bool isSupported{ m_nvim->apiLevel() >= 7 };
+	return isSupported;
+}
+
+void ScrollBar::handleNeovimNotification(const QByteArray& name, const QVariantList& args) noexcept
+{
+	if (args.size() <= 0) {
+		return;
+	}
+
+	if (name == "Gui") {
+		const QString guiEvName{ m_nvim->decode(args.at(0).toByteArray()) };
+
+		if (guiEvName == "CursorMoved") {
+			handleCursorMoved(args);
+			return;
+		}
+
+		if (guiEvName == "SetScrollBarVisible") {
+			handleSetScrollBarVisible(args);
+			return;
+		}
+	}
+
+	if (name == "redraw") {
+		Shell::DispatchRedrawNotifications<ScrollBar>(this, args);
+		return;
+	}
+}
+
+void ScrollBar::handleRedraw(const QByteArray& name, const QVariantList& args) noexcept
+{
+	if (name == "grid_scroll") {
+		handleGridScroll(args);
+		return;
+	}
+
+	if (name == "scroll") {
+		handleScroll(args);
+		return;
+	}
+
+	if (name == "win_viewport") {
+		handleWinViewport(args);
+		return;
+	}
+}
+
+void ScrollBar::setIsVisible(bool isVisible)
+{
+	setVisible(isVisible);
+}
+
+void ScrollBar::setAbsolutePosition(uint64_t minLine, uint64_t bufferSize, uint64_t windowHeight)
+{
+	setMaximum(bufferSize);
+	setPageStep(windowHeight);
+
+	m_lineScrollLockout -= m_lastKnownPosition - minLine;
+
+	m_lastKnownPosition = minLine;
+	m_lastKnownBufferSize = bufferSize;
+	m_lastKnownWindowHeight = windowHeight;
+
+	// Block valueChanged signals for scroll events triggered by Neovim.
+	{
+		QSignalBlocker blockValueChanged{ this };
+		setSliderPosition(minLine);
+	}
+}
+
+void ScrollBar::setRelativePosition(int64_t rowCount)
+{
+	m_lineScrollLockout -= rowCount;
+
+	// Block valueChanged signals for scroll events triggered by Neovim.
+	{
+		QSignalBlocker blockValueChanged{ this };
+		setSliderPosition(sliderPosition() + rowCount);
+	}
+}
+
+void ScrollBar::handleScroll(const QVariantList& args) noexcept
+{
+	// With win_viewport supported, scroll events aren't needed.
+	if (IsWinViewportSupported()) {
+		return;
+	}
+
+	if (args.size() < 1 || !args.at(0).canConvert<int64_t>()) {
+		return;
+	}
+
+	const int64_t count{ args.at(0).toLongLong() };
+
+	setRelativePosition(count);
+}
+
+void ScrollBar::handleGridScroll(const QVariantList& args) noexcept
+{
+	// With win_viewport supported, scroll events aren't needed.
+	if (IsWinViewportSupported()) {
+		return;
+	}
+
+	if (args.size() < 6 || !args.at(5).canConvert<uint64_t>()) {
+		return;
+	}
+
+	const int64_t rows{ args.at(5).toLongLong() };
+
+	setRelativePosition(rows);
+}
+
+void ScrollBar::handleWinViewport(const QVariantList& args) noexcept
+{
+	if (args.size() < 6
+		|| !args.at(0).canConvert<uint64_t>()
+		|| !args.at(1).canConvert<uint64_t>()
+		|| !args.at(2).canConvert<uint64_t>()
+		|| !args.at(3).canConvert<uint64_t>()
+		|| !args.at(4).canConvert<uint64_t>()
+		|| !args.at(5).canConvert<uint64_t>()) {
+		qWarning() << "Unexpected arguments for win_viewport:" << args;
+		return;
+	}
+
+	//const uint64_t grid { args.at(0).toULongLong() };
+	//const uint64_t win { args.at(1).toULongLong() };
+	//const uint64_t botline { args.at(3).toULongLong() };
+	//const uint64_t curline { args.at(4).toULongLong() };
+	//const uint64_t curcol { args.at(5).toULongLong() };
+
+	const uint64_t topline { args.at(2).toULongLong() };
+
+	setAbsolutePosition(topline, m_lastKnownBufferSize, m_lastKnownWindowHeight);
+}
+
+
+void ScrollBar::handleCursorMoved(const QVariantList& args) noexcept
+{
+	if (args.size() < 4
+		|| !args.at(1).canConvert<uint64_t>()
+		|| !args.at(2).canConvert<uint64_t>()
+		|| !args.at(3).canConvert<uint64_t>()) {
+		qWarning() << "Unexpected arguments for CursorMoved:" << args;
+		return;
+	}
+
+	const uint64_t minLineVisible{ args.at(1).toULongLong() };
+	const uint64_t bufferSize{ args.at(2).toULongLong() };
+	const uint64_t windowHeight{ args.at(3).toULongLong() };
+
+	setAbsolutePosition(minLineVisible, bufferSize, windowHeight);
+}
+
+void ScrollBar::handleSetScrollBarVisible(const QVariantList& args) noexcept
+{
+	if (args.size() < 2
+		|| !args.at(1).canConvert<bool>()) {
+		qWarning() << "Unexpected arguments for SetScrollBarVisible:" << args;
+		return;
+	}
+
+	const bool isVisible{ args.at(1).toBool() };
+	setVisible(isVisible);
+}
+
+void ScrollBar::handleValueChanged(int value)
+{
+	const int delta{ m_lastKnownPosition - value};
+	if (delta == 0) {
+		return;
+	}
+
+	m_lineScrollLockout += delta;
+
+	// Scroll Up: normal! {Control + Y}
+	// MSVC cannot parse the un-escaped sequence below `^Y`.
+	if (delta > 0) {
+		m_nvim->api0()->vim_command(
+			QStringLiteral("normal! %1\031").arg(delta).toLatin1());
+	}
+
+	// Scroll Down normal! {Control + E}
+	// MSVC cannot parse the un-escaped sequence below `^E`.
+	if (delta < 0) {
+		m_nvim->api0()->vim_command(
+			QStringLiteral("normal! %1\005").arg(delta).toLatin1());
+	}
+}
+
+} // namespace NeovimQt

--- a/src/gui/scrollbar.cpp
+++ b/src/gui/scrollbar.cpp
@@ -84,9 +84,6 @@ void ScrollBar::setIsVisible(bool isVisible)
 
 void ScrollBar::setAbsolutePosition(uint64_t minLine, uint64_t bufferSize, uint64_t windowHeight)
 {
-	setMaximum(bufferSize);
-	setPageStep(windowHeight);
-
 	m_lineScrollLockout -= m_lastKnownPosition - minLine;
 
 	m_lastKnownPosition = minLine;
@@ -96,6 +93,9 @@ void ScrollBar::setAbsolutePosition(uint64_t minLine, uint64_t bufferSize, uint6
 	// Block valueChanged signals for scroll events triggered by Neovim.
 	{
 		QSignalBlocker blockValueChanged{ this };
+
+		setMaximum(bufferSize);
+		setPageStep(windowHeight);
 		setSliderPosition(minLine);
 	}
 }
@@ -107,6 +107,7 @@ void ScrollBar::setRelativePosition(int64_t rowCount)
 	// Block valueChanged signals for scroll events triggered by Neovim.
 	{
 		QSignalBlocker blockValueChanged{ this };
+
 		setSliderPosition(sliderPosition() + rowCount);
 	}
 }

--- a/src/gui/scrollbar.h
+++ b/src/gui/scrollbar.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <QScrollBar>
+
+#include "neovimconnector.h"
+
+namespace NeovimQt {
+
+class ScrollBar : public QScrollBar
+{
+	Q_OBJECT
+
+public:
+	ScrollBar(NeovimConnector* nvim, QWidget* parent = nullptr) noexcept;
+
+	/// Checks the nvim client for support of win_viewport events.
+	bool IsWinViewportSupported() const noexcept;
+
+	void handleNeovimNotification(const QByteArray& name, const QVariantList& args) noexcept;
+	void handleRedraw(const QByteArray& name, const QVariantList& opargs) noexcept;
+
+public slots:
+	void setIsVisible(bool isVisible);
+	void setAbsolutePosition(uint64_t minLine, uint64_t bufferSize, uint64_t windowHeight);
+	void setRelativePosition(int64_t rowCount);
+
+private:
+	void neovimConnectorReady() noexcept;
+
+	// Gui Events
+	void handleCursorMoved(const QVariantList& opargs) noexcept;
+	void handleSetScrollBarVisible(const QVariantList& opargs) noexcept;
+
+	// Redraw Events
+	void handleGridScroll(const QVariantList& opargs) noexcept;
+	void handleScroll(const QVariantList& opargs) noexcept;
+	void handleWinViewport(const QVariantList& opargs) noexcept;
+
+	/// Attached to valueChanged signal. Sends scroll commands to Neovim API.
+	void handleValueChanged(int value);
+
+	NeovimConnector *m_nvim{ nullptr };
+
+	/// Locks out GUI triggered scrolling for a number of lines. Prevent double registration.
+	int m_lineScrollLockout{ 0 };
+
+	/// Last known cursor position. Cursor position is in absolute units, and scroll
+	/// commands are sent with relative units. Necessary for conversion.
+	int m_lastKnownPosition{ 0 };
+
+	/// Workaround for win_viewport. Saves buffer size from last cursor movement.
+	int m_lastKnownBufferSize{ 0 };
+
+	/// Workaround for win_viewport. Saves window height from last cursor movement.
+	int m_lastKnownWindowHeight{ 0 };
+};
+
+} // namespace NeovimQt

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -380,8 +380,6 @@ void Shell::handleScroll(const QVariantList& args)
 	scrollShellRegion(m_scroll_region.top(), m_scroll_region.bottom(),
 			m_scroll_region.left(), m_scroll_region.right(),
 			count);
-
-	emit neovimScrollEvent(count);
 }
 
 void Shell::handleSetScrollRegion(const QVariantList& opargs)
@@ -542,8 +540,8 @@ void Shell::handleRedraw(const QByteArray& name, const QVariantList& opargs)
 	} else if (name == "grid_scroll") {
 		handleGridScroll(opargs);
 	} else if (name == "hl_group_set") {
-	}
-	else {
+	} else if (name == "win_viewport") {
+	} else {
 		qDebug() << "Received unknown redraw notification" << name << opargs;
 	}
 
@@ -828,41 +826,13 @@ void Shell::handleNeovimNotification(const QByteArray &name, const QVariantList&
 			QGuiApplication::clipboard()->setMimeData(clipData, clipboard);
 		} else if (guiEvName == "ShowContextMenu") {
 			emit neovimShowContextMenu();
-		} else if (guiEvName == "CursorMovedUpdateScrollBar") {
-			handleCursorMovedUpdateScrollBar(args);
-		} else if (guiEvName == "SetScrollBarVisible") {
-			handleSetScrollBarVisible(args);
 		}
 		return;
 	} else if (name != "redraw") {
 		return;
 	}
 
-	foreach(const QVariant& update_item, args) {
-		if ((QMetaType::Type)update_item.type() != QMetaType::QVariantList) {
-			qWarning() << "Received unexpected redraw operation" << update_item;
-			continue;
-		}
-
-		const QVariantList& redrawupdate = update_item.toList();
-		if (redrawupdate.size() < 2) {
-			qWarning() << "Received unexpected redraw operation" << update_item;
-			continue;
-		}
-
-		const QByteArray& name = redrawupdate.at(0).toByteArray();
-		const QVariantList& update_args = redrawupdate.mid(1);
-
-		foreach (const QVariant& opargs_var, update_args) {
-			if ((QMetaType::Type)opargs_var.type() != QMetaType::QVariantList) {
-				qWarning() << "Received unexpected redraw arguments, expecting list" << opargs_var;
-				continue;
-			}
-
-			const QVariantList& opargs = opargs_var.toList();
-			handleRedraw(name, opargs);
-		}
-	}
+	DispatchRedrawNotifications(this, args);
 }
 
 void Shell::handleExtGuiOption(const QString& name, const QVariant& value)
@@ -1126,39 +1096,6 @@ void Shell::handleGridScroll(const QVariantList& opargs)
 
 	// Draw new cursor
 	update(neovimCursorRect());
-
-	emit neovimScrollEvent(rows);
-}
-
-void Shell::handleCursorMovedUpdateScrollBar(const QVariantList& opargs) noexcept
-{
-	if (opargs.size() < 4
-		|| !opargs.at(1).canConvert<uint64_t>()
-		|| !opargs.at(2).canConvert<uint64_t>()
-		|| !opargs.at(3).canConvert<uint64_t>()) {
-		qWarning() << "Unexpected arguments for CursorMovedUpdateScrollBar:" << opargs;
-		return;
-	}
-
-	const uint64_t minLineVisible{ opargs.at(1).toULongLong() };
-	const uint64_t bufferSize{ opargs.at(2).toULongLong() };
-	const uint64_t windowHeight{ opargs.at(3).toULongLong() };
-
-	m_lastScrollBarPosition = minLineVisible;
-
-	emit neovimCursorMovedUpdateScrollBar(minLineVisible, bufferSize, windowHeight);
-}
-
-void Shell::handleSetScrollBarVisible(const QVariantList& opargs) noexcept
-{
-	if (opargs.size() < 2
-		|| !opargs.at(1).canConvert<bool>()) {
-		qWarning() << "Unexpected arguments for SetScrollBarVisible:" << opargs;
-		return;
-	}
-
-	const bool isVisible{ opargs.at(1).toBool() };
-	emit setGuiScrollBarVisible(isVisible);
 }
 
 void Shell::paintEvent(QPaintEvent *ev)
@@ -1696,35 +1633,6 @@ void Shell::openFiles(QList<QUrl> urls)
 		// Neovim cannot open urls now. Store them to open later.
 		m_deferredOpen.append(urls);
 	}
-}
-
-void Shell::handleScrollBarChanged(int position)
-{
-	if (m_lastScrollBarPosition == position) {
-		return;
-	}
-
-	const int delta{ m_lastScrollBarPosition - position };
-
-	if (delta == 0) {
-		return;
-	}
-
-	// Scroll Up: normal! {Control + Y}
-	if (delta > 0) {
-		m_nvim->api0()->vim_command(
-			QStringLiteral("normal! %1\031").arg(delta).toLatin1());
-	}
-
-	// Scroll Down normal! {Control + E}
-	if (delta < 0) {
-		m_nvim->api0()->vim_command(
-			QStringLiteral("normal! %1\005").arg(delta).toLatin1());
-	}
-
-	// NOTE: MSVC cannot parse the unescaped sequences above: `^E` and `^Y`.
-
-	m_lastScrollBarPosition = position;
 }
 
 // If neovim is blocked waiting for input, attempt to bailout from


### PR DESCRIPTION
**Issue #661:**

Adds support for `win_viewport` event from neovim/neovim#11748.

The GuiScrollBar implementation has been isolated, and moved to `scrollbar.cpp`. This separates some of the `Shell` events, and reduces the required number of signal/slot connections.

Issue 661 was caused by `QScrollBar::setMinimum` triggering the `valueChanged` signal when buffer size goes from larger to smaller. `QScrollBar` properties should be set within a `QSignalBlocker` scope.

Basic GuiScrollBar scenarios should now work regardless of `win_viewport` support.