### PR TITLE
Install SVG icon to scalable directory

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -86,6 +86,9 @@ if(NOT APPLE)
 	install(FILES ${CMAKE_SOURCE_DIR}/third-party/neovim.png
 			RENAME nvim-qt.png
 			DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/192x192/apps/)
+	install(FILES ${CMAKE_SOURCE_DIR}/third-party/neovim.svg
+			RENAME nvim-qt.svg
+			DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/scalable/apps/)
 endif()
 
 if(WIN32 AND NOT CMAKE_CROSSCOMPILING)


### PR DESCRIPTION
N.B., neovim.png is actually 200x200, not 192x192.  Not sure how strict the consumers of the icon are, but thought I'd mention it.