### PR TITLE
Add GuiWindowOpacity command

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -107,6 +107,8 @@ void MainWindow::init(NeovimConnector *c)
 			this, &MainWindow::neovimFullScreen);
 	connect(m_shell, &Shell::neovimGuiCloseRequest,
 			this, &MainWindow::neovimGuiCloseRequest);
+	connect(m_shell, &Shell::neovimOpacity,
+			this, &MainWindow::setWindowOpacity);
 	connect(m_nvim, &NeovimConnector::processExited,
 			this, &MainWindow::neovimExited);
 	connect(m_nvim, &NeovimConnector::error,

--- a/src/gui/runtime/doc/nvim_gui_shim.txt
+++ b/src/gui/runtime/doc/nvim_gui_shim.txt
@@ -81,6 +81,11 @@ GuiPopupmenu	Enable or disable the external GUI popup menu
 								*GuiRenderLigatures*
 GuiRenderLigatures	Enable or disable rendering ligatures
 
+								*GuiWindowOpacity*
+GuiWindowOpacity	Set window opacity. Takes a single argument,
+				a double in the range 0.0 to 1.0 (fully opaque).
+				This capability might not be supported in some platforms.
+
 ==============================================================================
 2. GUI variables
 

--- a/src/gui/runtime/plugin/nvim_gui_shim.vim
+++ b/src/gui/runtime/plugin/nvim_gui_shim.vim
@@ -262,3 +262,9 @@ function! s:GuiRenderLigatures(enable) abort
 	call rpcnotify(0, 'Gui', 'Option', 'RenderLigatures', a:enable)
 endfunction
 command! -nargs=1 GuiRenderLigatures call s:GuiRenderLigatures(<args>)
+
+" Set window transparency, forwards to Qt setWindowOpacity
+function! s:GuiWindowOpacityCommand(value) abort
+  call rpcnotify(0, 'Gui', 'WindowOpacity', a:value)
+endfunction
+command! -nargs=1 GuiWindowOpacity call s:GuiWindowOpacityCommand("<args>")

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -817,6 +817,12 @@ void Shell::handleNeovimNotification(const QByteArray &name, const QVariantList&
 
 			qDebug() << "Neovim changed clipboard" << data << type << reg_name << clipboard;
 			QGuiApplication::clipboard()->setMimeData(clipData, clipboard);
+		} else if (guiEvName == "WindowOpacity" && args.size() == 2) {
+			bool ok = false;
+			auto val = args.at(1).toDouble(&ok);
+			if (ok) {
+				emit neovimOpacity(val);
+			}
 		} else if (guiEvName == "ShowContextMenu") {
 			emit neovimShowContextMenu();
 		} else if (guiEvName == "AdaptiveColor") {

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -84,6 +84,7 @@ signals:
 	void neovimAttached(bool);
 	void neovimMaximized(bool);
 	void neovimForeground();
+	void neovimOpacity(double);
 	void neovimSuspend();
 	void neovimFullScreen(bool);
 	void neovimGuiCloseRequest();


### PR DESCRIPTION
Directly maps to QWidget::setWindowOpacity().
Takes a double as an argument, the valid range is 0.0 to 1.0.

I have tested this in windows and it works, I have not checked X11 but I assume it depends on a working compositor.

ref https://github.com/equalsraf/neovim-qt/issues/411