### PR TITLE
Issue 728: Input layer sends Shift + Space as <S-Space>

### DIFF
--- a/src/gui/input.cpp
+++ b/src/gui/input.cpp
@@ -165,6 +165,11 @@ QString convertKey(const QKeyEvent& ev) noexcept
 	const QMap<int, QString>& specialKeys { GetSpecialKeysMap() };
 
 	if (specialKeys.contains(key)) {
+		// Issue#728: Shift + Space inserts ;2u in `:terminal`. Incorrectly sent as <S-Space>.
+		if (key == Qt::Key_Space) {
+			mod &= ~Qt::ShiftModifier;
+		}
+
 		return ToKeyString(GetModifierPrefix(mod), specialKeys.value(key));
 	}
 

--- a/src/gui/input.cpp
+++ b/src/gui/input.cpp
@@ -166,7 +166,9 @@ QString convertKey(const QKeyEvent& ev) noexcept
 
 	if (specialKeys.contains(key)) {
 		// Issue#728: Shift + Space inserts ;2u in `:terminal`. Incorrectly sent as <S-Space>.
-		if (key == Qt::Key_Space) {
+		// Issue#259: Shift + BackSpace inserts 7;2u in `:terminal`. Incorrectly sent as <S-BS>.
+		if (key == Qt::Key_Space
+			|| key == Qt::Key_Backspace) {
 			mod &= ~Qt::ShiftModifier;
 		}
 

--- a/test/tst_input_common.cpp
+++ b/test/tst_input_common.cpp
@@ -14,6 +14,7 @@ private slots:
 	void CapsLockIgnored() noexcept;
 	void AltGrAloneIgnored() noexcept;
 	void AltGrKeyEventWellFormed() noexcept;
+	void ShiftSpaceWellFormed() noexcept;
 };
 
 void TestInputCommon::LessThanKey() noexcept
@@ -127,6 +128,16 @@ void TestInputCommon::CapsLockIgnored() noexcept
 
 	QKeyEvent evMetaCapsLock{ QEvent::KeyPress, Qt::Key_CapsLock, Qt::MetaModifier};
 	QCOMPARE(NeovimQt::Input::convertKey(evMetaCapsLock), QString{ "" });
+}
+
+void TestInputCommon::ShiftSpaceWellFormed() noexcept
+{
+	// Issue#728: Shift + Space inserts ;2u in `:terminal`, mode sent as <S-Space>.
+	QKeyEvent evShift{ QEvent::KeyPress, Qt::Key_Shift, Qt::ShiftModifier, "" };
+	QCOMPARE(NeovimQt::Input::convertKey(evShift), QString{ "" });
+
+	QKeyEvent evShiftSpace{ QEvent::KeyPress, Qt::Key_Space, Qt::ShiftModifier, " " };
+	QCOMPARE(NeovimQt::Input::convertKey(evShiftSpace), QString{ "<Space>" });
 }
 
 #include "tst_input_common.moc"

--- a/test/tst_input_common.cpp
+++ b/test/tst_input_common.cpp
@@ -15,6 +15,7 @@ private slots:
 	void AltGrAloneIgnored() noexcept;
 	void AltGrKeyEventWellFormed() noexcept;
 	void ShiftSpaceWellFormed() noexcept;
+	void ShiftBackSpaceWellFormed() noexcept;
 };
 
 void TestInputCommon::LessThanKey() noexcept
@@ -138,6 +139,16 @@ void TestInputCommon::ShiftSpaceWellFormed() noexcept
 
 	QKeyEvent evShiftSpace{ QEvent::KeyPress, Qt::Key_Space, Qt::ShiftModifier, " " };
 	QCOMPARE(NeovimQt::Input::convertKey(evShiftSpace), QString{ "<Space>" });
+}
+
+void TestInputCommon::ShiftBackSpaceWellFormed() noexcept
+{
+	// Issue#259: Shift + BackSpace inserts 7;2u in `:terminal`, mode sent as <S-BS>.
+	QKeyEvent evShift{ QEvent::KeyPress, Qt::Key_Shift, Qt::ShiftModifier, "" };
+	QCOMPARE(NeovimQt::Input::convertKey(evShift), QString{ "" });
+
+	QKeyEvent evShiftBackSpace{ QEvent::KeyPress, Qt::Key_Backspace, Qt::ShiftModifier, "\b" };
+	QCOMPARE(NeovimQt::Input::convertKey(evShiftBackSpace), QString{ "<BS>" });
 }
 
 #include "tst_input_common.moc"


### PR DESCRIPTION
**Issue #728:** Shift + Space incorrectly sent as `<S-Space>`.
**Issue #437:** Shift + Space incorrectly sent as `<S-Space>`.
**Issue #259:** Shift + Space incorrect as `<S-Space>`; Shift + Backspace incorrect as `<S-Backspace>`

This issue manifests in `:terminal` mode, where Shift + Space results in `;2u` added to the terminal.

This input is malformed, and should be sent as <Space>. Adding test coverage, and removal of  `Qt::ShiftModifier`.