### PR TITLE
Add support for Float API values

### DIFF
--- a/bindings/generate_bindings.py
+++ b/bindings/generate_bindings.py
@@ -50,6 +50,7 @@ class NeovimTypeVal:
     SIMPLETYPES = {
             'void': 'void',
             'Integer': 'int64_t',
+            'Float': 'double',
             'Boolean': 'bool',
             'String': 'QByteArray',
             'Object': 'QVariant',

--- a/src/msgpackiodevice.cpp
+++ b/src/msgpackiodevice.cpp
@@ -515,6 +515,21 @@ bool MsgpackIODevice::decodeMsgpack(const msgpack_object& in, int64_t& out)
 	return false;
 }
 
+void MsgpackIODevice::send(double d)
+{
+	msgpack_pack_float(&m_pk, d);
+}
+bool MsgpackIODevice::decodeMsgpack(const msgpack_object& in, double& out)
+{
+	if ( in.type != MSGPACK_OBJECT_FLOAT) {
+		qWarning() << "Attempting to decode as double when type is" << in.type << in;
+		out = -1;
+		return true;
+	}
+	out = in.via.f64;
+	return false;
+}
+
 /**
  * Serialise a value into the msgpack stream
  */
@@ -597,6 +612,25 @@ bool MsgpackIODevice::decodeMsgpack(const msgpack_object& in, QList<int64_t>& ou
 
 	for (uint64_t i=0; i<in.via.array.size; i++) {
 		int64_t val;
+		if (decodeMsgpack(in.via.array.ptr[i], val)) {
+			out.clear();
+			return true;
+		}
+		out.append(val);
+	}
+	return false;
+}
+
+bool MsgpackIODevice::decodeMsgpack(const msgpack_object& in, QList<double>& out)
+{
+	out.clear();
+	if ( in.type != MSGPACK_OBJECT_ARRAY) {
+		qWarning() << "Attempting to decode as QList<double> when type is" << in.type << in;
+		return true;
+	}
+
+	for (uint64_t i=0; i<in.via.array.size; i++) {
+		double val;
 		if (decodeMsgpack(in.via.array.ptr[i], val)) {
 			out.clear();
 			return true;

--- a/src/msgpackiodevice.h
+++ b/src/msgpackiodevice.h
@@ -41,6 +41,7 @@ public:
 	MsgpackRequest* startRequestUnchecked(const QString& method, quint32 argcount);
 
 	void send(int64_t);
+	void send(double);
 	void send(const QVariant&);
 	void send(const QByteArray&);
 	void send(bool);
@@ -81,11 +82,13 @@ protected:
 	void dispatchNotification(msgpack_object& obj);
 
 	bool decodeMsgpack(const msgpack_object& in, int64_t& out);
+	bool decodeMsgpack(const msgpack_object& in, double& out);
 	bool decodeMsgpack(const msgpack_object& in, QVariant& out);
 	bool decodeMsgpack(const msgpack_object& in, QByteArray& out);
 	bool decodeMsgpack(const msgpack_object& in, bool& out);
 	bool decodeMsgpack(const msgpack_object& in, QList<QByteArray>& out);
 	bool decodeMsgpack(const msgpack_object& in, QList<int64_t>& out);
+	bool decodeMsgpack(const msgpack_object& in, QList<double>& out);
 	bool decodeMsgpack(const msgpack_object& in, QPoint& out);
 
 protected slots:


### PR DESCRIPTION
nvim 0.5 (API 7) has methods that use `Float` (`MSGPACK_OBJECT_FLOAT`) as their type.  Update bindings generation and msgpack handling so neovim-qt can access these APIs.