### PR TITLE
Enable native clipboard provider by default

### DIFF
--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -189,6 +189,8 @@ void Shell::setAttached(bool attached)
 
 		auto req_shim = m_nvim->api0()->vim_command("runtime plugin/nvim_gui_shim.vim");
 		connect(req_shim, &MsgpackRequest::error, this, &Shell::handleShimError);
+		connect(req_shim, &MsgpackRequest::finished, this, &Shell::handleShimLoad);
+
 		auto gviminit = qgetenv("GVIMINIT");
 		if (gviminit.isEmpty()) {
 			auto req_ginit = m_nvim->api0()->vim_command("runtime! ginit.vim");
@@ -1678,6 +1680,20 @@ void Shell::handleGinitError(quint32 msgid, quint64 fun, const QVariant& err)
 void Shell::handleShimError(quint32 msgid, quint64 fun, const QVariant& err)
 {
 	qDebug() << "GUI shim error " << err;
+}
+
+void Shell::handleShimLoad(quint32 msgid, quint64 fun, const QVariant& resp)
+{
+	// Enable native clipboard, if api version 6 is available
+	auto api6 = m_nvim->api6();
+	if (api6) {
+		qDebug() << "Enabling native clipboard";
+		// FIXME we need a way to disable this behaviour and debug messages
+		// on the nvim side
+		QVariantList args;
+		auto req = api6->nvim_call_function("GuiClipboard", args);
+		connect(req, &MsgpackRequest::error, this, &Shell::handleShimError);
+	}
 }
 
 void Shell::handleGetBackgroundOption(quint32 msgid, quint64 fun, const QVariant& val)

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -100,6 +100,7 @@ protected slots:
 	void updateClientInfo();
 	void handleGinitError(quint32 msgid, quint64 fun, const QVariant& err);
 	void handleShimError(quint32 msgid, quint64 fun, const QVariant& err);
+	void handleShimLoad(quint32 msgid, quint64 fun, const QVariant& resp);
 	void handleGetBackgroundOption(quint32 msgid, quint64 fun, const QVariant& val);
 
 protected:


### PR DESCRIPTION
After successfully loading the shim call GuiClipboard to enable the
native GUI clipboard by default.

ref #298

----

There is still plenty to do here

- the shim does its own checking, but we are even more conservative here and require api version 6 (which should be nvim 0.4)
- we need a way to disable this if needed - either QSettings or ginit