### PR TITLE
Issue 170: Send <C-6> as <C-^>

### DIFF
--- a/src/gui/input.cpp
+++ b/src/gui/input.cpp
@@ -175,6 +175,14 @@ QString convertKey(const QKeyEvent& ev) noexcept
 		return ToKeyString(GetModifierPrefix(modNoShift), "lt");
 	}
 
+	// Issue#170: Normalize modifiers, CTRL+^ always sends as <C-^>
+	const bool isCaretKey{ key == Qt::Key_6 || key == Qt::Key_AsciiCircum };
+	if (isCaretKey && mod & ControlModifier()) {
+		const Qt::KeyboardModifiers modNoShiftMeta{
+			mod & ~Qt::KeyboardModifier::ShiftModifier & ~CmdModifier() };
+		return ToKeyString(GetModifierPrefix(modNoShiftMeta), "^");
+	}
+
 	if (text == "\\") {
 		return ToKeyString(GetModifierPrefix(mod), "Bslash");
 	}

--- a/test/tst_input_mac.cpp
+++ b/test/tst_input_mac.cpp
@@ -11,6 +11,7 @@ private slots:
 	void LessThanModifierKeys() noexcept;
 	void SpecialKeys() noexcept;
 	void KeyboardLayoutUnicodeHexInput() noexcept;
+	void CtrlCaretWellFormed() noexcept;
 };
 
 void TestInputMac::AltSpecialCharacters() noexcept
@@ -73,6 +74,19 @@ void TestInputMac::KeyboardLayoutUnicodeHexInput() noexcept
 	QKeyEvent evCtrlAltShiftA{ QEvent::KeyPress, Qt::Key_A,
 		Qt::MetaModifier | Qt::AltModifier | Qt::ShiftModifier };
 	QCOMPARE(NeovimQt::Input::convertKey(evCtrlAltShiftA), QString{ "<C-A-A>" });
+}
+
+void TestInputMac::CtrlCaretWellFormed() noexcept
+{
+	QKeyEvent evCtrl6{ QEvent::KeyPress, Qt::Key_6, Qt::MetaModifier };
+	QCOMPARE(NeovimQt::Input::convertKey(evCtrl6), QString{ "<C-^>" });
+
+	QKeyEvent evCtrlShift6{ QEvent::KeyPress, Qt::Key_AsciiCircum, Qt::MetaModifier | Qt::ShiftModifier };
+	QCOMPARE(NeovimQt::Input::convertKey(evCtrlShift6), QString{ "<C-^>" });
+
+	QKeyEvent evCtrlShiftMeta6{ QEvent::KeyPress, Qt::Key_AsciiCircum,
+		Qt::MetaModifier | Qt::ShiftModifier | Qt::ControlModifier };
+	QCOMPARE(NeovimQt::Input::convertKey(evCtrlShiftMeta6), QString{ "<C-^>" });
 }
 
 #include "tst_input_mac.moc"

--- a/test/tst_input_unix.cpp
+++ b/test/tst_input_unix.cpp
@@ -9,6 +9,7 @@ class TestInputUnix : public QObject
 private slots:
 	void LessThanModifierKeys() noexcept;
 	void SpecialKeys() noexcept;
+	void CtrlCaretWellFormed() noexcept;
 };
 
 void TestInputUnix::LessThanModifierKeys() noexcept
@@ -41,6 +42,19 @@ void TestInputUnix::SpecialKeys() noexcept
 				keyEvent.second.arg(specialKeys.value(k)));
 		}
 	}
+}
+
+void TestInputUnix::CtrlCaretWellFormed() noexcept
+{
+	QKeyEvent evCtrl6{ QEvent::KeyPress, Qt::Key_6, Qt::ControlModifier, { "\u001E" } };
+	QCOMPARE(NeovimQt::Input::convertKey(evCtrl6), QString{ "<C-^>" });
+
+	QKeyEvent evCtrlShift6{ QEvent::KeyPress, Qt::Key_AsciiCircum, Qt::ControlModifier | Qt::ShiftModifier, { "\u001E" } };
+	QCOMPARE(NeovimQt::Input::convertKey(evCtrlShift6), QString{ "<C-^>" });
+
+	QKeyEvent evCtrlShiftMeta6{ QEvent::KeyPress, Qt::Key_AsciiCircum,
+		Qt::MetaModifier | Qt::ShiftModifier | Qt::ControlModifier , { "\u001E" } };
+	QCOMPARE(NeovimQt::Input::convertKey(evCtrlShiftMeta6), QString{ "<C-^>" });
 }
 
 #include "tst_input_unix.moc"

--- a/test/tst_input_win32.cpp
+++ b/test/tst_input_win32.cpp
@@ -9,6 +9,7 @@ class TestInputWin32 : public QObject
 private slots:
 	void LessThanModifierKeys() noexcept;
 	void SpecialKeys() noexcept;
+	void CtrlCaretWellFormed() noexcept;
 };
 
 void TestInputWin32::LessThanModifierKeys() noexcept
@@ -41,6 +42,15 @@ void TestInputWin32::SpecialKeys() noexcept
 				keyEvent.second.arg(specialKeys.value(k)));
 		}
 	}
+}
+
+void TestInputWin32::CtrlCaretWellFormed() noexcept
+{
+	QKeyEvent evCtrl6{ QEvent::KeyPress, Qt::Key_6, Qt::ControlModifier, { "6" } };
+	QCOMPARE(NeovimQt::Input::convertKey(evCtrl6), QString{ "<C-^>" });
+
+	QKeyEvent evCtrlShift6{ QEvent::KeyPress, Qt::Key_AsciiCircum, Qt::ControlModifier | Qt::ShiftModifier, { "\u001E" } };
+	QCOMPARE(NeovimQt::Input::convertKey(evCtrlShift6), QString{ "<C-^>" });
 }
 
 #include "tst_input_win32.moc"


### PR DESCRIPTION
**Issue #170:**

The key event <C-6> should be sent as <C-^>. When other modifiers are present (Shift, Meta) they should be ignored. For example, <C-S-^> should be <C-^> instead.