### PR TITLE
Issue 665: Busy cursor performance improvement

### DIFF
--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -1216,10 +1216,14 @@ void Shell::mouseMoveEvent(QMouseEvent *ev)
 
 void Shell::setCursorFromBusyState() noexcept
 {
-	unsetCursor();
+	Qt::CursorShape desiredCursor{};
 
 	if (m_neovimBusy) {
-		setCursor(Qt::CursorShape::WaitCursor);
+		desiredCursor = Qt::CursorShape::WaitCursor;
+	}
+
+	if (cursor().shape() != desiredCursor) {
+		setCursor(desiredCursor);
 	}
 }
 


### PR DESCRIPTION
**Issue #665:** Busy cursor flickering, sub-optimal performance

The original fix for 665 can be improved, there is no need to call `unsetCursor()` if there is not change in the cursor shape.

Only call `setCursor(...)` when the cursor shape actually changes. After this change, no flickering is observed on one of my slower machines.