### PR TITLE
Add GuiAdaptiveFont GuiAdaptiveColor

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -7,10 +7,9 @@
 
 namespace NeovimQt {
 
-MainWindow::MainWindow(NeovimConnector *c, ShellOptions opts, QWidget *parent)
-:QMainWindow(parent), m_nvim(0), m_errorWidget(0), m_shell(0),
-	m_delayedShow(DelayedShow::Disabled), m_tabline(0), m_tabline_bar(0),
-	m_shell_options(opts), m_neovim_requested_close(false)
+MainWindow::MainWindow(NeovimConnector* c, ShellOptions opts, QWidget* parent)
+	: QMainWindow(parent)
+	, m_shell_options(opts)
 {
 	m_errorWidget = new ErrorWidget();
 	m_stack.addWidget(m_errorWidget);

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -61,23 +61,31 @@ private slots:
 
 private:
 	void init(NeovimConnector *);
-	NeovimConnector *m_nvim;
-	ErrorWidget *m_errorWidget;
-	QSplitter *m_window;
-	TreeView *m_tree;
-	Shell *m_shell;
-	DelayedShow m_delayedShow;
+
+	NeovimConnector* m_nvim{ nullptr };
+	ErrorWidget* m_errorWidget{ nullptr };
+	QSplitter* m_window{ nullptr };
+	TreeView* m_tree{ nullptr };
+	Shell* m_shell{ nullptr };
+	DelayedShow m_delayedShow{ DelayedShow::Disabled };
 	QStackedWidget m_stack;
-	QTabBar *m_tabline;
-	QToolBar *m_tabline_bar;
+	QTabBar* m_tabline{ nullptr };
+	QToolBar* m_tabline_bar{ nullptr };
 	ShellOptions m_shell_options;
-	bool m_neovim_requested_close;
-	QMenu *m_contextMenu;
-	QAction *m_actCut;
-	QAction *m_actCopy;
-	QAction *m_actPaste;
-	QAction *m_actSelectAll;
-	ScrollBar *m_scrollbar;
+
+	bool m_neovim_requested_close{ false };
+	QMenu* m_contextMenu{ nullptr };
+	QAction* m_actCut{ nullptr };
+	QAction* m_actCopy{ nullptr };
+	QAction* m_actPaste{ nullptr };
+	QAction* m_actSelectAll{ nullptr };
+	ScrollBar* m_scrollbar{ nullptr };
+
+	// GuiAdaptive Color/Font
+	bool m_isAdaptiveColorEnabled{ false };
+	bool m_isAdaptiveFontEnabled{ false };
+	QFont m_defaultFont;
+	QPalette m_defaultPalette;
 };
 
 } // Namespace

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -2,14 +2,16 @@
 #define NEOVIM_QT_MAINWINDOW
 
 #include <QMainWindow>
+#include <QPalette>
+#include <QSplitter>
 #include <QStackedWidget>
 #include <QTabBar>
-#include <QSplitter>
-#include "treeview.h"
-#include "neovimconnector.h"
+
 #include "errorwidget.h"
+#include "neovimconnector.h"
 #include "scrollbar.h"
 #include "shell.h"
+#include "treeview.h"
 
 namespace NeovimQt {
 
@@ -59,6 +61,12 @@ private slots:
 	void changeTab(int index);
 	void saveWindowGeometry();
 
+	// GuiAdaptive Color/Font/Style Slots
+	void setGuiAdaptiveColorEnabled(bool isEnabled);
+	void setGuiAdaptiveFontEnabled(bool isEnabled);
+	void setGuiAdaptiveStyle(const QString& style);
+	void showGuiAdaptiveStyleList();
+
 private:
 	void init(NeovimConnector *);
 
@@ -81,11 +89,14 @@ private:
 	QAction* m_actSelectAll{ nullptr };
 	ScrollBar* m_scrollbar{ nullptr };
 
-	// GuiAdaptive Color/Font
+	// GuiAdaptive Color/Font/Style
 	bool m_isAdaptiveColorEnabled{ false };
 	bool m_isAdaptiveFontEnabled{ false };
 	QFont m_defaultFont;
 	QPalette m_defaultPalette;
+
+	void updateAdaptiveColor() noexcept;
+	void updateAdaptiveFont() noexcept;
 };
 
 } // Namespace

