### PR TITLE
Issue 693: GuiPopupmenu ScrollBar Truncation

### DIFF
--- a/src/gui/popupmenu.cpp
+++ b/src/gui/popupmenu.cpp
@@ -72,6 +72,13 @@ void PopupMenu::setGeometry(int64_t row, int64_t col)
 	int width = sizeHintContent.width();
 	int anchor_x = col * cell_width;
 
+	// Scrollbar visibility depends on content, increase width when necessary.
+	const QScrollBar* vScrollBar{ verticalScrollBar() };
+	if (vScrollBar && vScrollBar->isVisible())
+	{
+		width += vScrollBar->size().width();
+	}
+
 	// PUM must fit within available space to the right of anchor_x
 	if (anchor_x + width > total_width)
 	{


### PR DESCRIPTION
**Issue #693**: GuiPopupmenu ScrollBar Truncation

When content overflows, the size of the optional scrollbar is not accounted for in `setGeometry`. The `QAbstractScrollArea` should be polled for scrollbar width and visibility.

**Fixed Screenshot:**
![GuiPopupmenu_ScrollBar_Truncation_Fixed](https://user-images.githubusercontent.com/11207308/82125891-ff193a80-9776-11ea-99f1-61f21f2602a7.gif)