### PR TITLE
Issue 665: Busy mouse cursor overridden by mouse hide

### DIFF
--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -741,12 +741,10 @@ void Shell::handleBusy(bool busy)
 	if (busy != m_neovimBusy) {
 		update(neovimCursorRect());
 	}
+
 	m_neovimBusy = busy;
-	if (busy) {
-		this->setCursor(Qt::WaitCursor);
-	} else {
-		this->unsetCursor();
-	}
+
+	setCursorFromBusyState();
 	emit neovimBusy(busy);
 }
 
@@ -1294,15 +1292,26 @@ void Shell::mouseReleaseEvent(QMouseEvent *ev)
 {
 	neovimMouseEvent(ev);
 }
+
 void Shell::mouseMoveEvent(QMouseEvent *ev)
 {
-	unsetCursor();
+	setCursorFromBusyState();
+
 	QPoint pos(ev->x()/cellSize().width(),
 			ev->y()/cellSize().height());
 	if (pos != m_mouse_pos) {
 		m_mouse_pos = pos;
 		mouseClickReset();
 		neovimMouseEvent(ev);
+	}
+}
+
+void Shell::setCursorFromBusyState() noexcept
+{
+	unsetCursor();
+
+	if (m_neovimBusy) {
+		setCursor(Qt::CursorShape::WaitCursor);
 	}
 }
 

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -158,6 +158,7 @@ protected:
 	virtual void mouseReleaseEvent(QMouseEvent *ev) Q_DECL_OVERRIDE;
 	virtual void mouseMoveEvent(QMouseEvent *ev) Q_DECL_OVERRIDE;
 	void bailoutIfinputBlocking();
+	void setCursorFromBusyState() noexcept;
 
 	QString neovimErrorToString(const QVariant& err);
 


### PR DESCRIPTION
**Issue #665:**

After the mouse is hidden, movements can trigger the cursor to reappear. We
need to check the busy state to determine if a wait cursor or regular cursor
should be displayed.

@equalsraf
Simple fix, ready for merge.