--- a/src/gui/runtime/doc/nvim_gui_shim.txt
+++ b/src/gui/runtime/doc/nvim_gui_shim.txt
@@ -17,7 +17,25 @@ can be used in |ginit.vim| provided that
 ==============================================================================
 1. Commands
 
-								*Guifont* *GuiFont*
+								*GuiAdaptiveColor*
+GuiAdaptiveColor    Use the neovim `colorscheme` to style the GUI.
+>
+		    :GuiAdaptiveColor 1
+<
+								*GuiAdaptiveFont*
+GuiAdaptiveFont     Use the current `GuiFont`` to decorate the GUI.
+>
+		    :GuiAdaptiveFont 1
+<
+								*GuiAdaptiveStyle*
+GuiAdaptiveStyle    Override the default Qt Style/Theme. See
+>
+		    :GuiAdaptiveStyle Fusion
+<
+								*GuiAdaptiveStyleList*
+GuiAdaptiveStyleList    Shows the list of available Qt Styles.
+
+								*GuiFont*
 GuiFont		When called with no arguments this command display the
 		current font used by the GUI.
 

--- a/src/gui/runtime/plugin/nvim_gui_shim.vim
+++ b/src/gui/runtime/plugin/nvim_gui_shim.vim
@@ -232,3 +232,27 @@ function! s:GuiScrollBar(enable) abort
 endfunction
 
 command! -nargs=1 GuiScrollBar call s:GuiScrollBar(<args>)
+
+" Use Neovim theming for Qt Widgets
+function! s:GuiAdaptiveColor(enable) abort
+	call rpcnotify(0, 'Gui', 'AdaptiveColor', a:enable)
+endfunction
+command! -nargs=1 GuiAdaptiveColor call s:GuiAdaptiveColor(<args>)
+
+" Use Neovim font for Qt Widgets
+function! s:GuiAdaptiveFont(enable) abort
+	call rpcnotify(0, 'Gui', 'AdaptiveFont', a:enable)
+endfunction
+command! -nargs=1 GuiAdaptiveFont call s:GuiAdaptiveFont(<args>)
+
+" Override default Qt Style using QStyleFactory
+function! s:GuiAdaptiveStyle(styleName, ...) abort
+	call rpcnotify(0, 'Gui', 'AdaptiveStyle', a:styleName)
+endfunction
+command! -nargs=? GuiAdaptiveStyle call s:GuiAdaptiveStyle("<args>")
+
+" Print a list of available Qt Styles
+function! s:GuiAdaptiveStyleList() abort
+	call rpcnotify(0, 'Gui', 'AdaptiveStyleList')
+endfunction
+command! -nargs=0 GuiAdaptiveStyleList call s:GuiAdaptiveStyleList()

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -534,6 +534,7 @@ void Shell::handleRedraw(const QByteArray& name, const QVariantList& opargs)
 	} else if (name == "grid_scroll") {
 		handleGridScroll(opargs);
 	} else if (name == "hl_group_set") {
+		handleHighlightGroupSet(opargs);
 	} else if (name == "win_viewport") {
 	} else {
 		qDebug() << "Received unknown redraw notification" << name << opargs;
@@ -819,6 +820,14 @@ void Shell::handleNeovimNotification(const QByteArray &name, const QVariantList&
 			QGuiApplication::clipboard()->setMimeData(clipData, clipboard);
 		} else if (guiEvName == "ShowContextMenu") {
 			emit neovimShowContextMenu();
+		} else if (guiEvName == "AdaptiveColor") {
+			handleGuiAdaptiveColor(args);
+		} else if (guiEvName == "AdaptiveFont") {
+			handleGuiAdaptiveFont(args);
+		} else if (guiEvName == "AdaptiveStyle") {
+			handleGuiAdaptiveStyle(args);
+		} else if (guiEvName == "AdaptiveStyleList") {
+			handleGuiAdaptiveStyleList();
 		}
 		return;
 	} else if (name != "redraw") {
@@ -965,6 +974,7 @@ void Shell::handleDefaultColorsSet(const QVariantList& opargs)
 
 	// Cells drawn with the default colors require a re-paint
 	update();
+	emit colorsChanged();
 }
 
 void Shell::handleHighlightAttributeDefine(const QVariantList& opargs)
@@ -987,6 +997,20 @@ void Shell::handleHighlightAttributeDefine(const QVariantList& opargs)
 	m_highlightMap.insert(id, hl_attr);
 }
 
+void Shell::handleHighlightGroupSet(const QVariantList& opargs) noexcept
+{
+	if (opargs.size() < 2
+		|| opargs.at(0).type() != QVariant::Type::ByteArray
+		|| !opargs.at(1).canConvert<uint64_t>()) {
+		qWarning() << "Unexpected arguments for hl_group_set:" << opargs;
+		return;
+	}
+
+	const QString name{ m_nvim->decode(opargs.at(0).toByteArray()) };
+	const uint64_t hl_id{ opargs.at(1).toULongLong() };
+
+	m_highlightGroupNameMap.insert(name, hl_id);
+}
 
 void Shell::handleGridLine(const QVariantList& opargs)
 {
@@ -1094,6 +1118,50 @@ void Shell::handleGridScroll(const QVariantList& opargs)
 
 	// Draw new cursor
 	update(neovimCursorRect());
+}
+
+void Shell::handleGuiAdaptiveColor(const QVariantList& opargs) noexcept
+{
+	if (opargs.size() < 2
+		|| !opargs.at(1).canConvert<bool>()) {
+		qWarning() << "Unexpected arguments for GuiAdaptiveColor:" << opargs;
+		return;
+	}
+
+	const bool isEnabled{ opargs.at(1).toBool() };
+
+	emit setGuiAdaptiveColorEnabled(isEnabled);
+}
+
+void Shell::handleGuiAdaptiveFont(const QVariantList& opargs) noexcept
+{
+	if (opargs.size() < 2
+		|| !opargs.at(1).canConvert<bool>()) {
+		qWarning() << "Unexpected arguments for GuiAdaptiveFont:" << opargs;
+		return;
+	}
+
+	const bool isEnabled{ opargs.at(1).toBool() };
+
+	emit setGuiAdaptiveFontEnabled(isEnabled);
+}
+
+void Shell::handleGuiAdaptiveStyle(const QVariantList& opargs) noexcept
+{
+	if (opargs.size() < 2
+		|| !opargs.at(1).canConvert<QByteArray>()) {
+		qWarning() << "Unexpected arguments for GuiAdaptiveStyle:" << opargs;
+		return;
+	}
+
+	const QString styleName { opargs.at(1).toByteArray() };
+
+	emit setGuiAdaptiveStyle(styleName);
+}
+
+void Shell::handleGuiAdaptiveStyleList() noexcept
+{
+	emit showGuiAdaptiveStyleList();
 }
 
 void Shell::paintEvent(QPaintEvent *ev)


### PR DESCRIPTION
Inspired by Pull Request #517

This adds the commands `:GuiAdaptiveFont` and `:GuiAdaptiveColor` which each make the Qt GUI respond to the current Neovim theme.

Specific logic was added to `:GuiPopupmenu` uses the `Pmenu` highlight group.

**Screenshot:**
![GuiAdaptiveFontColor](https://user-images.githubusercontent.com/11207308/86313140-676e8f00-bbf2-11ea-814e-fd5256eeb22c.gif)
