### PR TITLE
Add Clazy (Clang Qt linter) to CI builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,34 +19,7 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR
 
 	if(ENABLE_CLAZY)
 		string(CONCAT CLAZY_CHECKS
-			"connect-by-name,"
-			"connect-non-signal,"
-			"connect-not-normalized,"
-			"container-anti-pattern,"
-			"empty-qstringliteral,"
-			"fully-qualified-moc-types,"
-#			"lambda-in-connect,"
-			"lambda-unique-connection,"
-			"lowercase-qml-type-name,"
-			"mutable-container-key,"
-			"overloaded-signal,"
-			"qcolor-from-literal,"
-			"qdatetime-utc,"
-			"qenums,"
-			"qfileinfo-exists,"
-			"qgetenv,"
-			"qmap-with-pointer-key,"
-			"qstring-arg,"
-			"qstring-comparison-to-implicit-char,"
-			"qstring-insensitive-allocation,"
-			"qstring-ref,"
-			"qt-macros,"
-			"strict-iterators,"
-			"temporary-iterator,"
-			"unused-non-trivial-variable,"
-			"writing-to-temporary,"
-			"wrong-qevent-cast,"
-			"wrong-qglobalstatic,"
+			"level0,"
 			)
 
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Xclang -plugin-arg-clazy -Xclang ${CLAZY_CHECKS} -Wno-deprecated-declarations -Werror")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR
 			"lambda-unique-connection,"
 			"lowercase-qml-type-name,"
 			"mutable-container-key,"
-#			"overloaded-signal,"
+			"overloaded-signal,"
 			"qcolor-from-literal,"
 			"qdatetime-utc,"
 #			"qenums,"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR
 			"qdatetime-utc,"
 #			"qenums,"
 			"qfileinfo-exists,"
-#			"qgetenv,"
+			"qgetenv,"
 			"qmap-with-pointer-key,"
 			"qstring-arg,"
 			"qstring-comparison-to-implicit-char,"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR
 			"overloaded-signal,"
 			"qcolor-from-literal,"
 			"qdatetime-utc,"
-#			"qenums,"
+			"qenums,"
 			"qfileinfo-exists,"
 			"qgetenv,"
 			"qmap-with-pointer-key,"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR
 			"level0,"
 			"auto-unexpected-qstringbuilder,"
 			"child-event-qobject-cast,"
-			#"connect-3arg-lambda,"
+			"connect-3arg-lambda,"
 			"const-signal-or-slot,"
 			"detaching-temporary,"
 			"foreach,"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR
 			"qlatin1string-non-ascii,"
 			#"qproperty-without-notify,"
 			"qstring-left,"
-			#"range-loop,"
+			"range-loop,"
 			"returning-data-from-temporary,"
 			"rule-of-two-soft,"
 			"skipped-base-method,"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,42 @@ endif()
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR
 		"${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-unused-parameter -std=c++11 -Wfatal-errors")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-unused-parameter -Wunused-variable -std=c++11")
+
+	if(ENABLE_CLAZY)
+		string(CONCAT CLAZY_CHECKS
+			"connect-by-name,"
+			"connect-non-signal,"
+#			"connect-not-normalized,"
+#			"container-anti-pattern,"
+#			"empty-qstringliteral,"
+#			"fully-qualified-moc-types,"
+#			"lambda-in-connect,"
+			"lambda-unique-connection,"
+			"lowercase-qml-type-name,"
+			"mutable-container-key,"
+#			"overloaded-signal,"
+			"qcolor-from-literal,"
+			"qdatetime-utc,"
+#			"qenums,"
+			"qfileinfo-exists,"
+#			"qgetenv,"
+			"qmap-with-pointer-key,"
+#			"qstring-arg,"
+			"qstring-comparison-to-implicit-char,"
+			"qstring-insensitive-allocation,"
+#			"qstring-ref,"
+			"qt-macros,"
+			"strict-iterators,"
+			"temporary-iterator,"
+#			"unused-non-trivial-variable,"
+			"writing-to-temporary,"
+			"wrong-qevent-cast,"
+			"wrong-qglobalstatic,"
+			)
+
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Xclang -plugin-arg-clazy -Xclang ${CLAZY_CHECKS} -Wno-deprecated-declarations -Werror")
+	endif()
 endif()
 
 option(USE_GCOV "Enable gcov support" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR
 			"connect-not-normalized,"
 			"container-anti-pattern,"
 			"empty-qstringliteral,"
-#			"fully-qualified-moc-types,"
+			"fully-qualified-moc-types,"
 #			"lambda-in-connect,"
 			"lambda-unique-connection,"
 			"lowercase-qml-type-name,"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR
 			"connect-non-signal,"
 #			"connect-not-normalized,"
 #			"container-anti-pattern,"
-#			"empty-qstringliteral,"
+			"empty-qstringliteral,"
 #			"fully-qualified-moc-types,"
 #			"lambda-in-connect,"
 			"lambda-unique-connection,"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR
 			"qstring-arg,"
 			"qstring-comparison-to-implicit-char,"
 			"qstring-insensitive-allocation,"
-#			"qstring-ref,"
+			"qstring-ref,"
 			"qt-macros,"
 			"strict-iterators,"
 			"temporary-iterator,"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR
 			"qfileinfo-exists,"
 #			"qgetenv,"
 			"qmap-with-pointer-key,"
-#			"qstring-arg,"
+			"qstring-arg,"
 			"qstring-comparison-to-implicit-char,"
 			"qstring-insensitive-allocation,"
 #			"qstring-ref,"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR
 		string(CONCAT CLAZY_CHECKS
 			"connect-by-name,"
 			"connect-non-signal,"
-#			"connect-not-normalized,"
+			"connect-not-normalized,"
 			"container-anti-pattern,"
 			"empty-qstringliteral,"
 #			"fully-qualified-moc-types,"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR
 			"connect-by-name,"
 			"connect-non-signal,"
 #			"connect-not-normalized,"
-#			"container-anti-pattern,"
+			"container-anti-pattern,"
 			"empty-qstringliteral,"
 #			"fully-qualified-moc-types,"
 #			"lambda-in-connect,"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,28 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR
 	if(ENABLE_CLAZY)
 		string(CONCAT CLAZY_CHECKS
 			"level0,"
+			"auto-unexpected-qstringbuilder,"
+			"child-event-qobject-cast,"
+			#"connect-3arg-lambda,"
+			"const-signal-or-slot,"
+			"detaching-temporary,"
+			"foreach,"
+			"incorrect-emit,"
+			#"inefficient-qlist-soft,"
+			"install-event-filter,"
+			"non-pod-global-static,"
+			#"overridden-signal,"
+			"post-event,"
+			"qdeleteall,"
+			"qhash-namespace,"
+			"qlatin1string-non-ascii,"
+			#"qproperty-without-notify,"
+			"qstring-left,"
+			#"range-loop,"
+			"returning-data-from-temporary,"
+			"rule-of-two-soft,"
+			"skipped-base-method,"
+			"virtual-signal,"
 			)
 
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Xclang -plugin-arg-clazy -Xclang ${CLAZY_CHECKS} -Wno-deprecated-declarations -Werror")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,28 +20,7 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR
 	if(ENABLE_CLAZY)
 		string(CONCAT CLAZY_CHECKS
 			"level0,"
-			"auto-unexpected-qstringbuilder,"
-			"child-event-qobject-cast,"
-			"connect-3arg-lambda,"
-			"const-signal-or-slot,"
-			"detaching-temporary,"
-			"foreach,"
-			"incorrect-emit,"
-			"inefficient-qlist-soft,"
-			"install-event-filter,"
-			"non-pod-global-static,"
-			"overridden-signal,"
-			"post-event,"
-			"qdeleteall,"
-			"qhash-namespace,"
-			"qlatin1string-non-ascii,"
-			#"qproperty-without-notify,"
-			"qstring-left,"
-			"range-loop,"
-			"returning-data-from-temporary,"
-			"rule-of-two-soft,"
-			"skipped-base-method,"
-			"virtual-signal,"
+			"level1,"
 			)
 
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Xclang -plugin-arg-clazy -Xclang ${CLAZY_CHECKS} -Wno-deprecated-declarations -Werror")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR
 			"inefficient-qlist-soft,"
 			"install-event-filter,"
 			"non-pod-global-static,"
-			#"overridden-signal,"
+			"overridden-signal,"
 			"post-event,"
 			"qdeleteall,"
 			"qhash-namespace,"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR
 			"detaching-temporary,"
 			"foreach,"
 			"incorrect-emit,"
-			#"inefficient-qlist-soft,"
+			"inefficient-qlist-soft,"
 			"install-event-filter,"
 			"non-pod-global-static,"
 			#"overridden-signal,"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR
 			"qt-macros,"
 			"strict-iterators,"
 			"temporary-iterator,"
-#			"unused-non-trivial-variable,"
+			"unused-non-trivial-variable,"
 			"writing-to-temporary,"
 			"wrong-qevent-cast,"
 			"wrong-qglobalstatic,"

--- a/bindings/generate_bindings.py
+++ b/bindings/generate_bindings.py
@@ -161,7 +161,8 @@ class Function:
             params += '%s %s' % (p.neovim_type, p.name)
             params += ', '
         notes = ''
-        return '%s %s(%s) %s' % (self.return_type.neovim_type,self.name,params, notes)
+        signature = '%s %s(%s) %s' % (self.return_type.neovim_type,self.name,params, notes)
+        return signature.rstrip()
 
 
 def print_api(api):

--- a/bindings/neovimapi.cpp
+++ b/bindings/neovimapi.cpp
@@ -149,7 +149,7 @@ void NeovimApi{{api_level}}::handleResponse(uint32_t msgid, uint64_t fun, const 
 	{% endfor %}
 	};
 
-	QList<Function> supported;
+	QVector<Function> supported;
 	supported.reserve(ftable.size());
 	for(const auto& val : ftable) {
 		auto f = Function::fromVariant(val);

--- a/bindings/neovimapi.cpp
+++ b/bindings/neovimapi.cpp
@@ -1,15 +1,15 @@
 // Auto generated {{date}} from nvim API level:{{api_level}}
 #include "auto/neovimapi{{api_level}}.h"
-#include "neovimconnector.h"
-#include "msgpackrequest.h"
 #include "msgpackiodevice.h"
+#include "msgpackrequest.h"
+#include "neovimconnector.h"
 #include "util.h"
 
 namespace NeovimQt {
 /* Unpack Neovim EXT types Window, Buffer Tabpage which are all
  * uint64_t see Neovim:msgpack_rpc_to_
  */
-QVariant unpackBufferApi{{api_level}}(MsgpackIODevice *dev, const char* in, quint32 size)
+static QVariant unpackBufferApi{{api_level}}(MsgpackIODevice *dev, const char* in, uint32_t size) noexcept
 {
 	msgpack_unpacked result;
 	msgpack_unpacked_init(&result);
@@ -20,10 +20,10 @@ QVariant unpackBufferApi{{api_level}}(MsgpackIODevice *dev, const char* in, quin
 	if (ret == MSGPACK_UNPACK_SUCCESS) {
 		switch (result.data.type) {
 			case MSGPACK_OBJECT_NEGATIVE_INTEGER:
-				variant = (qint64)result.data.via.i64;
+				variant.setValue<int64_t>(result.data.via.i64);
 				break;
 			case MSGPACK_OBJECT_POSITIVE_INTEGER:
-				variant = (quint64)result.data.via.u64;
+				variant.setValue<uint64_t>(result.data.via.u64);
 				break;
 			default:
 				// TODO it would be nice if we could call back MsgpackIoDevice method or primitive types here
@@ -34,38 +34,47 @@ QVariant unpackBufferApi{{api_level}}(MsgpackIODevice *dev, const char* in, quin
 	msgpack_unpacked_destroy(&result);
 	return variant;
 }
-#define unpackWindowApi{{api_level}} unpackBufferApi{{api_level}}
-#define unpackTabpageApi{{api_level}} unpackBufferApi{{api_level}}
 
-NeovimApi{{api_level}}::NeovimApi{{api_level}}(NeovimConnector *c)
-:m_c(c)
+static QVariant unpackWindowApi{{api_level}}(MsgpackIODevice *dev, const char* in, uint32_t size) noexcept
+{
+	return unpackBufferApi{{api_level}}(dev, in, size);
+}
+
+static QVariant unpackTabpageApi{{api_level}}(MsgpackIODevice *dev, const char* in, uint32_t size) noexcept
+{
+	return unpackBufferApi{{api_level}}(dev, in, size);
+}
+
+NeovimApi{{api_level}}::NeovimApi{{api_level}}(NeovimConnector *c) noexcept
+	: m_connector{ c }
 {
 	// EXT types
 	{% for typename in exttypes %}
-	m_c->m_dev->registerExtType({{exttypes[typename]}}, unpack{{typename}}Api{{api_level}});
+m_connector->m_dev->registerExtType({{exttypes[typename]}}, unpack{{typename}}Api{{api_level}});
 	{% endfor %}
-	connect(m_c->m_dev, &MsgpackIODevice::notification,
-			this, &NeovimApi{{api_level}}::neovimNotification);
+connect(m_connector->m_dev, &MsgpackIODevice::notification,
+		this, &NeovimApi{{api_level}}::neovimNotification);
 }
 
 // Slots
 {% for f in functions %}
 MsgpackRequest* NeovimApi{{api_level}}::{{f.name}}({{f.argstring}})
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("{{f.name}}", {{f.argcount}});
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("{{f.name}}", {{f.argcount}}) };
 	r->setFunction(NeovimApi{{api_level}}::NEOVIM_FN_{{f.name.upper()}});
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi{{api_level}}::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi{{api_level}}::handleResponseError);
 {% for param in f.parameters %}
-	m_c->m_dev->{{param.sendmethod}}({{param.name}});
+	m_connector->m_dev->{{param.sendmethod}}({{param.name}});
 {% endfor %}
 	return r;
 }
+
 {% endfor %}
 
 // Handlers
 
-void NeovimApi{{api_level}}::handleResponseError(quint32 msgid, quint64 fun, const QVariant& res)
+void NeovimApi{{api_level}}::handleResponseError(uint32_t msgid, uint64_t fun, const QVariant& res)
 {
 
 	// TODO: support Neovim error types Exception/Validation/etc
@@ -73,7 +82,7 @@ void NeovimApi{{api_level}}::handleResponseError(quint32 msgid, quint64 fun, con
 	const QVariantList asList = res.toList();
 	if (asList.size() >= 2) {
 		if (asList.at(1).canConvert<QByteArray>()) {
-			errMsg = m_c->m_dev->decode(asList.at(1).toByteArray());
+			errMsg = m_connector->m_dev->decode(asList.at(1).toByteArray());
 		} else {
 			errMsg = tr("Received unsupported Neovim error type");
 		}
@@ -86,30 +95,30 @@ void NeovimApi{{api_level}}::handleResponseError(quint32 msgid, quint64 fun, con
 		break;
 {% endfor %}
 	default:
-		m_c->setError(NeovimConnector::RuntimeMsgpackError, QString("Received error for function that should not fail: %s").arg(fun));
+		m_connector->setError(NeovimConnector::RuntimeMsgpackError, QString("Received error for function that should not fail: %s").arg(fun));
 	}
 }
 
-void NeovimApi{{api_level}}::handleResponse(quint32 msgid, quint64 fun, const QVariant& res)
+void NeovimApi{{api_level}}::handleResponse(uint32_t msgid, uint64_t fun, const QVariant& res)
 {
 	switch(fun) {
 {% for f in functions %}
-	case NeovimApi{{api_level}}::NEOVIM_FN_{{f.name.upper()}}:
+		case NeovimApi{{api_level}}::NEOVIM_FN_{{f.name.upper()}}:
 		{
 {% if f.return_type.native_type != 'void' %}
 			{{f.return_type.native_type}} data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for {{f.name}}");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for {{f.name}}");
 				return;
-			} else {
-				emit on_{{f.name}}(data);
 			}
+
+			emit on_{{f.name}}(data);
 {% else %}
 			emit on_{{f.name}}();
 {% endif %}
-
 		}
 		break;
+
 {% endfor %}
 	default:
 		qWarning() << "Received unexpected response";
@@ -124,24 +133,25 @@ void NeovimApi{{api_level}}::handleResponse(quint32 msgid, quint64 fun, const QV
  *
  * Returns false if there is an API mismatch
  */
-bool NeovimApi{{api_level}}::checkFunctions(const QVariantList& ftable)
+/*static*/ bool NeovimApi{{api_level}}::checkFunctions(const QVariantList& ftable) noexcept
 {
-
-	QList<Function> required;
-	required
+	static const QList<Function> required{
 	{% for f in functions %}
-	<< Function("{{f.return_type.neovim_type}}", "{{f.name}}",
-			QList<QString>()
+		Function{
+				QStringLiteral("{{f.return_type.neovim_type}}"),
+				QStringLiteral("{{f.name}}"),
+				QStringList{
 			{% for param in f.parameters %}
-			<< QString("{{param.neovim_type}}")
+		QStringLiteral("{{param.neovim_type}}"),
 			{% endfor %}
-			, false)
+		}
+				, false },
 	{% endfor %}
-	;
-
+	};
 
 	QList<Function> supported;
-	foreach(const QVariant& val, ftable) {
+	supported.reserve(ftable.size());
+	for(const auto& val : ftable) {
 		auto f = Function::fromVariant(val);
 		if (!f.isValid()) {
 			qDebug() << "Invalid function in metadata" << f;
@@ -155,7 +165,7 @@ bool NeovimApi{{api_level}}::checkFunctions(const QVariantList& ftable)
 	}
 
 	bool ok = true;
-	foreach(const Function& f, required) {
+	for(const auto& f : required) {
 		if (!supported.contains(f)) {
 			qDebug() << "- instance DOES NOT support API{{api_level}}:" << f;
 			ok = false;

--- a/bindings/neovimapi.h
+++ b/bindings/neovimapi.h
@@ -1,49 +1,55 @@
 // Auto generated {{date}} from nvim API level:{{api_level}}
-#ifndef NEOVIM_QT_NEOVIMAPI{{api_level}}
-#define NEOVIM_QT_NEOVIMAPI{{api_level}}
-#include "msgpack.h"
+#pragma once
+
 #include <QObject>
-#include <QVariant>
 #include <QPoint>
+#include <QVariant>
+
 #include "function.h"
+#include "msgpack.h"
 
 namespace NeovimQt {
+
 class NeovimConnector;
 class MsgpackRequest;
 
-class NeovimApi{{api_level}}: public QObject
+class NeovimApi{{api_level}} : public QObject
 {
 	Q_OBJECT
-	Q_ENUMS(FunctionId)
 
 public:
-
 	enum FunctionId {
-		NEOVIM_FN_NULL=0,
+		NEOVIM_FN_NULL,
 		{% for f in functions %}
-		NEOVIM_FN_{{ f.name.upper() }},
+NEOVIM_FN_{{ f.name.upper() }},
 		{% endfor %}
 	};
+	Q_ENUM(FunctionId)
 
-	static bool checkFunctions(const QVariantList& ftable);
-	static FunctionId functionId(const Function& f);
+	static bool checkFunctions(const QVariantList& ftable) noexcept;
 
-	NeovimApi{{api_level}}(NeovimConnector *);
+	static FunctionId functionId(const Function& f) noexcept;
+
+	NeovimApi{{api_level}}(NeovimConnector* c) noexcept;
+
 protected slots:
-	void handleResponse(quint32 id, quint64 fun, const QVariant&);
-	void handleResponseError(quint32 id, quint64 fun, const QVariant&);
+	void handleResponse(uint32_t id, uint64_t fun, const QVariant&);
+
+	void handleResponseError(uint32_t id, uint64_t fun, const QVariant&);
+
 signals:
 	void error(const QString& errmsg, const QVariant& errObj);
+
 	void neovimNotification(const QByteArray &name, const QVariantList& args);
+
 private:
-	NeovimConnector *m_c;
+	NeovimConnector* m_connector;
+
 public slots:
 {% for f in functions %}
-{% if f.deprecated() %}
-	// DEPRECATED
-{% endif %}
-	// {{f.signature()}}
-	MsgpackRequest* {{f.name}}({{f.argstring}});
+	/// {% if f.deprecated() %}DEPRECATED: {% endif %}{{f.signature()}}
+	NeovimQt::MsgpackRequest* {{f.name}}({{f.argstring}});
+
 {% endfor %}
 
 signals:
@@ -53,5 +59,5 @@ signals:
 
 {% endfor %}
 };
-} // namespace
-#endif
+
+} // namespace NeovimQt

--- a/contrib/azure-pipelines.yml
+++ b/contrib/azure-pipelines.yml
@@ -6,7 +6,7 @@ jobs:
     - script: |
         sudo add-apt-repository -y ppa:neovim-ppa/stable
         sudo apt update -y
-        sudo apt install -y neovim qt5-default ninja-build
+        sudo apt install -y neovim qt5-default libqt5svg5-dev ninja-build
       displayName: Install Dependencies
     - task: CMake@1
       inputs:
@@ -18,47 +18,47 @@ jobs:
         workingDirectory: $(Build.BinariesDirectory)
         cmakeArgs: --build .
       displayName: CMake Build
-  - job: Apple
-    pool:
-      vmImage: 'macOS-latest'
-    steps:
-    - script: brew install msgpack neovim ninja qt5
-      displayName: Install Dependencies
-    - task: CMake@1
-      inputs:
-        workingDirectory: $(Build.BinariesDirectory)
-        cmakeArgs: -GNinja -DUSE_SYSTEM_MSGPACK=OFF -DCMAKE_BUILD_TYPE=Debug $(Build.SourcesDirectory)
-      displayName: CMake Configure
-    - task: CMake@1
-      inputs:
-        workingDirectory: $(Build.BinariesDirectory)
-        cmakeArgs: --build .
-      displayName: CMake Build
-  - job: Windows
-    pool:
-      vmImage: 'vs2017-win2016'
-    steps:
-    - task: UsePythonVersion@0
-      inputs:
-        versionSpec: '3.7'
-        architecture: 'x64'
-      displayName: Setup Python
-    - script: |
-        cinst --no-progress -y 7zip neovim
-        pip install aqtinstall
-        cd $(Build.BinariesDirectory)
-        python -m aqt install 5.12.1 windows desktop win64_msvc2017_64
-      displayName: Install Dependencies
-    - powershell: |
-        Write-Host "##vso[task.setvariable variable=PATH;]${env:PATH};C:\tools\neovim\Neovim\bin";
-      displayName: Add Neovim to PATH
-    - task: CMake@1
-      inputs:
-        workingDirectory: $(Build.BinariesDirectory)
-        cmakeArgs: -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=$(Build.BinariesDirectory)\Qt5.12.1\5.12.1\msvc2017_64 $(Build.SourcesDirectory)
-      displayName: CMake Configure
-    - task: CMake@1
-      inputs:
-        workingDirectory: $(Build.BinariesDirectory)
-        cmakeArgs: --build .
-      displayName: CMake Build
+#  - job: Apple
+#    pool:
+#      vmImage: 'macOS-latest'
+#    steps:
+#    - script: brew install msgpack neovim ninja qt5
+#      displayName: Install Dependencies
+#    - task: CMake@1
+#      inputs:
+#        workingDirectory: $(Build.BinariesDirectory)
+#        cmakeArgs: -GNinja -DUSE_SYSTEM_MSGPACK=OFF -DCMAKE_BUILD_TYPE=Debug $(Build.SourcesDirectory)
+#      displayName: CMake Configure
+#    - task: CMake@1
+#      inputs:
+#        workingDirectory: $(Build.BinariesDirectory)
+#        cmakeArgs: --build .
+#      displayName: CMake Build
+#  - job: Windows
+#    pool:
+#      vmImage: 'vs2017-win2016'
+#    steps:
+#    - task: UsePythonVersion@0
+#      inputs:
+#        versionSpec: '3.7'
+#        architecture: 'x64'
+#      displayName: Setup Python
+#    - script: |
+#        cinst --no-progress -y 7zip neovim
+#        pip install aqtinstall
+#        cd $(Build.BinariesDirectory)
+#        python -m aqt install 5.12.1 windows desktop win64_msvc2017_64
+#      displayName: Install Dependencies
+#    - powershell: |
+#        Write-Host "##vso[task.setvariable variable=PATH;]${env:PATH};C:\tools\neovim\Neovim\bin";
+#      displayName: Add Neovim to PATH
+#    - task: CMake@1
+#      inputs:
+#        workingDirectory: $(Build.BinariesDirectory)
+#        cmakeArgs: -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=$(Build.BinariesDirectory)\Qt5.12.1\5.12.1\msvc2017_64 $(Build.SourcesDirectory)
+#      displayName: CMake Configure
+#    - task: CMake@1
+#      inputs:
+#        workingDirectory: $(Build.BinariesDirectory)
+#        cmakeArgs: --build .
+#      displayName: CMake Build

--- a/contrib/azure-pipelines.yml
+++ b/contrib/azure-pipelines.yml
@@ -1,0 +1,64 @@
+jobs:
+  - job: Linux
+    pool:
+      vmImage: 'ubuntu-latest'
+    steps:
+    - script: |
+        sudo add-apt-repository -y ppa:neovim-ppa/stable
+        sudo apt update -y
+        sudo apt install -y neovim qt5-default ninja-build
+      displayName: Install Dependencies
+    - task: CMake@1
+      inputs:
+        workingDirectory: $(Build.BinariesDirectory)
+        cmakeArgs: -GNinja -DCMAKE_BUILD_TYPE=Debug $(Build.SourcesDirectory)
+      displayName: CMake Configure
+    - task: CMake@1
+      inputs:
+        workingDirectory: $(Build.BinariesDirectory)
+        cmakeArgs: --build .
+      displayName: CMake Build
+  - job: Apple
+    pool:
+      vmImage: 'macOS-latest'
+    steps:
+    - script: brew install msgpack neovim ninja qt5
+      displayName: Install Dependencies
+    - task: CMake@1
+      inputs:
+        workingDirectory: $(Build.BinariesDirectory)
+        cmakeArgs: -GNinja -DUSE_SYSTEM_MSGPACK=OFF -DCMAKE_BUILD_TYPE=Debug $(Build.SourcesDirectory)
+      displayName: CMake Configure
+    - task: CMake@1
+      inputs:
+        workingDirectory: $(Build.BinariesDirectory)
+        cmakeArgs: --build .
+      displayName: CMake Build
+  - job: Windows
+    pool:
+      vmImage: 'vs2017-win2016'
+    steps:
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: '3.7'
+        architecture: 'x64'
+      displayName: Setup Python
+    - script: |
+        cinst --no-progress -y 7zip neovim
+        pip install aqtinstall
+        cd $(Build.BinariesDirectory)
+        python -m aqt install 5.12.1 windows desktop win64_msvc2017_64
+      displayName: Install Dependencies
+    - powershell: |
+        Write-Host "##vso[task.setvariable variable=PATH;]${env:PATH};C:\tools\neovim\Neovim\bin";
+      displayName: Add Neovim to PATH
+    - task: CMake@1
+      inputs:
+        workingDirectory: $(Build.BinariesDirectory)
+        cmakeArgs: -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=$(Build.BinariesDirectory)\Qt5.12.1\5.12.1\msvc2017_64 $(Build.SourcesDirectory)
+      displayName: CMake Configure
+    - task: CMake@1
+      inputs:
+        workingDirectory: $(Build.BinariesDirectory)
+        cmakeArgs: --build .
+      displayName: CMake Build

--- a/contrib/azure-pipelines.yml
+++ b/contrib/azure-pipelines.yml
@@ -1,21 +1,21 @@
 jobs:
   - job: Linux
     pool:
-      vmImage: 'ubuntu-latest'
+      vmImage: 'ubuntu-20.04'
     steps:
     - script: |
         sudo add-apt-repository -y ppa:neovim-ppa/stable
         sudo apt update -y
-        sudo apt install -y neovim qt5-default libqt5svg5-dev ninja-build
+        sudo apt install -y neovim qt5-default libqt5svg5-dev ninja-build clazy
       displayName: Install Dependencies
     - task: CMake@1
       inputs:
-        workingDirectory: $(Build.BinariesDirectory)
-        cmakeArgs: -GNinja -DCMAKE_BUILD_TYPE=Debug $(Build.SourcesDirectory)
+        workingDirectory: $(Build.SourcesDirectory)/build_clazy
+        cmakeArgs: -GNinja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=clazy -DENABLE_CLAZY=1 $(Build.SourcesDirectory)
       displayName: CMake Configure
     - task: CMake@1
       inputs:
-        workingDirectory: $(Build.BinariesDirectory)
+        workingDirectory: $(Build.SourcesDirectory)/build_clazy
         cmakeArgs: --build .
       displayName: CMake Build
 #  - job: Apple

--- a/src/auto/neovimapi0.cpp
+++ b/src/auto/neovimapi0.cpp
@@ -1,15 +1,15 @@
-// Auto generated 2017-10-31 14:14:44.011610 from nvim API level:0
+// Auto generated 2020-09-09 13:30:53.897511 from nvim API level:0
 #include "auto/neovimapi0.h"
-#include "neovimconnector.h"
-#include "msgpackrequest.h"
 #include "msgpackiodevice.h"
+#include "msgpackrequest.h"
+#include "neovimconnector.h"
 #include "util.h"
 
 namespace NeovimQt {
 /* Unpack Neovim EXT types Window, Buffer Tabpage which are all
  * uint64_t see Neovim:msgpack_rpc_to_
  */
-QVariant unpackBufferApi0(MsgpackIODevice *dev, const char* in, quint32 size)
+static QVariant unpackBufferApi0(MsgpackIODevice *dev, const char* in, uint32_t size) noexcept
 {
 	msgpack_unpacked result;
 	msgpack_unpacked_init(&result);
@@ -20,10 +20,10 @@ QVariant unpackBufferApi0(MsgpackIODevice *dev, const char* in, quint32 size)
 	if (ret == MSGPACK_UNPACK_SUCCESS) {
 		switch (result.data.type) {
 			case MSGPACK_OBJECT_NEGATIVE_INTEGER:
-				variant = (qint64)result.data.via.i64;
+				variant.setValue<int64_t>(result.data.via.i64);
 				break;
 			case MSGPACK_OBJECT_POSITIVE_INTEGER:
-				variant = (quint64)result.data.via.u64;
+				variant.setValue<uint64_t>(result.data.via.u64);
 				break;
 			default:
 				// TODO it would be nice if we could call back MsgpackIoDevice method or primitive types here
@@ -34,798 +34,886 @@ QVariant unpackBufferApi0(MsgpackIODevice *dev, const char* in, quint32 size)
 	msgpack_unpacked_destroy(&result);
 	return variant;
 }
-#define unpackWindowApi0 unpackBufferApi0
-#define unpackTabpageApi0 unpackBufferApi0
 
-NeovimApi0::NeovimApi0(NeovimConnector *c)
-:m_c(c)
+static QVariant unpackWindowApi0(MsgpackIODevice *dev, const char* in, uint32_t size) noexcept
+{
+	return unpackBufferApi0(dev, in, size);
+}
+
+static QVariant unpackTabpageApi0(MsgpackIODevice *dev, const char* in, uint32_t size) noexcept
+{
+	return unpackBufferApi0(dev, in, size);
+}
+
+NeovimApi0::NeovimApi0(NeovimConnector *c) noexcept
+	: m_connector{ c }
 {
 	// EXT types
-		m_c->m_dev->registerExtType(0, unpackBufferApi0);
-		m_c->m_dev->registerExtType(1, unpackWindowApi0);
-		m_c->m_dev->registerExtType(2, unpackTabpageApi0);
-		connect(m_c->m_dev, &MsgpackIODevice::notification,
-			this, &NeovimApi0::neovimNotification);
+	m_connector->m_dev->registerExtType(0, unpackBufferApi0);
+	m_connector->m_dev->registerExtType(1, unpackWindowApi0);
+	m_connector->m_dev->registerExtType(2, unpackTabpageApi0);
+	connect(m_connector->m_dev, &MsgpackIODevice::notification,
+		this, &NeovimApi0::neovimNotification);
 }
 
 // Slots
 MsgpackRequest* NeovimApi0::buffer_line_count(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_line_count", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_line_count", 1) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_BUFFER_LINE_COUNT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::buffer_get_line(int64_t buffer, int64_t index)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_line", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_get_line", 2) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_BUFFER_GET_LINE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(index);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(index);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::buffer_set_line(int64_t buffer, int64_t index, QByteArray line)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_set_line", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_set_line", 3) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_BUFFER_SET_LINE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(index);
-	m_c->m_dev->send(line);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(index);
+	m_connector->m_dev->send(line);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::buffer_del_line(int64_t buffer, int64_t index)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_del_line", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_del_line", 2) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_BUFFER_DEL_LINE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(index);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(index);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::buffer_get_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_line_slice", 5);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_get_line_slice", 5) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_BUFFER_GET_LINE_SLICE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(start);
-	m_c->m_dev->send(end);
-	m_c->m_dev->send(include_start);
-	m_c->m_dev->send(include_end);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(start);
+	m_connector->m_dev->send(end);
+	m_connector->m_dev->send(include_start);
+	m_connector->m_dev->send(include_end);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::buffer_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_lines", 4);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_get_lines", 4) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_BUFFER_GET_LINES);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(start);
-	m_c->m_dev->send(end);
-	m_c->m_dev->send(strict_indexing);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(start);
+	m_connector->m_dev->send(end);
+	m_connector->m_dev->send(strict_indexing);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::buffer_set_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end, QList<QByteArray> replacement)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_set_line_slice", 6);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_set_line_slice", 6) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_BUFFER_SET_LINE_SLICE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(start);
-	m_c->m_dev->send(end);
-	m_c->m_dev->send(include_start);
-	m_c->m_dev->send(include_end);
-	m_c->m_dev->sendArrayOf(replacement);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(start);
+	m_connector->m_dev->send(end);
+	m_connector->m_dev->send(include_start);
+	m_connector->m_dev->send(include_end);
+	m_connector->m_dev->sendArrayOf(replacement);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::buffer_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_set_lines", 5);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_set_lines", 5) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_BUFFER_SET_LINES);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(start);
-	m_c->m_dev->send(end);
-	m_c->m_dev->send(strict_indexing);
-	m_c->m_dev->sendArrayOf(replacement);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(start);
+	m_connector->m_dev->send(end);
+	m_connector->m_dev->send(strict_indexing);
+	m_connector->m_dev->sendArrayOf(replacement);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::buffer_get_var(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_get_var", 2) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_BUFFER_GET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::buffer_set_var(int64_t buffer, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_set_var", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_set_var", 3) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_BUFFER_SET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::buffer_del_var(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_del_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_del_var", 2) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_BUFFER_DEL_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::buffer_get_option(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_option", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_get_option", 2) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_BUFFER_GET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::buffer_set_option(int64_t buffer, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_set_option", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_set_option", 3) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_BUFFER_SET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::buffer_get_number(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_number", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_get_number", 1) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_BUFFER_GET_NUMBER);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::buffer_get_name(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_name", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_get_name", 1) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_BUFFER_GET_NAME);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::buffer_set_name(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_set_name", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_set_name", 2) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_BUFFER_SET_NAME);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::buffer_is_valid(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_is_valid", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_is_valid", 1) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_BUFFER_IS_VALID);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::buffer_insert(int64_t buffer, int64_t lnum, QList<QByteArray> lines)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_insert", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_insert", 3) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_BUFFER_INSERT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(lnum);
-	m_c->m_dev->sendArrayOf(lines);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(lnum);
+	m_connector->m_dev->sendArrayOf(lines);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::buffer_get_mark(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_mark", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_get_mark", 2) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_BUFFER_GET_MARK);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::buffer_add_highlight(int64_t buffer, int64_t src_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_add_highlight", 6);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_add_highlight", 6) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_BUFFER_ADD_HIGHLIGHT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(src_id);
-	m_c->m_dev->send(hl_group);
-	m_c->m_dev->send(line);
-	m_c->m_dev->send(col_start);
-	m_c->m_dev->send(col_end);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(src_id);
+	m_connector->m_dev->send(hl_group);
+	m_connector->m_dev->send(line);
+	m_connector->m_dev->send(col_start);
+	m_connector->m_dev->send(col_end);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::buffer_clear_highlight(int64_t buffer, int64_t src_id, int64_t line_start, int64_t line_end)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_clear_highlight", 4);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_clear_highlight", 4) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_BUFFER_CLEAR_HIGHLIGHT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(src_id);
-	m_c->m_dev->send(line_start);
-	m_c->m_dev->send(line_end);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(src_id);
+	m_connector->m_dev->send(line_start);
+	m_connector->m_dev->send(line_end);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::tabpage_get_windows(int64_t tabpage)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("tabpage_get_windows", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("tabpage_get_windows", 1) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_TABPAGE_GET_WINDOWS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(tabpage);
+	m_connector->m_dev->send(tabpage);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::tabpage_get_var(int64_t tabpage, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("tabpage_get_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("tabpage_get_var", 2) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_TABPAGE_GET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(tabpage);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(tabpage);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("tabpage_set_var", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("tabpage_set_var", 3) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_TABPAGE_SET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(tabpage);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(tabpage);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::tabpage_del_var(int64_t tabpage, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("tabpage_del_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("tabpage_del_var", 2) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_TABPAGE_DEL_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(tabpage);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(tabpage);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::tabpage_get_window(int64_t tabpage)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("tabpage_get_window", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("tabpage_get_window", 1) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_TABPAGE_GET_WINDOW);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(tabpage);
+	m_connector->m_dev->send(tabpage);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::tabpage_is_valid(int64_t tabpage)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("tabpage_is_valid", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("tabpage_is_valid", 1) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_TABPAGE_IS_VALID);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(tabpage);
+	m_connector->m_dev->send(tabpage);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::ui_attach(int64_t width, int64_t height, bool enable_rgb)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("ui_attach", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("ui_attach", 3) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_UI_ATTACH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(width);
-	m_c->m_dev->send(height);
-	m_c->m_dev->send(enable_rgb);
+	m_connector->m_dev->send(width);
+	m_connector->m_dev->send(height);
+	m_connector->m_dev->send(enable_rgb);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::ui_detach()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("ui_detach", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("ui_detach", 0) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_UI_DETACH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::ui_try_resize(int64_t width, int64_t height)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("ui_try_resize", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("ui_try_resize", 2) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_UI_TRY_RESIZE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(width);
-	m_c->m_dev->send(height);
+	m_connector->m_dev->send(width);
+	m_connector->m_dev->send(height);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::vim_command(QByteArray str)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_command", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_command", 1) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_VIM_COMMAND);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(str);
+	m_connector->m_dev->send(str);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::vim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_feedkeys", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_feedkeys", 3) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_VIM_FEEDKEYS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(keys);
-	m_c->m_dev->send(mode);
-	m_c->m_dev->send(escape_csi);
+	m_connector->m_dev->send(keys);
+	m_connector->m_dev->send(mode);
+	m_connector->m_dev->send(escape_csi);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::vim_input(QByteArray keys)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_input", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_input", 1) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_VIM_INPUT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(keys);
+	m_connector->m_dev->send(keys);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::vim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_replace_termcodes", 4);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_replace_termcodes", 4) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_VIM_REPLACE_TERMCODES);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(str);
-	m_c->m_dev->send(from_part);
-	m_c->m_dev->send(do_lt);
-	m_c->m_dev->send(special);
+	m_connector->m_dev->send(str);
+	m_connector->m_dev->send(from_part);
+	m_connector->m_dev->send(do_lt);
+	m_connector->m_dev->send(special);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::vim_command_output(QByteArray str)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_command_output", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_command_output", 1) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_VIM_COMMAND_OUTPUT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(str);
+	m_connector->m_dev->send(str);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::vim_eval(QByteArray str)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_eval", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_eval", 1) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_VIM_EVAL);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(str);
+	m_connector->m_dev->send(str);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::vim_call_function(QByteArray fname, QVariantList args)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_call_function", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_call_function", 2) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_VIM_CALL_FUNCTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(fname);
-	m_c->m_dev->send(args);
+	m_connector->m_dev->send(fname);
+	m_connector->m_dev->send(args);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::vim_strwidth(QByteArray str)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_strwidth", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_strwidth", 1) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_VIM_STRWIDTH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(str);
+	m_connector->m_dev->send(str);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::vim_list_runtime_paths()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_list_runtime_paths", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_list_runtime_paths", 0) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_VIM_LIST_RUNTIME_PATHS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::vim_change_directory(QByteArray dir)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_change_directory", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_change_directory", 1) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_VIM_CHANGE_DIRECTORY);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(dir);
+	m_connector->m_dev->send(dir);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::vim_get_current_line()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_current_line", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_current_line", 0) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_VIM_GET_CURRENT_LINE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::vim_set_current_line(QByteArray line)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_set_current_line", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_set_current_line", 1) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_VIM_SET_CURRENT_LINE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(line);
+	m_connector->m_dev->send(line);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::vim_del_current_line()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_del_current_line", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_del_current_line", 0) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_VIM_DEL_CURRENT_LINE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::vim_get_var(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_var", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_var", 1) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_VIM_GET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::vim_set_var(QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_set_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_set_var", 2) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_VIM_SET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::vim_del_var(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_del_var", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_del_var", 1) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_VIM_DEL_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::vim_get_vvar(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_vvar", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_vvar", 1) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_VIM_GET_VVAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::vim_get_option(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_option", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_option", 1) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_VIM_GET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::vim_set_option(QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_set_option", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_set_option", 2) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_VIM_SET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::vim_out_write(QByteArray str)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_out_write", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_out_write", 1) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_VIM_OUT_WRITE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(str);
+	m_connector->m_dev->send(str);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::vim_err_write(QByteArray str)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_err_write", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_err_write", 1) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_VIM_ERR_WRITE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(str);
+	m_connector->m_dev->send(str);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::vim_report_error(QByteArray str)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_report_error", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_report_error", 1) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_VIM_REPORT_ERROR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(str);
+	m_connector->m_dev->send(str);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::vim_get_buffers()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_buffers", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_buffers", 0) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_VIM_GET_BUFFERS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::vim_get_current_buffer()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_current_buffer", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_current_buffer", 0) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_VIM_GET_CURRENT_BUFFER);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::vim_set_current_buffer(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_set_current_buffer", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_set_current_buffer", 1) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_VIM_SET_CURRENT_BUFFER);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::vim_get_windows()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_windows", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_windows", 0) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_VIM_GET_WINDOWS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::vim_get_current_window()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_current_window", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_current_window", 0) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_VIM_GET_CURRENT_WINDOW);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::vim_set_current_window(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_set_current_window", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_set_current_window", 1) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_VIM_SET_CURRENT_WINDOW);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::vim_get_tabpages()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_tabpages", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_tabpages", 0) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_VIM_GET_TABPAGES);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::vim_get_current_tabpage()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_current_tabpage", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_current_tabpage", 0) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_VIM_GET_CURRENT_TABPAGE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::vim_set_current_tabpage(int64_t tabpage)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_set_current_tabpage", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_set_current_tabpage", 1) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_VIM_SET_CURRENT_TABPAGE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(tabpage);
+	m_connector->m_dev->send(tabpage);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::vim_subscribe(QByteArray event)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_subscribe", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_subscribe", 1) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_VIM_SUBSCRIBE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(event);
+	m_connector->m_dev->send(event);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::vim_unsubscribe(QByteArray event)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_unsubscribe", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_unsubscribe", 1) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_VIM_UNSUBSCRIBE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(event);
+	m_connector->m_dev->send(event);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::vim_name_to_color(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_name_to_color", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_name_to_color", 1) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_VIM_NAME_TO_COLOR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::vim_get_color_map()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_color_map", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_color_map", 0) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_VIM_GET_COLOR_MAP);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::window_get_buffer(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_buffer", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_get_buffer", 1) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_WINDOW_GET_BUFFER);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::window_get_cursor(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_cursor", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_get_cursor", 1) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_WINDOW_GET_CURSOR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::window_set_cursor(int64_t window, QPoint pos)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_set_cursor", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_set_cursor", 2) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_WINDOW_SET_CURSOR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(pos);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(pos);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::window_get_height(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_height", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_get_height", 1) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_WINDOW_GET_HEIGHT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::window_set_height(int64_t window, int64_t height)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_set_height", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_set_height", 2) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_WINDOW_SET_HEIGHT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(height);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(height);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::window_get_width(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_width", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_get_width", 1) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_WINDOW_GET_WIDTH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::window_set_width(int64_t window, int64_t width)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_set_width", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_set_width", 2) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_WINDOW_SET_WIDTH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(width);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(width);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::window_get_var(int64_t window, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_get_var", 2) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_WINDOW_GET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::window_set_var(int64_t window, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_set_var", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_set_var", 3) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_WINDOW_SET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::window_del_var(int64_t window, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_del_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_del_var", 2) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_WINDOW_DEL_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::window_get_option(int64_t window, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_option", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_get_option", 2) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_WINDOW_GET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::window_set_option(int64_t window, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_set_option", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_set_option", 3) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_WINDOW_SET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::window_get_position(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_position", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_get_position", 1) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_WINDOW_GET_POSITION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::window_get_tabpage(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_tabpage", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_get_tabpage", 1) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_WINDOW_GET_TABPAGE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi0::window_is_valid(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_is_valid", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_is_valid", 1) };
 	r->setFunction(NeovimApi0::NEOVIM_FN_WINDOW_IS_VALID);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi0::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi0::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
 
+
 // Handlers
 
-void NeovimApi0::handleResponseError(quint32 msgid, quint64 fun, const QVariant& res)
+void NeovimApi0::handleResponseError(uint32_t msgid, uint64_t fun, const QVariant& res)
 {
 
 	// TODO: support Neovim error types Exception/Validation/etc
@@ -833,7 +921,7 @@ void NeovimApi0::handleResponseError(quint32 msgid, quint64 fun, const QVariant&
 	const QVariantList asList = res.toList();
 	if (asList.size() >= 2) {
 		if (asList.at(1).canConvert<QByteArray>()) {
-			errMsg = m_c->m_dev->decode(asList.at(1).toByteArray());
+			errMsg = m_connector->m_dev->decode(asList.at(1).toByteArray());
 		} else {
 			errMsg = tr("Received unsupported Neovim error type");
 		}
@@ -1081,805 +1169,805 @@ void NeovimApi0::handleResponseError(quint32 msgid, quint64 fun, const QVariant&
 		emit err_window_is_valid(errMsg, res);
 		break;
 	default:
-		m_c->setError(NeovimConnector::RuntimeMsgpackError, QString("Received error for function that should not fail: %s").arg(fun));
+		m_connector->setError(NeovimConnector::RuntimeMsgpackError, QString("Received error for function that should not fail: %s").arg(fun));
 	}
 }
 
-void NeovimApi0::handleResponse(quint32 msgid, quint64 fun, const QVariant& res)
+void NeovimApi0::handleResponse(uint32_t msgid, uint64_t fun, const QVariant& res)
 {
 	switch(fun) {
-	case NeovimApi0::NEOVIM_FN_BUFFER_LINE_COUNT:
+		case NeovimApi0::NEOVIM_FN_BUFFER_LINE_COUNT:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_line_count");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_line_count");
 				return;
-			} else {
-				emit on_buffer_line_count(data);
 			}
 
+			emit on_buffer_line_count(data);
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_BUFFER_GET_LINE:
+
+		case NeovimApi0::NEOVIM_FN_BUFFER_GET_LINE:
 		{
 			QByteArray data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_line");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_line");
 				return;
-			} else {
-				emit on_buffer_get_line(data);
 			}
 
+			emit on_buffer_get_line(data);
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_BUFFER_SET_LINE:
+
+		case NeovimApi0::NEOVIM_FN_BUFFER_SET_LINE:
 		{
 			emit on_buffer_set_line();
-
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_BUFFER_DEL_LINE:
+
+		case NeovimApi0::NEOVIM_FN_BUFFER_DEL_LINE:
 		{
 			emit on_buffer_del_line();
-
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_BUFFER_GET_LINE_SLICE:
+
+		case NeovimApi0::NEOVIM_FN_BUFFER_GET_LINE_SLICE:
 		{
 			QList<QByteArray> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_line_slice");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_line_slice");
 				return;
-			} else {
-				emit on_buffer_get_line_slice(data);
 			}
 
+			emit on_buffer_get_line_slice(data);
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_BUFFER_GET_LINES:
+
+		case NeovimApi0::NEOVIM_FN_BUFFER_GET_LINES:
 		{
 			QList<QByteArray> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_lines");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_lines");
 				return;
-			} else {
-				emit on_buffer_get_lines(data);
 			}
 
+			emit on_buffer_get_lines(data);
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_BUFFER_SET_LINE_SLICE:
+
+		case NeovimApi0::NEOVIM_FN_BUFFER_SET_LINE_SLICE:
 		{
 			emit on_buffer_set_line_slice();
-
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_BUFFER_SET_LINES:
+
+		case NeovimApi0::NEOVIM_FN_BUFFER_SET_LINES:
 		{
 			emit on_buffer_set_lines();
-
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_BUFFER_GET_VAR:
+
+		case NeovimApi0::NEOVIM_FN_BUFFER_GET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_var");
 				return;
-			} else {
-				emit on_buffer_get_var(data);
 			}
 
+			emit on_buffer_get_var(data);
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_BUFFER_SET_VAR:
+
+		case NeovimApi0::NEOVIM_FN_BUFFER_SET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_set_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_set_var");
 				return;
-			} else {
-				emit on_buffer_set_var(data);
 			}
 
+			emit on_buffer_set_var(data);
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_BUFFER_DEL_VAR:
+
+		case NeovimApi0::NEOVIM_FN_BUFFER_DEL_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_del_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_del_var");
 				return;
-			} else {
-				emit on_buffer_del_var(data);
 			}
 
+			emit on_buffer_del_var(data);
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_BUFFER_GET_OPTION:
+
+		case NeovimApi0::NEOVIM_FN_BUFFER_GET_OPTION:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_option");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_option");
 				return;
-			} else {
-				emit on_buffer_get_option(data);
 			}
 
+			emit on_buffer_get_option(data);
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_BUFFER_SET_OPTION:
+
+		case NeovimApi0::NEOVIM_FN_BUFFER_SET_OPTION:
 		{
 			emit on_buffer_set_option();
-
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_BUFFER_GET_NUMBER:
+
+		case NeovimApi0::NEOVIM_FN_BUFFER_GET_NUMBER:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_number");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_number");
 				return;
-			} else {
-				emit on_buffer_get_number(data);
 			}
 
+			emit on_buffer_get_number(data);
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_BUFFER_GET_NAME:
+
+		case NeovimApi0::NEOVIM_FN_BUFFER_GET_NAME:
 		{
 			QByteArray data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_name");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_name");
 				return;
-			} else {
-				emit on_buffer_get_name(data);
 			}
 
+			emit on_buffer_get_name(data);
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_BUFFER_SET_NAME:
+
+		case NeovimApi0::NEOVIM_FN_BUFFER_SET_NAME:
 		{
 			emit on_buffer_set_name();
-
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_BUFFER_IS_VALID:
+
+		case NeovimApi0::NEOVIM_FN_BUFFER_IS_VALID:
 		{
 			bool data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_is_valid");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_is_valid");
 				return;
-			} else {
-				emit on_buffer_is_valid(data);
 			}
 
+			emit on_buffer_is_valid(data);
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_BUFFER_INSERT:
+
+		case NeovimApi0::NEOVIM_FN_BUFFER_INSERT:
 		{
 			emit on_buffer_insert();
-
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_BUFFER_GET_MARK:
+
+		case NeovimApi0::NEOVIM_FN_BUFFER_GET_MARK:
 		{
 			QPoint data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_mark");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_mark");
 				return;
-			} else {
-				emit on_buffer_get_mark(data);
 			}
 
+			emit on_buffer_get_mark(data);
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_BUFFER_ADD_HIGHLIGHT:
+
+		case NeovimApi0::NEOVIM_FN_BUFFER_ADD_HIGHLIGHT:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_add_highlight");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_add_highlight");
 				return;
-			} else {
-				emit on_buffer_add_highlight(data);
 			}
 
+			emit on_buffer_add_highlight(data);
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_BUFFER_CLEAR_HIGHLIGHT:
+
+		case NeovimApi0::NEOVIM_FN_BUFFER_CLEAR_HIGHLIGHT:
 		{
 			emit on_buffer_clear_highlight();
-
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_TABPAGE_GET_WINDOWS:
+
+		case NeovimApi0::NEOVIM_FN_TABPAGE_GET_WINDOWS:
 		{
 			QList<int64_t> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_get_windows");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_get_windows");
 				return;
-			} else {
-				emit on_tabpage_get_windows(data);
 			}
 
+			emit on_tabpage_get_windows(data);
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_TABPAGE_GET_VAR:
+
+		case NeovimApi0::NEOVIM_FN_TABPAGE_GET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_get_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_get_var");
 				return;
-			} else {
-				emit on_tabpage_get_var(data);
 			}
 
+			emit on_tabpage_get_var(data);
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_TABPAGE_SET_VAR:
+
+		case NeovimApi0::NEOVIM_FN_TABPAGE_SET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_set_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_set_var");
 				return;
-			} else {
-				emit on_tabpage_set_var(data);
 			}
 
+			emit on_tabpage_set_var(data);
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_TABPAGE_DEL_VAR:
+
+		case NeovimApi0::NEOVIM_FN_TABPAGE_DEL_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_del_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_del_var");
 				return;
-			} else {
-				emit on_tabpage_del_var(data);
 			}
 
+			emit on_tabpage_del_var(data);
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_TABPAGE_GET_WINDOW:
+
+		case NeovimApi0::NEOVIM_FN_TABPAGE_GET_WINDOW:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_get_window");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_get_window");
 				return;
-			} else {
-				emit on_tabpage_get_window(data);
 			}
 
+			emit on_tabpage_get_window(data);
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_TABPAGE_IS_VALID:
+
+		case NeovimApi0::NEOVIM_FN_TABPAGE_IS_VALID:
 		{
 			bool data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_is_valid");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_is_valid");
 				return;
-			} else {
-				emit on_tabpage_is_valid(data);
 			}
 
+			emit on_tabpage_is_valid(data);
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_UI_ATTACH:
+
+		case NeovimApi0::NEOVIM_FN_UI_ATTACH:
 		{
 			emit on_ui_attach();
-
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_UI_DETACH:
+
+		case NeovimApi0::NEOVIM_FN_UI_DETACH:
 		{
 			emit on_ui_detach();
-
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_UI_TRY_RESIZE:
+
+		case NeovimApi0::NEOVIM_FN_UI_TRY_RESIZE:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for ui_try_resize");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for ui_try_resize");
 				return;
-			} else {
-				emit on_ui_try_resize(data);
 			}
 
+			emit on_ui_try_resize(data);
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_VIM_COMMAND:
+
+		case NeovimApi0::NEOVIM_FN_VIM_COMMAND:
 		{
 			emit on_vim_command();
-
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_VIM_FEEDKEYS:
+
+		case NeovimApi0::NEOVIM_FN_VIM_FEEDKEYS:
 		{
 			emit on_vim_feedkeys();
-
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_VIM_INPUT:
+
+		case NeovimApi0::NEOVIM_FN_VIM_INPUT:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_input");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_input");
 				return;
-			} else {
-				emit on_vim_input(data);
 			}
 
+			emit on_vim_input(data);
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_VIM_REPLACE_TERMCODES:
+
+		case NeovimApi0::NEOVIM_FN_VIM_REPLACE_TERMCODES:
 		{
 			QByteArray data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_replace_termcodes");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_replace_termcodes");
 				return;
-			} else {
-				emit on_vim_replace_termcodes(data);
 			}
 
+			emit on_vim_replace_termcodes(data);
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_VIM_COMMAND_OUTPUT:
+
+		case NeovimApi0::NEOVIM_FN_VIM_COMMAND_OUTPUT:
 		{
 			QByteArray data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_command_output");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_command_output");
 				return;
-			} else {
-				emit on_vim_command_output(data);
 			}
 
+			emit on_vim_command_output(data);
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_VIM_EVAL:
+
+		case NeovimApi0::NEOVIM_FN_VIM_EVAL:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_eval");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_eval");
 				return;
-			} else {
-				emit on_vim_eval(data);
 			}
 
+			emit on_vim_eval(data);
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_VIM_CALL_FUNCTION:
+
+		case NeovimApi0::NEOVIM_FN_VIM_CALL_FUNCTION:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_call_function");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_call_function");
 				return;
-			} else {
-				emit on_vim_call_function(data);
 			}
 
+			emit on_vim_call_function(data);
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_VIM_STRWIDTH:
+
+		case NeovimApi0::NEOVIM_FN_VIM_STRWIDTH:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_strwidth");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_strwidth");
 				return;
-			} else {
-				emit on_vim_strwidth(data);
 			}
 
+			emit on_vim_strwidth(data);
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_VIM_LIST_RUNTIME_PATHS:
+
+		case NeovimApi0::NEOVIM_FN_VIM_LIST_RUNTIME_PATHS:
 		{
 			QList<QByteArray> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_list_runtime_paths");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_list_runtime_paths");
 				return;
-			} else {
-				emit on_vim_list_runtime_paths(data);
 			}
 
+			emit on_vim_list_runtime_paths(data);
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_VIM_CHANGE_DIRECTORY:
+
+		case NeovimApi0::NEOVIM_FN_VIM_CHANGE_DIRECTORY:
 		{
 			emit on_vim_change_directory();
-
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_VIM_GET_CURRENT_LINE:
+
+		case NeovimApi0::NEOVIM_FN_VIM_GET_CURRENT_LINE:
 		{
 			QByteArray data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_current_line");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_current_line");
 				return;
-			} else {
-				emit on_vim_get_current_line(data);
 			}
 
+			emit on_vim_get_current_line(data);
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_VIM_SET_CURRENT_LINE:
+
+		case NeovimApi0::NEOVIM_FN_VIM_SET_CURRENT_LINE:
 		{
 			emit on_vim_set_current_line();
-
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_VIM_DEL_CURRENT_LINE:
+
+		case NeovimApi0::NEOVIM_FN_VIM_DEL_CURRENT_LINE:
 		{
 			emit on_vim_del_current_line();
-
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_VIM_GET_VAR:
+
+		case NeovimApi0::NEOVIM_FN_VIM_GET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_var");
 				return;
-			} else {
-				emit on_vim_get_var(data);
 			}
 
+			emit on_vim_get_var(data);
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_VIM_SET_VAR:
+
+		case NeovimApi0::NEOVIM_FN_VIM_SET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_set_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_set_var");
 				return;
-			} else {
-				emit on_vim_set_var(data);
 			}
 
+			emit on_vim_set_var(data);
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_VIM_DEL_VAR:
+
+		case NeovimApi0::NEOVIM_FN_VIM_DEL_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_del_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_del_var");
 				return;
-			} else {
-				emit on_vim_del_var(data);
 			}
 
+			emit on_vim_del_var(data);
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_VIM_GET_VVAR:
+
+		case NeovimApi0::NEOVIM_FN_VIM_GET_VVAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_vvar");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_vvar");
 				return;
-			} else {
-				emit on_vim_get_vvar(data);
 			}
 
+			emit on_vim_get_vvar(data);
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_VIM_GET_OPTION:
+
+		case NeovimApi0::NEOVIM_FN_VIM_GET_OPTION:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_option");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_option");
 				return;
-			} else {
-				emit on_vim_get_option(data);
 			}
 
+			emit on_vim_get_option(data);
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_VIM_SET_OPTION:
+
+		case NeovimApi0::NEOVIM_FN_VIM_SET_OPTION:
 		{
 			emit on_vim_set_option();
-
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_VIM_OUT_WRITE:
+
+		case NeovimApi0::NEOVIM_FN_VIM_OUT_WRITE:
 		{
 			emit on_vim_out_write();
-
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_VIM_ERR_WRITE:
+
+		case NeovimApi0::NEOVIM_FN_VIM_ERR_WRITE:
 		{
 			emit on_vim_err_write();
-
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_VIM_REPORT_ERROR:
+
+		case NeovimApi0::NEOVIM_FN_VIM_REPORT_ERROR:
 		{
 			emit on_vim_report_error();
-
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_VIM_GET_BUFFERS:
+
+		case NeovimApi0::NEOVIM_FN_VIM_GET_BUFFERS:
 		{
 			QList<int64_t> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_buffers");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_buffers");
 				return;
-			} else {
-				emit on_vim_get_buffers(data);
 			}
 
+			emit on_vim_get_buffers(data);
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_VIM_GET_CURRENT_BUFFER:
+
+		case NeovimApi0::NEOVIM_FN_VIM_GET_CURRENT_BUFFER:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_current_buffer");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_current_buffer");
 				return;
-			} else {
-				emit on_vim_get_current_buffer(data);
 			}
 
+			emit on_vim_get_current_buffer(data);
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_VIM_SET_CURRENT_BUFFER:
+
+		case NeovimApi0::NEOVIM_FN_VIM_SET_CURRENT_BUFFER:
 		{
 			emit on_vim_set_current_buffer();
-
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_VIM_GET_WINDOWS:
+
+		case NeovimApi0::NEOVIM_FN_VIM_GET_WINDOWS:
 		{
 			QList<int64_t> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_windows");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_windows");
 				return;
-			} else {
-				emit on_vim_get_windows(data);
 			}
 
+			emit on_vim_get_windows(data);
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_VIM_GET_CURRENT_WINDOW:
+
+		case NeovimApi0::NEOVIM_FN_VIM_GET_CURRENT_WINDOW:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_current_window");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_current_window");
 				return;
-			} else {
-				emit on_vim_get_current_window(data);
 			}
 
+			emit on_vim_get_current_window(data);
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_VIM_SET_CURRENT_WINDOW:
+
+		case NeovimApi0::NEOVIM_FN_VIM_SET_CURRENT_WINDOW:
 		{
 			emit on_vim_set_current_window();
-
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_VIM_GET_TABPAGES:
+
+		case NeovimApi0::NEOVIM_FN_VIM_GET_TABPAGES:
 		{
 			QList<int64_t> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_tabpages");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_tabpages");
 				return;
-			} else {
-				emit on_vim_get_tabpages(data);
 			}
 
+			emit on_vim_get_tabpages(data);
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_VIM_GET_CURRENT_TABPAGE:
+
+		case NeovimApi0::NEOVIM_FN_VIM_GET_CURRENT_TABPAGE:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_current_tabpage");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_current_tabpage");
 				return;
-			} else {
-				emit on_vim_get_current_tabpage(data);
 			}
 
+			emit on_vim_get_current_tabpage(data);
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_VIM_SET_CURRENT_TABPAGE:
+
+		case NeovimApi0::NEOVIM_FN_VIM_SET_CURRENT_TABPAGE:
 		{
 			emit on_vim_set_current_tabpage();
-
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_VIM_SUBSCRIBE:
+
+		case NeovimApi0::NEOVIM_FN_VIM_SUBSCRIBE:
 		{
 			emit on_vim_subscribe();
-
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_VIM_UNSUBSCRIBE:
+
+		case NeovimApi0::NEOVIM_FN_VIM_UNSUBSCRIBE:
 		{
 			emit on_vim_unsubscribe();
-
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_VIM_NAME_TO_COLOR:
+
+		case NeovimApi0::NEOVIM_FN_VIM_NAME_TO_COLOR:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_name_to_color");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_name_to_color");
 				return;
-			} else {
-				emit on_vim_name_to_color(data);
 			}
 
+			emit on_vim_name_to_color(data);
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_VIM_GET_COLOR_MAP:
+
+		case NeovimApi0::NEOVIM_FN_VIM_GET_COLOR_MAP:
 		{
 			QVariantMap data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_color_map");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_color_map");
 				return;
-			} else {
-				emit on_vim_get_color_map(data);
 			}
 
+			emit on_vim_get_color_map(data);
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_WINDOW_GET_BUFFER:
+
+		case NeovimApi0::NEOVIM_FN_WINDOW_GET_BUFFER:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_buffer");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_buffer");
 				return;
-			} else {
-				emit on_window_get_buffer(data);
 			}
 
+			emit on_window_get_buffer(data);
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_WINDOW_GET_CURSOR:
+
+		case NeovimApi0::NEOVIM_FN_WINDOW_GET_CURSOR:
 		{
 			QPoint data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_cursor");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_cursor");
 				return;
-			} else {
-				emit on_window_get_cursor(data);
 			}
 
+			emit on_window_get_cursor(data);
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_WINDOW_SET_CURSOR:
+
+		case NeovimApi0::NEOVIM_FN_WINDOW_SET_CURSOR:
 		{
 			emit on_window_set_cursor();
-
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_WINDOW_GET_HEIGHT:
+
+		case NeovimApi0::NEOVIM_FN_WINDOW_GET_HEIGHT:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_height");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_height");
 				return;
-			} else {
-				emit on_window_get_height(data);
 			}
 
+			emit on_window_get_height(data);
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_WINDOW_SET_HEIGHT:
+
+		case NeovimApi0::NEOVIM_FN_WINDOW_SET_HEIGHT:
 		{
 			emit on_window_set_height();
-
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_WINDOW_GET_WIDTH:
+
+		case NeovimApi0::NEOVIM_FN_WINDOW_GET_WIDTH:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_width");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_width");
 				return;
-			} else {
-				emit on_window_get_width(data);
 			}
 
+			emit on_window_get_width(data);
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_WINDOW_SET_WIDTH:
+
+		case NeovimApi0::NEOVIM_FN_WINDOW_SET_WIDTH:
 		{
 			emit on_window_set_width();
-
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_WINDOW_GET_VAR:
+
+		case NeovimApi0::NEOVIM_FN_WINDOW_GET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_var");
 				return;
-			} else {
-				emit on_window_get_var(data);
 			}
 
+			emit on_window_get_var(data);
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_WINDOW_SET_VAR:
+
+		case NeovimApi0::NEOVIM_FN_WINDOW_SET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_set_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_set_var");
 				return;
-			} else {
-				emit on_window_set_var(data);
 			}
 
+			emit on_window_set_var(data);
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_WINDOW_DEL_VAR:
+
+		case NeovimApi0::NEOVIM_FN_WINDOW_DEL_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_del_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_del_var");
 				return;
-			} else {
-				emit on_window_del_var(data);
 			}
 
+			emit on_window_del_var(data);
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_WINDOW_GET_OPTION:
+
+		case NeovimApi0::NEOVIM_FN_WINDOW_GET_OPTION:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_option");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_option");
 				return;
-			} else {
-				emit on_window_get_option(data);
 			}
 
+			emit on_window_get_option(data);
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_WINDOW_SET_OPTION:
+
+		case NeovimApi0::NEOVIM_FN_WINDOW_SET_OPTION:
 		{
 			emit on_window_set_option();
-
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_WINDOW_GET_POSITION:
+
+		case NeovimApi0::NEOVIM_FN_WINDOW_GET_POSITION:
 		{
 			QPoint data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_position");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_position");
 				return;
-			} else {
-				emit on_window_get_position(data);
 			}
 
+			emit on_window_get_position(data);
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_WINDOW_GET_TABPAGE:
+
+		case NeovimApi0::NEOVIM_FN_WINDOW_GET_TABPAGE:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_tabpage");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_tabpage");
 				return;
-			} else {
-				emit on_window_get_tabpage(data);
 			}
 
+			emit on_window_get_tabpage(data);
 		}
 		break;
-	case NeovimApi0::NEOVIM_FN_WINDOW_IS_VALID:
+
+		case NeovimApi0::NEOVIM_FN_WINDOW_IS_VALID:
 		{
 			bool data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_is_valid");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_is_valid");
 				return;
-			} else {
-				emit on_window_is_valid(data);
 			}
 
+			emit on_window_is_valid(data);
 		}
 		break;
+
 	default:
 		qWarning() << "Received unexpected response";
 	}
@@ -1893,389 +1981,627 @@ void NeovimApi0::handleResponse(quint32 msgid, quint64 fun, const QVariant& res)
  *
  * Returns false if there is an API mismatch
  */
-bool NeovimApi0::checkFunctions(const QVariantList& ftable)
+/*static*/ bool NeovimApi0::checkFunctions(const QVariantList& ftable) noexcept
 {
-
-	QList<Function> required;
-	required
-		<< Function("Integer", "buffer_line_count",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("String", "buffer_get_line",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						, false)
-		<< Function("void", "buffer_set_line",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("String")
-						, false)
-		<< Function("void", "buffer_del_line",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						, false)
-		<< Function("ArrayOf(String)", "buffer_get_line_slice",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Boolean")
-						<< QString("Boolean")
-						, false)
-		<< Function("ArrayOf(String)", "buffer_get_lines",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Boolean")
-						, false)
-		<< Function("void", "buffer_set_line_slice",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Boolean")
-						<< QString("Boolean")
-						<< QString("ArrayOf(String)")
-						, false)
-		<< Function("void", "buffer_set_lines",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Boolean")
-						<< QString("ArrayOf(String)")
-						, false)
-		<< Function("Object", "buffer_get_var",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("Object", "buffer_set_var",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("Object", "buffer_del_var",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("Object", "buffer_get_option",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("void", "buffer_set_option",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("Integer", "buffer_get_number",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("String", "buffer_get_name",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("void", "buffer_set_name",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("Boolean", "buffer_is_valid",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("void", "buffer_insert",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("ArrayOf(String)")
-						, false)
-		<< Function("ArrayOf(Integer, 2)", "buffer_get_mark",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("Integer", "buffer_add_highlight",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("String")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Integer")
-						, false)
-		<< Function("void", "buffer_clear_highlight",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Integer")
-						, false)
-		<< Function("ArrayOf(Window)", "tabpage_get_windows",
-			QList<QString>()
-						<< QString("Tabpage")
-						, false)
-		<< Function("Object", "tabpage_get_var",
-			QList<QString>()
-						<< QString("Tabpage")
-						<< QString("String")
-						, false)
-		<< Function("Object", "tabpage_set_var",
-			QList<QString>()
-						<< QString("Tabpage")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("Object", "tabpage_del_var",
-			QList<QString>()
-						<< QString("Tabpage")
-						<< QString("String")
-						, false)
-		<< Function("Window", "tabpage_get_window",
-			QList<QString>()
-						<< QString("Tabpage")
-						, false)
-		<< Function("Boolean", "tabpage_is_valid",
-			QList<QString>()
-						<< QString("Tabpage")
-						, false)
-		<< Function("void", "ui_attach",
-			QList<QString>()
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Boolean")
-						, false)
-		<< Function("void", "ui_detach",
-			QList<QString>()
-						, false)
-		<< Function("Object", "ui_try_resize",
-			QList<QString>()
-						<< QString("Integer")
-						<< QString("Integer")
-						, false)
-		<< Function("void", "vim_command",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "vim_feedkeys",
-			QList<QString>()
-						<< QString("String")
-						<< QString("String")
-						<< QString("Boolean")
-						, false)
-		<< Function("Integer", "vim_input",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("String", "vim_replace_termcodes",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Boolean")
-						<< QString("Boolean")
-						<< QString("Boolean")
-						, false)
-		<< Function("String", "vim_command_output",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Object", "vim_eval",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Object", "vim_call_function",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Array")
-						, false)
-		<< Function("Integer", "vim_strwidth",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("ArrayOf(String)", "vim_list_runtime_paths",
-			QList<QString>()
-						, false)
-		<< Function("void", "vim_change_directory",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("String", "vim_get_current_line",
-			QList<QString>()
-						, false)
-		<< Function("void", "vim_set_current_line",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "vim_del_current_line",
-			QList<QString>()
-						, false)
-		<< Function("Object", "vim_get_var",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Object", "vim_set_var",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("Object", "vim_del_var",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Object", "vim_get_vvar",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Object", "vim_get_option",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "vim_set_option",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("void", "vim_out_write",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "vim_err_write",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "vim_report_error",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("ArrayOf(Buffer)", "vim_get_buffers",
-			QList<QString>()
-						, false)
-		<< Function("Buffer", "vim_get_current_buffer",
-			QList<QString>()
-						, false)
-		<< Function("void", "vim_set_current_buffer",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("ArrayOf(Window)", "vim_get_windows",
-			QList<QString>()
-						, false)
-		<< Function("Window", "vim_get_current_window",
-			QList<QString>()
-						, false)
-		<< Function("void", "vim_set_current_window",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("ArrayOf(Tabpage)", "vim_get_tabpages",
-			QList<QString>()
-						, false)
-		<< Function("Tabpage", "vim_get_current_tabpage",
-			QList<QString>()
-						, false)
-		<< Function("void", "vim_set_current_tabpage",
-			QList<QString>()
-						<< QString("Tabpage")
-						, false)
-		<< Function("void", "vim_subscribe",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "vim_unsubscribe",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Integer", "vim_name_to_color",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Dictionary", "vim_get_color_map",
-			QList<QString>()
-						, false)
-		<< Function("Buffer", "window_get_buffer",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("ArrayOf(Integer, 2)", "window_get_cursor",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("void", "window_set_cursor",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("ArrayOf(Integer, 2)")
-						, false)
-		<< Function("Integer", "window_get_height",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("void", "window_set_height",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("Integer")
-						, false)
-		<< Function("Integer", "window_get_width",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("void", "window_set_width",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("Integer")
-						, false)
-		<< Function("Object", "window_get_var",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						, false)
-		<< Function("Object", "window_set_var",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("Object", "window_del_var",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						, false)
-		<< Function("Object", "window_get_option",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						, false)
-		<< Function("void", "window_set_option",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("ArrayOf(Integer, 2)", "window_get_position",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("Tabpage", "window_get_tabpage",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("Boolean", "window_is_valid",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		;
-
+	static const QList<Function> required{
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("buffer_line_count"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("String"),
+				QStringLiteral("buffer_get_line"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("buffer_set_line"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("buffer_del_line"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(String)"),
+				QStringLiteral("buffer_get_line_slice"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(String)"),
+				QStringLiteral("buffer_get_lines"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("buffer_set_line_slice"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("ArrayOf(String)"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("buffer_set_lines"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("ArrayOf(String)"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("buffer_get_var"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("buffer_set_var"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("buffer_del_var"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("buffer_get_option"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("buffer_set_option"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("buffer_get_number"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("String"),
+				QStringLiteral("buffer_get_name"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("buffer_set_name"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Boolean"),
+				QStringLiteral("buffer_is_valid"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("buffer_insert"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("ArrayOf(String)"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Integer, 2)"),
+				QStringLiteral("buffer_get_mark"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("buffer_add_highlight"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("String"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("buffer_clear_highlight"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Window)"),
+				QStringLiteral("tabpage_get_windows"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("tabpage_get_var"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("tabpage_set_var"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("tabpage_del_var"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Window"),
+				QStringLiteral("tabpage_get_window"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Boolean"),
+				QStringLiteral("tabpage_is_valid"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("ui_attach"),
+				QStringList{
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("ui_detach"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("ui_try_resize"),
+				QStringList{
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_command"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_feedkeys"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("String"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("vim_input"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("String"),
+				QStringLiteral("vim_replace_termcodes"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("String"),
+				QStringLiteral("vim_command_output"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("vim_eval"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("vim_call_function"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Array"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("vim_strwidth"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(String)"),
+				QStringLiteral("vim_list_runtime_paths"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_change_directory"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("String"),
+				QStringLiteral("vim_get_current_line"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_set_current_line"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_del_current_line"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("vim_get_var"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("vim_set_var"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("vim_del_var"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("vim_get_vvar"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("vim_get_option"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_set_option"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_out_write"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_err_write"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_report_error"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Buffer)"),
+				QStringLiteral("vim_get_buffers"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Buffer"),
+				QStringLiteral("vim_get_current_buffer"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_set_current_buffer"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Window)"),
+				QStringLiteral("vim_get_windows"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Window"),
+				QStringLiteral("vim_get_current_window"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_set_current_window"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Tabpage)"),
+				QStringLiteral("vim_get_tabpages"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Tabpage"),
+				QStringLiteral("vim_get_current_tabpage"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_set_current_tabpage"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_subscribe"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_unsubscribe"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("vim_name_to_color"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Dictionary"),
+				QStringLiteral("vim_get_color_map"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Buffer"),
+				QStringLiteral("window_get_buffer"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Integer, 2)"),
+				QStringLiteral("window_get_cursor"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("window_set_cursor"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("ArrayOf(Integer, 2)"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("window_get_height"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("window_set_height"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("window_get_width"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("window_set_width"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("window_get_var"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("window_set_var"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("window_del_var"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("window_get_option"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("window_set_option"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Integer, 2)"),
+				QStringLiteral("window_get_position"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Tabpage"),
+				QStringLiteral("window_get_tabpage"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Boolean"),
+				QStringLiteral("window_is_valid"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+		};
 
 	QList<Function> supported;
-	foreach(const QVariant& val, ftable) {
+	supported.reserve(ftable.size());
+	for(const auto& val : ftable) {
 		auto f = Function::fromVariant(val);
 		if (!f.isValid()) {
 			qDebug() << "Invalid function in metadata" << f;
@@ -2289,7 +2615,7 @@ bool NeovimApi0::checkFunctions(const QVariantList& ftable)
 	}
 
 	bool ok = true;
-	foreach(const Function& f, required) {
+	for(const auto& f : required) {
 		if (!supported.contains(f)) {
 			qDebug() << "- instance DOES NOT support API0:" << f;
 			ok = false;

--- a/src/auto/neovimapi0.cpp
+++ b/src/auto/neovimapi0.cpp
@@ -1,4 +1,4 @@
-// Auto generated 2020-09-09 13:30:53.897511 from nvim API level:0
+// Auto generated 2020-09-09 15:16:42.548828 from nvim API level:0
 #include "auto/neovimapi0.h"
 #include "msgpackiodevice.h"
 #include "msgpackrequest.h"
@@ -2599,7 +2599,7 @@ void NeovimApi0::handleResponse(uint32_t msgid, uint64_t fun, const QVariant& re
 				, false },
 		};
 
-	QList<Function> supported;
+	QVector<Function> supported;
 	supported.reserve(ftable.size());
 	for(const auto& val : ftable) {
 		auto f = Function::fromVariant(val);

--- a/src/auto/neovimapi0.h
+++ b/src/auto/neovimapi0.h
@@ -1,280 +1,368 @@
-// Auto generated 2017-10-31 14:14:43.997573 from nvim API level:0
-#ifndef NEOVIM_QT_NEOVIMAPI0
-#define NEOVIM_QT_NEOVIMAPI0
-#include "msgpack.h"
+// Auto generated 2020-09-09 13:30:53.914258 from nvim API level:0
+#pragma once
+
 #include <QObject>
-#include <QVariant>
 #include <QPoint>
+#include <QVariant>
+
 #include "function.h"
+#include "msgpack.h"
 
 namespace NeovimQt {
+
 class NeovimConnector;
 class MsgpackRequest;
 
-class NeovimApi0: public QObject
+class NeovimApi0 : public QObject
 {
 	Q_OBJECT
-	Q_ENUMS(FunctionId)
 
 public:
-
 	enum FunctionId {
-		NEOVIM_FN_NULL=0,
-				NEOVIM_FN_BUFFER_LINE_COUNT,
-				NEOVIM_FN_BUFFER_GET_LINE,
-				NEOVIM_FN_BUFFER_SET_LINE,
-				NEOVIM_FN_BUFFER_DEL_LINE,
-				NEOVIM_FN_BUFFER_GET_LINE_SLICE,
-				NEOVIM_FN_BUFFER_GET_LINES,
-				NEOVIM_FN_BUFFER_SET_LINE_SLICE,
-				NEOVIM_FN_BUFFER_SET_LINES,
-				NEOVIM_FN_BUFFER_GET_VAR,
-				NEOVIM_FN_BUFFER_SET_VAR,
-				NEOVIM_FN_BUFFER_DEL_VAR,
-				NEOVIM_FN_BUFFER_GET_OPTION,
-				NEOVIM_FN_BUFFER_SET_OPTION,
-				NEOVIM_FN_BUFFER_GET_NUMBER,
-				NEOVIM_FN_BUFFER_GET_NAME,
-				NEOVIM_FN_BUFFER_SET_NAME,
-				NEOVIM_FN_BUFFER_IS_VALID,
-				NEOVIM_FN_BUFFER_INSERT,
-				NEOVIM_FN_BUFFER_GET_MARK,
-				NEOVIM_FN_BUFFER_ADD_HIGHLIGHT,
-				NEOVIM_FN_BUFFER_CLEAR_HIGHLIGHT,
-				NEOVIM_FN_TABPAGE_GET_WINDOWS,
-				NEOVIM_FN_TABPAGE_GET_VAR,
-				NEOVIM_FN_TABPAGE_SET_VAR,
-				NEOVIM_FN_TABPAGE_DEL_VAR,
-				NEOVIM_FN_TABPAGE_GET_WINDOW,
-				NEOVIM_FN_TABPAGE_IS_VALID,
-				NEOVIM_FN_UI_ATTACH,
-				NEOVIM_FN_UI_DETACH,
-				NEOVIM_FN_UI_TRY_RESIZE,
-				NEOVIM_FN_VIM_COMMAND,
-				NEOVIM_FN_VIM_FEEDKEYS,
-				NEOVIM_FN_VIM_INPUT,
-				NEOVIM_FN_VIM_REPLACE_TERMCODES,
-				NEOVIM_FN_VIM_COMMAND_OUTPUT,
-				NEOVIM_FN_VIM_EVAL,
-				NEOVIM_FN_VIM_CALL_FUNCTION,
-				NEOVIM_FN_VIM_STRWIDTH,
-				NEOVIM_FN_VIM_LIST_RUNTIME_PATHS,
-				NEOVIM_FN_VIM_CHANGE_DIRECTORY,
-				NEOVIM_FN_VIM_GET_CURRENT_LINE,
-				NEOVIM_FN_VIM_SET_CURRENT_LINE,
-				NEOVIM_FN_VIM_DEL_CURRENT_LINE,
-				NEOVIM_FN_VIM_GET_VAR,
-				NEOVIM_FN_VIM_SET_VAR,
-				NEOVIM_FN_VIM_DEL_VAR,
-				NEOVIM_FN_VIM_GET_VVAR,
-				NEOVIM_FN_VIM_GET_OPTION,
-				NEOVIM_FN_VIM_SET_OPTION,
-				NEOVIM_FN_VIM_OUT_WRITE,
-				NEOVIM_FN_VIM_ERR_WRITE,
-				NEOVIM_FN_VIM_REPORT_ERROR,
-				NEOVIM_FN_VIM_GET_BUFFERS,
-				NEOVIM_FN_VIM_GET_CURRENT_BUFFER,
-				NEOVIM_FN_VIM_SET_CURRENT_BUFFER,
-				NEOVIM_FN_VIM_GET_WINDOWS,
-				NEOVIM_FN_VIM_GET_CURRENT_WINDOW,
-				NEOVIM_FN_VIM_SET_CURRENT_WINDOW,
-				NEOVIM_FN_VIM_GET_TABPAGES,
-				NEOVIM_FN_VIM_GET_CURRENT_TABPAGE,
-				NEOVIM_FN_VIM_SET_CURRENT_TABPAGE,
-				NEOVIM_FN_VIM_SUBSCRIBE,
-				NEOVIM_FN_VIM_UNSUBSCRIBE,
-				NEOVIM_FN_VIM_NAME_TO_COLOR,
-				NEOVIM_FN_VIM_GET_COLOR_MAP,
-				NEOVIM_FN_WINDOW_GET_BUFFER,
-				NEOVIM_FN_WINDOW_GET_CURSOR,
-				NEOVIM_FN_WINDOW_SET_CURSOR,
-				NEOVIM_FN_WINDOW_GET_HEIGHT,
-				NEOVIM_FN_WINDOW_SET_HEIGHT,
-				NEOVIM_FN_WINDOW_GET_WIDTH,
-				NEOVIM_FN_WINDOW_SET_WIDTH,
-				NEOVIM_FN_WINDOW_GET_VAR,
-				NEOVIM_FN_WINDOW_SET_VAR,
-				NEOVIM_FN_WINDOW_DEL_VAR,
-				NEOVIM_FN_WINDOW_GET_OPTION,
-				NEOVIM_FN_WINDOW_SET_OPTION,
-				NEOVIM_FN_WINDOW_GET_POSITION,
-				NEOVIM_FN_WINDOW_GET_TABPAGE,
-				NEOVIM_FN_WINDOW_IS_VALID,
+		NEOVIM_FN_NULL,
+		NEOVIM_FN_BUFFER_LINE_COUNT,
+		NEOVIM_FN_BUFFER_GET_LINE,
+		NEOVIM_FN_BUFFER_SET_LINE,
+		NEOVIM_FN_BUFFER_DEL_LINE,
+		NEOVIM_FN_BUFFER_GET_LINE_SLICE,
+		NEOVIM_FN_BUFFER_GET_LINES,
+		NEOVIM_FN_BUFFER_SET_LINE_SLICE,
+		NEOVIM_FN_BUFFER_SET_LINES,
+		NEOVIM_FN_BUFFER_GET_VAR,
+		NEOVIM_FN_BUFFER_SET_VAR,
+		NEOVIM_FN_BUFFER_DEL_VAR,
+		NEOVIM_FN_BUFFER_GET_OPTION,
+		NEOVIM_FN_BUFFER_SET_OPTION,
+		NEOVIM_FN_BUFFER_GET_NUMBER,
+		NEOVIM_FN_BUFFER_GET_NAME,
+		NEOVIM_FN_BUFFER_SET_NAME,
+		NEOVIM_FN_BUFFER_IS_VALID,
+		NEOVIM_FN_BUFFER_INSERT,
+		NEOVIM_FN_BUFFER_GET_MARK,
+		NEOVIM_FN_BUFFER_ADD_HIGHLIGHT,
+		NEOVIM_FN_BUFFER_CLEAR_HIGHLIGHT,
+		NEOVIM_FN_TABPAGE_GET_WINDOWS,
+		NEOVIM_FN_TABPAGE_GET_VAR,
+		NEOVIM_FN_TABPAGE_SET_VAR,
+		NEOVIM_FN_TABPAGE_DEL_VAR,
+		NEOVIM_FN_TABPAGE_GET_WINDOW,
+		NEOVIM_FN_TABPAGE_IS_VALID,
+		NEOVIM_FN_UI_ATTACH,
+		NEOVIM_FN_UI_DETACH,
+		NEOVIM_FN_UI_TRY_RESIZE,
+		NEOVIM_FN_VIM_COMMAND,
+		NEOVIM_FN_VIM_FEEDKEYS,
+		NEOVIM_FN_VIM_INPUT,
+		NEOVIM_FN_VIM_REPLACE_TERMCODES,
+		NEOVIM_FN_VIM_COMMAND_OUTPUT,
+		NEOVIM_FN_VIM_EVAL,
+		NEOVIM_FN_VIM_CALL_FUNCTION,
+		NEOVIM_FN_VIM_STRWIDTH,
+		NEOVIM_FN_VIM_LIST_RUNTIME_PATHS,
+		NEOVIM_FN_VIM_CHANGE_DIRECTORY,
+		NEOVIM_FN_VIM_GET_CURRENT_LINE,
+		NEOVIM_FN_VIM_SET_CURRENT_LINE,
+		NEOVIM_FN_VIM_DEL_CURRENT_LINE,
+		NEOVIM_FN_VIM_GET_VAR,
+		NEOVIM_FN_VIM_SET_VAR,
+		NEOVIM_FN_VIM_DEL_VAR,
+		NEOVIM_FN_VIM_GET_VVAR,
+		NEOVIM_FN_VIM_GET_OPTION,
+		NEOVIM_FN_VIM_SET_OPTION,
+		NEOVIM_FN_VIM_OUT_WRITE,
+		NEOVIM_FN_VIM_ERR_WRITE,
+		NEOVIM_FN_VIM_REPORT_ERROR,
+		NEOVIM_FN_VIM_GET_BUFFERS,
+		NEOVIM_FN_VIM_GET_CURRENT_BUFFER,
+		NEOVIM_FN_VIM_SET_CURRENT_BUFFER,
+		NEOVIM_FN_VIM_GET_WINDOWS,
+		NEOVIM_FN_VIM_GET_CURRENT_WINDOW,
+		NEOVIM_FN_VIM_SET_CURRENT_WINDOW,
+		NEOVIM_FN_VIM_GET_TABPAGES,
+		NEOVIM_FN_VIM_GET_CURRENT_TABPAGE,
+		NEOVIM_FN_VIM_SET_CURRENT_TABPAGE,
+		NEOVIM_FN_VIM_SUBSCRIBE,
+		NEOVIM_FN_VIM_UNSUBSCRIBE,
+		NEOVIM_FN_VIM_NAME_TO_COLOR,
+		NEOVIM_FN_VIM_GET_COLOR_MAP,
+		NEOVIM_FN_WINDOW_GET_BUFFER,
+		NEOVIM_FN_WINDOW_GET_CURSOR,
+		NEOVIM_FN_WINDOW_SET_CURSOR,
+		NEOVIM_FN_WINDOW_GET_HEIGHT,
+		NEOVIM_FN_WINDOW_SET_HEIGHT,
+		NEOVIM_FN_WINDOW_GET_WIDTH,
+		NEOVIM_FN_WINDOW_SET_WIDTH,
+		NEOVIM_FN_WINDOW_GET_VAR,
+		NEOVIM_FN_WINDOW_SET_VAR,
+		NEOVIM_FN_WINDOW_DEL_VAR,
+		NEOVIM_FN_WINDOW_GET_OPTION,
+		NEOVIM_FN_WINDOW_SET_OPTION,
+		NEOVIM_FN_WINDOW_GET_POSITION,
+		NEOVIM_FN_WINDOW_GET_TABPAGE,
+		NEOVIM_FN_WINDOW_IS_VALID,
 			};
+	Q_ENUM(FunctionId)
 
-	static bool checkFunctions(const QVariantList& ftable);
-	static FunctionId functionId(const Function& f);
+	static bool checkFunctions(const QVariantList& ftable) noexcept;
 
-	NeovimApi0(NeovimConnector *);
+	static FunctionId functionId(const Function& f) noexcept;
+
+	NeovimApi0(NeovimConnector* c) noexcept;
+
 protected slots:
-	void handleResponse(quint32 id, quint64 fun, const QVariant&);
-	void handleResponseError(quint32 id, quint64 fun, const QVariant&);
+	void handleResponse(uint32_t id, uint64_t fun, const QVariant&);
+
+	void handleResponseError(uint32_t id, uint64_t fun, const QVariant&);
+
 signals:
 	void error(const QString& errmsg, const QVariant& errObj);
+
 	void neovimNotification(const QByteArray &name, const QVariantList& args);
+
 private:
-	NeovimConnector *m_c;
+	NeovimConnector* m_connector;
+
 public slots:
-	// Integer buffer_line_count(Buffer buffer, ) 
-	MsgpackRequest* buffer_line_count(int64_t buffer);
-	// String buffer_get_line(Buffer buffer, Integer index, ) 
-	MsgpackRequest* buffer_get_line(int64_t buffer, int64_t index);
-	// void buffer_set_line(Buffer buffer, Integer index, String line, ) 
-	MsgpackRequest* buffer_set_line(int64_t buffer, int64_t index, QByteArray line);
-	// void buffer_del_line(Buffer buffer, Integer index, ) 
-	MsgpackRequest* buffer_del_line(int64_t buffer, int64_t index);
-	// ArrayOf(String) buffer_get_line_slice(Buffer buffer, Integer start, Integer end, Boolean include_start, Boolean include_end, ) 
-	MsgpackRequest* buffer_get_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end);
-	// ArrayOf(String) buffer_get_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ) 
-	MsgpackRequest* buffer_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing);
-	// void buffer_set_line_slice(Buffer buffer, Integer start, Integer end, Boolean include_start, Boolean include_end, ArrayOf(String) replacement, ) 
-	MsgpackRequest* buffer_set_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end, QList<QByteArray> replacement);
-	// void buffer_set_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ArrayOf(String) replacement, ) 
-	MsgpackRequest* buffer_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement);
-	// Object buffer_get_var(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_get_var(int64_t buffer, QByteArray name);
-	// Object buffer_set_var(Buffer buffer, String name, Object value, ) 
-	MsgpackRequest* buffer_set_var(int64_t buffer, QByteArray name, QVariant value);
-	// Object buffer_del_var(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_del_var(int64_t buffer, QByteArray name);
-	// Object buffer_get_option(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_get_option(int64_t buffer, QByteArray name);
-	// void buffer_set_option(Buffer buffer, String name, Object value, ) 
-	MsgpackRequest* buffer_set_option(int64_t buffer, QByteArray name, QVariant value);
-	// Integer buffer_get_number(Buffer buffer, ) 
-	MsgpackRequest* buffer_get_number(int64_t buffer);
-	// String buffer_get_name(Buffer buffer, ) 
-	MsgpackRequest* buffer_get_name(int64_t buffer);
-	// void buffer_set_name(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_set_name(int64_t buffer, QByteArray name);
-	// Boolean buffer_is_valid(Buffer buffer, ) 
-	MsgpackRequest* buffer_is_valid(int64_t buffer);
-	// void buffer_insert(Buffer buffer, Integer lnum, ArrayOf(String) lines, ) 
-	MsgpackRequest* buffer_insert(int64_t buffer, int64_t lnum, QList<QByteArray> lines);
-	// ArrayOf(Integer, 2) buffer_get_mark(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_get_mark(int64_t buffer, QByteArray name);
-	// Integer buffer_add_highlight(Buffer buffer, Integer src_id, String hl_group, Integer line, Integer col_start, Integer col_end, ) 
-	MsgpackRequest* buffer_add_highlight(int64_t buffer, int64_t src_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end);
-	// void buffer_clear_highlight(Buffer buffer, Integer src_id, Integer line_start, Integer line_end, ) 
-	MsgpackRequest* buffer_clear_highlight(int64_t buffer, int64_t src_id, int64_t line_start, int64_t line_end);
-	// ArrayOf(Window) tabpage_get_windows(Tabpage tabpage, ) 
-	MsgpackRequest* tabpage_get_windows(int64_t tabpage);
-	// Object tabpage_get_var(Tabpage tabpage, String name, ) 
-	MsgpackRequest* tabpage_get_var(int64_t tabpage, QByteArray name);
-	// Object tabpage_set_var(Tabpage tabpage, String name, Object value, ) 
-	MsgpackRequest* tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value);
-	// Object tabpage_del_var(Tabpage tabpage, String name, ) 
-	MsgpackRequest* tabpage_del_var(int64_t tabpage, QByteArray name);
-	// Window tabpage_get_window(Tabpage tabpage, ) 
-	MsgpackRequest* tabpage_get_window(int64_t tabpage);
-	// Boolean tabpage_is_valid(Tabpage tabpage, ) 
-	MsgpackRequest* tabpage_is_valid(int64_t tabpage);
-	// void ui_attach(Integer width, Integer height, Boolean enable_rgb, ) 
-	MsgpackRequest* ui_attach(int64_t width, int64_t height, bool enable_rgb);
-	// void ui_detach() 
-	MsgpackRequest* ui_detach();
-	// Object ui_try_resize(Integer width, Integer height, ) 
-	MsgpackRequest* ui_try_resize(int64_t width, int64_t height);
-	// void vim_command(String str, ) 
-	MsgpackRequest* vim_command(QByteArray str);
-	// void vim_feedkeys(String keys, String mode, Boolean escape_csi, ) 
-	MsgpackRequest* vim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi);
-	// Integer vim_input(String keys, ) 
-	MsgpackRequest* vim_input(QByteArray keys);
-	// String vim_replace_termcodes(String str, Boolean from_part, Boolean do_lt, Boolean special, ) 
-	MsgpackRequest* vim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special);
-	// String vim_command_output(String str, ) 
-	MsgpackRequest* vim_command_output(QByteArray str);
-	// Object vim_eval(String str, ) 
-	MsgpackRequest* vim_eval(QByteArray str);
-	// Object vim_call_function(String fname, Array args, ) 
-	MsgpackRequest* vim_call_function(QByteArray fname, QVariantList args);
-	// Integer vim_strwidth(String str, ) 
-	MsgpackRequest* vim_strwidth(QByteArray str);
-	// ArrayOf(String) vim_list_runtime_paths() 
-	MsgpackRequest* vim_list_runtime_paths();
-	// void vim_change_directory(String dir, ) 
-	MsgpackRequest* vim_change_directory(QByteArray dir);
-	// String vim_get_current_line() 
-	MsgpackRequest* vim_get_current_line();
-	// void vim_set_current_line(String line, ) 
-	MsgpackRequest* vim_set_current_line(QByteArray line);
-	// void vim_del_current_line() 
-	MsgpackRequest* vim_del_current_line();
-	// Object vim_get_var(String name, ) 
-	MsgpackRequest* vim_get_var(QByteArray name);
-	// Object vim_set_var(String name, Object value, ) 
-	MsgpackRequest* vim_set_var(QByteArray name, QVariant value);
-	// Object vim_del_var(String name, ) 
-	MsgpackRequest* vim_del_var(QByteArray name);
-	// Object vim_get_vvar(String name, ) 
-	MsgpackRequest* vim_get_vvar(QByteArray name);
-	// Object vim_get_option(String name, ) 
-	MsgpackRequest* vim_get_option(QByteArray name);
-	// void vim_set_option(String name, Object value, ) 
-	MsgpackRequest* vim_set_option(QByteArray name, QVariant value);
-	// void vim_out_write(String str, ) 
-	MsgpackRequest* vim_out_write(QByteArray str);
-	// void vim_err_write(String str, ) 
-	MsgpackRequest* vim_err_write(QByteArray str);
-	// void vim_report_error(String str, ) 
-	MsgpackRequest* vim_report_error(QByteArray str);
-	// ArrayOf(Buffer) vim_get_buffers() 
-	MsgpackRequest* vim_get_buffers();
-	// Buffer vim_get_current_buffer() 
-	MsgpackRequest* vim_get_current_buffer();
-	// void vim_set_current_buffer(Buffer buffer, ) 
-	MsgpackRequest* vim_set_current_buffer(int64_t buffer);
-	// ArrayOf(Window) vim_get_windows() 
-	MsgpackRequest* vim_get_windows();
-	// Window vim_get_current_window() 
-	MsgpackRequest* vim_get_current_window();
-	// void vim_set_current_window(Window window, ) 
-	MsgpackRequest* vim_set_current_window(int64_t window);
-	// ArrayOf(Tabpage) vim_get_tabpages() 
-	MsgpackRequest* vim_get_tabpages();
-	// Tabpage vim_get_current_tabpage() 
-	MsgpackRequest* vim_get_current_tabpage();
-	// void vim_set_current_tabpage(Tabpage tabpage, ) 
-	MsgpackRequest* vim_set_current_tabpage(int64_t tabpage);
-	// void vim_subscribe(String event, ) 
-	MsgpackRequest* vim_subscribe(QByteArray event);
-	// void vim_unsubscribe(String event, ) 
-	MsgpackRequest* vim_unsubscribe(QByteArray event);
-	// Integer vim_name_to_color(String name, ) 
-	MsgpackRequest* vim_name_to_color(QByteArray name);
-	// Dictionary vim_get_color_map() 
-	MsgpackRequest* vim_get_color_map();
-	// Buffer window_get_buffer(Window window, ) 
-	MsgpackRequest* window_get_buffer(int64_t window);
-	// ArrayOf(Integer, 2) window_get_cursor(Window window, ) 
-	MsgpackRequest* window_get_cursor(int64_t window);
-	// void window_set_cursor(Window window, ArrayOf(Integer, 2) pos, ) 
-	MsgpackRequest* window_set_cursor(int64_t window, QPoint pos);
-	// Integer window_get_height(Window window, ) 
-	MsgpackRequest* window_get_height(int64_t window);
-	// void window_set_height(Window window, Integer height, ) 
-	MsgpackRequest* window_set_height(int64_t window, int64_t height);
-	// Integer window_get_width(Window window, ) 
-	MsgpackRequest* window_get_width(int64_t window);
-	// void window_set_width(Window window, Integer width, ) 
-	MsgpackRequest* window_set_width(int64_t window, int64_t width);
-	// Object window_get_var(Window window, String name, ) 
-	MsgpackRequest* window_get_var(int64_t window, QByteArray name);
-	// Object window_set_var(Window window, String name, Object value, ) 
-	MsgpackRequest* window_set_var(int64_t window, QByteArray name, QVariant value);
-	// Object window_del_var(Window window, String name, ) 
-	MsgpackRequest* window_del_var(int64_t window, QByteArray name);
-	// Object window_get_option(Window window, String name, ) 
-	MsgpackRequest* window_get_option(int64_t window, QByteArray name);
-	// void window_set_option(Window window, String name, Object value, ) 
-	MsgpackRequest* window_set_option(int64_t window, QByteArray name, QVariant value);
-	// ArrayOf(Integer, 2) window_get_position(Window window, ) 
-	MsgpackRequest* window_get_position(int64_t window);
-	// Tabpage window_get_tabpage(Window window, ) 
-	MsgpackRequest* window_get_tabpage(int64_t window);
-	// Boolean window_is_valid(Window window, ) 
-	MsgpackRequest* window_is_valid(int64_t window);
+	/// Integer buffer_line_count(Buffer buffer, )
+	NeovimQt::MsgpackRequest* buffer_line_count(int64_t buffer);
+
+	/// String buffer_get_line(Buffer buffer, Integer index, )
+	NeovimQt::MsgpackRequest* buffer_get_line(int64_t buffer, int64_t index);
+
+	/// void buffer_set_line(Buffer buffer, Integer index, String line, )
+	NeovimQt::MsgpackRequest* buffer_set_line(int64_t buffer, int64_t index, QByteArray line);
+
+	/// void buffer_del_line(Buffer buffer, Integer index, )
+	NeovimQt::MsgpackRequest* buffer_del_line(int64_t buffer, int64_t index);
+
+	/// ArrayOf(String) buffer_get_line_slice(Buffer buffer, Integer start, Integer end, Boolean include_start, Boolean include_end, )
+	NeovimQt::MsgpackRequest* buffer_get_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end);
+
+	/// ArrayOf(String) buffer_get_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, )
+	NeovimQt::MsgpackRequest* buffer_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing);
+
+	/// void buffer_set_line_slice(Buffer buffer, Integer start, Integer end, Boolean include_start, Boolean include_end, ArrayOf(String) replacement, )
+	NeovimQt::MsgpackRequest* buffer_set_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end, QList<QByteArray> replacement);
+
+	/// void buffer_set_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ArrayOf(String) replacement, )
+	NeovimQt::MsgpackRequest* buffer_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement);
+
+	/// Object buffer_get_var(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* buffer_get_var(int64_t buffer, QByteArray name);
+
+	/// Object buffer_set_var(Buffer buffer, String name, Object value, )
+	NeovimQt::MsgpackRequest* buffer_set_var(int64_t buffer, QByteArray name, QVariant value);
+
+	/// Object buffer_del_var(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* buffer_del_var(int64_t buffer, QByteArray name);
+
+	/// Object buffer_get_option(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* buffer_get_option(int64_t buffer, QByteArray name);
+
+	/// void buffer_set_option(Buffer buffer, String name, Object value, )
+	NeovimQt::MsgpackRequest* buffer_set_option(int64_t buffer, QByteArray name, QVariant value);
+
+	/// Integer buffer_get_number(Buffer buffer, )
+	NeovimQt::MsgpackRequest* buffer_get_number(int64_t buffer);
+
+	/// String buffer_get_name(Buffer buffer, )
+	NeovimQt::MsgpackRequest* buffer_get_name(int64_t buffer);
+
+	/// void buffer_set_name(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* buffer_set_name(int64_t buffer, QByteArray name);
+
+	/// Boolean buffer_is_valid(Buffer buffer, )
+	NeovimQt::MsgpackRequest* buffer_is_valid(int64_t buffer);
+
+	/// void buffer_insert(Buffer buffer, Integer lnum, ArrayOf(String) lines, )
+	NeovimQt::MsgpackRequest* buffer_insert(int64_t buffer, int64_t lnum, QList<QByteArray> lines);
+
+	/// ArrayOf(Integer, 2) buffer_get_mark(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* buffer_get_mark(int64_t buffer, QByteArray name);
+
+	/// Integer buffer_add_highlight(Buffer buffer, Integer src_id, String hl_group, Integer line, Integer col_start, Integer col_end, )
+	NeovimQt::MsgpackRequest* buffer_add_highlight(int64_t buffer, int64_t src_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end);
+
+	/// void buffer_clear_highlight(Buffer buffer, Integer src_id, Integer line_start, Integer line_end, )
+	NeovimQt::MsgpackRequest* buffer_clear_highlight(int64_t buffer, int64_t src_id, int64_t line_start, int64_t line_end);
+
+	/// ArrayOf(Window) tabpage_get_windows(Tabpage tabpage, )
+	NeovimQt::MsgpackRequest* tabpage_get_windows(int64_t tabpage);
+
+	/// Object tabpage_get_var(Tabpage tabpage, String name, )
+	NeovimQt::MsgpackRequest* tabpage_get_var(int64_t tabpage, QByteArray name);
+
+	/// Object tabpage_set_var(Tabpage tabpage, String name, Object value, )
+	NeovimQt::MsgpackRequest* tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value);
+
+	/// Object tabpage_del_var(Tabpage tabpage, String name, )
+	NeovimQt::MsgpackRequest* tabpage_del_var(int64_t tabpage, QByteArray name);
+
+	/// Window tabpage_get_window(Tabpage tabpage, )
+	NeovimQt::MsgpackRequest* tabpage_get_window(int64_t tabpage);
+
+	/// Boolean tabpage_is_valid(Tabpage tabpage, )
+	NeovimQt::MsgpackRequest* tabpage_is_valid(int64_t tabpage);
+
+	/// void ui_attach(Integer width, Integer height, Boolean enable_rgb, )
+	NeovimQt::MsgpackRequest* ui_attach(int64_t width, int64_t height, bool enable_rgb);
+
+	/// void ui_detach()
+	NeovimQt::MsgpackRequest* ui_detach();
+
+	/// Object ui_try_resize(Integer width, Integer height, )
+	NeovimQt::MsgpackRequest* ui_try_resize(int64_t width, int64_t height);
+
+	/// void vim_command(String str, )
+	NeovimQt::MsgpackRequest* vim_command(QByteArray str);
+
+	/// void vim_feedkeys(String keys, String mode, Boolean escape_csi, )
+	NeovimQt::MsgpackRequest* vim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi);
+
+	/// Integer vim_input(String keys, )
+	NeovimQt::MsgpackRequest* vim_input(QByteArray keys);
+
+	/// String vim_replace_termcodes(String str, Boolean from_part, Boolean do_lt, Boolean special, )
+	NeovimQt::MsgpackRequest* vim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special);
+
+	/// String vim_command_output(String str, )
+	NeovimQt::MsgpackRequest* vim_command_output(QByteArray str);
+
+	/// Object vim_eval(String str, )
+	NeovimQt::MsgpackRequest* vim_eval(QByteArray str);
+
+	/// Object vim_call_function(String fname, Array args, )
+	NeovimQt::MsgpackRequest* vim_call_function(QByteArray fname, QVariantList args);
+
+	/// Integer vim_strwidth(String str, )
+	NeovimQt::MsgpackRequest* vim_strwidth(QByteArray str);
+
+	/// ArrayOf(String) vim_list_runtime_paths()
+	NeovimQt::MsgpackRequest* vim_list_runtime_paths();
+
+	/// void vim_change_directory(String dir, )
+	NeovimQt::MsgpackRequest* vim_change_directory(QByteArray dir);
+
+	/// String vim_get_current_line()
+	NeovimQt::MsgpackRequest* vim_get_current_line();
+
+	/// void vim_set_current_line(String line, )
+	NeovimQt::MsgpackRequest* vim_set_current_line(QByteArray line);
+
+	/// void vim_del_current_line()
+	NeovimQt::MsgpackRequest* vim_del_current_line();
+
+	/// Object vim_get_var(String name, )
+	NeovimQt::MsgpackRequest* vim_get_var(QByteArray name);
+
+	/// Object vim_set_var(String name, Object value, )
+	NeovimQt::MsgpackRequest* vim_set_var(QByteArray name, QVariant value);
+
+	/// Object vim_del_var(String name, )
+	NeovimQt::MsgpackRequest* vim_del_var(QByteArray name);
+
+	/// Object vim_get_vvar(String name, )
+	NeovimQt::MsgpackRequest* vim_get_vvar(QByteArray name);
+
+	/// Object vim_get_option(String name, )
+	NeovimQt::MsgpackRequest* vim_get_option(QByteArray name);
+
+	/// void vim_set_option(String name, Object value, )
+	NeovimQt::MsgpackRequest* vim_set_option(QByteArray name, QVariant value);
+
+	/// void vim_out_write(String str, )
+	NeovimQt::MsgpackRequest* vim_out_write(QByteArray str);
+
+	/// void vim_err_write(String str, )
+	NeovimQt::MsgpackRequest* vim_err_write(QByteArray str);
+
+	/// void vim_report_error(String str, )
+	NeovimQt::MsgpackRequest* vim_report_error(QByteArray str);
+
+	/// ArrayOf(Buffer) vim_get_buffers()
+	NeovimQt::MsgpackRequest* vim_get_buffers();
+
+	/// Buffer vim_get_current_buffer()
+	NeovimQt::MsgpackRequest* vim_get_current_buffer();
+
+	/// void vim_set_current_buffer(Buffer buffer, )
+	NeovimQt::MsgpackRequest* vim_set_current_buffer(int64_t buffer);
+
+	/// ArrayOf(Window) vim_get_windows()
+	NeovimQt::MsgpackRequest* vim_get_windows();
+
+	/// Window vim_get_current_window()
+	NeovimQt::MsgpackRequest* vim_get_current_window();
+
+	/// void vim_set_current_window(Window window, )
+	NeovimQt::MsgpackRequest* vim_set_current_window(int64_t window);
+
+	/// ArrayOf(Tabpage) vim_get_tabpages()
+	NeovimQt::MsgpackRequest* vim_get_tabpages();
+
+	/// Tabpage vim_get_current_tabpage()
+	NeovimQt::MsgpackRequest* vim_get_current_tabpage();
+
+	/// void vim_set_current_tabpage(Tabpage tabpage, )
+	NeovimQt::MsgpackRequest* vim_set_current_tabpage(int64_t tabpage);
+
+	/// void vim_subscribe(String event, )
+	NeovimQt::MsgpackRequest* vim_subscribe(QByteArray event);
+
+	/// void vim_unsubscribe(String event, )
+	NeovimQt::MsgpackRequest* vim_unsubscribe(QByteArray event);
+
+	/// Integer vim_name_to_color(String name, )
+	NeovimQt::MsgpackRequest* vim_name_to_color(QByteArray name);
+
+	/// Dictionary vim_get_color_map()
+	NeovimQt::MsgpackRequest* vim_get_color_map();
+
+	/// Buffer window_get_buffer(Window window, )
+	NeovimQt::MsgpackRequest* window_get_buffer(int64_t window);
+
+	/// ArrayOf(Integer, 2) window_get_cursor(Window window, )
+	NeovimQt::MsgpackRequest* window_get_cursor(int64_t window);
+
+	/// void window_set_cursor(Window window, ArrayOf(Integer, 2) pos, )
+	NeovimQt::MsgpackRequest* window_set_cursor(int64_t window, QPoint pos);
+
+	/// Integer window_get_height(Window window, )
+	NeovimQt::MsgpackRequest* window_get_height(int64_t window);
+
+	/// void window_set_height(Window window, Integer height, )
+	NeovimQt::MsgpackRequest* window_set_height(int64_t window, int64_t height);
+
+	/// Integer window_get_width(Window window, )
+	NeovimQt::MsgpackRequest* window_get_width(int64_t window);
+
+	/// void window_set_width(Window window, Integer width, )
+	NeovimQt::MsgpackRequest* window_set_width(int64_t window, int64_t width);
+
+	/// Object window_get_var(Window window, String name, )
+	NeovimQt::MsgpackRequest* window_get_var(int64_t window, QByteArray name);
+
+	/// Object window_set_var(Window window, String name, Object value, )
+	NeovimQt::MsgpackRequest* window_set_var(int64_t window, QByteArray name, QVariant value);
+
+	/// Object window_del_var(Window window, String name, )
+	NeovimQt::MsgpackRequest* window_del_var(int64_t window, QByteArray name);
+
+	/// Object window_get_option(Window window, String name, )
+	NeovimQt::MsgpackRequest* window_get_option(int64_t window, QByteArray name);
+
+	/// void window_set_option(Window window, String name, Object value, )
+	NeovimQt::MsgpackRequest* window_set_option(int64_t window, QByteArray name, QVariant value);
+
+	/// ArrayOf(Integer, 2) window_get_position(Window window, )
+	NeovimQt::MsgpackRequest* window_get_position(int64_t window);
+
+	/// Tabpage window_get_tabpage(Window window, )
+	NeovimQt::MsgpackRequest* window_get_tabpage(int64_t window);
+
+	/// Boolean window_is_valid(Window window, )
+	NeovimQt::MsgpackRequest* window_is_valid(int64_t window);
+
 
 signals:
 	void on_buffer_line_count(int64_t);
@@ -518,5 +606,5 @@ signals:
 	void err_window_is_valid(const QString&, const QVariant&);
 
 };
-} // namespace
-#endif
+
+} // namespace NeovimQt

--- a/src/auto/neovimapi0.h
+++ b/src/auto/neovimapi0.h
@@ -1,4 +1,4 @@
-// Auto generated 2020-09-09 13:30:53.914258 from nvim API level:0
+// Auto generated 2020-09-09 15:16:42.563876 from nvim API level:0
 #pragma once
 
 #include <QObject>

--- a/src/auto/neovimapi1.cpp
+++ b/src/auto/neovimapi1.cpp
@@ -1,15 +1,15 @@
-// Auto generated 2017-10-31 14:21:01.901429 from nvim API level:1
+// Auto generated 2020-09-09 13:30:53.979298 from nvim API level:1
 #include "auto/neovimapi1.h"
-#include "neovimconnector.h"
-#include "msgpackrequest.h"
 #include "msgpackiodevice.h"
+#include "msgpackrequest.h"
+#include "neovimconnector.h"
 #include "util.h"
 
 namespace NeovimQt {
 /* Unpack Neovim EXT types Window, Buffer Tabpage which are all
  * uint64_t see Neovim:msgpack_rpc_to_
  */
-QVariant unpackBufferApi1(MsgpackIODevice *dev, const char* in, quint32 size)
+static QVariant unpackBufferApi1(MsgpackIODevice *dev, const char* in, uint32_t size) noexcept
 {
 	msgpack_unpacked result;
 	msgpack_unpacked_init(&result);
@@ -20,10 +20,10 @@ QVariant unpackBufferApi1(MsgpackIODevice *dev, const char* in, quint32 size)
 	if (ret == MSGPACK_UNPACK_SUCCESS) {
 		switch (result.data.type) {
 			case MSGPACK_OBJECT_NEGATIVE_INTEGER:
-				variant = (qint64)result.data.via.i64;
+				variant.setValue<int64_t>(result.data.via.i64);
 				break;
 			case MSGPACK_OBJECT_POSITIVE_INTEGER:
-				variant = (quint64)result.data.via.u64;
+				variant.setValue<uint64_t>(result.data.via.u64);
 				break;
 			default:
 				// TODO it would be nice if we could call back MsgpackIoDevice method or primitive types here
@@ -34,1547 +34,1714 @@ QVariant unpackBufferApi1(MsgpackIODevice *dev, const char* in, quint32 size)
 	msgpack_unpacked_destroy(&result);
 	return variant;
 }
-#define unpackWindowApi1 unpackBufferApi1
-#define unpackTabpageApi1 unpackBufferApi1
 
-NeovimApi1::NeovimApi1(NeovimConnector *c)
-:m_c(c)
+static QVariant unpackWindowApi1(MsgpackIODevice *dev, const char* in, uint32_t size) noexcept
+{
+	return unpackBufferApi1(dev, in, size);
+}
+
+static QVariant unpackTabpageApi1(MsgpackIODevice *dev, const char* in, uint32_t size) noexcept
+{
+	return unpackBufferApi1(dev, in, size);
+}
+
+NeovimApi1::NeovimApi1(NeovimConnector *c) noexcept
+	: m_connector{ c }
 {
 	// EXT types
-		m_c->m_dev->registerExtType(0, unpackBufferApi1);
-		m_c->m_dev->registerExtType(1, unpackWindowApi1);
-		m_c->m_dev->registerExtType(2, unpackTabpageApi1);
-		connect(m_c->m_dev, &MsgpackIODevice::notification,
-			this, &NeovimApi1::neovimNotification);
+	m_connector->m_dev->registerExtType(0, unpackBufferApi1);
+	m_connector->m_dev->registerExtType(1, unpackWindowApi1);
+	m_connector->m_dev->registerExtType(2, unpackTabpageApi1);
+	connect(m_connector->m_dev, &MsgpackIODevice::notification,
+		this, &NeovimApi1::neovimNotification);
 }
 
 // Slots
 MsgpackRequest* NeovimApi1::nvim_buf_line_count(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_line_count", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_line_count", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_BUF_LINE_COUNT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::buffer_get_line(int64_t buffer, int64_t index)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_line", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_get_line", 2) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_BUFFER_GET_LINE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(index);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(index);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::buffer_set_line(int64_t buffer, int64_t index, QByteArray line)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_set_line", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_set_line", 3) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_BUFFER_SET_LINE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(index);
-	m_c->m_dev->send(line);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(index);
+	m_connector->m_dev->send(line);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::buffer_del_line(int64_t buffer, int64_t index)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_del_line", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_del_line", 2) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_BUFFER_DEL_LINE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(index);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(index);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::buffer_get_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_line_slice", 5);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_get_line_slice", 5) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_BUFFER_GET_LINE_SLICE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(start);
-	m_c->m_dev->send(end);
-	m_c->m_dev->send(include_start);
-	m_c->m_dev->send(include_end);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(start);
+	m_connector->m_dev->send(end);
+	m_connector->m_dev->send(include_start);
+	m_connector->m_dev->send(include_end);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_buf_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_get_lines", 4);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_get_lines", 4) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_BUF_GET_LINES);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(start);
-	m_c->m_dev->send(end);
-	m_c->m_dev->send(strict_indexing);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(start);
+	m_connector->m_dev->send(end);
+	m_connector->m_dev->send(strict_indexing);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::buffer_set_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end, QList<QByteArray> replacement)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_set_line_slice", 6);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_set_line_slice", 6) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_BUFFER_SET_LINE_SLICE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(start);
-	m_c->m_dev->send(end);
-	m_c->m_dev->send(include_start);
-	m_c->m_dev->send(include_end);
-	m_c->m_dev->sendArrayOf(replacement);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(start);
+	m_connector->m_dev->send(end);
+	m_connector->m_dev->send(include_start);
+	m_connector->m_dev->send(include_end);
+	m_connector->m_dev->sendArrayOf(replacement);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_buf_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_set_lines", 5);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_set_lines", 5) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_BUF_SET_LINES);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(start);
-	m_c->m_dev->send(end);
-	m_c->m_dev->send(strict_indexing);
-	m_c->m_dev->sendArrayOf(replacement);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(start);
+	m_connector->m_dev->send(end);
+	m_connector->m_dev->send(strict_indexing);
+	m_connector->m_dev->sendArrayOf(replacement);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_buf_get_var(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_get_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_get_var", 2) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_BUF_GET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_buf_set_var(int64_t buffer, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_set_var", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_set_var", 3) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_BUF_SET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_buf_del_var(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_del_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_del_var", 2) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_BUF_DEL_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::buffer_set_var(int64_t buffer, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_set_var", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_set_var", 3) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_BUFFER_SET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::buffer_del_var(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_del_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_del_var", 2) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_BUFFER_DEL_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_buf_get_option(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_get_option", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_get_option", 2) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_BUF_GET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_buf_set_option(int64_t buffer, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_set_option", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_set_option", 3) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_BUF_SET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_buf_get_number(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_get_number", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_get_number", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_BUF_GET_NUMBER);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_buf_get_name(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_get_name", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_get_name", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_BUF_GET_NAME);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_buf_set_name(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_set_name", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_set_name", 2) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_BUF_SET_NAME);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_buf_is_valid(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_is_valid", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_is_valid", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_BUF_IS_VALID);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::buffer_insert(int64_t buffer, int64_t lnum, QList<QByteArray> lines)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_insert", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_insert", 3) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_BUFFER_INSERT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(lnum);
-	m_c->m_dev->sendArrayOf(lines);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(lnum);
+	m_connector->m_dev->sendArrayOf(lines);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_buf_get_mark(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_get_mark", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_get_mark", 2) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_BUF_GET_MARK);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_buf_add_highlight(int64_t buffer, int64_t src_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_add_highlight", 6);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_add_highlight", 6) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_BUF_ADD_HIGHLIGHT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(src_id);
-	m_c->m_dev->send(hl_group);
-	m_c->m_dev->send(line);
-	m_c->m_dev->send(col_start);
-	m_c->m_dev->send(col_end);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(src_id);
+	m_connector->m_dev->send(hl_group);
+	m_connector->m_dev->send(line);
+	m_connector->m_dev->send(col_start);
+	m_connector->m_dev->send(col_end);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_buf_clear_highlight(int64_t buffer, int64_t src_id, int64_t line_start, int64_t line_end)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_clear_highlight", 4);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_clear_highlight", 4) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_BUF_CLEAR_HIGHLIGHT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(src_id);
-	m_c->m_dev->send(line_start);
-	m_c->m_dev->send(line_end);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(src_id);
+	m_connector->m_dev->send(line_start);
+	m_connector->m_dev->send(line_end);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_tabpage_list_wins(int64_t tabpage)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_tabpage_list_wins", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_tabpage_list_wins", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_TABPAGE_LIST_WINS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(tabpage);
+	m_connector->m_dev->send(tabpage);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_tabpage_get_var(int64_t tabpage, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_tabpage_get_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_tabpage_get_var", 2) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_TABPAGE_GET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(tabpage);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(tabpage);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_tabpage_set_var", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_tabpage_set_var", 3) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_TABPAGE_SET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(tabpage);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(tabpage);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_tabpage_del_var(int64_t tabpage, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_tabpage_del_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_tabpage_del_var", 2) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_TABPAGE_DEL_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(tabpage);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(tabpage);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("tabpage_set_var", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("tabpage_set_var", 3) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_TABPAGE_SET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(tabpage);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(tabpage);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::tabpage_del_var(int64_t tabpage, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("tabpage_del_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("tabpage_del_var", 2) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_TABPAGE_DEL_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(tabpage);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(tabpage);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_tabpage_get_win(int64_t tabpage)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_tabpage_get_win", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_tabpage_get_win", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_TABPAGE_GET_WIN);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(tabpage);
+	m_connector->m_dev->send(tabpage);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_tabpage_get_number(int64_t tabpage)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_tabpage_get_number", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_tabpage_get_number", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_TABPAGE_GET_NUMBER);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(tabpage);
+	m_connector->m_dev->send(tabpage);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_tabpage_is_valid(int64_t tabpage)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_tabpage_is_valid", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_tabpage_is_valid", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_TABPAGE_IS_VALID);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(tabpage);
+	m_connector->m_dev->send(tabpage);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_ui_attach(int64_t width, int64_t height, QVariantMap options)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_ui_attach", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_ui_attach", 3) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_UI_ATTACH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(width);
-	m_c->m_dev->send(height);
-	m_c->m_dev->send(options);
+	m_connector->m_dev->send(width);
+	m_connector->m_dev->send(height);
+	m_connector->m_dev->send(options);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::ui_attach(int64_t width, int64_t height, bool enable_rgb)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("ui_attach", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("ui_attach", 3) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_UI_ATTACH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(width);
-	m_c->m_dev->send(height);
-	m_c->m_dev->send(enable_rgb);
+	m_connector->m_dev->send(width);
+	m_connector->m_dev->send(height);
+	m_connector->m_dev->send(enable_rgb);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_ui_detach()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_ui_detach", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_ui_detach", 0) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_UI_DETACH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_ui_try_resize(int64_t width, int64_t height)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_ui_try_resize", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_ui_try_resize", 2) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_UI_TRY_RESIZE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(width);
-	m_c->m_dev->send(height);
+	m_connector->m_dev->send(width);
+	m_connector->m_dev->send(height);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_ui_set_option(QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_ui_set_option", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_ui_set_option", 2) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_UI_SET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_command(QByteArray command)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_command", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_command", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_COMMAND);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(command);
+	m_connector->m_dev->send(command);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_feedkeys", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_feedkeys", 3) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_FEEDKEYS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(keys);
-	m_c->m_dev->send(mode);
-	m_c->m_dev->send(escape_csi);
+	m_connector->m_dev->send(keys);
+	m_connector->m_dev->send(mode);
+	m_connector->m_dev->send(escape_csi);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_input(QByteArray keys)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_input", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_input", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_INPUT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(keys);
+	m_connector->m_dev->send(keys);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_replace_termcodes", 4);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_replace_termcodes", 4) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_REPLACE_TERMCODES);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(str);
-	m_c->m_dev->send(from_part);
-	m_c->m_dev->send(do_lt);
-	m_c->m_dev->send(special);
+	m_connector->m_dev->send(str);
+	m_connector->m_dev->send(from_part);
+	m_connector->m_dev->send(do_lt);
+	m_connector->m_dev->send(special);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_command_output(QByteArray str)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_command_output", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_command_output", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_COMMAND_OUTPUT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(str);
+	m_connector->m_dev->send(str);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_eval(QByteArray expr)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_eval", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_eval", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_EVAL);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(expr);
+	m_connector->m_dev->send(expr);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_call_function(QByteArray fname, QVariantList args)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_call_function", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_call_function", 2) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_CALL_FUNCTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(fname);
-	m_c->m_dev->send(args);
+	m_connector->m_dev->send(fname);
+	m_connector->m_dev->send(args);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_strwidth(QByteArray str)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_strwidth", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_strwidth", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_STRWIDTH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(str);
+	m_connector->m_dev->send(str);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_list_runtime_paths()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_list_runtime_paths", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_list_runtime_paths", 0) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_LIST_RUNTIME_PATHS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_set_current_dir(QByteArray dir)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_set_current_dir", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_set_current_dir", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_SET_CURRENT_DIR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(dir);
+	m_connector->m_dev->send(dir);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_get_current_line()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_current_line", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_current_line", 0) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_GET_CURRENT_LINE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_set_current_line(QByteArray line)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_set_current_line", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_set_current_line", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_SET_CURRENT_LINE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(line);
+	m_connector->m_dev->send(line);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_del_current_line()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_del_current_line", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_del_current_line", 0) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_DEL_CURRENT_LINE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_get_var(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_var", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_var", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_GET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_set_var(QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_set_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_set_var", 2) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_SET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_del_var(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_del_var", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_del_var", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_DEL_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::vim_set_var(QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_set_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_set_var", 2) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_VIM_SET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::vim_del_var(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_del_var", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_del_var", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_VIM_DEL_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_get_vvar(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_vvar", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_vvar", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_GET_VVAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_get_option(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_option", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_option", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_GET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_set_option(QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_set_option", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_set_option", 2) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_SET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_out_write(QByteArray str)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_out_write", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_out_write", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_OUT_WRITE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(str);
+	m_connector->m_dev->send(str);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_err_write(QByteArray str)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_err_write", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_err_write", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_ERR_WRITE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(str);
+	m_connector->m_dev->send(str);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_err_writeln(QByteArray str)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_err_writeln", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_err_writeln", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_ERR_WRITELN);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(str);
+	m_connector->m_dev->send(str);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_list_bufs()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_list_bufs", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_list_bufs", 0) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_LIST_BUFS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_get_current_buf()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_current_buf", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_current_buf", 0) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_GET_CURRENT_BUF);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_set_current_buf(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_set_current_buf", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_set_current_buf", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_SET_CURRENT_BUF);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_list_wins()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_list_wins", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_list_wins", 0) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_LIST_WINS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_get_current_win()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_current_win", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_current_win", 0) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_GET_CURRENT_WIN);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_set_current_win(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_set_current_win", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_set_current_win", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_SET_CURRENT_WIN);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_list_tabpages()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_list_tabpages", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_list_tabpages", 0) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_LIST_TABPAGES);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_get_current_tabpage()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_current_tabpage", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_current_tabpage", 0) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_GET_CURRENT_TABPAGE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_set_current_tabpage(int64_t tabpage)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_set_current_tabpage", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_set_current_tabpage", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_SET_CURRENT_TABPAGE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(tabpage);
+	m_connector->m_dev->send(tabpage);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_subscribe(QByteArray event)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_subscribe", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_subscribe", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_SUBSCRIBE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(event);
+	m_connector->m_dev->send(event);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_unsubscribe(QByteArray event)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_unsubscribe", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_unsubscribe", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_UNSUBSCRIBE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(event);
+	m_connector->m_dev->send(event);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_get_color_by_name(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_color_by_name", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_color_by_name", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_GET_COLOR_BY_NAME);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_get_color_map()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_color_map", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_color_map", 0) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_GET_COLOR_MAP);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_get_api_info()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_api_info", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_api_info", 0) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_GET_API_INFO);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_call_atomic(QVariantList calls)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_call_atomic", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_call_atomic", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_CALL_ATOMIC);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(calls);
+	m_connector->m_dev->send(calls);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_win_get_buf(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_buf", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_get_buf", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_WIN_GET_BUF);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_win_get_cursor(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_cursor", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_get_cursor", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_WIN_GET_CURSOR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_win_set_cursor(int64_t window, QPoint pos)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_set_cursor", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_set_cursor", 2) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_WIN_SET_CURSOR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(pos);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(pos);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_win_get_height(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_height", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_get_height", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_WIN_GET_HEIGHT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_win_set_height(int64_t window, int64_t height)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_set_height", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_set_height", 2) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_WIN_SET_HEIGHT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(height);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(height);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_win_get_width(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_width", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_get_width", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_WIN_GET_WIDTH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_win_set_width(int64_t window, int64_t width)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_set_width", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_set_width", 2) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_WIN_SET_WIDTH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(width);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(width);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_win_get_var(int64_t window, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_get_var", 2) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_WIN_GET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_win_set_var(int64_t window, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_set_var", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_set_var", 3) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_WIN_SET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_win_del_var(int64_t window, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_del_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_del_var", 2) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_WIN_DEL_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::window_set_var(int64_t window, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_set_var", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_set_var", 3) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_WINDOW_SET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::window_del_var(int64_t window, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_del_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_del_var", 2) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_WINDOW_DEL_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_win_get_option(int64_t window, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_option", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_get_option", 2) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_WIN_GET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_win_set_option(int64_t window, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_set_option", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_set_option", 3) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_WIN_SET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_win_get_position(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_position", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_get_position", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_WIN_GET_POSITION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_win_get_tabpage(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_tabpage", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_get_tabpage", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_WIN_GET_TABPAGE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_win_get_number(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_number", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_get_number", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_WIN_GET_NUMBER);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::nvim_win_is_valid(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_is_valid", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_is_valid", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_NVIM_WIN_IS_VALID);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::buffer_line_count(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_line_count", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_line_count", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_BUFFER_LINE_COUNT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::buffer_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_lines", 4);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_get_lines", 4) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_BUFFER_GET_LINES);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(start);
-	m_c->m_dev->send(end);
-	m_c->m_dev->send(strict_indexing);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(start);
+	m_connector->m_dev->send(end);
+	m_connector->m_dev->send(strict_indexing);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::buffer_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_set_lines", 5);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_set_lines", 5) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_BUFFER_SET_LINES);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(start);
-	m_c->m_dev->send(end);
-	m_c->m_dev->send(strict_indexing);
-	m_c->m_dev->sendArrayOf(replacement);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(start);
+	m_connector->m_dev->send(end);
+	m_connector->m_dev->send(strict_indexing);
+	m_connector->m_dev->sendArrayOf(replacement);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::buffer_get_var(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_get_var", 2) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_BUFFER_GET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::buffer_get_option(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_option", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_get_option", 2) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_BUFFER_GET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::buffer_set_option(int64_t buffer, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_set_option", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_set_option", 3) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_BUFFER_SET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::buffer_get_number(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_number", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_get_number", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_BUFFER_GET_NUMBER);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::buffer_get_name(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_name", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_get_name", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_BUFFER_GET_NAME);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::buffer_set_name(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_set_name", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_set_name", 2) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_BUFFER_SET_NAME);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::buffer_is_valid(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_is_valid", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_is_valid", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_BUFFER_IS_VALID);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::buffer_get_mark(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_mark", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_get_mark", 2) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_BUFFER_GET_MARK);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::buffer_add_highlight(int64_t buffer, int64_t src_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_add_highlight", 6);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_add_highlight", 6) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_BUFFER_ADD_HIGHLIGHT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(src_id);
-	m_c->m_dev->send(hl_group);
-	m_c->m_dev->send(line);
-	m_c->m_dev->send(col_start);
-	m_c->m_dev->send(col_end);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(src_id);
+	m_connector->m_dev->send(hl_group);
+	m_connector->m_dev->send(line);
+	m_connector->m_dev->send(col_start);
+	m_connector->m_dev->send(col_end);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::buffer_clear_highlight(int64_t buffer, int64_t src_id, int64_t line_start, int64_t line_end)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_clear_highlight", 4);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_clear_highlight", 4) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_BUFFER_CLEAR_HIGHLIGHT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(src_id);
-	m_c->m_dev->send(line_start);
-	m_c->m_dev->send(line_end);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(src_id);
+	m_connector->m_dev->send(line_start);
+	m_connector->m_dev->send(line_end);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::tabpage_get_windows(int64_t tabpage)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("tabpage_get_windows", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("tabpage_get_windows", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_TABPAGE_GET_WINDOWS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(tabpage);
+	m_connector->m_dev->send(tabpage);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::tabpage_get_var(int64_t tabpage, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("tabpage_get_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("tabpage_get_var", 2) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_TABPAGE_GET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(tabpage);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(tabpage);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::tabpage_get_window(int64_t tabpage)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("tabpage_get_window", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("tabpage_get_window", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_TABPAGE_GET_WINDOW);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(tabpage);
+	m_connector->m_dev->send(tabpage);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::tabpage_is_valid(int64_t tabpage)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("tabpage_is_valid", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("tabpage_is_valid", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_TABPAGE_IS_VALID);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(tabpage);
+	m_connector->m_dev->send(tabpage);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::ui_detach()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("ui_detach", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("ui_detach", 0) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_UI_DETACH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::ui_try_resize(int64_t width, int64_t height)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("ui_try_resize", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("ui_try_resize", 2) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_UI_TRY_RESIZE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(width);
-	m_c->m_dev->send(height);
+	m_connector->m_dev->send(width);
+	m_connector->m_dev->send(height);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::vim_command(QByteArray command)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_command", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_command", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_VIM_COMMAND);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(command);
+	m_connector->m_dev->send(command);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::vim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_feedkeys", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_feedkeys", 3) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_VIM_FEEDKEYS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(keys);
-	m_c->m_dev->send(mode);
-	m_c->m_dev->send(escape_csi);
+	m_connector->m_dev->send(keys);
+	m_connector->m_dev->send(mode);
+	m_connector->m_dev->send(escape_csi);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::vim_input(QByteArray keys)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_input", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_input", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_VIM_INPUT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(keys);
+	m_connector->m_dev->send(keys);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::vim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_replace_termcodes", 4);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_replace_termcodes", 4) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_VIM_REPLACE_TERMCODES);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(str);
-	m_c->m_dev->send(from_part);
-	m_c->m_dev->send(do_lt);
-	m_c->m_dev->send(special);
+	m_connector->m_dev->send(str);
+	m_connector->m_dev->send(from_part);
+	m_connector->m_dev->send(do_lt);
+	m_connector->m_dev->send(special);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::vim_command_output(QByteArray str)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_command_output", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_command_output", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_VIM_COMMAND_OUTPUT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(str);
+	m_connector->m_dev->send(str);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::vim_eval(QByteArray expr)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_eval", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_eval", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_VIM_EVAL);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(expr);
+	m_connector->m_dev->send(expr);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::vim_call_function(QByteArray fname, QVariantList args)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_call_function", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_call_function", 2) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_VIM_CALL_FUNCTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(fname);
-	m_c->m_dev->send(args);
+	m_connector->m_dev->send(fname);
+	m_connector->m_dev->send(args);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::vim_strwidth(QByteArray str)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_strwidth", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_strwidth", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_VIM_STRWIDTH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(str);
+	m_connector->m_dev->send(str);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::vim_list_runtime_paths()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_list_runtime_paths", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_list_runtime_paths", 0) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_VIM_LIST_RUNTIME_PATHS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::vim_change_directory(QByteArray dir)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_change_directory", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_change_directory", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_VIM_CHANGE_DIRECTORY);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(dir);
+	m_connector->m_dev->send(dir);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::vim_get_current_line()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_current_line", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_current_line", 0) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_VIM_GET_CURRENT_LINE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::vim_set_current_line(QByteArray line)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_set_current_line", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_set_current_line", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_VIM_SET_CURRENT_LINE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(line);
+	m_connector->m_dev->send(line);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::vim_del_current_line()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_del_current_line", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_del_current_line", 0) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_VIM_DEL_CURRENT_LINE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::vim_get_var(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_var", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_var", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_VIM_GET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::vim_get_vvar(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_vvar", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_vvar", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_VIM_GET_VVAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::vim_get_option(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_option", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_option", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_VIM_GET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::vim_set_option(QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_set_option", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_set_option", 2) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_VIM_SET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::vim_out_write(QByteArray str)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_out_write", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_out_write", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_VIM_OUT_WRITE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(str);
+	m_connector->m_dev->send(str);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::vim_err_write(QByteArray str)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_err_write", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_err_write", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_VIM_ERR_WRITE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(str);
+	m_connector->m_dev->send(str);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::vim_report_error(QByteArray str)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_report_error", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_report_error", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_VIM_REPORT_ERROR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(str);
+	m_connector->m_dev->send(str);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::vim_get_buffers()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_buffers", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_buffers", 0) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_VIM_GET_BUFFERS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::vim_get_current_buffer()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_current_buffer", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_current_buffer", 0) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_VIM_GET_CURRENT_BUFFER);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::vim_set_current_buffer(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_set_current_buffer", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_set_current_buffer", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_VIM_SET_CURRENT_BUFFER);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::vim_get_windows()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_windows", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_windows", 0) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_VIM_GET_WINDOWS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::vim_get_current_window()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_current_window", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_current_window", 0) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_VIM_GET_CURRENT_WINDOW);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::vim_set_current_window(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_set_current_window", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_set_current_window", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_VIM_SET_CURRENT_WINDOW);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::vim_get_tabpages()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_tabpages", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_tabpages", 0) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_VIM_GET_TABPAGES);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::vim_get_current_tabpage()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_current_tabpage", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_current_tabpage", 0) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_VIM_GET_CURRENT_TABPAGE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::vim_set_current_tabpage(int64_t tabpage)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_set_current_tabpage", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_set_current_tabpage", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_VIM_SET_CURRENT_TABPAGE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(tabpage);
+	m_connector->m_dev->send(tabpage);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::vim_subscribe(QByteArray event)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_subscribe", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_subscribe", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_VIM_SUBSCRIBE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(event);
+	m_connector->m_dev->send(event);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::vim_unsubscribe(QByteArray event)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_unsubscribe", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_unsubscribe", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_VIM_UNSUBSCRIBE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(event);
+	m_connector->m_dev->send(event);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::vim_name_to_color(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_name_to_color", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_name_to_color", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_VIM_NAME_TO_COLOR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::vim_get_color_map()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_color_map", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_color_map", 0) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_VIM_GET_COLOR_MAP);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::window_get_buffer(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_buffer", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_get_buffer", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_WINDOW_GET_BUFFER);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::window_get_cursor(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_cursor", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_get_cursor", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_WINDOW_GET_CURSOR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::window_set_cursor(int64_t window, QPoint pos)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_set_cursor", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_set_cursor", 2) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_WINDOW_SET_CURSOR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(pos);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(pos);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::window_get_height(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_height", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_get_height", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_WINDOW_GET_HEIGHT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::window_set_height(int64_t window, int64_t height)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_set_height", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_set_height", 2) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_WINDOW_SET_HEIGHT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(height);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(height);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::window_get_width(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_width", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_get_width", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_WINDOW_GET_WIDTH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::window_set_width(int64_t window, int64_t width)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_set_width", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_set_width", 2) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_WINDOW_SET_WIDTH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(width);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(width);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::window_get_var(int64_t window, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_get_var", 2) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_WINDOW_GET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::window_get_option(int64_t window, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_option", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_get_option", 2) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_WINDOW_GET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::window_set_option(int64_t window, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_set_option", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_set_option", 3) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_WINDOW_SET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::window_get_position(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_position", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_get_position", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_WINDOW_GET_POSITION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::window_get_tabpage(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_tabpage", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_get_tabpage", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_WINDOW_GET_TABPAGE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi1::window_is_valid(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_is_valid", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_is_valid", 1) };
 	r->setFunction(NeovimApi1::NEOVIM_FN_WINDOW_IS_VALID);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi1::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi1::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
 
+
 // Handlers
 
-void NeovimApi1::handleResponseError(quint32 msgid, quint64 fun, const QVariant& res)
+void NeovimApi1::handleResponseError(uint32_t msgid, uint64_t fun, const QVariant& res)
 {
 
 	// TODO: support Neovim error types Exception/Validation/etc
@@ -1582,7 +1749,7 @@ void NeovimApi1::handleResponseError(quint32 msgid, quint64 fun, const QVariant&
 	const QVariantList asList = res.toList();
 	if (asList.size() >= 2) {
 		if (asList.at(1).canConvert<QByteArray>()) {
-			errMsg = m_c->m_dev->decode(asList.at(1).toByteArray());
+			errMsg = m_connector->m_dev->decode(asList.at(1).toByteArray());
 		} else {
 			errMsg = tr("Received unsupported Neovim error type");
 		}
@@ -2067,1549 +2234,1549 @@ void NeovimApi1::handleResponseError(quint32 msgid, quint64 fun, const QVariant&
 		emit err_window_is_valid(errMsg, res);
 		break;
 	default:
-		m_c->setError(NeovimConnector::RuntimeMsgpackError, QString("Received error for function that should not fail: %s").arg(fun));
+		m_connector->setError(NeovimConnector::RuntimeMsgpackError, QString("Received error for function that should not fail: %s").arg(fun));
 	}
 }
 
-void NeovimApi1::handleResponse(quint32 msgid, quint64 fun, const QVariant& res)
+void NeovimApi1::handleResponse(uint32_t msgid, uint64_t fun, const QVariant& res)
 {
 	switch(fun) {
-	case NeovimApi1::NEOVIM_FN_NVIM_BUF_LINE_COUNT:
+		case NeovimApi1::NEOVIM_FN_NVIM_BUF_LINE_COUNT:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_line_count");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_line_count");
 				return;
-			} else {
-				emit on_nvim_buf_line_count(data);
 			}
 
+			emit on_nvim_buf_line_count(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_BUFFER_GET_LINE:
+
+		case NeovimApi1::NEOVIM_FN_BUFFER_GET_LINE:
 		{
 			QByteArray data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_line");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_line");
 				return;
-			} else {
-				emit on_buffer_get_line(data);
 			}
 
+			emit on_buffer_get_line(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_BUFFER_SET_LINE:
+
+		case NeovimApi1::NEOVIM_FN_BUFFER_SET_LINE:
 		{
 			emit on_buffer_set_line();
-
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_BUFFER_DEL_LINE:
+
+		case NeovimApi1::NEOVIM_FN_BUFFER_DEL_LINE:
 		{
 			emit on_buffer_del_line();
-
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_BUFFER_GET_LINE_SLICE:
+
+		case NeovimApi1::NEOVIM_FN_BUFFER_GET_LINE_SLICE:
 		{
 			QList<QByteArray> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_line_slice");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_line_slice");
 				return;
-			} else {
-				emit on_buffer_get_line_slice(data);
 			}
 
+			emit on_buffer_get_line_slice(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_BUF_GET_LINES:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_BUF_GET_LINES:
 		{
 			QList<QByteArray> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_lines");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_lines");
 				return;
-			} else {
-				emit on_nvim_buf_get_lines(data);
 			}
 
+			emit on_nvim_buf_get_lines(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_BUFFER_SET_LINE_SLICE:
+
+		case NeovimApi1::NEOVIM_FN_BUFFER_SET_LINE_SLICE:
 		{
 			emit on_buffer_set_line_slice();
-
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_BUF_SET_LINES:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_BUF_SET_LINES:
 		{
 			emit on_nvim_buf_set_lines();
-
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_BUF_GET_VAR:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_BUF_GET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_var");
 				return;
-			} else {
-				emit on_nvim_buf_get_var(data);
 			}
 
+			emit on_nvim_buf_get_var(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_BUF_SET_VAR:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_BUF_SET_VAR:
 		{
 			emit on_nvim_buf_set_var();
-
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_BUF_DEL_VAR:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_BUF_DEL_VAR:
 		{
 			emit on_nvim_buf_del_var();
-
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_BUFFER_SET_VAR:
+
+		case NeovimApi1::NEOVIM_FN_BUFFER_SET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_set_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_set_var");
 				return;
-			} else {
-				emit on_buffer_set_var(data);
 			}
 
+			emit on_buffer_set_var(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_BUFFER_DEL_VAR:
+
+		case NeovimApi1::NEOVIM_FN_BUFFER_DEL_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_del_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_del_var");
 				return;
-			} else {
-				emit on_buffer_del_var(data);
 			}
 
+			emit on_buffer_del_var(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_BUF_GET_OPTION:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_BUF_GET_OPTION:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_option");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_option");
 				return;
-			} else {
-				emit on_nvim_buf_get_option(data);
 			}
 
+			emit on_nvim_buf_get_option(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_BUF_SET_OPTION:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_BUF_SET_OPTION:
 		{
 			emit on_nvim_buf_set_option();
-
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_BUF_GET_NUMBER:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_BUF_GET_NUMBER:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_number");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_number");
 				return;
-			} else {
-				emit on_nvim_buf_get_number(data);
 			}
 
+			emit on_nvim_buf_get_number(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_BUF_GET_NAME:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_BUF_GET_NAME:
 		{
 			QByteArray data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_name");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_name");
 				return;
-			} else {
-				emit on_nvim_buf_get_name(data);
 			}
 
+			emit on_nvim_buf_get_name(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_BUF_SET_NAME:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_BUF_SET_NAME:
 		{
 			emit on_nvim_buf_set_name();
-
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_BUF_IS_VALID:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_BUF_IS_VALID:
 		{
 			bool data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_is_valid");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_is_valid");
 				return;
-			} else {
-				emit on_nvim_buf_is_valid(data);
 			}
 
+			emit on_nvim_buf_is_valid(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_BUFFER_INSERT:
+
+		case NeovimApi1::NEOVIM_FN_BUFFER_INSERT:
 		{
 			emit on_buffer_insert();
-
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_BUF_GET_MARK:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_BUF_GET_MARK:
 		{
 			QPoint data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_mark");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_mark");
 				return;
-			} else {
-				emit on_nvim_buf_get_mark(data);
 			}
 
+			emit on_nvim_buf_get_mark(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_BUF_ADD_HIGHLIGHT:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_BUF_ADD_HIGHLIGHT:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_add_highlight");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_add_highlight");
 				return;
-			} else {
-				emit on_nvim_buf_add_highlight(data);
 			}
 
+			emit on_nvim_buf_add_highlight(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_BUF_CLEAR_HIGHLIGHT:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_BUF_CLEAR_HIGHLIGHT:
 		{
 			emit on_nvim_buf_clear_highlight();
-
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_TABPAGE_LIST_WINS:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_TABPAGE_LIST_WINS:
 		{
 			QList<int64_t> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_list_wins");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_list_wins");
 				return;
-			} else {
-				emit on_nvim_tabpage_list_wins(data);
 			}
 
+			emit on_nvim_tabpage_list_wins(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_TABPAGE_GET_VAR:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_TABPAGE_GET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_get_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_get_var");
 				return;
-			} else {
-				emit on_nvim_tabpage_get_var(data);
 			}
 
+			emit on_nvim_tabpage_get_var(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_TABPAGE_SET_VAR:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_TABPAGE_SET_VAR:
 		{
 			emit on_nvim_tabpage_set_var();
-
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_TABPAGE_DEL_VAR:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_TABPAGE_DEL_VAR:
 		{
 			emit on_nvim_tabpage_del_var();
-
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_TABPAGE_SET_VAR:
+
+		case NeovimApi1::NEOVIM_FN_TABPAGE_SET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_set_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_set_var");
 				return;
-			} else {
-				emit on_tabpage_set_var(data);
 			}
 
+			emit on_tabpage_set_var(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_TABPAGE_DEL_VAR:
+
+		case NeovimApi1::NEOVIM_FN_TABPAGE_DEL_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_del_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_del_var");
 				return;
-			} else {
-				emit on_tabpage_del_var(data);
 			}
 
+			emit on_tabpage_del_var(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_TABPAGE_GET_WIN:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_TABPAGE_GET_WIN:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_get_win");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_get_win");
 				return;
-			} else {
-				emit on_nvim_tabpage_get_win(data);
 			}
 
+			emit on_nvim_tabpage_get_win(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_TABPAGE_GET_NUMBER:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_TABPAGE_GET_NUMBER:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_get_number");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_get_number");
 				return;
-			} else {
-				emit on_nvim_tabpage_get_number(data);
 			}
 
+			emit on_nvim_tabpage_get_number(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_TABPAGE_IS_VALID:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_TABPAGE_IS_VALID:
 		{
 			bool data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_is_valid");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_is_valid");
 				return;
-			} else {
-				emit on_nvim_tabpage_is_valid(data);
 			}
 
+			emit on_nvim_tabpage_is_valid(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_UI_ATTACH:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_UI_ATTACH:
 		{
 			emit on_nvim_ui_attach();
-
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_UI_ATTACH:
+
+		case NeovimApi1::NEOVIM_FN_UI_ATTACH:
 		{
 			emit on_ui_attach();
-
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_UI_DETACH:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_UI_DETACH:
 		{
 			emit on_nvim_ui_detach();
-
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_UI_TRY_RESIZE:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_UI_TRY_RESIZE:
 		{
 			emit on_nvim_ui_try_resize();
-
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_UI_SET_OPTION:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_UI_SET_OPTION:
 		{
 			emit on_nvim_ui_set_option();
-
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_COMMAND:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_COMMAND:
 		{
 			emit on_nvim_command();
-
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_FEEDKEYS:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_FEEDKEYS:
 		{
 			emit on_nvim_feedkeys();
-
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_INPUT:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_INPUT:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_input");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_input");
 				return;
-			} else {
-				emit on_nvim_input(data);
 			}
 
+			emit on_nvim_input(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_REPLACE_TERMCODES:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_REPLACE_TERMCODES:
 		{
 			QByteArray data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_replace_termcodes");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_replace_termcodes");
 				return;
-			} else {
-				emit on_nvim_replace_termcodes(data);
 			}
 
+			emit on_nvim_replace_termcodes(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_COMMAND_OUTPUT:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_COMMAND_OUTPUT:
 		{
 			QByteArray data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_command_output");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_command_output");
 				return;
-			} else {
-				emit on_nvim_command_output(data);
 			}
 
+			emit on_nvim_command_output(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_EVAL:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_EVAL:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_eval");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_eval");
 				return;
-			} else {
-				emit on_nvim_eval(data);
 			}
 
+			emit on_nvim_eval(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_CALL_FUNCTION:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_CALL_FUNCTION:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_call_function");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_call_function");
 				return;
-			} else {
-				emit on_nvim_call_function(data);
 			}
 
+			emit on_nvim_call_function(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_STRWIDTH:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_STRWIDTH:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_strwidth");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_strwidth");
 				return;
-			} else {
-				emit on_nvim_strwidth(data);
 			}
 
+			emit on_nvim_strwidth(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_LIST_RUNTIME_PATHS:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_LIST_RUNTIME_PATHS:
 		{
 			QList<QByteArray> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_runtime_paths");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_runtime_paths");
 				return;
-			} else {
-				emit on_nvim_list_runtime_paths(data);
 			}
 
+			emit on_nvim_list_runtime_paths(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_SET_CURRENT_DIR:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_SET_CURRENT_DIR:
 		{
 			emit on_nvim_set_current_dir();
-
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_GET_CURRENT_LINE:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_GET_CURRENT_LINE:
 		{
 			QByteArray data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_current_line");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_current_line");
 				return;
-			} else {
-				emit on_nvim_get_current_line(data);
 			}
 
+			emit on_nvim_get_current_line(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_SET_CURRENT_LINE:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_SET_CURRENT_LINE:
 		{
 			emit on_nvim_set_current_line();
-
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_DEL_CURRENT_LINE:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_DEL_CURRENT_LINE:
 		{
 			emit on_nvim_del_current_line();
-
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_GET_VAR:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_GET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_var");
 				return;
-			} else {
-				emit on_nvim_get_var(data);
 			}
 
+			emit on_nvim_get_var(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_SET_VAR:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_SET_VAR:
 		{
 			emit on_nvim_set_var();
-
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_DEL_VAR:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_DEL_VAR:
 		{
 			emit on_nvim_del_var();
-
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_VIM_SET_VAR:
+
+		case NeovimApi1::NEOVIM_FN_VIM_SET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_set_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_set_var");
 				return;
-			} else {
-				emit on_vim_set_var(data);
 			}
 
+			emit on_vim_set_var(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_VIM_DEL_VAR:
+
+		case NeovimApi1::NEOVIM_FN_VIM_DEL_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_del_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_del_var");
 				return;
-			} else {
-				emit on_vim_del_var(data);
 			}
 
+			emit on_vim_del_var(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_GET_VVAR:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_GET_VVAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_vvar");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_vvar");
 				return;
-			} else {
-				emit on_nvim_get_vvar(data);
 			}
 
+			emit on_nvim_get_vvar(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_GET_OPTION:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_GET_OPTION:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_option");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_option");
 				return;
-			} else {
-				emit on_nvim_get_option(data);
 			}
 
+			emit on_nvim_get_option(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_SET_OPTION:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_SET_OPTION:
 		{
 			emit on_nvim_set_option();
-
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_OUT_WRITE:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_OUT_WRITE:
 		{
 			emit on_nvim_out_write();
-
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_ERR_WRITE:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_ERR_WRITE:
 		{
 			emit on_nvim_err_write();
-
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_ERR_WRITELN:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_ERR_WRITELN:
 		{
 			emit on_nvim_err_writeln();
-
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_LIST_BUFS:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_LIST_BUFS:
 		{
 			QList<int64_t> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_bufs");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_bufs");
 				return;
-			} else {
-				emit on_nvim_list_bufs(data);
 			}
 
+			emit on_nvim_list_bufs(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_GET_CURRENT_BUF:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_GET_CURRENT_BUF:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_current_buf");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_current_buf");
 				return;
-			} else {
-				emit on_nvim_get_current_buf(data);
 			}
 
+			emit on_nvim_get_current_buf(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_SET_CURRENT_BUF:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_SET_CURRENT_BUF:
 		{
 			emit on_nvim_set_current_buf();
-
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_LIST_WINS:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_LIST_WINS:
 		{
 			QList<int64_t> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_wins");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_wins");
 				return;
-			} else {
-				emit on_nvim_list_wins(data);
 			}
 
+			emit on_nvim_list_wins(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_GET_CURRENT_WIN:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_GET_CURRENT_WIN:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_current_win");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_current_win");
 				return;
-			} else {
-				emit on_nvim_get_current_win(data);
 			}
 
+			emit on_nvim_get_current_win(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_SET_CURRENT_WIN:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_SET_CURRENT_WIN:
 		{
 			emit on_nvim_set_current_win();
-
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_LIST_TABPAGES:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_LIST_TABPAGES:
 		{
 			QList<int64_t> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_tabpages");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_tabpages");
 				return;
-			} else {
-				emit on_nvim_list_tabpages(data);
 			}
 
+			emit on_nvim_list_tabpages(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_GET_CURRENT_TABPAGE:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_GET_CURRENT_TABPAGE:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_current_tabpage");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_current_tabpage");
 				return;
-			} else {
-				emit on_nvim_get_current_tabpage(data);
 			}
 
+			emit on_nvim_get_current_tabpage(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_SET_CURRENT_TABPAGE:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_SET_CURRENT_TABPAGE:
 		{
 			emit on_nvim_set_current_tabpage();
-
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_SUBSCRIBE:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_SUBSCRIBE:
 		{
 			emit on_nvim_subscribe();
-
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_UNSUBSCRIBE:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_UNSUBSCRIBE:
 		{
 			emit on_nvim_unsubscribe();
-
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_GET_COLOR_BY_NAME:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_GET_COLOR_BY_NAME:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_color_by_name");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_color_by_name");
 				return;
-			} else {
-				emit on_nvim_get_color_by_name(data);
 			}
 
+			emit on_nvim_get_color_by_name(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_GET_COLOR_MAP:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_GET_COLOR_MAP:
 		{
 			QVariantMap data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_color_map");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_color_map");
 				return;
-			} else {
-				emit on_nvim_get_color_map(data);
 			}
 
+			emit on_nvim_get_color_map(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_GET_API_INFO:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_GET_API_INFO:
 		{
 			QVariantList data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_api_info");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_api_info");
 				return;
-			} else {
-				emit on_nvim_get_api_info(data);
 			}
 
+			emit on_nvim_get_api_info(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_CALL_ATOMIC:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_CALL_ATOMIC:
 		{
 			QVariantList data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_call_atomic");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_call_atomic");
 				return;
-			} else {
-				emit on_nvim_call_atomic(data);
 			}
 
+			emit on_nvim_call_atomic(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_WIN_GET_BUF:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_WIN_GET_BUF:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_buf");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_buf");
 				return;
-			} else {
-				emit on_nvim_win_get_buf(data);
 			}
 
+			emit on_nvim_win_get_buf(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_WIN_GET_CURSOR:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_WIN_GET_CURSOR:
 		{
 			QPoint data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_cursor");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_cursor");
 				return;
-			} else {
-				emit on_nvim_win_get_cursor(data);
 			}
 
+			emit on_nvim_win_get_cursor(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_WIN_SET_CURSOR:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_WIN_SET_CURSOR:
 		{
 			emit on_nvim_win_set_cursor();
-
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_WIN_GET_HEIGHT:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_WIN_GET_HEIGHT:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_height");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_height");
 				return;
-			} else {
-				emit on_nvim_win_get_height(data);
 			}
 
+			emit on_nvim_win_get_height(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_WIN_SET_HEIGHT:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_WIN_SET_HEIGHT:
 		{
 			emit on_nvim_win_set_height();
-
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_WIN_GET_WIDTH:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_WIN_GET_WIDTH:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_width");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_width");
 				return;
-			} else {
-				emit on_nvim_win_get_width(data);
 			}
 
+			emit on_nvim_win_get_width(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_WIN_SET_WIDTH:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_WIN_SET_WIDTH:
 		{
 			emit on_nvim_win_set_width();
-
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_WIN_GET_VAR:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_WIN_GET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_var");
 				return;
-			} else {
-				emit on_nvim_win_get_var(data);
 			}
 
+			emit on_nvim_win_get_var(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_WIN_SET_VAR:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_WIN_SET_VAR:
 		{
 			emit on_nvim_win_set_var();
-
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_WIN_DEL_VAR:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_WIN_DEL_VAR:
 		{
 			emit on_nvim_win_del_var();
-
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_WINDOW_SET_VAR:
+
+		case NeovimApi1::NEOVIM_FN_WINDOW_SET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_set_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_set_var");
 				return;
-			} else {
-				emit on_window_set_var(data);
 			}
 
+			emit on_window_set_var(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_WINDOW_DEL_VAR:
+
+		case NeovimApi1::NEOVIM_FN_WINDOW_DEL_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_del_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_del_var");
 				return;
-			} else {
-				emit on_window_del_var(data);
 			}
 
+			emit on_window_del_var(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_WIN_GET_OPTION:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_WIN_GET_OPTION:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_option");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_option");
 				return;
-			} else {
-				emit on_nvim_win_get_option(data);
 			}
 
+			emit on_nvim_win_get_option(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_WIN_SET_OPTION:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_WIN_SET_OPTION:
 		{
 			emit on_nvim_win_set_option();
-
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_WIN_GET_POSITION:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_WIN_GET_POSITION:
 		{
 			QPoint data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_position");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_position");
 				return;
-			} else {
-				emit on_nvim_win_get_position(data);
 			}
 
+			emit on_nvim_win_get_position(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_WIN_GET_TABPAGE:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_WIN_GET_TABPAGE:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_tabpage");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_tabpage");
 				return;
-			} else {
-				emit on_nvim_win_get_tabpage(data);
 			}
 
+			emit on_nvim_win_get_tabpage(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_WIN_GET_NUMBER:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_WIN_GET_NUMBER:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_number");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_number");
 				return;
-			} else {
-				emit on_nvim_win_get_number(data);
 			}
 
+			emit on_nvim_win_get_number(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_NVIM_WIN_IS_VALID:
+
+		case NeovimApi1::NEOVIM_FN_NVIM_WIN_IS_VALID:
 		{
 			bool data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_is_valid");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_is_valid");
 				return;
-			} else {
-				emit on_nvim_win_is_valid(data);
 			}
 
+			emit on_nvim_win_is_valid(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_BUFFER_LINE_COUNT:
+
+		case NeovimApi1::NEOVIM_FN_BUFFER_LINE_COUNT:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_line_count");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_line_count");
 				return;
-			} else {
-				emit on_buffer_line_count(data);
 			}
 
+			emit on_buffer_line_count(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_BUFFER_GET_LINES:
+
+		case NeovimApi1::NEOVIM_FN_BUFFER_GET_LINES:
 		{
 			QList<QByteArray> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_lines");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_lines");
 				return;
-			} else {
-				emit on_buffer_get_lines(data);
 			}
 
+			emit on_buffer_get_lines(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_BUFFER_SET_LINES:
+
+		case NeovimApi1::NEOVIM_FN_BUFFER_SET_LINES:
 		{
 			emit on_buffer_set_lines();
-
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_BUFFER_GET_VAR:
+
+		case NeovimApi1::NEOVIM_FN_BUFFER_GET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_var");
 				return;
-			} else {
-				emit on_buffer_get_var(data);
 			}
 
+			emit on_buffer_get_var(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_BUFFER_GET_OPTION:
+
+		case NeovimApi1::NEOVIM_FN_BUFFER_GET_OPTION:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_option");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_option");
 				return;
-			} else {
-				emit on_buffer_get_option(data);
 			}
 
+			emit on_buffer_get_option(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_BUFFER_SET_OPTION:
+
+		case NeovimApi1::NEOVIM_FN_BUFFER_SET_OPTION:
 		{
 			emit on_buffer_set_option();
-
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_BUFFER_GET_NUMBER:
+
+		case NeovimApi1::NEOVIM_FN_BUFFER_GET_NUMBER:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_number");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_number");
 				return;
-			} else {
-				emit on_buffer_get_number(data);
 			}
 
+			emit on_buffer_get_number(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_BUFFER_GET_NAME:
+
+		case NeovimApi1::NEOVIM_FN_BUFFER_GET_NAME:
 		{
 			QByteArray data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_name");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_name");
 				return;
-			} else {
-				emit on_buffer_get_name(data);
 			}
 
+			emit on_buffer_get_name(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_BUFFER_SET_NAME:
+
+		case NeovimApi1::NEOVIM_FN_BUFFER_SET_NAME:
 		{
 			emit on_buffer_set_name();
-
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_BUFFER_IS_VALID:
+
+		case NeovimApi1::NEOVIM_FN_BUFFER_IS_VALID:
 		{
 			bool data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_is_valid");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_is_valid");
 				return;
-			} else {
-				emit on_buffer_is_valid(data);
 			}
 
+			emit on_buffer_is_valid(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_BUFFER_GET_MARK:
+
+		case NeovimApi1::NEOVIM_FN_BUFFER_GET_MARK:
 		{
 			QPoint data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_mark");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_mark");
 				return;
-			} else {
-				emit on_buffer_get_mark(data);
 			}
 
+			emit on_buffer_get_mark(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_BUFFER_ADD_HIGHLIGHT:
+
+		case NeovimApi1::NEOVIM_FN_BUFFER_ADD_HIGHLIGHT:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_add_highlight");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_add_highlight");
 				return;
-			} else {
-				emit on_buffer_add_highlight(data);
 			}
 
+			emit on_buffer_add_highlight(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_BUFFER_CLEAR_HIGHLIGHT:
+
+		case NeovimApi1::NEOVIM_FN_BUFFER_CLEAR_HIGHLIGHT:
 		{
 			emit on_buffer_clear_highlight();
-
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_TABPAGE_GET_WINDOWS:
+
+		case NeovimApi1::NEOVIM_FN_TABPAGE_GET_WINDOWS:
 		{
 			QList<int64_t> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_get_windows");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_get_windows");
 				return;
-			} else {
-				emit on_tabpage_get_windows(data);
 			}
 
+			emit on_tabpage_get_windows(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_TABPAGE_GET_VAR:
+
+		case NeovimApi1::NEOVIM_FN_TABPAGE_GET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_get_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_get_var");
 				return;
-			} else {
-				emit on_tabpage_get_var(data);
 			}
 
+			emit on_tabpage_get_var(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_TABPAGE_GET_WINDOW:
+
+		case NeovimApi1::NEOVIM_FN_TABPAGE_GET_WINDOW:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_get_window");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_get_window");
 				return;
-			} else {
-				emit on_tabpage_get_window(data);
 			}
 
+			emit on_tabpage_get_window(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_TABPAGE_IS_VALID:
+
+		case NeovimApi1::NEOVIM_FN_TABPAGE_IS_VALID:
 		{
 			bool data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_is_valid");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_is_valid");
 				return;
-			} else {
-				emit on_tabpage_is_valid(data);
 			}
 
+			emit on_tabpage_is_valid(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_UI_DETACH:
+
+		case NeovimApi1::NEOVIM_FN_UI_DETACH:
 		{
 			emit on_ui_detach();
-
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_UI_TRY_RESIZE:
+
+		case NeovimApi1::NEOVIM_FN_UI_TRY_RESIZE:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for ui_try_resize");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for ui_try_resize");
 				return;
-			} else {
-				emit on_ui_try_resize(data);
 			}
 
+			emit on_ui_try_resize(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_VIM_COMMAND:
+
+		case NeovimApi1::NEOVIM_FN_VIM_COMMAND:
 		{
 			emit on_vim_command();
-
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_VIM_FEEDKEYS:
+
+		case NeovimApi1::NEOVIM_FN_VIM_FEEDKEYS:
 		{
 			emit on_vim_feedkeys();
-
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_VIM_INPUT:
+
+		case NeovimApi1::NEOVIM_FN_VIM_INPUT:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_input");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_input");
 				return;
-			} else {
-				emit on_vim_input(data);
 			}
 
+			emit on_vim_input(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_VIM_REPLACE_TERMCODES:
+
+		case NeovimApi1::NEOVIM_FN_VIM_REPLACE_TERMCODES:
 		{
 			QByteArray data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_replace_termcodes");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_replace_termcodes");
 				return;
-			} else {
-				emit on_vim_replace_termcodes(data);
 			}
 
+			emit on_vim_replace_termcodes(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_VIM_COMMAND_OUTPUT:
+
+		case NeovimApi1::NEOVIM_FN_VIM_COMMAND_OUTPUT:
 		{
 			QByteArray data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_command_output");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_command_output");
 				return;
-			} else {
-				emit on_vim_command_output(data);
 			}
 
+			emit on_vim_command_output(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_VIM_EVAL:
+
+		case NeovimApi1::NEOVIM_FN_VIM_EVAL:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_eval");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_eval");
 				return;
-			} else {
-				emit on_vim_eval(data);
 			}
 
+			emit on_vim_eval(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_VIM_CALL_FUNCTION:
+
+		case NeovimApi1::NEOVIM_FN_VIM_CALL_FUNCTION:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_call_function");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_call_function");
 				return;
-			} else {
-				emit on_vim_call_function(data);
 			}
 
+			emit on_vim_call_function(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_VIM_STRWIDTH:
+
+		case NeovimApi1::NEOVIM_FN_VIM_STRWIDTH:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_strwidth");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_strwidth");
 				return;
-			} else {
-				emit on_vim_strwidth(data);
 			}
 
+			emit on_vim_strwidth(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_VIM_LIST_RUNTIME_PATHS:
+
+		case NeovimApi1::NEOVIM_FN_VIM_LIST_RUNTIME_PATHS:
 		{
 			QList<QByteArray> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_list_runtime_paths");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_list_runtime_paths");
 				return;
-			} else {
-				emit on_vim_list_runtime_paths(data);
 			}
 
+			emit on_vim_list_runtime_paths(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_VIM_CHANGE_DIRECTORY:
+
+		case NeovimApi1::NEOVIM_FN_VIM_CHANGE_DIRECTORY:
 		{
 			emit on_vim_change_directory();
-
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_VIM_GET_CURRENT_LINE:
+
+		case NeovimApi1::NEOVIM_FN_VIM_GET_CURRENT_LINE:
 		{
 			QByteArray data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_current_line");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_current_line");
 				return;
-			} else {
-				emit on_vim_get_current_line(data);
 			}
 
+			emit on_vim_get_current_line(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_VIM_SET_CURRENT_LINE:
+
+		case NeovimApi1::NEOVIM_FN_VIM_SET_CURRENT_LINE:
 		{
 			emit on_vim_set_current_line();
-
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_VIM_DEL_CURRENT_LINE:
+
+		case NeovimApi1::NEOVIM_FN_VIM_DEL_CURRENT_LINE:
 		{
 			emit on_vim_del_current_line();
-
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_VIM_GET_VAR:
+
+		case NeovimApi1::NEOVIM_FN_VIM_GET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_var");
 				return;
-			} else {
-				emit on_vim_get_var(data);
 			}
 
+			emit on_vim_get_var(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_VIM_GET_VVAR:
+
+		case NeovimApi1::NEOVIM_FN_VIM_GET_VVAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_vvar");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_vvar");
 				return;
-			} else {
-				emit on_vim_get_vvar(data);
 			}
 
+			emit on_vim_get_vvar(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_VIM_GET_OPTION:
+
+		case NeovimApi1::NEOVIM_FN_VIM_GET_OPTION:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_option");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_option");
 				return;
-			} else {
-				emit on_vim_get_option(data);
 			}
 
+			emit on_vim_get_option(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_VIM_SET_OPTION:
+
+		case NeovimApi1::NEOVIM_FN_VIM_SET_OPTION:
 		{
 			emit on_vim_set_option();
-
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_VIM_OUT_WRITE:
+
+		case NeovimApi1::NEOVIM_FN_VIM_OUT_WRITE:
 		{
 			emit on_vim_out_write();
-
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_VIM_ERR_WRITE:
+
+		case NeovimApi1::NEOVIM_FN_VIM_ERR_WRITE:
 		{
 			emit on_vim_err_write();
-
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_VIM_REPORT_ERROR:
+
+		case NeovimApi1::NEOVIM_FN_VIM_REPORT_ERROR:
 		{
 			emit on_vim_report_error();
-
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_VIM_GET_BUFFERS:
+
+		case NeovimApi1::NEOVIM_FN_VIM_GET_BUFFERS:
 		{
 			QList<int64_t> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_buffers");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_buffers");
 				return;
-			} else {
-				emit on_vim_get_buffers(data);
 			}
 
+			emit on_vim_get_buffers(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_VIM_GET_CURRENT_BUFFER:
+
+		case NeovimApi1::NEOVIM_FN_VIM_GET_CURRENT_BUFFER:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_current_buffer");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_current_buffer");
 				return;
-			} else {
-				emit on_vim_get_current_buffer(data);
 			}
 
+			emit on_vim_get_current_buffer(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_VIM_SET_CURRENT_BUFFER:
+
+		case NeovimApi1::NEOVIM_FN_VIM_SET_CURRENT_BUFFER:
 		{
 			emit on_vim_set_current_buffer();
-
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_VIM_GET_WINDOWS:
+
+		case NeovimApi1::NEOVIM_FN_VIM_GET_WINDOWS:
 		{
 			QList<int64_t> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_windows");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_windows");
 				return;
-			} else {
-				emit on_vim_get_windows(data);
 			}
 
+			emit on_vim_get_windows(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_VIM_GET_CURRENT_WINDOW:
+
+		case NeovimApi1::NEOVIM_FN_VIM_GET_CURRENT_WINDOW:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_current_window");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_current_window");
 				return;
-			} else {
-				emit on_vim_get_current_window(data);
 			}
 
+			emit on_vim_get_current_window(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_VIM_SET_CURRENT_WINDOW:
+
+		case NeovimApi1::NEOVIM_FN_VIM_SET_CURRENT_WINDOW:
 		{
 			emit on_vim_set_current_window();
-
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_VIM_GET_TABPAGES:
+
+		case NeovimApi1::NEOVIM_FN_VIM_GET_TABPAGES:
 		{
 			QList<int64_t> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_tabpages");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_tabpages");
 				return;
-			} else {
-				emit on_vim_get_tabpages(data);
 			}
 
+			emit on_vim_get_tabpages(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_VIM_GET_CURRENT_TABPAGE:
+
+		case NeovimApi1::NEOVIM_FN_VIM_GET_CURRENT_TABPAGE:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_current_tabpage");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_current_tabpage");
 				return;
-			} else {
-				emit on_vim_get_current_tabpage(data);
 			}
 
+			emit on_vim_get_current_tabpage(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_VIM_SET_CURRENT_TABPAGE:
+
+		case NeovimApi1::NEOVIM_FN_VIM_SET_CURRENT_TABPAGE:
 		{
 			emit on_vim_set_current_tabpage();
-
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_VIM_SUBSCRIBE:
+
+		case NeovimApi1::NEOVIM_FN_VIM_SUBSCRIBE:
 		{
 			emit on_vim_subscribe();
-
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_VIM_UNSUBSCRIBE:
+
+		case NeovimApi1::NEOVIM_FN_VIM_UNSUBSCRIBE:
 		{
 			emit on_vim_unsubscribe();
-
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_VIM_NAME_TO_COLOR:
+
+		case NeovimApi1::NEOVIM_FN_VIM_NAME_TO_COLOR:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_name_to_color");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_name_to_color");
 				return;
-			} else {
-				emit on_vim_name_to_color(data);
 			}
 
+			emit on_vim_name_to_color(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_VIM_GET_COLOR_MAP:
+
+		case NeovimApi1::NEOVIM_FN_VIM_GET_COLOR_MAP:
 		{
 			QVariantMap data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_color_map");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_color_map");
 				return;
-			} else {
-				emit on_vim_get_color_map(data);
 			}
 
+			emit on_vim_get_color_map(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_WINDOW_GET_BUFFER:
+
+		case NeovimApi1::NEOVIM_FN_WINDOW_GET_BUFFER:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_buffer");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_buffer");
 				return;
-			} else {
-				emit on_window_get_buffer(data);
 			}
 
+			emit on_window_get_buffer(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_WINDOW_GET_CURSOR:
+
+		case NeovimApi1::NEOVIM_FN_WINDOW_GET_CURSOR:
 		{
 			QPoint data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_cursor");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_cursor");
 				return;
-			} else {
-				emit on_window_get_cursor(data);
 			}
 
+			emit on_window_get_cursor(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_WINDOW_SET_CURSOR:
+
+		case NeovimApi1::NEOVIM_FN_WINDOW_SET_CURSOR:
 		{
 			emit on_window_set_cursor();
-
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_WINDOW_GET_HEIGHT:
+
+		case NeovimApi1::NEOVIM_FN_WINDOW_GET_HEIGHT:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_height");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_height");
 				return;
-			} else {
-				emit on_window_get_height(data);
 			}
 
+			emit on_window_get_height(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_WINDOW_SET_HEIGHT:
+
+		case NeovimApi1::NEOVIM_FN_WINDOW_SET_HEIGHT:
 		{
 			emit on_window_set_height();
-
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_WINDOW_GET_WIDTH:
+
+		case NeovimApi1::NEOVIM_FN_WINDOW_GET_WIDTH:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_width");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_width");
 				return;
-			} else {
-				emit on_window_get_width(data);
 			}
 
+			emit on_window_get_width(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_WINDOW_SET_WIDTH:
+
+		case NeovimApi1::NEOVIM_FN_WINDOW_SET_WIDTH:
 		{
 			emit on_window_set_width();
-
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_WINDOW_GET_VAR:
+
+		case NeovimApi1::NEOVIM_FN_WINDOW_GET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_var");
 				return;
-			} else {
-				emit on_window_get_var(data);
 			}
 
+			emit on_window_get_var(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_WINDOW_GET_OPTION:
+
+		case NeovimApi1::NEOVIM_FN_WINDOW_GET_OPTION:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_option");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_option");
 				return;
-			} else {
-				emit on_window_get_option(data);
 			}
 
+			emit on_window_get_option(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_WINDOW_SET_OPTION:
+
+		case NeovimApi1::NEOVIM_FN_WINDOW_SET_OPTION:
 		{
 			emit on_window_set_option();
-
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_WINDOW_GET_POSITION:
+
+		case NeovimApi1::NEOVIM_FN_WINDOW_GET_POSITION:
 		{
 			QPoint data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_position");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_position");
 				return;
-			} else {
-				emit on_window_get_position(data);
 			}
 
+			emit on_window_get_position(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_WINDOW_GET_TABPAGE:
+
+		case NeovimApi1::NEOVIM_FN_WINDOW_GET_TABPAGE:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_tabpage");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_tabpage");
 				return;
-			} else {
-				emit on_window_get_tabpage(data);
 			}
 
+			emit on_window_get_tabpage(data);
 		}
 		break;
-	case NeovimApi1::NEOVIM_FN_WINDOW_IS_VALID:
+
+		case NeovimApi1::NEOVIM_FN_WINDOW_IS_VALID:
 		{
 			bool data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_is_valid");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_is_valid");
 				return;
-			} else {
-				emit on_window_is_valid(data);
 			}
 
+			emit on_window_is_valid(data);
 		}
 		break;
+
 	default:
 		qWarning() << "Received unexpected response";
 	}
@@ -3623,743 +3790,1218 @@ void NeovimApi1::handleResponse(quint32 msgid, quint64 fun, const QVariant& res)
  *
  * Returns false if there is an API mismatch
  */
-bool NeovimApi1::checkFunctions(const QVariantList& ftable)
+/*static*/ bool NeovimApi1::checkFunctions(const QVariantList& ftable) noexcept
 {
-
-	QList<Function> required;
-	required
-		<< Function("Integer", "nvim_buf_line_count",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("String", "buffer_get_line",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						, false)
-		<< Function("void", "buffer_set_line",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("String")
-						, false)
-		<< Function("void", "buffer_del_line",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						, false)
-		<< Function("ArrayOf(String)", "buffer_get_line_slice",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Boolean")
-						<< QString("Boolean")
-						, false)
-		<< Function("ArrayOf(String)", "nvim_buf_get_lines",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Boolean")
-						, false)
-		<< Function("void", "buffer_set_line_slice",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Boolean")
-						<< QString("Boolean")
-						<< QString("ArrayOf(String)")
-						, false)
-		<< Function("void", "nvim_buf_set_lines",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Boolean")
-						<< QString("ArrayOf(String)")
-						, false)
-		<< Function("Object", "nvim_buf_get_var",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_buf_set_var",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("void", "nvim_buf_del_var",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("Object", "buffer_set_var",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("Object", "buffer_del_var",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("Object", "nvim_buf_get_option",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_buf_set_option",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("Integer", "nvim_buf_get_number",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("String", "nvim_buf_get_name",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("void", "nvim_buf_set_name",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("Boolean", "nvim_buf_is_valid",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("void", "buffer_insert",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("ArrayOf(String)")
-						, false)
-		<< Function("ArrayOf(Integer, 2)", "nvim_buf_get_mark",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("Integer", "nvim_buf_add_highlight",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("String")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Integer")
-						, false)
-		<< Function("void", "nvim_buf_clear_highlight",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Integer")
-						, false)
-		<< Function("ArrayOf(Window)", "nvim_tabpage_list_wins",
-			QList<QString>()
-						<< QString("Tabpage")
-						, false)
-		<< Function("Object", "nvim_tabpage_get_var",
-			QList<QString>()
-						<< QString("Tabpage")
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_tabpage_set_var",
-			QList<QString>()
-						<< QString("Tabpage")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("void", "nvim_tabpage_del_var",
-			QList<QString>()
-						<< QString("Tabpage")
-						<< QString("String")
-						, false)
-		<< Function("Object", "tabpage_set_var",
-			QList<QString>()
-						<< QString("Tabpage")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("Object", "tabpage_del_var",
-			QList<QString>()
-						<< QString("Tabpage")
-						<< QString("String")
-						, false)
-		<< Function("Window", "nvim_tabpage_get_win",
-			QList<QString>()
-						<< QString("Tabpage")
-						, false)
-		<< Function("Integer", "nvim_tabpage_get_number",
-			QList<QString>()
-						<< QString("Tabpage")
-						, false)
-		<< Function("Boolean", "nvim_tabpage_is_valid",
-			QList<QString>()
-						<< QString("Tabpage")
-						, false)
-		<< Function("void", "nvim_ui_attach",
-			QList<QString>()
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Dictionary")
-						, false)
-		<< Function("void", "ui_attach",
-			QList<QString>()
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Boolean")
-						, false)
-		<< Function("void", "nvim_ui_detach",
-			QList<QString>()
-						, false)
-		<< Function("void", "nvim_ui_try_resize",
-			QList<QString>()
-						<< QString("Integer")
-						<< QString("Integer")
-						, false)
-		<< Function("void", "nvim_ui_set_option",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("void", "nvim_command",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_feedkeys",
-			QList<QString>()
-						<< QString("String")
-						<< QString("String")
-						<< QString("Boolean")
-						, false)
-		<< Function("Integer", "nvim_input",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("String", "nvim_replace_termcodes",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Boolean")
-						<< QString("Boolean")
-						<< QString("Boolean")
-						, false)
-		<< Function("String", "nvim_command_output",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Object", "nvim_eval",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Object", "nvim_call_function",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Array")
-						, false)
-		<< Function("Integer", "nvim_strwidth",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("ArrayOf(String)", "nvim_list_runtime_paths",
-			QList<QString>()
-						, false)
-		<< Function("void", "nvim_set_current_dir",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("String", "nvim_get_current_line",
-			QList<QString>()
-						, false)
-		<< Function("void", "nvim_set_current_line",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_del_current_line",
-			QList<QString>()
-						, false)
-		<< Function("Object", "nvim_get_var",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_set_var",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("void", "nvim_del_var",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Object", "vim_set_var",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("Object", "vim_del_var",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Object", "nvim_get_vvar",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Object", "nvim_get_option",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_set_option",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("void", "nvim_out_write",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_err_write",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_err_writeln",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("ArrayOf(Buffer)", "nvim_list_bufs",
-			QList<QString>()
-						, false)
-		<< Function("Buffer", "nvim_get_current_buf",
-			QList<QString>()
-						, false)
-		<< Function("void", "nvim_set_current_buf",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("ArrayOf(Window)", "nvim_list_wins",
-			QList<QString>()
-						, false)
-		<< Function("Window", "nvim_get_current_win",
-			QList<QString>()
-						, false)
-		<< Function("void", "nvim_set_current_win",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("ArrayOf(Tabpage)", "nvim_list_tabpages",
-			QList<QString>()
-						, false)
-		<< Function("Tabpage", "nvim_get_current_tabpage",
-			QList<QString>()
-						, false)
-		<< Function("void", "nvim_set_current_tabpage",
-			QList<QString>()
-						<< QString("Tabpage")
-						, false)
-		<< Function("void", "nvim_subscribe",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_unsubscribe",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Integer", "nvim_get_color_by_name",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Dictionary", "nvim_get_color_map",
-			QList<QString>()
-						, false)
-		<< Function("Array", "nvim_get_api_info",
-			QList<QString>()
-						, false)
-		<< Function("Array", "nvim_call_atomic",
-			QList<QString>()
-						<< QString("Array")
-						, false)
-		<< Function("Buffer", "nvim_win_get_buf",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("ArrayOf(Integer, 2)", "nvim_win_get_cursor",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("void", "nvim_win_set_cursor",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("ArrayOf(Integer, 2)")
-						, false)
-		<< Function("Integer", "nvim_win_get_height",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("void", "nvim_win_set_height",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("Integer")
-						, false)
-		<< Function("Integer", "nvim_win_get_width",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("void", "nvim_win_set_width",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("Integer")
-						, false)
-		<< Function("Object", "nvim_win_get_var",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_win_set_var",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("void", "nvim_win_del_var",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						, false)
-		<< Function("Object", "window_set_var",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("Object", "window_del_var",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						, false)
-		<< Function("Object", "nvim_win_get_option",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_win_set_option",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("ArrayOf(Integer, 2)", "nvim_win_get_position",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("Tabpage", "nvim_win_get_tabpage",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("Integer", "nvim_win_get_number",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("Boolean", "nvim_win_is_valid",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("Integer", "buffer_line_count",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("ArrayOf(String)", "buffer_get_lines",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Boolean")
-						, false)
-		<< Function("void", "buffer_set_lines",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Boolean")
-						<< QString("ArrayOf(String)")
-						, false)
-		<< Function("Object", "buffer_get_var",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("Object", "buffer_get_option",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("void", "buffer_set_option",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("Integer", "buffer_get_number",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("String", "buffer_get_name",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("void", "buffer_set_name",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("Boolean", "buffer_is_valid",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("ArrayOf(Integer, 2)", "buffer_get_mark",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("Integer", "buffer_add_highlight",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("String")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Integer")
-						, false)
-		<< Function("void", "buffer_clear_highlight",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Integer")
-						, false)
-		<< Function("ArrayOf(Window)", "tabpage_get_windows",
-			QList<QString>()
-						<< QString("Tabpage")
-						, false)
-		<< Function("Object", "tabpage_get_var",
-			QList<QString>()
-						<< QString("Tabpage")
-						<< QString("String")
-						, false)
-		<< Function("Window", "tabpage_get_window",
-			QList<QString>()
-						<< QString("Tabpage")
-						, false)
-		<< Function("Boolean", "tabpage_is_valid",
-			QList<QString>()
-						<< QString("Tabpage")
-						, false)
-		<< Function("void", "ui_detach",
-			QList<QString>()
-						, false)
-		<< Function("Object", "ui_try_resize",
-			QList<QString>()
-						<< QString("Integer")
-						<< QString("Integer")
-						, false)
-		<< Function("void", "vim_command",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "vim_feedkeys",
-			QList<QString>()
-						<< QString("String")
-						<< QString("String")
-						<< QString("Boolean")
-						, false)
-		<< Function("Integer", "vim_input",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("String", "vim_replace_termcodes",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Boolean")
-						<< QString("Boolean")
-						<< QString("Boolean")
-						, false)
-		<< Function("String", "vim_command_output",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Object", "vim_eval",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Object", "vim_call_function",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Array")
-						, false)
-		<< Function("Integer", "vim_strwidth",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("ArrayOf(String)", "vim_list_runtime_paths",
-			QList<QString>()
-						, false)
-		<< Function("void", "vim_change_directory",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("String", "vim_get_current_line",
-			QList<QString>()
-						, false)
-		<< Function("void", "vim_set_current_line",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "vim_del_current_line",
-			QList<QString>()
-						, false)
-		<< Function("Object", "vim_get_var",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Object", "vim_get_vvar",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Object", "vim_get_option",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "vim_set_option",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("void", "vim_out_write",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "vim_err_write",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "vim_report_error",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("ArrayOf(Buffer)", "vim_get_buffers",
-			QList<QString>()
-						, false)
-		<< Function("Buffer", "vim_get_current_buffer",
-			QList<QString>()
-						, false)
-		<< Function("void", "vim_set_current_buffer",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("ArrayOf(Window)", "vim_get_windows",
-			QList<QString>()
-						, false)
-		<< Function("Window", "vim_get_current_window",
-			QList<QString>()
-						, false)
-		<< Function("void", "vim_set_current_window",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("ArrayOf(Tabpage)", "vim_get_tabpages",
-			QList<QString>()
-						, false)
-		<< Function("Tabpage", "vim_get_current_tabpage",
-			QList<QString>()
-						, false)
-		<< Function("void", "vim_set_current_tabpage",
-			QList<QString>()
-						<< QString("Tabpage")
-						, false)
-		<< Function("void", "vim_subscribe",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "vim_unsubscribe",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Integer", "vim_name_to_color",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Dictionary", "vim_get_color_map",
-			QList<QString>()
-						, false)
-		<< Function("Buffer", "window_get_buffer",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("ArrayOf(Integer, 2)", "window_get_cursor",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("void", "window_set_cursor",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("ArrayOf(Integer, 2)")
-						, false)
-		<< Function("Integer", "window_get_height",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("void", "window_set_height",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("Integer")
-						, false)
-		<< Function("Integer", "window_get_width",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("void", "window_set_width",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("Integer")
-						, false)
-		<< Function("Object", "window_get_var",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						, false)
-		<< Function("Object", "window_get_option",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						, false)
-		<< Function("void", "window_set_option",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("ArrayOf(Integer, 2)", "window_get_position",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("Tabpage", "window_get_tabpage",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("Boolean", "window_is_valid",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		;
-
+	static const QList<Function> required{
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_buf_line_count"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("String"),
+				QStringLiteral("buffer_get_line"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("buffer_set_line"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("buffer_del_line"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(String)"),
+				QStringLiteral("buffer_get_line_slice"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(String)"),
+				QStringLiteral("nvim_buf_get_lines"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("buffer_set_line_slice"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("ArrayOf(String)"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_buf_set_lines"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("ArrayOf(String)"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_buf_get_var"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_buf_set_var"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_buf_del_var"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("buffer_set_var"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("buffer_del_var"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_buf_get_option"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_buf_set_option"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_buf_get_number"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("String"),
+				QStringLiteral("nvim_buf_get_name"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_buf_set_name"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Boolean"),
+				QStringLiteral("nvim_buf_is_valid"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("buffer_insert"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("ArrayOf(String)"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Integer, 2)"),
+				QStringLiteral("nvim_buf_get_mark"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_buf_add_highlight"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("String"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_buf_clear_highlight"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Window)"),
+				QStringLiteral("nvim_tabpage_list_wins"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_tabpage_get_var"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_tabpage_set_var"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_tabpage_del_var"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("tabpage_set_var"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("tabpage_del_var"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Window"),
+				QStringLiteral("nvim_tabpage_get_win"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_tabpage_get_number"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Boolean"),
+				QStringLiteral("nvim_tabpage_is_valid"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_ui_attach"),
+				QStringList{
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Dictionary"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("ui_attach"),
+				QStringList{
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_ui_detach"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_ui_try_resize"),
+				QStringList{
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_ui_set_option"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_command"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_feedkeys"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("String"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_input"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("String"),
+				QStringLiteral("nvim_replace_termcodes"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("String"),
+				QStringLiteral("nvim_command_output"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_eval"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_call_function"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Array"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_strwidth"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(String)"),
+				QStringLiteral("nvim_list_runtime_paths"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_set_current_dir"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("String"),
+				QStringLiteral("nvim_get_current_line"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_set_current_line"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_del_current_line"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_get_var"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_set_var"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_del_var"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("vim_set_var"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("vim_del_var"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_get_vvar"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_get_option"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_set_option"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_out_write"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_err_write"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_err_writeln"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Buffer)"),
+				QStringLiteral("nvim_list_bufs"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Buffer"),
+				QStringLiteral("nvim_get_current_buf"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_set_current_buf"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Window)"),
+				QStringLiteral("nvim_list_wins"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Window"),
+				QStringLiteral("nvim_get_current_win"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_set_current_win"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Tabpage)"),
+				QStringLiteral("nvim_list_tabpages"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Tabpage"),
+				QStringLiteral("nvim_get_current_tabpage"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_set_current_tabpage"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_subscribe"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_unsubscribe"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_get_color_by_name"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Dictionary"),
+				QStringLiteral("nvim_get_color_map"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Array"),
+				QStringLiteral("nvim_get_api_info"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Array"),
+				QStringLiteral("nvim_call_atomic"),
+				QStringList{
+					QStringLiteral("Array"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Buffer"),
+				QStringLiteral("nvim_win_get_buf"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Integer, 2)"),
+				QStringLiteral("nvim_win_get_cursor"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_win_set_cursor"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("ArrayOf(Integer, 2)"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_win_get_height"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_win_set_height"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_win_get_width"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_win_set_width"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_win_get_var"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_win_set_var"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_win_del_var"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("window_set_var"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("window_del_var"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_win_get_option"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_win_set_option"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Integer, 2)"),
+				QStringLiteral("nvim_win_get_position"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Tabpage"),
+				QStringLiteral("nvim_win_get_tabpage"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_win_get_number"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Boolean"),
+				QStringLiteral("nvim_win_is_valid"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("buffer_line_count"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(String)"),
+				QStringLiteral("buffer_get_lines"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("buffer_set_lines"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("ArrayOf(String)"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("buffer_get_var"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("buffer_get_option"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("buffer_set_option"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("buffer_get_number"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("String"),
+				QStringLiteral("buffer_get_name"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("buffer_set_name"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Boolean"),
+				QStringLiteral("buffer_is_valid"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Integer, 2)"),
+				QStringLiteral("buffer_get_mark"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("buffer_add_highlight"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("String"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("buffer_clear_highlight"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Window)"),
+				QStringLiteral("tabpage_get_windows"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("tabpage_get_var"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Window"),
+				QStringLiteral("tabpage_get_window"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Boolean"),
+				QStringLiteral("tabpage_is_valid"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("ui_detach"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("ui_try_resize"),
+				QStringList{
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_command"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_feedkeys"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("String"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("vim_input"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("String"),
+				QStringLiteral("vim_replace_termcodes"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("String"),
+				QStringLiteral("vim_command_output"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("vim_eval"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("vim_call_function"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Array"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("vim_strwidth"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(String)"),
+				QStringLiteral("vim_list_runtime_paths"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_change_directory"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("String"),
+				QStringLiteral("vim_get_current_line"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_set_current_line"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_del_current_line"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("vim_get_var"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("vim_get_vvar"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("vim_get_option"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_set_option"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_out_write"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_err_write"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_report_error"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Buffer)"),
+				QStringLiteral("vim_get_buffers"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Buffer"),
+				QStringLiteral("vim_get_current_buffer"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_set_current_buffer"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Window)"),
+				QStringLiteral("vim_get_windows"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Window"),
+				QStringLiteral("vim_get_current_window"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_set_current_window"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Tabpage)"),
+				QStringLiteral("vim_get_tabpages"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Tabpage"),
+				QStringLiteral("vim_get_current_tabpage"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_set_current_tabpage"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_subscribe"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_unsubscribe"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("vim_name_to_color"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Dictionary"),
+				QStringLiteral("vim_get_color_map"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Buffer"),
+				QStringLiteral("window_get_buffer"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Integer, 2)"),
+				QStringLiteral("window_get_cursor"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("window_set_cursor"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("ArrayOf(Integer, 2)"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("window_get_height"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("window_set_height"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("window_get_width"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("window_set_width"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("window_get_var"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("window_get_option"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("window_set_option"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Integer, 2)"),
+				QStringLiteral("window_get_position"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Tabpage"),
+				QStringLiteral("window_get_tabpage"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Boolean"),
+				QStringLiteral("window_is_valid"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+		};
 
 	QList<Function> supported;
-	foreach(const QVariant& val, ftable) {
+	supported.reserve(ftable.size());
+	for(const auto& val : ftable) {
 		auto f = Function::fromVariant(val);
 		if (!f.isValid()) {
 			qDebug() << "Invalid function in metadata" << f;
@@ -4373,7 +5015,7 @@ bool NeovimApi1::checkFunctions(const QVariantList& ftable)
 	}
 
 	bool ok = true;
-	foreach(const Function& f, required) {
+	for(const auto& f : required) {
 		if (!supported.contains(f)) {
 			qDebug() << "- instance DOES NOT support API1:" << f;
 			ok = false;

--- a/src/auto/neovimapi1.cpp
+++ b/src/auto/neovimapi1.cpp
@@ -1,4 +1,4 @@
-// Auto generated 2020-09-09 13:30:53.979298 from nvim API level:1
+// Auto generated 2020-09-09 15:16:42.629836 from nvim API level:1
 #include "auto/neovimapi1.h"
 #include "msgpackiodevice.h"
 #include "msgpackrequest.h"
@@ -4999,7 +4999,7 @@ void NeovimApi1::handleResponse(uint32_t msgid, uint64_t fun, const QVariant& re
 				, false },
 		};
 
-	QList<Function> supported;
+	QVector<Function> supported;
 	supported.reserve(ftable.size());
 	for(const auto& val : ftable) {
 		auto f = Function::fromVariant(val);

--- a/src/auto/neovimapi1.h
+++ b/src/auto/neovimapi1.h
@@ -1,4 +1,4 @@
-// Auto generated 2020-09-09 13:30:53.997744 from nvim API level:1
+// Auto generated 2020-09-09 15:16:42.646773 from nvim API level:1
 #pragma once
 
 #include <QObject>

--- a/src/auto/neovimapi1.h
+++ b/src/auto/neovimapi1.h
@@ -1,597 +1,684 @@
-// Auto generated 2017-10-31 14:21:01.884363 from nvim API level:1
-#ifndef NEOVIM_QT_NEOVIMAPI1
-#define NEOVIM_QT_NEOVIMAPI1
-#include "msgpack.h"
+// Auto generated 2020-09-09 13:30:53.997744 from nvim API level:1
+#pragma once
+
 #include <QObject>
-#include <QVariant>
 #include <QPoint>
+#include <QVariant>
+
 #include "function.h"
+#include "msgpack.h"
 
 namespace NeovimQt {
+
 class NeovimConnector;
 class MsgpackRequest;
 
-class NeovimApi1: public QObject
+class NeovimApi1 : public QObject
 {
 	Q_OBJECT
-	Q_ENUMS(FunctionId)
 
 public:
-
 	enum FunctionId {
-		NEOVIM_FN_NULL=0,
-				NEOVIM_FN_NVIM_BUF_LINE_COUNT,
-				NEOVIM_FN_BUFFER_GET_LINE,
-				NEOVIM_FN_BUFFER_SET_LINE,
-				NEOVIM_FN_BUFFER_DEL_LINE,
-				NEOVIM_FN_BUFFER_GET_LINE_SLICE,
-				NEOVIM_FN_NVIM_BUF_GET_LINES,
-				NEOVIM_FN_BUFFER_SET_LINE_SLICE,
-				NEOVIM_FN_NVIM_BUF_SET_LINES,
-				NEOVIM_FN_NVIM_BUF_GET_VAR,
-				NEOVIM_FN_NVIM_BUF_SET_VAR,
-				NEOVIM_FN_NVIM_BUF_DEL_VAR,
-				NEOVIM_FN_BUFFER_SET_VAR,
-				NEOVIM_FN_BUFFER_DEL_VAR,
-				NEOVIM_FN_NVIM_BUF_GET_OPTION,
-				NEOVIM_FN_NVIM_BUF_SET_OPTION,
-				NEOVIM_FN_NVIM_BUF_GET_NUMBER,
-				NEOVIM_FN_NVIM_BUF_GET_NAME,
-				NEOVIM_FN_NVIM_BUF_SET_NAME,
-				NEOVIM_FN_NVIM_BUF_IS_VALID,
-				NEOVIM_FN_BUFFER_INSERT,
-				NEOVIM_FN_NVIM_BUF_GET_MARK,
-				NEOVIM_FN_NVIM_BUF_ADD_HIGHLIGHT,
-				NEOVIM_FN_NVIM_BUF_CLEAR_HIGHLIGHT,
-				NEOVIM_FN_NVIM_TABPAGE_LIST_WINS,
-				NEOVIM_FN_NVIM_TABPAGE_GET_VAR,
-				NEOVIM_FN_NVIM_TABPAGE_SET_VAR,
-				NEOVIM_FN_NVIM_TABPAGE_DEL_VAR,
-				NEOVIM_FN_TABPAGE_SET_VAR,
-				NEOVIM_FN_TABPAGE_DEL_VAR,
-				NEOVIM_FN_NVIM_TABPAGE_GET_WIN,
-				NEOVIM_FN_NVIM_TABPAGE_GET_NUMBER,
-				NEOVIM_FN_NVIM_TABPAGE_IS_VALID,
-				NEOVIM_FN_NVIM_UI_ATTACH,
-				NEOVIM_FN_UI_ATTACH,
-				NEOVIM_FN_NVIM_UI_DETACH,
-				NEOVIM_FN_NVIM_UI_TRY_RESIZE,
-				NEOVIM_FN_NVIM_UI_SET_OPTION,
-				NEOVIM_FN_NVIM_COMMAND,
-				NEOVIM_FN_NVIM_FEEDKEYS,
-				NEOVIM_FN_NVIM_INPUT,
-				NEOVIM_FN_NVIM_REPLACE_TERMCODES,
-				NEOVIM_FN_NVIM_COMMAND_OUTPUT,
-				NEOVIM_FN_NVIM_EVAL,
-				NEOVIM_FN_NVIM_CALL_FUNCTION,
-				NEOVIM_FN_NVIM_STRWIDTH,
-				NEOVIM_FN_NVIM_LIST_RUNTIME_PATHS,
-				NEOVIM_FN_NVIM_SET_CURRENT_DIR,
-				NEOVIM_FN_NVIM_GET_CURRENT_LINE,
-				NEOVIM_FN_NVIM_SET_CURRENT_LINE,
-				NEOVIM_FN_NVIM_DEL_CURRENT_LINE,
-				NEOVIM_FN_NVIM_GET_VAR,
-				NEOVIM_FN_NVIM_SET_VAR,
-				NEOVIM_FN_NVIM_DEL_VAR,
-				NEOVIM_FN_VIM_SET_VAR,
-				NEOVIM_FN_VIM_DEL_VAR,
-				NEOVIM_FN_NVIM_GET_VVAR,
-				NEOVIM_FN_NVIM_GET_OPTION,
-				NEOVIM_FN_NVIM_SET_OPTION,
-				NEOVIM_FN_NVIM_OUT_WRITE,
-				NEOVIM_FN_NVIM_ERR_WRITE,
-				NEOVIM_FN_NVIM_ERR_WRITELN,
-				NEOVIM_FN_NVIM_LIST_BUFS,
-				NEOVIM_FN_NVIM_GET_CURRENT_BUF,
-				NEOVIM_FN_NVIM_SET_CURRENT_BUF,
-				NEOVIM_FN_NVIM_LIST_WINS,
-				NEOVIM_FN_NVIM_GET_CURRENT_WIN,
-				NEOVIM_FN_NVIM_SET_CURRENT_WIN,
-				NEOVIM_FN_NVIM_LIST_TABPAGES,
-				NEOVIM_FN_NVIM_GET_CURRENT_TABPAGE,
-				NEOVIM_FN_NVIM_SET_CURRENT_TABPAGE,
-				NEOVIM_FN_NVIM_SUBSCRIBE,
-				NEOVIM_FN_NVIM_UNSUBSCRIBE,
-				NEOVIM_FN_NVIM_GET_COLOR_BY_NAME,
-				NEOVIM_FN_NVIM_GET_COLOR_MAP,
-				NEOVIM_FN_NVIM_GET_API_INFO,
-				NEOVIM_FN_NVIM_CALL_ATOMIC,
-				NEOVIM_FN_NVIM_WIN_GET_BUF,
-				NEOVIM_FN_NVIM_WIN_GET_CURSOR,
-				NEOVIM_FN_NVIM_WIN_SET_CURSOR,
-				NEOVIM_FN_NVIM_WIN_GET_HEIGHT,
-				NEOVIM_FN_NVIM_WIN_SET_HEIGHT,
-				NEOVIM_FN_NVIM_WIN_GET_WIDTH,
-				NEOVIM_FN_NVIM_WIN_SET_WIDTH,
-				NEOVIM_FN_NVIM_WIN_GET_VAR,
-				NEOVIM_FN_NVIM_WIN_SET_VAR,
-				NEOVIM_FN_NVIM_WIN_DEL_VAR,
-				NEOVIM_FN_WINDOW_SET_VAR,
-				NEOVIM_FN_WINDOW_DEL_VAR,
-				NEOVIM_FN_NVIM_WIN_GET_OPTION,
-				NEOVIM_FN_NVIM_WIN_SET_OPTION,
-				NEOVIM_FN_NVIM_WIN_GET_POSITION,
-				NEOVIM_FN_NVIM_WIN_GET_TABPAGE,
-				NEOVIM_FN_NVIM_WIN_GET_NUMBER,
-				NEOVIM_FN_NVIM_WIN_IS_VALID,
-				NEOVIM_FN_BUFFER_LINE_COUNT,
-				NEOVIM_FN_BUFFER_GET_LINES,
-				NEOVIM_FN_BUFFER_SET_LINES,
-				NEOVIM_FN_BUFFER_GET_VAR,
-				NEOVIM_FN_BUFFER_GET_OPTION,
-				NEOVIM_FN_BUFFER_SET_OPTION,
-				NEOVIM_FN_BUFFER_GET_NUMBER,
-				NEOVIM_FN_BUFFER_GET_NAME,
-				NEOVIM_FN_BUFFER_SET_NAME,
-				NEOVIM_FN_BUFFER_IS_VALID,
-				NEOVIM_FN_BUFFER_GET_MARK,
-				NEOVIM_FN_BUFFER_ADD_HIGHLIGHT,
-				NEOVIM_FN_BUFFER_CLEAR_HIGHLIGHT,
-				NEOVIM_FN_TABPAGE_GET_WINDOWS,
-				NEOVIM_FN_TABPAGE_GET_VAR,
-				NEOVIM_FN_TABPAGE_GET_WINDOW,
-				NEOVIM_FN_TABPAGE_IS_VALID,
-				NEOVIM_FN_UI_DETACH,
-				NEOVIM_FN_UI_TRY_RESIZE,
-				NEOVIM_FN_VIM_COMMAND,
-				NEOVIM_FN_VIM_FEEDKEYS,
-				NEOVIM_FN_VIM_INPUT,
-				NEOVIM_FN_VIM_REPLACE_TERMCODES,
-				NEOVIM_FN_VIM_COMMAND_OUTPUT,
-				NEOVIM_FN_VIM_EVAL,
-				NEOVIM_FN_VIM_CALL_FUNCTION,
-				NEOVIM_FN_VIM_STRWIDTH,
-				NEOVIM_FN_VIM_LIST_RUNTIME_PATHS,
-				NEOVIM_FN_VIM_CHANGE_DIRECTORY,
-				NEOVIM_FN_VIM_GET_CURRENT_LINE,
-				NEOVIM_FN_VIM_SET_CURRENT_LINE,
-				NEOVIM_FN_VIM_DEL_CURRENT_LINE,
-				NEOVIM_FN_VIM_GET_VAR,
-				NEOVIM_FN_VIM_GET_VVAR,
-				NEOVIM_FN_VIM_GET_OPTION,
-				NEOVIM_FN_VIM_SET_OPTION,
-				NEOVIM_FN_VIM_OUT_WRITE,
-				NEOVIM_FN_VIM_ERR_WRITE,
-				NEOVIM_FN_VIM_REPORT_ERROR,
-				NEOVIM_FN_VIM_GET_BUFFERS,
-				NEOVIM_FN_VIM_GET_CURRENT_BUFFER,
-				NEOVIM_FN_VIM_SET_CURRENT_BUFFER,
-				NEOVIM_FN_VIM_GET_WINDOWS,
-				NEOVIM_FN_VIM_GET_CURRENT_WINDOW,
-				NEOVIM_FN_VIM_SET_CURRENT_WINDOW,
-				NEOVIM_FN_VIM_GET_TABPAGES,
-				NEOVIM_FN_VIM_GET_CURRENT_TABPAGE,
-				NEOVIM_FN_VIM_SET_CURRENT_TABPAGE,
-				NEOVIM_FN_VIM_SUBSCRIBE,
-				NEOVIM_FN_VIM_UNSUBSCRIBE,
-				NEOVIM_FN_VIM_NAME_TO_COLOR,
-				NEOVIM_FN_VIM_GET_COLOR_MAP,
-				NEOVIM_FN_WINDOW_GET_BUFFER,
-				NEOVIM_FN_WINDOW_GET_CURSOR,
-				NEOVIM_FN_WINDOW_SET_CURSOR,
-				NEOVIM_FN_WINDOW_GET_HEIGHT,
-				NEOVIM_FN_WINDOW_SET_HEIGHT,
-				NEOVIM_FN_WINDOW_GET_WIDTH,
-				NEOVIM_FN_WINDOW_SET_WIDTH,
-				NEOVIM_FN_WINDOW_GET_VAR,
-				NEOVIM_FN_WINDOW_GET_OPTION,
-				NEOVIM_FN_WINDOW_SET_OPTION,
-				NEOVIM_FN_WINDOW_GET_POSITION,
-				NEOVIM_FN_WINDOW_GET_TABPAGE,
-				NEOVIM_FN_WINDOW_IS_VALID,
+		NEOVIM_FN_NULL,
+		NEOVIM_FN_NVIM_BUF_LINE_COUNT,
+		NEOVIM_FN_BUFFER_GET_LINE,
+		NEOVIM_FN_BUFFER_SET_LINE,
+		NEOVIM_FN_BUFFER_DEL_LINE,
+		NEOVIM_FN_BUFFER_GET_LINE_SLICE,
+		NEOVIM_FN_NVIM_BUF_GET_LINES,
+		NEOVIM_FN_BUFFER_SET_LINE_SLICE,
+		NEOVIM_FN_NVIM_BUF_SET_LINES,
+		NEOVIM_FN_NVIM_BUF_GET_VAR,
+		NEOVIM_FN_NVIM_BUF_SET_VAR,
+		NEOVIM_FN_NVIM_BUF_DEL_VAR,
+		NEOVIM_FN_BUFFER_SET_VAR,
+		NEOVIM_FN_BUFFER_DEL_VAR,
+		NEOVIM_FN_NVIM_BUF_GET_OPTION,
+		NEOVIM_FN_NVIM_BUF_SET_OPTION,
+		NEOVIM_FN_NVIM_BUF_GET_NUMBER,
+		NEOVIM_FN_NVIM_BUF_GET_NAME,
+		NEOVIM_FN_NVIM_BUF_SET_NAME,
+		NEOVIM_FN_NVIM_BUF_IS_VALID,
+		NEOVIM_FN_BUFFER_INSERT,
+		NEOVIM_FN_NVIM_BUF_GET_MARK,
+		NEOVIM_FN_NVIM_BUF_ADD_HIGHLIGHT,
+		NEOVIM_FN_NVIM_BUF_CLEAR_HIGHLIGHT,
+		NEOVIM_FN_NVIM_TABPAGE_LIST_WINS,
+		NEOVIM_FN_NVIM_TABPAGE_GET_VAR,
+		NEOVIM_FN_NVIM_TABPAGE_SET_VAR,
+		NEOVIM_FN_NVIM_TABPAGE_DEL_VAR,
+		NEOVIM_FN_TABPAGE_SET_VAR,
+		NEOVIM_FN_TABPAGE_DEL_VAR,
+		NEOVIM_FN_NVIM_TABPAGE_GET_WIN,
+		NEOVIM_FN_NVIM_TABPAGE_GET_NUMBER,
+		NEOVIM_FN_NVIM_TABPAGE_IS_VALID,
+		NEOVIM_FN_NVIM_UI_ATTACH,
+		NEOVIM_FN_UI_ATTACH,
+		NEOVIM_FN_NVIM_UI_DETACH,
+		NEOVIM_FN_NVIM_UI_TRY_RESIZE,
+		NEOVIM_FN_NVIM_UI_SET_OPTION,
+		NEOVIM_FN_NVIM_COMMAND,
+		NEOVIM_FN_NVIM_FEEDKEYS,
+		NEOVIM_FN_NVIM_INPUT,
+		NEOVIM_FN_NVIM_REPLACE_TERMCODES,
+		NEOVIM_FN_NVIM_COMMAND_OUTPUT,
+		NEOVIM_FN_NVIM_EVAL,
+		NEOVIM_FN_NVIM_CALL_FUNCTION,
+		NEOVIM_FN_NVIM_STRWIDTH,
+		NEOVIM_FN_NVIM_LIST_RUNTIME_PATHS,
+		NEOVIM_FN_NVIM_SET_CURRENT_DIR,
+		NEOVIM_FN_NVIM_GET_CURRENT_LINE,
+		NEOVIM_FN_NVIM_SET_CURRENT_LINE,
+		NEOVIM_FN_NVIM_DEL_CURRENT_LINE,
+		NEOVIM_FN_NVIM_GET_VAR,
+		NEOVIM_FN_NVIM_SET_VAR,
+		NEOVIM_FN_NVIM_DEL_VAR,
+		NEOVIM_FN_VIM_SET_VAR,
+		NEOVIM_FN_VIM_DEL_VAR,
+		NEOVIM_FN_NVIM_GET_VVAR,
+		NEOVIM_FN_NVIM_GET_OPTION,
+		NEOVIM_FN_NVIM_SET_OPTION,
+		NEOVIM_FN_NVIM_OUT_WRITE,
+		NEOVIM_FN_NVIM_ERR_WRITE,
+		NEOVIM_FN_NVIM_ERR_WRITELN,
+		NEOVIM_FN_NVIM_LIST_BUFS,
+		NEOVIM_FN_NVIM_GET_CURRENT_BUF,
+		NEOVIM_FN_NVIM_SET_CURRENT_BUF,
+		NEOVIM_FN_NVIM_LIST_WINS,
+		NEOVIM_FN_NVIM_GET_CURRENT_WIN,
+		NEOVIM_FN_NVIM_SET_CURRENT_WIN,
+		NEOVIM_FN_NVIM_LIST_TABPAGES,
+		NEOVIM_FN_NVIM_GET_CURRENT_TABPAGE,
+		NEOVIM_FN_NVIM_SET_CURRENT_TABPAGE,
+		NEOVIM_FN_NVIM_SUBSCRIBE,
+		NEOVIM_FN_NVIM_UNSUBSCRIBE,
+		NEOVIM_FN_NVIM_GET_COLOR_BY_NAME,
+		NEOVIM_FN_NVIM_GET_COLOR_MAP,
+		NEOVIM_FN_NVIM_GET_API_INFO,
+		NEOVIM_FN_NVIM_CALL_ATOMIC,
+		NEOVIM_FN_NVIM_WIN_GET_BUF,
+		NEOVIM_FN_NVIM_WIN_GET_CURSOR,
+		NEOVIM_FN_NVIM_WIN_SET_CURSOR,
+		NEOVIM_FN_NVIM_WIN_GET_HEIGHT,
+		NEOVIM_FN_NVIM_WIN_SET_HEIGHT,
+		NEOVIM_FN_NVIM_WIN_GET_WIDTH,
+		NEOVIM_FN_NVIM_WIN_SET_WIDTH,
+		NEOVIM_FN_NVIM_WIN_GET_VAR,
+		NEOVIM_FN_NVIM_WIN_SET_VAR,
+		NEOVIM_FN_NVIM_WIN_DEL_VAR,
+		NEOVIM_FN_WINDOW_SET_VAR,
+		NEOVIM_FN_WINDOW_DEL_VAR,
+		NEOVIM_FN_NVIM_WIN_GET_OPTION,
+		NEOVIM_FN_NVIM_WIN_SET_OPTION,
+		NEOVIM_FN_NVIM_WIN_GET_POSITION,
+		NEOVIM_FN_NVIM_WIN_GET_TABPAGE,
+		NEOVIM_FN_NVIM_WIN_GET_NUMBER,
+		NEOVIM_FN_NVIM_WIN_IS_VALID,
+		NEOVIM_FN_BUFFER_LINE_COUNT,
+		NEOVIM_FN_BUFFER_GET_LINES,
+		NEOVIM_FN_BUFFER_SET_LINES,
+		NEOVIM_FN_BUFFER_GET_VAR,
+		NEOVIM_FN_BUFFER_GET_OPTION,
+		NEOVIM_FN_BUFFER_SET_OPTION,
+		NEOVIM_FN_BUFFER_GET_NUMBER,
+		NEOVIM_FN_BUFFER_GET_NAME,
+		NEOVIM_FN_BUFFER_SET_NAME,
+		NEOVIM_FN_BUFFER_IS_VALID,
+		NEOVIM_FN_BUFFER_GET_MARK,
+		NEOVIM_FN_BUFFER_ADD_HIGHLIGHT,
+		NEOVIM_FN_BUFFER_CLEAR_HIGHLIGHT,
+		NEOVIM_FN_TABPAGE_GET_WINDOWS,
+		NEOVIM_FN_TABPAGE_GET_VAR,
+		NEOVIM_FN_TABPAGE_GET_WINDOW,
+		NEOVIM_FN_TABPAGE_IS_VALID,
+		NEOVIM_FN_UI_DETACH,
+		NEOVIM_FN_UI_TRY_RESIZE,
+		NEOVIM_FN_VIM_COMMAND,
+		NEOVIM_FN_VIM_FEEDKEYS,
+		NEOVIM_FN_VIM_INPUT,
+		NEOVIM_FN_VIM_REPLACE_TERMCODES,
+		NEOVIM_FN_VIM_COMMAND_OUTPUT,
+		NEOVIM_FN_VIM_EVAL,
+		NEOVIM_FN_VIM_CALL_FUNCTION,
+		NEOVIM_FN_VIM_STRWIDTH,
+		NEOVIM_FN_VIM_LIST_RUNTIME_PATHS,
+		NEOVIM_FN_VIM_CHANGE_DIRECTORY,
+		NEOVIM_FN_VIM_GET_CURRENT_LINE,
+		NEOVIM_FN_VIM_SET_CURRENT_LINE,
+		NEOVIM_FN_VIM_DEL_CURRENT_LINE,
+		NEOVIM_FN_VIM_GET_VAR,
+		NEOVIM_FN_VIM_GET_VVAR,
+		NEOVIM_FN_VIM_GET_OPTION,
+		NEOVIM_FN_VIM_SET_OPTION,
+		NEOVIM_FN_VIM_OUT_WRITE,
+		NEOVIM_FN_VIM_ERR_WRITE,
+		NEOVIM_FN_VIM_REPORT_ERROR,
+		NEOVIM_FN_VIM_GET_BUFFERS,
+		NEOVIM_FN_VIM_GET_CURRENT_BUFFER,
+		NEOVIM_FN_VIM_SET_CURRENT_BUFFER,
+		NEOVIM_FN_VIM_GET_WINDOWS,
+		NEOVIM_FN_VIM_GET_CURRENT_WINDOW,
+		NEOVIM_FN_VIM_SET_CURRENT_WINDOW,
+		NEOVIM_FN_VIM_GET_TABPAGES,
+		NEOVIM_FN_VIM_GET_CURRENT_TABPAGE,
+		NEOVIM_FN_VIM_SET_CURRENT_TABPAGE,
+		NEOVIM_FN_VIM_SUBSCRIBE,
+		NEOVIM_FN_VIM_UNSUBSCRIBE,
+		NEOVIM_FN_VIM_NAME_TO_COLOR,
+		NEOVIM_FN_VIM_GET_COLOR_MAP,
+		NEOVIM_FN_WINDOW_GET_BUFFER,
+		NEOVIM_FN_WINDOW_GET_CURSOR,
+		NEOVIM_FN_WINDOW_SET_CURSOR,
+		NEOVIM_FN_WINDOW_GET_HEIGHT,
+		NEOVIM_FN_WINDOW_SET_HEIGHT,
+		NEOVIM_FN_WINDOW_GET_WIDTH,
+		NEOVIM_FN_WINDOW_SET_WIDTH,
+		NEOVIM_FN_WINDOW_GET_VAR,
+		NEOVIM_FN_WINDOW_GET_OPTION,
+		NEOVIM_FN_WINDOW_SET_OPTION,
+		NEOVIM_FN_WINDOW_GET_POSITION,
+		NEOVIM_FN_WINDOW_GET_TABPAGE,
+		NEOVIM_FN_WINDOW_IS_VALID,
 			};
+	Q_ENUM(FunctionId)
 
-	static bool checkFunctions(const QVariantList& ftable);
-	static FunctionId functionId(const Function& f);
+	static bool checkFunctions(const QVariantList& ftable) noexcept;
 
-	NeovimApi1(NeovimConnector *);
+	static FunctionId functionId(const Function& f) noexcept;
+
+	NeovimApi1(NeovimConnector* c) noexcept;
+
 protected slots:
-	void handleResponse(quint32 id, quint64 fun, const QVariant&);
-	void handleResponseError(quint32 id, quint64 fun, const QVariant&);
+	void handleResponse(uint32_t id, uint64_t fun, const QVariant&);
+
+	void handleResponseError(uint32_t id, uint64_t fun, const QVariant&);
+
 signals:
 	void error(const QString& errmsg, const QVariant& errObj);
+
 	void neovimNotification(const QByteArray &name, const QVariantList& args);
+
 private:
-	NeovimConnector *m_c;
+	NeovimConnector* m_connector;
+
 public slots:
-	// Integer nvim_buf_line_count(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_line_count(int64_t buffer);
-	// DEPRECATED
-	// String buffer_get_line(Buffer buffer, Integer index, ) 
-	MsgpackRequest* buffer_get_line(int64_t buffer, int64_t index);
-	// DEPRECATED
-	// void buffer_set_line(Buffer buffer, Integer index, String line, ) 
-	MsgpackRequest* buffer_set_line(int64_t buffer, int64_t index, QByteArray line);
-	// DEPRECATED
-	// void buffer_del_line(Buffer buffer, Integer index, ) 
-	MsgpackRequest* buffer_del_line(int64_t buffer, int64_t index);
-	// DEPRECATED
-	// ArrayOf(String) buffer_get_line_slice(Buffer buffer, Integer start, Integer end, Boolean include_start, Boolean include_end, ) 
-	MsgpackRequest* buffer_get_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end);
-	// ArrayOf(String) nvim_buf_get_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ) 
-	MsgpackRequest* nvim_buf_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing);
-	// DEPRECATED
-	// void buffer_set_line_slice(Buffer buffer, Integer start, Integer end, Boolean include_start, Boolean include_end, ArrayOf(String) replacement, ) 
-	MsgpackRequest* buffer_set_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end, QList<QByteArray> replacement);
-	// void nvim_buf_set_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ArrayOf(String) replacement, ) 
-	MsgpackRequest* nvim_buf_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement);
-	// Object nvim_buf_get_var(Buffer buffer, String name, ) 
-	MsgpackRequest* nvim_buf_get_var(int64_t buffer, QByteArray name);
-	// void nvim_buf_set_var(Buffer buffer, String name, Object value, ) 
-	MsgpackRequest* nvim_buf_set_var(int64_t buffer, QByteArray name, QVariant value);
-	// void nvim_buf_del_var(Buffer buffer, String name, ) 
-	MsgpackRequest* nvim_buf_del_var(int64_t buffer, QByteArray name);
-	// DEPRECATED
-	// Object buffer_set_var(Buffer buffer, String name, Object value, ) 
-	MsgpackRequest* buffer_set_var(int64_t buffer, QByteArray name, QVariant value);
-	// DEPRECATED
-	// Object buffer_del_var(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_del_var(int64_t buffer, QByteArray name);
-	// Object nvim_buf_get_option(Buffer buffer, String name, ) 
-	MsgpackRequest* nvim_buf_get_option(int64_t buffer, QByteArray name);
-	// void nvim_buf_set_option(Buffer buffer, String name, Object value, ) 
-	MsgpackRequest* nvim_buf_set_option(int64_t buffer, QByteArray name, QVariant value);
-	// Integer nvim_buf_get_number(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_get_number(int64_t buffer);
-	// String nvim_buf_get_name(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_get_name(int64_t buffer);
-	// void nvim_buf_set_name(Buffer buffer, String name, ) 
-	MsgpackRequest* nvim_buf_set_name(int64_t buffer, QByteArray name);
-	// Boolean nvim_buf_is_valid(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_is_valid(int64_t buffer);
-	// DEPRECATED
-	// void buffer_insert(Buffer buffer, Integer lnum, ArrayOf(String) lines, ) 
-	MsgpackRequest* buffer_insert(int64_t buffer, int64_t lnum, QList<QByteArray> lines);
-	// ArrayOf(Integer, 2) nvim_buf_get_mark(Buffer buffer, String name, ) 
-	MsgpackRequest* nvim_buf_get_mark(int64_t buffer, QByteArray name);
-	// Integer nvim_buf_add_highlight(Buffer buffer, Integer src_id, String hl_group, Integer line, Integer col_start, Integer col_end, ) 
-	MsgpackRequest* nvim_buf_add_highlight(int64_t buffer, int64_t src_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end);
-	// void nvim_buf_clear_highlight(Buffer buffer, Integer src_id, Integer line_start, Integer line_end, ) 
-	MsgpackRequest* nvim_buf_clear_highlight(int64_t buffer, int64_t src_id, int64_t line_start, int64_t line_end);
-	// ArrayOf(Window) nvim_tabpage_list_wins(Tabpage tabpage, ) 
-	MsgpackRequest* nvim_tabpage_list_wins(int64_t tabpage);
-	// Object nvim_tabpage_get_var(Tabpage tabpage, String name, ) 
-	MsgpackRequest* nvim_tabpage_get_var(int64_t tabpage, QByteArray name);
-	// void nvim_tabpage_set_var(Tabpage tabpage, String name, Object value, ) 
-	MsgpackRequest* nvim_tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value);
-	// void nvim_tabpage_del_var(Tabpage tabpage, String name, ) 
-	MsgpackRequest* nvim_tabpage_del_var(int64_t tabpage, QByteArray name);
-	// DEPRECATED
-	// Object tabpage_set_var(Tabpage tabpage, String name, Object value, ) 
-	MsgpackRequest* tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value);
-	// DEPRECATED
-	// Object tabpage_del_var(Tabpage tabpage, String name, ) 
-	MsgpackRequest* tabpage_del_var(int64_t tabpage, QByteArray name);
-	// Window nvim_tabpage_get_win(Tabpage tabpage, ) 
-	MsgpackRequest* nvim_tabpage_get_win(int64_t tabpage);
-	// Integer nvim_tabpage_get_number(Tabpage tabpage, ) 
-	MsgpackRequest* nvim_tabpage_get_number(int64_t tabpage);
-	// Boolean nvim_tabpage_is_valid(Tabpage tabpage, ) 
-	MsgpackRequest* nvim_tabpage_is_valid(int64_t tabpage);
-	// void nvim_ui_attach(Integer width, Integer height, Dictionary options, ) 
-	MsgpackRequest* nvim_ui_attach(int64_t width, int64_t height, QVariantMap options);
-	// DEPRECATED
-	// void ui_attach(Integer width, Integer height, Boolean enable_rgb, ) 
-	MsgpackRequest* ui_attach(int64_t width, int64_t height, bool enable_rgb);
-	// void nvim_ui_detach() 
-	MsgpackRequest* nvim_ui_detach();
-	// void nvim_ui_try_resize(Integer width, Integer height, ) 
-	MsgpackRequest* nvim_ui_try_resize(int64_t width, int64_t height);
-	// void nvim_ui_set_option(String name, Object value, ) 
-	MsgpackRequest* nvim_ui_set_option(QByteArray name, QVariant value);
-	// void nvim_command(String command, ) 
-	MsgpackRequest* nvim_command(QByteArray command);
-	// void nvim_feedkeys(String keys, String mode, Boolean escape_csi, ) 
-	MsgpackRequest* nvim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi);
-	// Integer nvim_input(String keys, ) 
-	MsgpackRequest* nvim_input(QByteArray keys);
-	// String nvim_replace_termcodes(String str, Boolean from_part, Boolean do_lt, Boolean special, ) 
-	MsgpackRequest* nvim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special);
-	// String nvim_command_output(String str, ) 
-	MsgpackRequest* nvim_command_output(QByteArray str);
-	// Object nvim_eval(String expr, ) 
-	MsgpackRequest* nvim_eval(QByteArray expr);
-	// Object nvim_call_function(String fname, Array args, ) 
-	MsgpackRequest* nvim_call_function(QByteArray fname, QVariantList args);
-	// Integer nvim_strwidth(String str, ) 
-	MsgpackRequest* nvim_strwidth(QByteArray str);
-	// ArrayOf(String) nvim_list_runtime_paths() 
-	MsgpackRequest* nvim_list_runtime_paths();
-	// void nvim_set_current_dir(String dir, ) 
-	MsgpackRequest* nvim_set_current_dir(QByteArray dir);
-	// String nvim_get_current_line() 
-	MsgpackRequest* nvim_get_current_line();
-	// void nvim_set_current_line(String line, ) 
-	MsgpackRequest* nvim_set_current_line(QByteArray line);
-	// void nvim_del_current_line() 
-	MsgpackRequest* nvim_del_current_line();
-	// Object nvim_get_var(String name, ) 
-	MsgpackRequest* nvim_get_var(QByteArray name);
-	// void nvim_set_var(String name, Object value, ) 
-	MsgpackRequest* nvim_set_var(QByteArray name, QVariant value);
-	// void nvim_del_var(String name, ) 
-	MsgpackRequest* nvim_del_var(QByteArray name);
-	// DEPRECATED
-	// Object vim_set_var(String name, Object value, ) 
-	MsgpackRequest* vim_set_var(QByteArray name, QVariant value);
-	// DEPRECATED
-	// Object vim_del_var(String name, ) 
-	MsgpackRequest* vim_del_var(QByteArray name);
-	// Object nvim_get_vvar(String name, ) 
-	MsgpackRequest* nvim_get_vvar(QByteArray name);
-	// Object nvim_get_option(String name, ) 
-	MsgpackRequest* nvim_get_option(QByteArray name);
-	// void nvim_set_option(String name, Object value, ) 
-	MsgpackRequest* nvim_set_option(QByteArray name, QVariant value);
-	// void nvim_out_write(String str, ) 
-	MsgpackRequest* nvim_out_write(QByteArray str);
-	// void nvim_err_write(String str, ) 
-	MsgpackRequest* nvim_err_write(QByteArray str);
-	// void nvim_err_writeln(String str, ) 
-	MsgpackRequest* nvim_err_writeln(QByteArray str);
-	// ArrayOf(Buffer) nvim_list_bufs() 
-	MsgpackRequest* nvim_list_bufs();
-	// Buffer nvim_get_current_buf() 
-	MsgpackRequest* nvim_get_current_buf();
-	// void nvim_set_current_buf(Buffer buffer, ) 
-	MsgpackRequest* nvim_set_current_buf(int64_t buffer);
-	// ArrayOf(Window) nvim_list_wins() 
-	MsgpackRequest* nvim_list_wins();
-	// Window nvim_get_current_win() 
-	MsgpackRequest* nvim_get_current_win();
-	// void nvim_set_current_win(Window window, ) 
-	MsgpackRequest* nvim_set_current_win(int64_t window);
-	// ArrayOf(Tabpage) nvim_list_tabpages() 
-	MsgpackRequest* nvim_list_tabpages();
-	// Tabpage nvim_get_current_tabpage() 
-	MsgpackRequest* nvim_get_current_tabpage();
-	// void nvim_set_current_tabpage(Tabpage tabpage, ) 
-	MsgpackRequest* nvim_set_current_tabpage(int64_t tabpage);
-	// void nvim_subscribe(String event, ) 
-	MsgpackRequest* nvim_subscribe(QByteArray event);
-	// void nvim_unsubscribe(String event, ) 
-	MsgpackRequest* nvim_unsubscribe(QByteArray event);
-	// Integer nvim_get_color_by_name(String name, ) 
-	MsgpackRequest* nvim_get_color_by_name(QByteArray name);
-	// Dictionary nvim_get_color_map() 
-	MsgpackRequest* nvim_get_color_map();
-	// Array nvim_get_api_info() 
-	MsgpackRequest* nvim_get_api_info();
-	// Array nvim_call_atomic(Array calls, ) 
-	MsgpackRequest* nvim_call_atomic(QVariantList calls);
-	// Buffer nvim_win_get_buf(Window window, ) 
-	MsgpackRequest* nvim_win_get_buf(int64_t window);
-	// ArrayOf(Integer, 2) nvim_win_get_cursor(Window window, ) 
-	MsgpackRequest* nvim_win_get_cursor(int64_t window);
-	// void nvim_win_set_cursor(Window window, ArrayOf(Integer, 2) pos, ) 
-	MsgpackRequest* nvim_win_set_cursor(int64_t window, QPoint pos);
-	// Integer nvim_win_get_height(Window window, ) 
-	MsgpackRequest* nvim_win_get_height(int64_t window);
-	// void nvim_win_set_height(Window window, Integer height, ) 
-	MsgpackRequest* nvim_win_set_height(int64_t window, int64_t height);
-	// Integer nvim_win_get_width(Window window, ) 
-	MsgpackRequest* nvim_win_get_width(int64_t window);
-	// void nvim_win_set_width(Window window, Integer width, ) 
-	MsgpackRequest* nvim_win_set_width(int64_t window, int64_t width);
-	// Object nvim_win_get_var(Window window, String name, ) 
-	MsgpackRequest* nvim_win_get_var(int64_t window, QByteArray name);
-	// void nvim_win_set_var(Window window, String name, Object value, ) 
-	MsgpackRequest* nvim_win_set_var(int64_t window, QByteArray name, QVariant value);
-	// void nvim_win_del_var(Window window, String name, ) 
-	MsgpackRequest* nvim_win_del_var(int64_t window, QByteArray name);
-	// DEPRECATED
-	// Object window_set_var(Window window, String name, Object value, ) 
-	MsgpackRequest* window_set_var(int64_t window, QByteArray name, QVariant value);
-	// DEPRECATED
-	// Object window_del_var(Window window, String name, ) 
-	MsgpackRequest* window_del_var(int64_t window, QByteArray name);
-	// Object nvim_win_get_option(Window window, String name, ) 
-	MsgpackRequest* nvim_win_get_option(int64_t window, QByteArray name);
-	// void nvim_win_set_option(Window window, String name, Object value, ) 
-	MsgpackRequest* nvim_win_set_option(int64_t window, QByteArray name, QVariant value);
-	// ArrayOf(Integer, 2) nvim_win_get_position(Window window, ) 
-	MsgpackRequest* nvim_win_get_position(int64_t window);
-	// Tabpage nvim_win_get_tabpage(Window window, ) 
-	MsgpackRequest* nvim_win_get_tabpage(int64_t window);
-	// Integer nvim_win_get_number(Window window, ) 
-	MsgpackRequest* nvim_win_get_number(int64_t window);
-	// Boolean nvim_win_is_valid(Window window, ) 
-	MsgpackRequest* nvim_win_is_valid(int64_t window);
-	// DEPRECATED
-	// Integer buffer_line_count(Buffer buffer, ) 
-	MsgpackRequest* buffer_line_count(int64_t buffer);
-	// DEPRECATED
-	// ArrayOf(String) buffer_get_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ) 
-	MsgpackRequest* buffer_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing);
-	// DEPRECATED
-	// void buffer_set_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ArrayOf(String) replacement, ) 
-	MsgpackRequest* buffer_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement);
-	// DEPRECATED
-	// Object buffer_get_var(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_get_var(int64_t buffer, QByteArray name);
-	// DEPRECATED
-	// Object buffer_get_option(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_get_option(int64_t buffer, QByteArray name);
-	// DEPRECATED
-	// void buffer_set_option(Buffer buffer, String name, Object value, ) 
-	MsgpackRequest* buffer_set_option(int64_t buffer, QByteArray name, QVariant value);
-	// DEPRECATED
-	// Integer buffer_get_number(Buffer buffer, ) 
-	MsgpackRequest* buffer_get_number(int64_t buffer);
-	// DEPRECATED
-	// String buffer_get_name(Buffer buffer, ) 
-	MsgpackRequest* buffer_get_name(int64_t buffer);
-	// DEPRECATED
-	// void buffer_set_name(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_set_name(int64_t buffer, QByteArray name);
-	// DEPRECATED
-	// Boolean buffer_is_valid(Buffer buffer, ) 
-	MsgpackRequest* buffer_is_valid(int64_t buffer);
-	// DEPRECATED
-	// ArrayOf(Integer, 2) buffer_get_mark(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_get_mark(int64_t buffer, QByteArray name);
-	// DEPRECATED
-	// Integer buffer_add_highlight(Buffer buffer, Integer src_id, String hl_group, Integer line, Integer col_start, Integer col_end, ) 
-	MsgpackRequest* buffer_add_highlight(int64_t buffer, int64_t src_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end);
-	// DEPRECATED
-	// void buffer_clear_highlight(Buffer buffer, Integer src_id, Integer line_start, Integer line_end, ) 
-	MsgpackRequest* buffer_clear_highlight(int64_t buffer, int64_t src_id, int64_t line_start, int64_t line_end);
-	// DEPRECATED
-	// ArrayOf(Window) tabpage_get_windows(Tabpage tabpage, ) 
-	MsgpackRequest* tabpage_get_windows(int64_t tabpage);
-	// DEPRECATED
-	// Object tabpage_get_var(Tabpage tabpage, String name, ) 
-	MsgpackRequest* tabpage_get_var(int64_t tabpage, QByteArray name);
-	// DEPRECATED
-	// Window tabpage_get_window(Tabpage tabpage, ) 
-	MsgpackRequest* tabpage_get_window(int64_t tabpage);
-	// DEPRECATED
-	// Boolean tabpage_is_valid(Tabpage tabpage, ) 
-	MsgpackRequest* tabpage_is_valid(int64_t tabpage);
-	// DEPRECATED
-	// void ui_detach() 
-	MsgpackRequest* ui_detach();
-	// DEPRECATED
-	// Object ui_try_resize(Integer width, Integer height, ) 
-	MsgpackRequest* ui_try_resize(int64_t width, int64_t height);
-	// DEPRECATED
-	// void vim_command(String command, ) 
-	MsgpackRequest* vim_command(QByteArray command);
-	// DEPRECATED
-	// void vim_feedkeys(String keys, String mode, Boolean escape_csi, ) 
-	MsgpackRequest* vim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi);
-	// DEPRECATED
-	// Integer vim_input(String keys, ) 
-	MsgpackRequest* vim_input(QByteArray keys);
-	// DEPRECATED
-	// String vim_replace_termcodes(String str, Boolean from_part, Boolean do_lt, Boolean special, ) 
-	MsgpackRequest* vim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special);
-	// DEPRECATED
-	// String vim_command_output(String str, ) 
-	MsgpackRequest* vim_command_output(QByteArray str);
-	// DEPRECATED
-	// Object vim_eval(String expr, ) 
-	MsgpackRequest* vim_eval(QByteArray expr);
-	// DEPRECATED
-	// Object vim_call_function(String fname, Array args, ) 
-	MsgpackRequest* vim_call_function(QByteArray fname, QVariantList args);
-	// DEPRECATED
-	// Integer vim_strwidth(String str, ) 
-	MsgpackRequest* vim_strwidth(QByteArray str);
-	// DEPRECATED
-	// ArrayOf(String) vim_list_runtime_paths() 
-	MsgpackRequest* vim_list_runtime_paths();
-	// DEPRECATED
-	// void vim_change_directory(String dir, ) 
-	MsgpackRequest* vim_change_directory(QByteArray dir);
-	// DEPRECATED
-	// String vim_get_current_line() 
-	MsgpackRequest* vim_get_current_line();
-	// DEPRECATED
-	// void vim_set_current_line(String line, ) 
-	MsgpackRequest* vim_set_current_line(QByteArray line);
-	// DEPRECATED
-	// void vim_del_current_line() 
-	MsgpackRequest* vim_del_current_line();
-	// DEPRECATED
-	// Object vim_get_var(String name, ) 
-	MsgpackRequest* vim_get_var(QByteArray name);
-	// DEPRECATED
-	// Object vim_get_vvar(String name, ) 
-	MsgpackRequest* vim_get_vvar(QByteArray name);
-	// DEPRECATED
-	// Object vim_get_option(String name, ) 
-	MsgpackRequest* vim_get_option(QByteArray name);
-	// DEPRECATED
-	// void vim_set_option(String name, Object value, ) 
-	MsgpackRequest* vim_set_option(QByteArray name, QVariant value);
-	// DEPRECATED
-	// void vim_out_write(String str, ) 
-	MsgpackRequest* vim_out_write(QByteArray str);
-	// DEPRECATED
-	// void vim_err_write(String str, ) 
-	MsgpackRequest* vim_err_write(QByteArray str);
-	// DEPRECATED
-	// void vim_report_error(String str, ) 
-	MsgpackRequest* vim_report_error(QByteArray str);
-	// DEPRECATED
-	// ArrayOf(Buffer) vim_get_buffers() 
-	MsgpackRequest* vim_get_buffers();
-	// DEPRECATED
-	// Buffer vim_get_current_buffer() 
-	MsgpackRequest* vim_get_current_buffer();
-	// DEPRECATED
-	// void vim_set_current_buffer(Buffer buffer, ) 
-	MsgpackRequest* vim_set_current_buffer(int64_t buffer);
-	// DEPRECATED
-	// ArrayOf(Window) vim_get_windows() 
-	MsgpackRequest* vim_get_windows();
-	// DEPRECATED
-	// Window vim_get_current_window() 
-	MsgpackRequest* vim_get_current_window();
-	// DEPRECATED
-	// void vim_set_current_window(Window window, ) 
-	MsgpackRequest* vim_set_current_window(int64_t window);
-	// DEPRECATED
-	// ArrayOf(Tabpage) vim_get_tabpages() 
-	MsgpackRequest* vim_get_tabpages();
-	// DEPRECATED
-	// Tabpage vim_get_current_tabpage() 
-	MsgpackRequest* vim_get_current_tabpage();
-	// DEPRECATED
-	// void vim_set_current_tabpage(Tabpage tabpage, ) 
-	MsgpackRequest* vim_set_current_tabpage(int64_t tabpage);
-	// DEPRECATED
-	// void vim_subscribe(String event, ) 
-	MsgpackRequest* vim_subscribe(QByteArray event);
-	// DEPRECATED
-	// void vim_unsubscribe(String event, ) 
-	MsgpackRequest* vim_unsubscribe(QByteArray event);
-	// DEPRECATED
-	// Integer vim_name_to_color(String name, ) 
-	MsgpackRequest* vim_name_to_color(QByteArray name);
-	// DEPRECATED
-	// Dictionary vim_get_color_map() 
-	MsgpackRequest* vim_get_color_map();
-	// DEPRECATED
-	// Buffer window_get_buffer(Window window, ) 
-	MsgpackRequest* window_get_buffer(int64_t window);
-	// DEPRECATED
-	// ArrayOf(Integer, 2) window_get_cursor(Window window, ) 
-	MsgpackRequest* window_get_cursor(int64_t window);
-	// DEPRECATED
-	// void window_set_cursor(Window window, ArrayOf(Integer, 2) pos, ) 
-	MsgpackRequest* window_set_cursor(int64_t window, QPoint pos);
-	// DEPRECATED
-	// Integer window_get_height(Window window, ) 
-	MsgpackRequest* window_get_height(int64_t window);
-	// DEPRECATED
-	// void window_set_height(Window window, Integer height, ) 
-	MsgpackRequest* window_set_height(int64_t window, int64_t height);
-	// DEPRECATED
-	// Integer window_get_width(Window window, ) 
-	MsgpackRequest* window_get_width(int64_t window);
-	// DEPRECATED
-	// void window_set_width(Window window, Integer width, ) 
-	MsgpackRequest* window_set_width(int64_t window, int64_t width);
-	// DEPRECATED
-	// Object window_get_var(Window window, String name, ) 
-	MsgpackRequest* window_get_var(int64_t window, QByteArray name);
-	// DEPRECATED
-	// Object window_get_option(Window window, String name, ) 
-	MsgpackRequest* window_get_option(int64_t window, QByteArray name);
-	// DEPRECATED
-	// void window_set_option(Window window, String name, Object value, ) 
-	MsgpackRequest* window_set_option(int64_t window, QByteArray name, QVariant value);
-	// DEPRECATED
-	// ArrayOf(Integer, 2) window_get_position(Window window, ) 
-	MsgpackRequest* window_get_position(int64_t window);
-	// DEPRECATED
-	// Tabpage window_get_tabpage(Window window, ) 
-	MsgpackRequest* window_get_tabpage(int64_t window);
-	// DEPRECATED
-	// Boolean window_is_valid(Window window, ) 
-	MsgpackRequest* window_is_valid(int64_t window);
+	/// Integer nvim_buf_line_count(Buffer buffer, )
+	NeovimQt::MsgpackRequest* nvim_buf_line_count(int64_t buffer);
+
+	/// DEPRECATED: String buffer_get_line(Buffer buffer, Integer index, )
+	NeovimQt::MsgpackRequest* buffer_get_line(int64_t buffer, int64_t index);
+
+	/// DEPRECATED: void buffer_set_line(Buffer buffer, Integer index, String line, )
+	NeovimQt::MsgpackRequest* buffer_set_line(int64_t buffer, int64_t index, QByteArray line);
+
+	/// DEPRECATED: void buffer_del_line(Buffer buffer, Integer index, )
+	NeovimQt::MsgpackRequest* buffer_del_line(int64_t buffer, int64_t index);
+
+	/// DEPRECATED: ArrayOf(String) buffer_get_line_slice(Buffer buffer, Integer start, Integer end, Boolean include_start, Boolean include_end, )
+	NeovimQt::MsgpackRequest* buffer_get_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end);
+
+	/// ArrayOf(String) nvim_buf_get_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, )
+	NeovimQt::MsgpackRequest* nvim_buf_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing);
+
+	/// DEPRECATED: void buffer_set_line_slice(Buffer buffer, Integer start, Integer end, Boolean include_start, Boolean include_end, ArrayOf(String) replacement, )
+	NeovimQt::MsgpackRequest* buffer_set_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end, QList<QByteArray> replacement);
+
+	/// void nvim_buf_set_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ArrayOf(String) replacement, )
+	NeovimQt::MsgpackRequest* nvim_buf_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement);
+
+	/// Object nvim_buf_get_var(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* nvim_buf_get_var(int64_t buffer, QByteArray name);
+
+	/// void nvim_buf_set_var(Buffer buffer, String name, Object value, )
+	NeovimQt::MsgpackRequest* nvim_buf_set_var(int64_t buffer, QByteArray name, QVariant value);
+
+	/// void nvim_buf_del_var(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* nvim_buf_del_var(int64_t buffer, QByteArray name);
+
+	/// DEPRECATED: Object buffer_set_var(Buffer buffer, String name, Object value, )
+	NeovimQt::MsgpackRequest* buffer_set_var(int64_t buffer, QByteArray name, QVariant value);
+
+	/// DEPRECATED: Object buffer_del_var(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* buffer_del_var(int64_t buffer, QByteArray name);
+
+	/// Object nvim_buf_get_option(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* nvim_buf_get_option(int64_t buffer, QByteArray name);
+
+	/// void nvim_buf_set_option(Buffer buffer, String name, Object value, )
+	NeovimQt::MsgpackRequest* nvim_buf_set_option(int64_t buffer, QByteArray name, QVariant value);
+
+	/// Integer nvim_buf_get_number(Buffer buffer, )
+	NeovimQt::MsgpackRequest* nvim_buf_get_number(int64_t buffer);
+
+	/// String nvim_buf_get_name(Buffer buffer, )
+	NeovimQt::MsgpackRequest* nvim_buf_get_name(int64_t buffer);
+
+	/// void nvim_buf_set_name(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* nvim_buf_set_name(int64_t buffer, QByteArray name);
+
+	/// Boolean nvim_buf_is_valid(Buffer buffer, )
+	NeovimQt::MsgpackRequest* nvim_buf_is_valid(int64_t buffer);
+
+	/// DEPRECATED: void buffer_insert(Buffer buffer, Integer lnum, ArrayOf(String) lines, )
+	NeovimQt::MsgpackRequest* buffer_insert(int64_t buffer, int64_t lnum, QList<QByteArray> lines);
+
+	/// ArrayOf(Integer, 2) nvim_buf_get_mark(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* nvim_buf_get_mark(int64_t buffer, QByteArray name);
+
+	/// Integer nvim_buf_add_highlight(Buffer buffer, Integer src_id, String hl_group, Integer line, Integer col_start, Integer col_end, )
+	NeovimQt::MsgpackRequest* nvim_buf_add_highlight(int64_t buffer, int64_t src_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end);
+
+	/// void nvim_buf_clear_highlight(Buffer buffer, Integer src_id, Integer line_start, Integer line_end, )
+	NeovimQt::MsgpackRequest* nvim_buf_clear_highlight(int64_t buffer, int64_t src_id, int64_t line_start, int64_t line_end);
+
+	/// ArrayOf(Window) nvim_tabpage_list_wins(Tabpage tabpage, )
+	NeovimQt::MsgpackRequest* nvim_tabpage_list_wins(int64_t tabpage);
+
+	/// Object nvim_tabpage_get_var(Tabpage tabpage, String name, )
+	NeovimQt::MsgpackRequest* nvim_tabpage_get_var(int64_t tabpage, QByteArray name);
+
+	/// void nvim_tabpage_set_var(Tabpage tabpage, String name, Object value, )
+	NeovimQt::MsgpackRequest* nvim_tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value);
+
+	/// void nvim_tabpage_del_var(Tabpage tabpage, String name, )
+	NeovimQt::MsgpackRequest* nvim_tabpage_del_var(int64_t tabpage, QByteArray name);
+
+	/// DEPRECATED: Object tabpage_set_var(Tabpage tabpage, String name, Object value, )
+	NeovimQt::MsgpackRequest* tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value);
+
+	/// DEPRECATED: Object tabpage_del_var(Tabpage tabpage, String name, )
+	NeovimQt::MsgpackRequest* tabpage_del_var(int64_t tabpage, QByteArray name);
+
+	/// Window nvim_tabpage_get_win(Tabpage tabpage, )
+	NeovimQt::MsgpackRequest* nvim_tabpage_get_win(int64_t tabpage);
+
+	/// Integer nvim_tabpage_get_number(Tabpage tabpage, )
+	NeovimQt::MsgpackRequest* nvim_tabpage_get_number(int64_t tabpage);
+
+	/// Boolean nvim_tabpage_is_valid(Tabpage tabpage, )
+	NeovimQt::MsgpackRequest* nvim_tabpage_is_valid(int64_t tabpage);
+
+	/// void nvim_ui_attach(Integer width, Integer height, Dictionary options, )
+	NeovimQt::MsgpackRequest* nvim_ui_attach(int64_t width, int64_t height, QVariantMap options);
+
+	/// DEPRECATED: void ui_attach(Integer width, Integer height, Boolean enable_rgb, )
+	NeovimQt::MsgpackRequest* ui_attach(int64_t width, int64_t height, bool enable_rgb);
+
+	/// void nvim_ui_detach()
+	NeovimQt::MsgpackRequest* nvim_ui_detach();
+
+	/// void nvim_ui_try_resize(Integer width, Integer height, )
+	NeovimQt::MsgpackRequest* nvim_ui_try_resize(int64_t width, int64_t height);
+
+	/// void nvim_ui_set_option(String name, Object value, )
+	NeovimQt::MsgpackRequest* nvim_ui_set_option(QByteArray name, QVariant value);
+
+	/// void nvim_command(String command, )
+	NeovimQt::MsgpackRequest* nvim_command(QByteArray command);
+
+	/// void nvim_feedkeys(String keys, String mode, Boolean escape_csi, )
+	NeovimQt::MsgpackRequest* nvim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi);
+
+	/// Integer nvim_input(String keys, )
+	NeovimQt::MsgpackRequest* nvim_input(QByteArray keys);
+
+	/// String nvim_replace_termcodes(String str, Boolean from_part, Boolean do_lt, Boolean special, )
+	NeovimQt::MsgpackRequest* nvim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special);
+
+	/// String nvim_command_output(String str, )
+	NeovimQt::MsgpackRequest* nvim_command_output(QByteArray str);
+
+	/// Object nvim_eval(String expr, )
+	NeovimQt::MsgpackRequest* nvim_eval(QByteArray expr);
+
+	/// Object nvim_call_function(String fname, Array args, )
+	NeovimQt::MsgpackRequest* nvim_call_function(QByteArray fname, QVariantList args);
+
+	/// Integer nvim_strwidth(String str, )
+	NeovimQt::MsgpackRequest* nvim_strwidth(QByteArray str);
+
+	/// ArrayOf(String) nvim_list_runtime_paths()
+	NeovimQt::MsgpackRequest* nvim_list_runtime_paths();
+
+	/// void nvim_set_current_dir(String dir, )
+	NeovimQt::MsgpackRequest* nvim_set_current_dir(QByteArray dir);
+
+	/// String nvim_get_current_line()
+	NeovimQt::MsgpackRequest* nvim_get_current_line();
+
+	/// void nvim_set_current_line(String line, )
+	NeovimQt::MsgpackRequest* nvim_set_current_line(QByteArray line);
+
+	/// void nvim_del_current_line()
+	NeovimQt::MsgpackRequest* nvim_del_current_line();
+
+	/// Object nvim_get_var(String name, )
+	NeovimQt::MsgpackRequest* nvim_get_var(QByteArray name);
+
+	/// void nvim_set_var(String name, Object value, )
+	NeovimQt::MsgpackRequest* nvim_set_var(QByteArray name, QVariant value);
+
+	/// void nvim_del_var(String name, )
+	NeovimQt::MsgpackRequest* nvim_del_var(QByteArray name);
+
+	/// DEPRECATED: Object vim_set_var(String name, Object value, )
+	NeovimQt::MsgpackRequest* vim_set_var(QByteArray name, QVariant value);
+
+	/// DEPRECATED: Object vim_del_var(String name, )
+	NeovimQt::MsgpackRequest* vim_del_var(QByteArray name);
+
+	/// Object nvim_get_vvar(String name, )
+	NeovimQt::MsgpackRequest* nvim_get_vvar(QByteArray name);
+
+	/// Object nvim_get_option(String name, )
+	NeovimQt::MsgpackRequest* nvim_get_option(QByteArray name);
+
+	/// void nvim_set_option(String name, Object value, )
+	NeovimQt::MsgpackRequest* nvim_set_option(QByteArray name, QVariant value);
+
+	/// void nvim_out_write(String str, )
+	NeovimQt::MsgpackRequest* nvim_out_write(QByteArray str);
+
+	/// void nvim_err_write(String str, )
+	NeovimQt::MsgpackRequest* nvim_err_write(QByteArray str);
+
+	/// void nvim_err_writeln(String str, )
+	NeovimQt::MsgpackRequest* nvim_err_writeln(QByteArray str);
+
+	/// ArrayOf(Buffer) nvim_list_bufs()
+	NeovimQt::MsgpackRequest* nvim_list_bufs();
+
+	/// Buffer nvim_get_current_buf()
+	NeovimQt::MsgpackRequest* nvim_get_current_buf();
+
+	/// void nvim_set_current_buf(Buffer buffer, )
+	NeovimQt::MsgpackRequest* nvim_set_current_buf(int64_t buffer);
+
+	/// ArrayOf(Window) nvim_list_wins()
+	NeovimQt::MsgpackRequest* nvim_list_wins();
+
+	/// Window nvim_get_current_win()
+	NeovimQt::MsgpackRequest* nvim_get_current_win();
+
+	/// void nvim_set_current_win(Window window, )
+	NeovimQt::MsgpackRequest* nvim_set_current_win(int64_t window);
+
+	/// ArrayOf(Tabpage) nvim_list_tabpages()
+	NeovimQt::MsgpackRequest* nvim_list_tabpages();
+
+	/// Tabpage nvim_get_current_tabpage()
+	NeovimQt::MsgpackRequest* nvim_get_current_tabpage();
+
+	/// void nvim_set_current_tabpage(Tabpage tabpage, )
+	NeovimQt::MsgpackRequest* nvim_set_current_tabpage(int64_t tabpage);
+
+	/// void nvim_subscribe(String event, )
+	NeovimQt::MsgpackRequest* nvim_subscribe(QByteArray event);
+
+	/// void nvim_unsubscribe(String event, )
+	NeovimQt::MsgpackRequest* nvim_unsubscribe(QByteArray event);
+
+	/// Integer nvim_get_color_by_name(String name, )
+	NeovimQt::MsgpackRequest* nvim_get_color_by_name(QByteArray name);
+
+	/// Dictionary nvim_get_color_map()
+	NeovimQt::MsgpackRequest* nvim_get_color_map();
+
+	/// Array nvim_get_api_info()
+	NeovimQt::MsgpackRequest* nvim_get_api_info();
+
+	/// Array nvim_call_atomic(Array calls, )
+	NeovimQt::MsgpackRequest* nvim_call_atomic(QVariantList calls);
+
+	/// Buffer nvim_win_get_buf(Window window, )
+	NeovimQt::MsgpackRequest* nvim_win_get_buf(int64_t window);
+
+	/// ArrayOf(Integer, 2) nvim_win_get_cursor(Window window, )
+	NeovimQt::MsgpackRequest* nvim_win_get_cursor(int64_t window);
+
+	/// void nvim_win_set_cursor(Window window, ArrayOf(Integer, 2) pos, )
+	NeovimQt::MsgpackRequest* nvim_win_set_cursor(int64_t window, QPoint pos);
+
+	/// Integer nvim_win_get_height(Window window, )
+	NeovimQt::MsgpackRequest* nvim_win_get_height(int64_t window);
+
+	/// void nvim_win_set_height(Window window, Integer height, )
+	NeovimQt::MsgpackRequest* nvim_win_set_height(int64_t window, int64_t height);
+
+	/// Integer nvim_win_get_width(Window window, )
+	NeovimQt::MsgpackRequest* nvim_win_get_width(int64_t window);
+
+	/// void nvim_win_set_width(Window window, Integer width, )
+	NeovimQt::MsgpackRequest* nvim_win_set_width(int64_t window, int64_t width);
+
+	/// Object nvim_win_get_var(Window window, String name, )
+	NeovimQt::MsgpackRequest* nvim_win_get_var(int64_t window, QByteArray name);
+
+	/// void nvim_win_set_var(Window window, String name, Object value, )
+	NeovimQt::MsgpackRequest* nvim_win_set_var(int64_t window, QByteArray name, QVariant value);
+
+	/// void nvim_win_del_var(Window window, String name, )
+	NeovimQt::MsgpackRequest* nvim_win_del_var(int64_t window, QByteArray name);
+
+	/// DEPRECATED: Object window_set_var(Window window, String name, Object value, )
+	NeovimQt::MsgpackRequest* window_set_var(int64_t window, QByteArray name, QVariant value);
+
+	/// DEPRECATED: Object window_del_var(Window window, String name, )
+	NeovimQt::MsgpackRequest* window_del_var(int64_t window, QByteArray name);
+
+	/// Object nvim_win_get_option(Window window, String name, )
+	NeovimQt::MsgpackRequest* nvim_win_get_option(int64_t window, QByteArray name);
+
+	/// void nvim_win_set_option(Window window, String name, Object value, )
+	NeovimQt::MsgpackRequest* nvim_win_set_option(int64_t window, QByteArray name, QVariant value);
+
+	/// ArrayOf(Integer, 2) nvim_win_get_position(Window window, )
+	NeovimQt::MsgpackRequest* nvim_win_get_position(int64_t window);
+
+	/// Tabpage nvim_win_get_tabpage(Window window, )
+	NeovimQt::MsgpackRequest* nvim_win_get_tabpage(int64_t window);
+
+	/// Integer nvim_win_get_number(Window window, )
+	NeovimQt::MsgpackRequest* nvim_win_get_number(int64_t window);
+
+	/// Boolean nvim_win_is_valid(Window window, )
+	NeovimQt::MsgpackRequest* nvim_win_is_valid(int64_t window);
+
+	/// DEPRECATED: Integer buffer_line_count(Buffer buffer, )
+	NeovimQt::MsgpackRequest* buffer_line_count(int64_t buffer);
+
+	/// DEPRECATED: ArrayOf(String) buffer_get_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, )
+	NeovimQt::MsgpackRequest* buffer_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing);
+
+	/// DEPRECATED: void buffer_set_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ArrayOf(String) replacement, )
+	NeovimQt::MsgpackRequest* buffer_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement);
+
+	/// DEPRECATED: Object buffer_get_var(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* buffer_get_var(int64_t buffer, QByteArray name);
+
+	/// DEPRECATED: Object buffer_get_option(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* buffer_get_option(int64_t buffer, QByteArray name);
+
+	/// DEPRECATED: void buffer_set_option(Buffer buffer, String name, Object value, )
+	NeovimQt::MsgpackRequest* buffer_set_option(int64_t buffer, QByteArray name, QVariant value);
+
+	/// DEPRECATED: Integer buffer_get_number(Buffer buffer, )
+	NeovimQt::MsgpackRequest* buffer_get_number(int64_t buffer);
+
+	/// DEPRECATED: String buffer_get_name(Buffer buffer, )
+	NeovimQt::MsgpackRequest* buffer_get_name(int64_t buffer);
+
+	/// DEPRECATED: void buffer_set_name(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* buffer_set_name(int64_t buffer, QByteArray name);
+
+	/// DEPRECATED: Boolean buffer_is_valid(Buffer buffer, )
+	NeovimQt::MsgpackRequest* buffer_is_valid(int64_t buffer);
+
+	/// DEPRECATED: ArrayOf(Integer, 2) buffer_get_mark(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* buffer_get_mark(int64_t buffer, QByteArray name);
+
+	/// DEPRECATED: Integer buffer_add_highlight(Buffer buffer, Integer src_id, String hl_group, Integer line, Integer col_start, Integer col_end, )
+	NeovimQt::MsgpackRequest* buffer_add_highlight(int64_t buffer, int64_t src_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end);
+
+	/// DEPRECATED: void buffer_clear_highlight(Buffer buffer, Integer src_id, Integer line_start, Integer line_end, )
+	NeovimQt::MsgpackRequest* buffer_clear_highlight(int64_t buffer, int64_t src_id, int64_t line_start, int64_t line_end);
+
+	/// DEPRECATED: ArrayOf(Window) tabpage_get_windows(Tabpage tabpage, )
+	NeovimQt::MsgpackRequest* tabpage_get_windows(int64_t tabpage);
+
+	/// DEPRECATED: Object tabpage_get_var(Tabpage tabpage, String name, )
+	NeovimQt::MsgpackRequest* tabpage_get_var(int64_t tabpage, QByteArray name);
+
+	/// DEPRECATED: Window tabpage_get_window(Tabpage tabpage, )
+	NeovimQt::MsgpackRequest* tabpage_get_window(int64_t tabpage);
+
+	/// DEPRECATED: Boolean tabpage_is_valid(Tabpage tabpage, )
+	NeovimQt::MsgpackRequest* tabpage_is_valid(int64_t tabpage);
+
+	/// DEPRECATED: void ui_detach()
+	NeovimQt::MsgpackRequest* ui_detach();
+
+	/// DEPRECATED: Object ui_try_resize(Integer width, Integer height, )
+	NeovimQt::MsgpackRequest* ui_try_resize(int64_t width, int64_t height);
+
+	/// DEPRECATED: void vim_command(String command, )
+	NeovimQt::MsgpackRequest* vim_command(QByteArray command);
+
+	/// DEPRECATED: void vim_feedkeys(String keys, String mode, Boolean escape_csi, )
+	NeovimQt::MsgpackRequest* vim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi);
+
+	/// DEPRECATED: Integer vim_input(String keys, )
+	NeovimQt::MsgpackRequest* vim_input(QByteArray keys);
+
+	/// DEPRECATED: String vim_replace_termcodes(String str, Boolean from_part, Boolean do_lt, Boolean special, )
+	NeovimQt::MsgpackRequest* vim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special);
+
+	/// DEPRECATED: String vim_command_output(String str, )
+	NeovimQt::MsgpackRequest* vim_command_output(QByteArray str);
+
+	/// DEPRECATED: Object vim_eval(String expr, )
+	NeovimQt::MsgpackRequest* vim_eval(QByteArray expr);
+
+	/// DEPRECATED: Object vim_call_function(String fname, Array args, )
+	NeovimQt::MsgpackRequest* vim_call_function(QByteArray fname, QVariantList args);
+
+	/// DEPRECATED: Integer vim_strwidth(String str, )
+	NeovimQt::MsgpackRequest* vim_strwidth(QByteArray str);
+
+	/// DEPRECATED: ArrayOf(String) vim_list_runtime_paths()
+	NeovimQt::MsgpackRequest* vim_list_runtime_paths();
+
+	/// DEPRECATED: void vim_change_directory(String dir, )
+	NeovimQt::MsgpackRequest* vim_change_directory(QByteArray dir);
+
+	/// DEPRECATED: String vim_get_current_line()
+	NeovimQt::MsgpackRequest* vim_get_current_line();
+
+	/// DEPRECATED: void vim_set_current_line(String line, )
+	NeovimQt::MsgpackRequest* vim_set_current_line(QByteArray line);
+
+	/// DEPRECATED: void vim_del_current_line()
+	NeovimQt::MsgpackRequest* vim_del_current_line();
+
+	/// DEPRECATED: Object vim_get_var(String name, )
+	NeovimQt::MsgpackRequest* vim_get_var(QByteArray name);
+
+	/// DEPRECATED: Object vim_get_vvar(String name, )
+	NeovimQt::MsgpackRequest* vim_get_vvar(QByteArray name);
+
+	/// DEPRECATED: Object vim_get_option(String name, )
+	NeovimQt::MsgpackRequest* vim_get_option(QByteArray name);
+
+	/// DEPRECATED: void vim_set_option(String name, Object value, )
+	NeovimQt::MsgpackRequest* vim_set_option(QByteArray name, QVariant value);
+
+	/// DEPRECATED: void vim_out_write(String str, )
+	NeovimQt::MsgpackRequest* vim_out_write(QByteArray str);
+
+	/// DEPRECATED: void vim_err_write(String str, )
+	NeovimQt::MsgpackRequest* vim_err_write(QByteArray str);
+
+	/// DEPRECATED: void vim_report_error(String str, )
+	NeovimQt::MsgpackRequest* vim_report_error(QByteArray str);
+
+	/// DEPRECATED: ArrayOf(Buffer) vim_get_buffers()
+	NeovimQt::MsgpackRequest* vim_get_buffers();
+
+	/// DEPRECATED: Buffer vim_get_current_buffer()
+	NeovimQt::MsgpackRequest* vim_get_current_buffer();
+
+	/// DEPRECATED: void vim_set_current_buffer(Buffer buffer, )
+	NeovimQt::MsgpackRequest* vim_set_current_buffer(int64_t buffer);
+
+	/// DEPRECATED: ArrayOf(Window) vim_get_windows()
+	NeovimQt::MsgpackRequest* vim_get_windows();
+
+	/// DEPRECATED: Window vim_get_current_window()
+	NeovimQt::MsgpackRequest* vim_get_current_window();
+
+	/// DEPRECATED: void vim_set_current_window(Window window, )
+	NeovimQt::MsgpackRequest* vim_set_current_window(int64_t window);
+
+	/// DEPRECATED: ArrayOf(Tabpage) vim_get_tabpages()
+	NeovimQt::MsgpackRequest* vim_get_tabpages();
+
+	/// DEPRECATED: Tabpage vim_get_current_tabpage()
+	NeovimQt::MsgpackRequest* vim_get_current_tabpage();
+
+	/// DEPRECATED: void vim_set_current_tabpage(Tabpage tabpage, )
+	NeovimQt::MsgpackRequest* vim_set_current_tabpage(int64_t tabpage);
+
+	/// DEPRECATED: void vim_subscribe(String event, )
+	NeovimQt::MsgpackRequest* vim_subscribe(QByteArray event);
+
+	/// DEPRECATED: void vim_unsubscribe(String event, )
+	NeovimQt::MsgpackRequest* vim_unsubscribe(QByteArray event);
+
+	/// DEPRECATED: Integer vim_name_to_color(String name, )
+	NeovimQt::MsgpackRequest* vim_name_to_color(QByteArray name);
+
+	/// DEPRECATED: Dictionary vim_get_color_map()
+	NeovimQt::MsgpackRequest* vim_get_color_map();
+
+	/// DEPRECATED: Buffer window_get_buffer(Window window, )
+	NeovimQt::MsgpackRequest* window_get_buffer(int64_t window);
+
+	/// DEPRECATED: ArrayOf(Integer, 2) window_get_cursor(Window window, )
+	NeovimQt::MsgpackRequest* window_get_cursor(int64_t window);
+
+	/// DEPRECATED: void window_set_cursor(Window window, ArrayOf(Integer, 2) pos, )
+	NeovimQt::MsgpackRequest* window_set_cursor(int64_t window, QPoint pos);
+
+	/// DEPRECATED: Integer window_get_height(Window window, )
+	NeovimQt::MsgpackRequest* window_get_height(int64_t window);
+
+	/// DEPRECATED: void window_set_height(Window window, Integer height, )
+	NeovimQt::MsgpackRequest* window_set_height(int64_t window, int64_t height);
+
+	/// DEPRECATED: Integer window_get_width(Window window, )
+	NeovimQt::MsgpackRequest* window_get_width(int64_t window);
+
+	/// DEPRECATED: void window_set_width(Window window, Integer width, )
+	NeovimQt::MsgpackRequest* window_set_width(int64_t window, int64_t width);
+
+	/// DEPRECATED: Object window_get_var(Window window, String name, )
+	NeovimQt::MsgpackRequest* window_get_var(int64_t window, QByteArray name);
+
+	/// DEPRECATED: Object window_get_option(Window window, String name, )
+	NeovimQt::MsgpackRequest* window_get_option(int64_t window, QByteArray name);
+
+	/// DEPRECATED: void window_set_option(Window window, String name, Object value, )
+	NeovimQt::MsgpackRequest* window_set_option(int64_t window, QByteArray name, QVariant value);
+
+	/// DEPRECATED: ArrayOf(Integer, 2) window_get_position(Window window, )
+	NeovimQt::MsgpackRequest* window_get_position(int64_t window);
+
+	/// DEPRECATED: Tabpage window_get_tabpage(Window window, )
+	NeovimQt::MsgpackRequest* window_get_tabpage(int64_t window);
+
+	/// DEPRECATED: Boolean window_is_valid(Window window, )
+	NeovimQt::MsgpackRequest* window_is_valid(int64_t window);
+
 
 signals:
 	void on_nvim_buf_line_count(int64_t);
@@ -1072,5 +1159,5 @@ signals:
 	void err_window_is_valid(const QString&, const QVariant&);
 
 };
-} // namespace
-#endif
+
+} // namespace NeovimQt

--- a/src/auto/neovimapi2.cpp
+++ b/src/auto/neovimapi2.cpp
@@ -1,4 +1,4 @@
-// Auto generated 2020-09-09 13:30:54.064229 from nvim API level:2
+// Auto generated 2020-09-09 15:16:42.714119 from nvim API level:2
 #include "auto/neovimapi2.h"
 #include "msgpackiodevice.h"
 #include "msgpackrequest.h"
@@ -5061,7 +5061,7 @@ void NeovimApi2::handleResponse(uint32_t msgid, uint64_t fun, const QVariant& re
 				, false },
 		};
 
-	QList<Function> supported;
+	QVector<Function> supported;
 	supported.reserve(ftable.size());
 	for(const auto& val : ftable) {
 		auto f = Function::fromVariant(val);

--- a/src/auto/neovimapi2.cpp
+++ b/src/auto/neovimapi2.cpp
@@ -1,15 +1,15 @@
-// Auto generated 2017-10-31 14:35:34.305529 from nvim API level:2
+// Auto generated 2020-09-09 13:30:54.064229 from nvim API level:2
 #include "auto/neovimapi2.h"
-#include "neovimconnector.h"
-#include "msgpackrequest.h"
 #include "msgpackiodevice.h"
+#include "msgpackrequest.h"
+#include "neovimconnector.h"
 #include "util.h"
 
 namespace NeovimQt {
 /* Unpack Neovim EXT types Window, Buffer Tabpage which are all
  * uint64_t see Neovim:msgpack_rpc_to_
  */
-QVariant unpackBufferApi2(MsgpackIODevice *dev, const char* in, quint32 size)
+static QVariant unpackBufferApi2(MsgpackIODevice *dev, const char* in, uint32_t size) noexcept
 {
 	msgpack_unpacked result;
 	msgpack_unpacked_init(&result);
@@ -20,10 +20,10 @@ QVariant unpackBufferApi2(MsgpackIODevice *dev, const char* in, quint32 size)
 	if (ret == MSGPACK_UNPACK_SUCCESS) {
 		switch (result.data.type) {
 			case MSGPACK_OBJECT_NEGATIVE_INTEGER:
-				variant = (qint64)result.data.via.i64;
+				variant.setValue<int64_t>(result.data.via.i64);
 				break;
 			case MSGPACK_OBJECT_POSITIVE_INTEGER:
-				variant = (quint64)result.data.via.u64;
+				variant.setValue<uint64_t>(result.data.via.u64);
 				break;
 			default:
 				// TODO it would be nice if we could call back MsgpackIoDevice method or primitive types here
@@ -34,1564 +34,1733 @@ QVariant unpackBufferApi2(MsgpackIODevice *dev, const char* in, quint32 size)
 	msgpack_unpacked_destroy(&result);
 	return variant;
 }
-#define unpackWindowApi2 unpackBufferApi2
-#define unpackTabpageApi2 unpackBufferApi2
 
-NeovimApi2::NeovimApi2(NeovimConnector *c)
-:m_c(c)
+static QVariant unpackWindowApi2(MsgpackIODevice *dev, const char* in, uint32_t size) noexcept
+{
+	return unpackBufferApi2(dev, in, size);
+}
+
+static QVariant unpackTabpageApi2(MsgpackIODevice *dev, const char* in, uint32_t size) noexcept
+{
+	return unpackBufferApi2(dev, in, size);
+}
+
+NeovimApi2::NeovimApi2(NeovimConnector *c) noexcept
+	: m_connector{ c }
 {
 	// EXT types
-		m_c->m_dev->registerExtType(0, unpackBufferApi2);
-		m_c->m_dev->registerExtType(1, unpackWindowApi2);
-		m_c->m_dev->registerExtType(2, unpackTabpageApi2);
-		connect(m_c->m_dev, &MsgpackIODevice::notification,
-			this, &NeovimApi2::neovimNotification);
+	m_connector->m_dev->registerExtType(0, unpackBufferApi2);
+	m_connector->m_dev->registerExtType(1, unpackWindowApi2);
+	m_connector->m_dev->registerExtType(2, unpackTabpageApi2);
+	connect(m_connector->m_dev, &MsgpackIODevice::notification,
+		this, &NeovimApi2::neovimNotification);
 }
 
 // Slots
 MsgpackRequest* NeovimApi2::nvim_buf_line_count(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_line_count", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_line_count", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_BUF_LINE_COUNT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::buffer_get_line(int64_t buffer, int64_t index)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_line", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_get_line", 2) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_BUFFER_GET_LINE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(index);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(index);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::buffer_set_line(int64_t buffer, int64_t index, QByteArray line)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_set_line", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_set_line", 3) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_BUFFER_SET_LINE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(index);
-	m_c->m_dev->send(line);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(index);
+	m_connector->m_dev->send(line);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::buffer_del_line(int64_t buffer, int64_t index)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_del_line", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_del_line", 2) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_BUFFER_DEL_LINE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(index);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(index);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::buffer_get_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_line_slice", 5);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_get_line_slice", 5) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_BUFFER_GET_LINE_SLICE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(start);
-	m_c->m_dev->send(end);
-	m_c->m_dev->send(include_start);
-	m_c->m_dev->send(include_end);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(start);
+	m_connector->m_dev->send(end);
+	m_connector->m_dev->send(include_start);
+	m_connector->m_dev->send(include_end);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_buf_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_get_lines", 4);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_get_lines", 4) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_BUF_GET_LINES);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(start);
-	m_c->m_dev->send(end);
-	m_c->m_dev->send(strict_indexing);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(start);
+	m_connector->m_dev->send(end);
+	m_connector->m_dev->send(strict_indexing);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::buffer_set_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end, QList<QByteArray> replacement)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_set_line_slice", 6);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_set_line_slice", 6) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_BUFFER_SET_LINE_SLICE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(start);
-	m_c->m_dev->send(end);
-	m_c->m_dev->send(include_start);
-	m_c->m_dev->send(include_end);
-	m_c->m_dev->sendArrayOf(replacement);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(start);
+	m_connector->m_dev->send(end);
+	m_connector->m_dev->send(include_start);
+	m_connector->m_dev->send(include_end);
+	m_connector->m_dev->sendArrayOf(replacement);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_buf_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_set_lines", 5);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_set_lines", 5) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_BUF_SET_LINES);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(start);
-	m_c->m_dev->send(end);
-	m_c->m_dev->send(strict_indexing);
-	m_c->m_dev->sendArrayOf(replacement);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(start);
+	m_connector->m_dev->send(end);
+	m_connector->m_dev->send(strict_indexing);
+	m_connector->m_dev->sendArrayOf(replacement);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_buf_get_var(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_get_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_get_var", 2) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_BUF_GET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_buf_get_changedtick(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_get_changedtick", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_get_changedtick", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_BUF_GET_CHANGEDTICK);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_buf_set_var(int64_t buffer, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_set_var", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_set_var", 3) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_BUF_SET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_buf_del_var(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_del_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_del_var", 2) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_BUF_DEL_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::buffer_set_var(int64_t buffer, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_set_var", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_set_var", 3) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_BUFFER_SET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::buffer_del_var(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_del_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_del_var", 2) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_BUFFER_DEL_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_buf_get_option(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_get_option", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_get_option", 2) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_BUF_GET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_buf_set_option(int64_t buffer, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_set_option", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_set_option", 3) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_BUF_SET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_buf_get_number(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_get_number", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_get_number", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_BUF_GET_NUMBER);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_buf_get_name(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_get_name", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_get_name", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_BUF_GET_NAME);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_buf_set_name(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_set_name", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_set_name", 2) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_BUF_SET_NAME);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_buf_is_valid(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_is_valid", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_is_valid", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_BUF_IS_VALID);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::buffer_insert(int64_t buffer, int64_t lnum, QList<QByteArray> lines)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_insert", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_insert", 3) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_BUFFER_INSERT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(lnum);
-	m_c->m_dev->sendArrayOf(lines);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(lnum);
+	m_connector->m_dev->sendArrayOf(lines);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_buf_get_mark(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_get_mark", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_get_mark", 2) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_BUF_GET_MARK);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_buf_add_highlight(int64_t buffer, int64_t src_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_add_highlight", 6);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_add_highlight", 6) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_BUF_ADD_HIGHLIGHT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(src_id);
-	m_c->m_dev->send(hl_group);
-	m_c->m_dev->send(line);
-	m_c->m_dev->send(col_start);
-	m_c->m_dev->send(col_end);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(src_id);
+	m_connector->m_dev->send(hl_group);
+	m_connector->m_dev->send(line);
+	m_connector->m_dev->send(col_start);
+	m_connector->m_dev->send(col_end);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_buf_clear_highlight(int64_t buffer, int64_t src_id, int64_t line_start, int64_t line_end)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_clear_highlight", 4);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_clear_highlight", 4) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_BUF_CLEAR_HIGHLIGHT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(src_id);
-	m_c->m_dev->send(line_start);
-	m_c->m_dev->send(line_end);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(src_id);
+	m_connector->m_dev->send(line_start);
+	m_connector->m_dev->send(line_end);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_tabpage_list_wins(int64_t tabpage)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_tabpage_list_wins", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_tabpage_list_wins", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_TABPAGE_LIST_WINS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(tabpage);
+	m_connector->m_dev->send(tabpage);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_tabpage_get_var(int64_t tabpage, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_tabpage_get_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_tabpage_get_var", 2) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_TABPAGE_GET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(tabpage);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(tabpage);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_tabpage_set_var", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_tabpage_set_var", 3) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_TABPAGE_SET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(tabpage);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(tabpage);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_tabpage_del_var(int64_t tabpage, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_tabpage_del_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_tabpage_del_var", 2) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_TABPAGE_DEL_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(tabpage);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(tabpage);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("tabpage_set_var", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("tabpage_set_var", 3) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_TABPAGE_SET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(tabpage);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(tabpage);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::tabpage_del_var(int64_t tabpage, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("tabpage_del_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("tabpage_del_var", 2) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_TABPAGE_DEL_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(tabpage);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(tabpage);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_tabpage_get_win(int64_t tabpage)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_tabpage_get_win", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_tabpage_get_win", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_TABPAGE_GET_WIN);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(tabpage);
+	m_connector->m_dev->send(tabpage);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_tabpage_get_number(int64_t tabpage)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_tabpage_get_number", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_tabpage_get_number", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_TABPAGE_GET_NUMBER);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(tabpage);
+	m_connector->m_dev->send(tabpage);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_tabpage_is_valid(int64_t tabpage)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_tabpage_is_valid", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_tabpage_is_valid", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_TABPAGE_IS_VALID);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(tabpage);
+	m_connector->m_dev->send(tabpage);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_ui_attach(int64_t width, int64_t height, QVariantMap options)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_ui_attach", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_ui_attach", 3) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_UI_ATTACH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(width);
-	m_c->m_dev->send(height);
-	m_c->m_dev->send(options);
+	m_connector->m_dev->send(width);
+	m_connector->m_dev->send(height);
+	m_connector->m_dev->send(options);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::ui_attach(int64_t width, int64_t height, bool enable_rgb)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("ui_attach", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("ui_attach", 3) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_UI_ATTACH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(width);
-	m_c->m_dev->send(height);
-	m_c->m_dev->send(enable_rgb);
+	m_connector->m_dev->send(width);
+	m_connector->m_dev->send(height);
+	m_connector->m_dev->send(enable_rgb);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_ui_detach()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_ui_detach", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_ui_detach", 0) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_UI_DETACH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_ui_try_resize(int64_t width, int64_t height)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_ui_try_resize", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_ui_try_resize", 2) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_UI_TRY_RESIZE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(width);
-	m_c->m_dev->send(height);
+	m_connector->m_dev->send(width);
+	m_connector->m_dev->send(height);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_ui_set_option(QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_ui_set_option", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_ui_set_option", 2) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_UI_SET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_command(QByteArray command)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_command", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_command", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_COMMAND);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(command);
+	m_connector->m_dev->send(command);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_feedkeys", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_feedkeys", 3) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_FEEDKEYS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(keys);
-	m_c->m_dev->send(mode);
-	m_c->m_dev->send(escape_csi);
+	m_connector->m_dev->send(keys);
+	m_connector->m_dev->send(mode);
+	m_connector->m_dev->send(escape_csi);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_input(QByteArray keys)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_input", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_input", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_INPUT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(keys);
+	m_connector->m_dev->send(keys);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_replace_termcodes", 4);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_replace_termcodes", 4) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_REPLACE_TERMCODES);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(str);
-	m_c->m_dev->send(from_part);
-	m_c->m_dev->send(do_lt);
-	m_c->m_dev->send(special);
+	m_connector->m_dev->send(str);
+	m_connector->m_dev->send(from_part);
+	m_connector->m_dev->send(do_lt);
+	m_connector->m_dev->send(special);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_command_output(QByteArray str)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_command_output", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_command_output", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_COMMAND_OUTPUT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(str);
+	m_connector->m_dev->send(str);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_eval(QByteArray expr)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_eval", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_eval", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_EVAL);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(expr);
+	m_connector->m_dev->send(expr);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_call_function(QByteArray fname, QVariantList args)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_call_function", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_call_function", 2) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_CALL_FUNCTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(fname);
-	m_c->m_dev->send(args);
+	m_connector->m_dev->send(fname);
+	m_connector->m_dev->send(args);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_strwidth(QByteArray str)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_strwidth", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_strwidth", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_STRWIDTH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(str);
+	m_connector->m_dev->send(str);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_list_runtime_paths()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_list_runtime_paths", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_list_runtime_paths", 0) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_LIST_RUNTIME_PATHS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_set_current_dir(QByteArray dir)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_set_current_dir", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_set_current_dir", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_SET_CURRENT_DIR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(dir);
+	m_connector->m_dev->send(dir);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_get_current_line()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_current_line", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_current_line", 0) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_GET_CURRENT_LINE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_set_current_line(QByteArray line)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_set_current_line", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_set_current_line", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_SET_CURRENT_LINE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(line);
+	m_connector->m_dev->send(line);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_del_current_line()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_del_current_line", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_del_current_line", 0) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_DEL_CURRENT_LINE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_get_var(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_var", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_var", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_GET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_set_var(QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_set_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_set_var", 2) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_SET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_del_var(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_del_var", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_del_var", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_DEL_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::vim_set_var(QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_set_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_set_var", 2) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_VIM_SET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::vim_del_var(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_del_var", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_del_var", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_VIM_DEL_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_get_vvar(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_vvar", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_vvar", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_GET_VVAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_get_option(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_option", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_option", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_GET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_set_option(QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_set_option", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_set_option", 2) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_SET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_out_write(QByteArray str)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_out_write", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_out_write", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_OUT_WRITE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(str);
+	m_connector->m_dev->send(str);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_err_write(QByteArray str)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_err_write", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_err_write", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_ERR_WRITE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(str);
+	m_connector->m_dev->send(str);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_err_writeln(QByteArray str)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_err_writeln", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_err_writeln", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_ERR_WRITELN);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(str);
+	m_connector->m_dev->send(str);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_list_bufs()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_list_bufs", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_list_bufs", 0) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_LIST_BUFS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_get_current_buf()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_current_buf", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_current_buf", 0) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_GET_CURRENT_BUF);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_set_current_buf(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_set_current_buf", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_set_current_buf", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_SET_CURRENT_BUF);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_list_wins()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_list_wins", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_list_wins", 0) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_LIST_WINS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_get_current_win()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_current_win", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_current_win", 0) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_GET_CURRENT_WIN);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_set_current_win(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_set_current_win", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_set_current_win", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_SET_CURRENT_WIN);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_list_tabpages()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_list_tabpages", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_list_tabpages", 0) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_LIST_TABPAGES);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_get_current_tabpage()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_current_tabpage", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_current_tabpage", 0) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_GET_CURRENT_TABPAGE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_set_current_tabpage(int64_t tabpage)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_set_current_tabpage", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_set_current_tabpage", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_SET_CURRENT_TABPAGE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(tabpage);
+	m_connector->m_dev->send(tabpage);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_subscribe(QByteArray event)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_subscribe", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_subscribe", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_SUBSCRIBE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(event);
+	m_connector->m_dev->send(event);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_unsubscribe(QByteArray event)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_unsubscribe", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_unsubscribe", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_UNSUBSCRIBE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(event);
+	m_connector->m_dev->send(event);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_get_color_by_name(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_color_by_name", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_color_by_name", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_GET_COLOR_BY_NAME);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_get_color_map()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_color_map", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_color_map", 0) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_GET_COLOR_MAP);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_get_mode()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_mode", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_mode", 0) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_GET_MODE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_get_api_info()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_api_info", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_api_info", 0) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_GET_API_INFO);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_call_atomic(QVariantList calls)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_call_atomic", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_call_atomic", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_CALL_ATOMIC);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(calls);
+	m_connector->m_dev->send(calls);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_win_get_buf(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_buf", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_get_buf", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_WIN_GET_BUF);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_win_get_cursor(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_cursor", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_get_cursor", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_WIN_GET_CURSOR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_win_set_cursor(int64_t window, QPoint pos)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_set_cursor", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_set_cursor", 2) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_WIN_SET_CURSOR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(pos);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(pos);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_win_get_height(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_height", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_get_height", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_WIN_GET_HEIGHT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_win_set_height(int64_t window, int64_t height)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_set_height", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_set_height", 2) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_WIN_SET_HEIGHT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(height);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(height);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_win_get_width(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_width", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_get_width", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_WIN_GET_WIDTH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_win_set_width(int64_t window, int64_t width)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_set_width", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_set_width", 2) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_WIN_SET_WIDTH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(width);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(width);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_win_get_var(int64_t window, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_get_var", 2) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_WIN_GET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_win_set_var(int64_t window, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_set_var", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_set_var", 3) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_WIN_SET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_win_del_var(int64_t window, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_del_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_del_var", 2) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_WIN_DEL_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::window_set_var(int64_t window, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_set_var", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_set_var", 3) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_WINDOW_SET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::window_del_var(int64_t window, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_del_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_del_var", 2) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_WINDOW_DEL_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_win_get_option(int64_t window, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_option", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_get_option", 2) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_WIN_GET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_win_set_option(int64_t window, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_set_option", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_set_option", 3) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_WIN_SET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_win_get_position(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_position", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_get_position", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_WIN_GET_POSITION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_win_get_tabpage(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_tabpage", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_get_tabpage", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_WIN_GET_TABPAGE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_win_get_number(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_number", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_get_number", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_WIN_GET_NUMBER);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::nvim_win_is_valid(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_is_valid", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_is_valid", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_NVIM_WIN_IS_VALID);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::buffer_line_count(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_line_count", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_line_count", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_BUFFER_LINE_COUNT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::buffer_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_lines", 4);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_get_lines", 4) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_BUFFER_GET_LINES);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(start);
-	m_c->m_dev->send(end);
-	m_c->m_dev->send(strict_indexing);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(start);
+	m_connector->m_dev->send(end);
+	m_connector->m_dev->send(strict_indexing);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::buffer_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_set_lines", 5);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_set_lines", 5) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_BUFFER_SET_LINES);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(start);
-	m_c->m_dev->send(end);
-	m_c->m_dev->send(strict_indexing);
-	m_c->m_dev->sendArrayOf(replacement);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(start);
+	m_connector->m_dev->send(end);
+	m_connector->m_dev->send(strict_indexing);
+	m_connector->m_dev->sendArrayOf(replacement);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::buffer_get_var(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_get_var", 2) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_BUFFER_GET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::buffer_get_option(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_option", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_get_option", 2) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_BUFFER_GET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::buffer_set_option(int64_t buffer, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_set_option", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_set_option", 3) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_BUFFER_SET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::buffer_get_number(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_number", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_get_number", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_BUFFER_GET_NUMBER);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::buffer_get_name(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_name", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_get_name", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_BUFFER_GET_NAME);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::buffer_set_name(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_set_name", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_set_name", 2) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_BUFFER_SET_NAME);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::buffer_is_valid(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_is_valid", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_is_valid", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_BUFFER_IS_VALID);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::buffer_get_mark(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_mark", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_get_mark", 2) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_BUFFER_GET_MARK);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::buffer_add_highlight(int64_t buffer, int64_t src_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_add_highlight", 6);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_add_highlight", 6) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_BUFFER_ADD_HIGHLIGHT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(src_id);
-	m_c->m_dev->send(hl_group);
-	m_c->m_dev->send(line);
-	m_c->m_dev->send(col_start);
-	m_c->m_dev->send(col_end);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(src_id);
+	m_connector->m_dev->send(hl_group);
+	m_connector->m_dev->send(line);
+	m_connector->m_dev->send(col_start);
+	m_connector->m_dev->send(col_end);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::buffer_clear_highlight(int64_t buffer, int64_t src_id, int64_t line_start, int64_t line_end)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_clear_highlight", 4);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_clear_highlight", 4) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_BUFFER_CLEAR_HIGHLIGHT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(src_id);
-	m_c->m_dev->send(line_start);
-	m_c->m_dev->send(line_end);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(src_id);
+	m_connector->m_dev->send(line_start);
+	m_connector->m_dev->send(line_end);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::tabpage_get_windows(int64_t tabpage)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("tabpage_get_windows", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("tabpage_get_windows", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_TABPAGE_GET_WINDOWS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(tabpage);
+	m_connector->m_dev->send(tabpage);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::tabpage_get_var(int64_t tabpage, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("tabpage_get_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("tabpage_get_var", 2) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_TABPAGE_GET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(tabpage);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(tabpage);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::tabpage_get_window(int64_t tabpage)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("tabpage_get_window", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("tabpage_get_window", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_TABPAGE_GET_WINDOW);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(tabpage);
+	m_connector->m_dev->send(tabpage);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::tabpage_is_valid(int64_t tabpage)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("tabpage_is_valid", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("tabpage_is_valid", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_TABPAGE_IS_VALID);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(tabpage);
+	m_connector->m_dev->send(tabpage);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::ui_detach()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("ui_detach", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("ui_detach", 0) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_UI_DETACH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::ui_try_resize(int64_t width, int64_t height)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("ui_try_resize", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("ui_try_resize", 2) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_UI_TRY_RESIZE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(width);
-	m_c->m_dev->send(height);
+	m_connector->m_dev->send(width);
+	m_connector->m_dev->send(height);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::vim_command(QByteArray command)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_command", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_command", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_VIM_COMMAND);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(command);
+	m_connector->m_dev->send(command);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::vim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_feedkeys", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_feedkeys", 3) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_VIM_FEEDKEYS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(keys);
-	m_c->m_dev->send(mode);
-	m_c->m_dev->send(escape_csi);
+	m_connector->m_dev->send(keys);
+	m_connector->m_dev->send(mode);
+	m_connector->m_dev->send(escape_csi);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::vim_input(QByteArray keys)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_input", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_input", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_VIM_INPUT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(keys);
+	m_connector->m_dev->send(keys);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::vim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_replace_termcodes", 4);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_replace_termcodes", 4) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_VIM_REPLACE_TERMCODES);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(str);
-	m_c->m_dev->send(from_part);
-	m_c->m_dev->send(do_lt);
-	m_c->m_dev->send(special);
+	m_connector->m_dev->send(str);
+	m_connector->m_dev->send(from_part);
+	m_connector->m_dev->send(do_lt);
+	m_connector->m_dev->send(special);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::vim_command_output(QByteArray str)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_command_output", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_command_output", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_VIM_COMMAND_OUTPUT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(str);
+	m_connector->m_dev->send(str);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::vim_eval(QByteArray expr)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_eval", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_eval", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_VIM_EVAL);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(expr);
+	m_connector->m_dev->send(expr);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::vim_call_function(QByteArray fname, QVariantList args)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_call_function", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_call_function", 2) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_VIM_CALL_FUNCTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(fname);
-	m_c->m_dev->send(args);
+	m_connector->m_dev->send(fname);
+	m_connector->m_dev->send(args);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::vim_strwidth(QByteArray str)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_strwidth", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_strwidth", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_VIM_STRWIDTH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(str);
+	m_connector->m_dev->send(str);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::vim_list_runtime_paths()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_list_runtime_paths", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_list_runtime_paths", 0) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_VIM_LIST_RUNTIME_PATHS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::vim_change_directory(QByteArray dir)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_change_directory", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_change_directory", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_VIM_CHANGE_DIRECTORY);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(dir);
+	m_connector->m_dev->send(dir);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::vim_get_current_line()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_current_line", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_current_line", 0) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_VIM_GET_CURRENT_LINE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::vim_set_current_line(QByteArray line)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_set_current_line", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_set_current_line", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_VIM_SET_CURRENT_LINE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(line);
+	m_connector->m_dev->send(line);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::vim_del_current_line()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_del_current_line", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_del_current_line", 0) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_VIM_DEL_CURRENT_LINE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::vim_get_var(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_var", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_var", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_VIM_GET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::vim_get_vvar(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_vvar", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_vvar", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_VIM_GET_VVAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::vim_get_option(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_option", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_option", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_VIM_GET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::vim_set_option(QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_set_option", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_set_option", 2) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_VIM_SET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::vim_out_write(QByteArray str)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_out_write", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_out_write", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_VIM_OUT_WRITE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(str);
+	m_connector->m_dev->send(str);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::vim_err_write(QByteArray str)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_err_write", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_err_write", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_VIM_ERR_WRITE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(str);
+	m_connector->m_dev->send(str);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::vim_report_error(QByteArray str)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_report_error", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_report_error", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_VIM_REPORT_ERROR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(str);
+	m_connector->m_dev->send(str);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::vim_get_buffers()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_buffers", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_buffers", 0) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_VIM_GET_BUFFERS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::vim_get_current_buffer()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_current_buffer", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_current_buffer", 0) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_VIM_GET_CURRENT_BUFFER);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::vim_set_current_buffer(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_set_current_buffer", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_set_current_buffer", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_VIM_SET_CURRENT_BUFFER);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::vim_get_windows()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_windows", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_windows", 0) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_VIM_GET_WINDOWS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::vim_get_current_window()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_current_window", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_current_window", 0) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_VIM_GET_CURRENT_WINDOW);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::vim_set_current_window(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_set_current_window", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_set_current_window", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_VIM_SET_CURRENT_WINDOW);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::vim_get_tabpages()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_tabpages", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_tabpages", 0) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_VIM_GET_TABPAGES);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::vim_get_current_tabpage()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_current_tabpage", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_current_tabpage", 0) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_VIM_GET_CURRENT_TABPAGE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::vim_set_current_tabpage(int64_t tabpage)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_set_current_tabpage", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_set_current_tabpage", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_VIM_SET_CURRENT_TABPAGE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(tabpage);
+	m_connector->m_dev->send(tabpage);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::vim_subscribe(QByteArray event)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_subscribe", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_subscribe", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_VIM_SUBSCRIBE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(event);
+	m_connector->m_dev->send(event);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::vim_unsubscribe(QByteArray event)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_unsubscribe", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_unsubscribe", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_VIM_UNSUBSCRIBE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(event);
+	m_connector->m_dev->send(event);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::vim_name_to_color(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_name_to_color", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_name_to_color", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_VIM_NAME_TO_COLOR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::vim_get_color_map()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_color_map", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_color_map", 0) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_VIM_GET_COLOR_MAP);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::window_get_buffer(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_buffer", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_get_buffer", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_WINDOW_GET_BUFFER);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::window_get_cursor(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_cursor", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_get_cursor", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_WINDOW_GET_CURSOR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::window_set_cursor(int64_t window, QPoint pos)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_set_cursor", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_set_cursor", 2) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_WINDOW_SET_CURSOR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(pos);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(pos);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::window_get_height(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_height", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_get_height", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_WINDOW_GET_HEIGHT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::window_set_height(int64_t window, int64_t height)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_set_height", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_set_height", 2) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_WINDOW_SET_HEIGHT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(height);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(height);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::window_get_width(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_width", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_get_width", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_WINDOW_GET_WIDTH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::window_set_width(int64_t window, int64_t width)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_set_width", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_set_width", 2) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_WINDOW_SET_WIDTH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(width);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(width);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::window_get_var(int64_t window, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_get_var", 2) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_WINDOW_GET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::window_get_option(int64_t window, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_option", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_get_option", 2) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_WINDOW_GET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::window_set_option(int64_t window, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_set_option", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_set_option", 3) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_WINDOW_SET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::window_get_position(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_position", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_get_position", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_WINDOW_GET_POSITION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::window_get_tabpage(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_tabpage", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_get_tabpage", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_WINDOW_GET_TABPAGE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi2::window_is_valid(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_is_valid", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_is_valid", 1) };
 	r->setFunction(NeovimApi2::NEOVIM_FN_WINDOW_IS_VALID);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi2::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi2::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
 
+
 // Handlers
 
-void NeovimApi2::handleResponseError(quint32 msgid, quint64 fun, const QVariant& res)
+void NeovimApi2::handleResponseError(uint32_t msgid, uint64_t fun, const QVariant& res)
 {
 
 	// TODO: support Neovim error types Exception/Validation/etc
@@ -1599,7 +1768,7 @@ void NeovimApi2::handleResponseError(quint32 msgid, quint64 fun, const QVariant&
 	const QVariantList asList = res.toList();
 	if (asList.size() >= 2) {
 		if (asList.at(1).canConvert<QByteArray>()) {
-			errMsg = m_c->m_dev->decode(asList.at(1).toByteArray());
+			errMsg = m_connector->m_dev->decode(asList.at(1).toByteArray());
 		} else {
 			errMsg = tr("Received unsupported Neovim error type");
 		}
@@ -2090,1573 +2259,1573 @@ void NeovimApi2::handleResponseError(quint32 msgid, quint64 fun, const QVariant&
 		emit err_window_is_valid(errMsg, res);
 		break;
 	default:
-		m_c->setError(NeovimConnector::RuntimeMsgpackError, QString("Received error for function that should not fail: %s").arg(fun));
+		m_connector->setError(NeovimConnector::RuntimeMsgpackError, QString("Received error for function that should not fail: %s").arg(fun));
 	}
 }
 
-void NeovimApi2::handleResponse(quint32 msgid, quint64 fun, const QVariant& res)
+void NeovimApi2::handleResponse(uint32_t msgid, uint64_t fun, const QVariant& res)
 {
 	switch(fun) {
-	case NeovimApi2::NEOVIM_FN_NVIM_BUF_LINE_COUNT:
+		case NeovimApi2::NEOVIM_FN_NVIM_BUF_LINE_COUNT:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_line_count");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_line_count");
 				return;
-			} else {
-				emit on_nvim_buf_line_count(data);
 			}
 
+			emit on_nvim_buf_line_count(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_BUFFER_GET_LINE:
+
+		case NeovimApi2::NEOVIM_FN_BUFFER_GET_LINE:
 		{
 			QByteArray data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_line");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_line");
 				return;
-			} else {
-				emit on_buffer_get_line(data);
 			}
 
+			emit on_buffer_get_line(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_BUFFER_SET_LINE:
+
+		case NeovimApi2::NEOVIM_FN_BUFFER_SET_LINE:
 		{
 			emit on_buffer_set_line();
-
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_BUFFER_DEL_LINE:
+
+		case NeovimApi2::NEOVIM_FN_BUFFER_DEL_LINE:
 		{
 			emit on_buffer_del_line();
-
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_BUFFER_GET_LINE_SLICE:
+
+		case NeovimApi2::NEOVIM_FN_BUFFER_GET_LINE_SLICE:
 		{
 			QList<QByteArray> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_line_slice");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_line_slice");
 				return;
-			} else {
-				emit on_buffer_get_line_slice(data);
 			}
 
+			emit on_buffer_get_line_slice(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_BUF_GET_LINES:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_BUF_GET_LINES:
 		{
 			QList<QByteArray> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_lines");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_lines");
 				return;
-			} else {
-				emit on_nvim_buf_get_lines(data);
 			}
 
+			emit on_nvim_buf_get_lines(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_BUFFER_SET_LINE_SLICE:
+
+		case NeovimApi2::NEOVIM_FN_BUFFER_SET_LINE_SLICE:
 		{
 			emit on_buffer_set_line_slice();
-
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_BUF_SET_LINES:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_BUF_SET_LINES:
 		{
 			emit on_nvim_buf_set_lines();
-
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_BUF_GET_VAR:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_BUF_GET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_var");
 				return;
-			} else {
-				emit on_nvim_buf_get_var(data);
 			}
 
+			emit on_nvim_buf_get_var(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_BUF_GET_CHANGEDTICK:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_BUF_GET_CHANGEDTICK:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_changedtick");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_changedtick");
 				return;
-			} else {
-				emit on_nvim_buf_get_changedtick(data);
 			}
 
+			emit on_nvim_buf_get_changedtick(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_BUF_SET_VAR:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_BUF_SET_VAR:
 		{
 			emit on_nvim_buf_set_var();
-
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_BUF_DEL_VAR:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_BUF_DEL_VAR:
 		{
 			emit on_nvim_buf_del_var();
-
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_BUFFER_SET_VAR:
+
+		case NeovimApi2::NEOVIM_FN_BUFFER_SET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_set_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_set_var");
 				return;
-			} else {
-				emit on_buffer_set_var(data);
 			}
 
+			emit on_buffer_set_var(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_BUFFER_DEL_VAR:
+
+		case NeovimApi2::NEOVIM_FN_BUFFER_DEL_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_del_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_del_var");
 				return;
-			} else {
-				emit on_buffer_del_var(data);
 			}
 
+			emit on_buffer_del_var(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_BUF_GET_OPTION:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_BUF_GET_OPTION:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_option");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_option");
 				return;
-			} else {
-				emit on_nvim_buf_get_option(data);
 			}
 
+			emit on_nvim_buf_get_option(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_BUF_SET_OPTION:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_BUF_SET_OPTION:
 		{
 			emit on_nvim_buf_set_option();
-
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_BUF_GET_NUMBER:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_BUF_GET_NUMBER:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_number");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_number");
 				return;
-			} else {
-				emit on_nvim_buf_get_number(data);
 			}
 
+			emit on_nvim_buf_get_number(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_BUF_GET_NAME:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_BUF_GET_NAME:
 		{
 			QByteArray data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_name");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_name");
 				return;
-			} else {
-				emit on_nvim_buf_get_name(data);
 			}
 
+			emit on_nvim_buf_get_name(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_BUF_SET_NAME:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_BUF_SET_NAME:
 		{
 			emit on_nvim_buf_set_name();
-
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_BUF_IS_VALID:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_BUF_IS_VALID:
 		{
 			bool data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_is_valid");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_is_valid");
 				return;
-			} else {
-				emit on_nvim_buf_is_valid(data);
 			}
 
+			emit on_nvim_buf_is_valid(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_BUFFER_INSERT:
+
+		case NeovimApi2::NEOVIM_FN_BUFFER_INSERT:
 		{
 			emit on_buffer_insert();
-
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_BUF_GET_MARK:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_BUF_GET_MARK:
 		{
 			QPoint data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_mark");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_mark");
 				return;
-			} else {
-				emit on_nvim_buf_get_mark(data);
 			}
 
+			emit on_nvim_buf_get_mark(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_BUF_ADD_HIGHLIGHT:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_BUF_ADD_HIGHLIGHT:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_add_highlight");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_add_highlight");
 				return;
-			} else {
-				emit on_nvim_buf_add_highlight(data);
 			}
 
+			emit on_nvim_buf_add_highlight(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_BUF_CLEAR_HIGHLIGHT:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_BUF_CLEAR_HIGHLIGHT:
 		{
 			emit on_nvim_buf_clear_highlight();
-
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_TABPAGE_LIST_WINS:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_TABPAGE_LIST_WINS:
 		{
 			QList<int64_t> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_list_wins");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_list_wins");
 				return;
-			} else {
-				emit on_nvim_tabpage_list_wins(data);
 			}
 
+			emit on_nvim_tabpage_list_wins(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_TABPAGE_GET_VAR:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_TABPAGE_GET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_get_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_get_var");
 				return;
-			} else {
-				emit on_nvim_tabpage_get_var(data);
 			}
 
+			emit on_nvim_tabpage_get_var(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_TABPAGE_SET_VAR:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_TABPAGE_SET_VAR:
 		{
 			emit on_nvim_tabpage_set_var();
-
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_TABPAGE_DEL_VAR:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_TABPAGE_DEL_VAR:
 		{
 			emit on_nvim_tabpage_del_var();
-
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_TABPAGE_SET_VAR:
+
+		case NeovimApi2::NEOVIM_FN_TABPAGE_SET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_set_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_set_var");
 				return;
-			} else {
-				emit on_tabpage_set_var(data);
 			}
 
+			emit on_tabpage_set_var(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_TABPAGE_DEL_VAR:
+
+		case NeovimApi2::NEOVIM_FN_TABPAGE_DEL_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_del_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_del_var");
 				return;
-			} else {
-				emit on_tabpage_del_var(data);
 			}
 
+			emit on_tabpage_del_var(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_TABPAGE_GET_WIN:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_TABPAGE_GET_WIN:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_get_win");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_get_win");
 				return;
-			} else {
-				emit on_nvim_tabpage_get_win(data);
 			}
 
+			emit on_nvim_tabpage_get_win(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_TABPAGE_GET_NUMBER:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_TABPAGE_GET_NUMBER:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_get_number");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_get_number");
 				return;
-			} else {
-				emit on_nvim_tabpage_get_number(data);
 			}
 
+			emit on_nvim_tabpage_get_number(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_TABPAGE_IS_VALID:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_TABPAGE_IS_VALID:
 		{
 			bool data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_is_valid");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_is_valid");
 				return;
-			} else {
-				emit on_nvim_tabpage_is_valid(data);
 			}
 
+			emit on_nvim_tabpage_is_valid(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_UI_ATTACH:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_UI_ATTACH:
 		{
 			emit on_nvim_ui_attach();
-
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_UI_ATTACH:
+
+		case NeovimApi2::NEOVIM_FN_UI_ATTACH:
 		{
 			emit on_ui_attach();
-
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_UI_DETACH:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_UI_DETACH:
 		{
 			emit on_nvim_ui_detach();
-
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_UI_TRY_RESIZE:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_UI_TRY_RESIZE:
 		{
 			emit on_nvim_ui_try_resize();
-
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_UI_SET_OPTION:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_UI_SET_OPTION:
 		{
 			emit on_nvim_ui_set_option();
-
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_COMMAND:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_COMMAND:
 		{
 			emit on_nvim_command();
-
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_FEEDKEYS:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_FEEDKEYS:
 		{
 			emit on_nvim_feedkeys();
-
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_INPUT:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_INPUT:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_input");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_input");
 				return;
-			} else {
-				emit on_nvim_input(data);
 			}
 
+			emit on_nvim_input(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_REPLACE_TERMCODES:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_REPLACE_TERMCODES:
 		{
 			QByteArray data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_replace_termcodes");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_replace_termcodes");
 				return;
-			} else {
-				emit on_nvim_replace_termcodes(data);
 			}
 
+			emit on_nvim_replace_termcodes(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_COMMAND_OUTPUT:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_COMMAND_OUTPUT:
 		{
 			QByteArray data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_command_output");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_command_output");
 				return;
-			} else {
-				emit on_nvim_command_output(data);
 			}
 
+			emit on_nvim_command_output(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_EVAL:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_EVAL:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_eval");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_eval");
 				return;
-			} else {
-				emit on_nvim_eval(data);
 			}
 
+			emit on_nvim_eval(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_CALL_FUNCTION:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_CALL_FUNCTION:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_call_function");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_call_function");
 				return;
-			} else {
-				emit on_nvim_call_function(data);
 			}
 
+			emit on_nvim_call_function(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_STRWIDTH:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_STRWIDTH:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_strwidth");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_strwidth");
 				return;
-			} else {
-				emit on_nvim_strwidth(data);
 			}
 
+			emit on_nvim_strwidth(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_LIST_RUNTIME_PATHS:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_LIST_RUNTIME_PATHS:
 		{
 			QList<QByteArray> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_runtime_paths");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_runtime_paths");
 				return;
-			} else {
-				emit on_nvim_list_runtime_paths(data);
 			}
 
+			emit on_nvim_list_runtime_paths(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_SET_CURRENT_DIR:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_SET_CURRENT_DIR:
 		{
 			emit on_nvim_set_current_dir();
-
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_GET_CURRENT_LINE:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_GET_CURRENT_LINE:
 		{
 			QByteArray data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_current_line");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_current_line");
 				return;
-			} else {
-				emit on_nvim_get_current_line(data);
 			}
 
+			emit on_nvim_get_current_line(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_SET_CURRENT_LINE:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_SET_CURRENT_LINE:
 		{
 			emit on_nvim_set_current_line();
-
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_DEL_CURRENT_LINE:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_DEL_CURRENT_LINE:
 		{
 			emit on_nvim_del_current_line();
-
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_GET_VAR:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_GET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_var");
 				return;
-			} else {
-				emit on_nvim_get_var(data);
 			}
 
+			emit on_nvim_get_var(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_SET_VAR:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_SET_VAR:
 		{
 			emit on_nvim_set_var();
-
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_DEL_VAR:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_DEL_VAR:
 		{
 			emit on_nvim_del_var();
-
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_VIM_SET_VAR:
+
+		case NeovimApi2::NEOVIM_FN_VIM_SET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_set_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_set_var");
 				return;
-			} else {
-				emit on_vim_set_var(data);
 			}
 
+			emit on_vim_set_var(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_VIM_DEL_VAR:
+
+		case NeovimApi2::NEOVIM_FN_VIM_DEL_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_del_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_del_var");
 				return;
-			} else {
-				emit on_vim_del_var(data);
 			}
 
+			emit on_vim_del_var(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_GET_VVAR:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_GET_VVAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_vvar");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_vvar");
 				return;
-			} else {
-				emit on_nvim_get_vvar(data);
 			}
 
+			emit on_nvim_get_vvar(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_GET_OPTION:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_GET_OPTION:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_option");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_option");
 				return;
-			} else {
-				emit on_nvim_get_option(data);
 			}
 
+			emit on_nvim_get_option(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_SET_OPTION:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_SET_OPTION:
 		{
 			emit on_nvim_set_option();
-
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_OUT_WRITE:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_OUT_WRITE:
 		{
 			emit on_nvim_out_write();
-
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_ERR_WRITE:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_ERR_WRITE:
 		{
 			emit on_nvim_err_write();
-
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_ERR_WRITELN:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_ERR_WRITELN:
 		{
 			emit on_nvim_err_writeln();
-
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_LIST_BUFS:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_LIST_BUFS:
 		{
 			QList<int64_t> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_bufs");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_bufs");
 				return;
-			} else {
-				emit on_nvim_list_bufs(data);
 			}
 
+			emit on_nvim_list_bufs(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_GET_CURRENT_BUF:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_GET_CURRENT_BUF:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_current_buf");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_current_buf");
 				return;
-			} else {
-				emit on_nvim_get_current_buf(data);
 			}
 
+			emit on_nvim_get_current_buf(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_SET_CURRENT_BUF:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_SET_CURRENT_BUF:
 		{
 			emit on_nvim_set_current_buf();
-
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_LIST_WINS:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_LIST_WINS:
 		{
 			QList<int64_t> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_wins");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_wins");
 				return;
-			} else {
-				emit on_nvim_list_wins(data);
 			}
 
+			emit on_nvim_list_wins(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_GET_CURRENT_WIN:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_GET_CURRENT_WIN:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_current_win");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_current_win");
 				return;
-			} else {
-				emit on_nvim_get_current_win(data);
 			}
 
+			emit on_nvim_get_current_win(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_SET_CURRENT_WIN:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_SET_CURRENT_WIN:
 		{
 			emit on_nvim_set_current_win();
-
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_LIST_TABPAGES:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_LIST_TABPAGES:
 		{
 			QList<int64_t> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_tabpages");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_tabpages");
 				return;
-			} else {
-				emit on_nvim_list_tabpages(data);
 			}
 
+			emit on_nvim_list_tabpages(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_GET_CURRENT_TABPAGE:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_GET_CURRENT_TABPAGE:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_current_tabpage");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_current_tabpage");
 				return;
-			} else {
-				emit on_nvim_get_current_tabpage(data);
 			}
 
+			emit on_nvim_get_current_tabpage(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_SET_CURRENT_TABPAGE:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_SET_CURRENT_TABPAGE:
 		{
 			emit on_nvim_set_current_tabpage();
-
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_SUBSCRIBE:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_SUBSCRIBE:
 		{
 			emit on_nvim_subscribe();
-
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_UNSUBSCRIBE:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_UNSUBSCRIBE:
 		{
 			emit on_nvim_unsubscribe();
-
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_GET_COLOR_BY_NAME:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_GET_COLOR_BY_NAME:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_color_by_name");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_color_by_name");
 				return;
-			} else {
-				emit on_nvim_get_color_by_name(data);
 			}
 
+			emit on_nvim_get_color_by_name(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_GET_COLOR_MAP:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_GET_COLOR_MAP:
 		{
 			QVariantMap data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_color_map");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_color_map");
 				return;
-			} else {
-				emit on_nvim_get_color_map(data);
 			}
 
+			emit on_nvim_get_color_map(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_GET_MODE:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_GET_MODE:
 		{
 			QVariantMap data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_mode");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_mode");
 				return;
-			} else {
-				emit on_nvim_get_mode(data);
 			}
 
+			emit on_nvim_get_mode(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_GET_API_INFO:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_GET_API_INFO:
 		{
 			QVariantList data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_api_info");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_api_info");
 				return;
-			} else {
-				emit on_nvim_get_api_info(data);
 			}
 
+			emit on_nvim_get_api_info(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_CALL_ATOMIC:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_CALL_ATOMIC:
 		{
 			QVariantList data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_call_atomic");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_call_atomic");
 				return;
-			} else {
-				emit on_nvim_call_atomic(data);
 			}
 
+			emit on_nvim_call_atomic(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_WIN_GET_BUF:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_WIN_GET_BUF:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_buf");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_buf");
 				return;
-			} else {
-				emit on_nvim_win_get_buf(data);
 			}
 
+			emit on_nvim_win_get_buf(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_WIN_GET_CURSOR:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_WIN_GET_CURSOR:
 		{
 			QPoint data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_cursor");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_cursor");
 				return;
-			} else {
-				emit on_nvim_win_get_cursor(data);
 			}
 
+			emit on_nvim_win_get_cursor(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_WIN_SET_CURSOR:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_WIN_SET_CURSOR:
 		{
 			emit on_nvim_win_set_cursor();
-
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_WIN_GET_HEIGHT:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_WIN_GET_HEIGHT:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_height");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_height");
 				return;
-			} else {
-				emit on_nvim_win_get_height(data);
 			}
 
+			emit on_nvim_win_get_height(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_WIN_SET_HEIGHT:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_WIN_SET_HEIGHT:
 		{
 			emit on_nvim_win_set_height();
-
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_WIN_GET_WIDTH:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_WIN_GET_WIDTH:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_width");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_width");
 				return;
-			} else {
-				emit on_nvim_win_get_width(data);
 			}
 
+			emit on_nvim_win_get_width(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_WIN_SET_WIDTH:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_WIN_SET_WIDTH:
 		{
 			emit on_nvim_win_set_width();
-
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_WIN_GET_VAR:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_WIN_GET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_var");
 				return;
-			} else {
-				emit on_nvim_win_get_var(data);
 			}
 
+			emit on_nvim_win_get_var(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_WIN_SET_VAR:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_WIN_SET_VAR:
 		{
 			emit on_nvim_win_set_var();
-
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_WIN_DEL_VAR:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_WIN_DEL_VAR:
 		{
 			emit on_nvim_win_del_var();
-
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_WINDOW_SET_VAR:
+
+		case NeovimApi2::NEOVIM_FN_WINDOW_SET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_set_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_set_var");
 				return;
-			} else {
-				emit on_window_set_var(data);
 			}
 
+			emit on_window_set_var(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_WINDOW_DEL_VAR:
+
+		case NeovimApi2::NEOVIM_FN_WINDOW_DEL_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_del_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_del_var");
 				return;
-			} else {
-				emit on_window_del_var(data);
 			}
 
+			emit on_window_del_var(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_WIN_GET_OPTION:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_WIN_GET_OPTION:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_option");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_option");
 				return;
-			} else {
-				emit on_nvim_win_get_option(data);
 			}
 
+			emit on_nvim_win_get_option(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_WIN_SET_OPTION:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_WIN_SET_OPTION:
 		{
 			emit on_nvim_win_set_option();
-
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_WIN_GET_POSITION:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_WIN_GET_POSITION:
 		{
 			QPoint data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_position");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_position");
 				return;
-			} else {
-				emit on_nvim_win_get_position(data);
 			}
 
+			emit on_nvim_win_get_position(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_WIN_GET_TABPAGE:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_WIN_GET_TABPAGE:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_tabpage");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_tabpage");
 				return;
-			} else {
-				emit on_nvim_win_get_tabpage(data);
 			}
 
+			emit on_nvim_win_get_tabpage(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_WIN_GET_NUMBER:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_WIN_GET_NUMBER:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_number");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_number");
 				return;
-			} else {
-				emit on_nvim_win_get_number(data);
 			}
 
+			emit on_nvim_win_get_number(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_NVIM_WIN_IS_VALID:
+
+		case NeovimApi2::NEOVIM_FN_NVIM_WIN_IS_VALID:
 		{
 			bool data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_is_valid");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_is_valid");
 				return;
-			} else {
-				emit on_nvim_win_is_valid(data);
 			}
 
+			emit on_nvim_win_is_valid(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_BUFFER_LINE_COUNT:
+
+		case NeovimApi2::NEOVIM_FN_BUFFER_LINE_COUNT:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_line_count");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_line_count");
 				return;
-			} else {
-				emit on_buffer_line_count(data);
 			}
 
+			emit on_buffer_line_count(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_BUFFER_GET_LINES:
+
+		case NeovimApi2::NEOVIM_FN_BUFFER_GET_LINES:
 		{
 			QList<QByteArray> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_lines");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_lines");
 				return;
-			} else {
-				emit on_buffer_get_lines(data);
 			}
 
+			emit on_buffer_get_lines(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_BUFFER_SET_LINES:
+
+		case NeovimApi2::NEOVIM_FN_BUFFER_SET_LINES:
 		{
 			emit on_buffer_set_lines();
-
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_BUFFER_GET_VAR:
+
+		case NeovimApi2::NEOVIM_FN_BUFFER_GET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_var");
 				return;
-			} else {
-				emit on_buffer_get_var(data);
 			}
 
+			emit on_buffer_get_var(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_BUFFER_GET_OPTION:
+
+		case NeovimApi2::NEOVIM_FN_BUFFER_GET_OPTION:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_option");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_option");
 				return;
-			} else {
-				emit on_buffer_get_option(data);
 			}
 
+			emit on_buffer_get_option(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_BUFFER_SET_OPTION:
+
+		case NeovimApi2::NEOVIM_FN_BUFFER_SET_OPTION:
 		{
 			emit on_buffer_set_option();
-
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_BUFFER_GET_NUMBER:
+
+		case NeovimApi2::NEOVIM_FN_BUFFER_GET_NUMBER:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_number");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_number");
 				return;
-			} else {
-				emit on_buffer_get_number(data);
 			}
 
+			emit on_buffer_get_number(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_BUFFER_GET_NAME:
+
+		case NeovimApi2::NEOVIM_FN_BUFFER_GET_NAME:
 		{
 			QByteArray data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_name");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_name");
 				return;
-			} else {
-				emit on_buffer_get_name(data);
 			}
 
+			emit on_buffer_get_name(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_BUFFER_SET_NAME:
+
+		case NeovimApi2::NEOVIM_FN_BUFFER_SET_NAME:
 		{
 			emit on_buffer_set_name();
-
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_BUFFER_IS_VALID:
+
+		case NeovimApi2::NEOVIM_FN_BUFFER_IS_VALID:
 		{
 			bool data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_is_valid");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_is_valid");
 				return;
-			} else {
-				emit on_buffer_is_valid(data);
 			}
 
+			emit on_buffer_is_valid(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_BUFFER_GET_MARK:
+
+		case NeovimApi2::NEOVIM_FN_BUFFER_GET_MARK:
 		{
 			QPoint data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_mark");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_mark");
 				return;
-			} else {
-				emit on_buffer_get_mark(data);
 			}
 
+			emit on_buffer_get_mark(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_BUFFER_ADD_HIGHLIGHT:
+
+		case NeovimApi2::NEOVIM_FN_BUFFER_ADD_HIGHLIGHT:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_add_highlight");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_add_highlight");
 				return;
-			} else {
-				emit on_buffer_add_highlight(data);
 			}
 
+			emit on_buffer_add_highlight(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_BUFFER_CLEAR_HIGHLIGHT:
+
+		case NeovimApi2::NEOVIM_FN_BUFFER_CLEAR_HIGHLIGHT:
 		{
 			emit on_buffer_clear_highlight();
-
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_TABPAGE_GET_WINDOWS:
+
+		case NeovimApi2::NEOVIM_FN_TABPAGE_GET_WINDOWS:
 		{
 			QList<int64_t> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_get_windows");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_get_windows");
 				return;
-			} else {
-				emit on_tabpage_get_windows(data);
 			}
 
+			emit on_tabpage_get_windows(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_TABPAGE_GET_VAR:
+
+		case NeovimApi2::NEOVIM_FN_TABPAGE_GET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_get_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_get_var");
 				return;
-			} else {
-				emit on_tabpage_get_var(data);
 			}
 
+			emit on_tabpage_get_var(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_TABPAGE_GET_WINDOW:
+
+		case NeovimApi2::NEOVIM_FN_TABPAGE_GET_WINDOW:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_get_window");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_get_window");
 				return;
-			} else {
-				emit on_tabpage_get_window(data);
 			}
 
+			emit on_tabpage_get_window(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_TABPAGE_IS_VALID:
+
+		case NeovimApi2::NEOVIM_FN_TABPAGE_IS_VALID:
 		{
 			bool data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_is_valid");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_is_valid");
 				return;
-			} else {
-				emit on_tabpage_is_valid(data);
 			}
 
+			emit on_tabpage_is_valid(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_UI_DETACH:
+
+		case NeovimApi2::NEOVIM_FN_UI_DETACH:
 		{
 			emit on_ui_detach();
-
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_UI_TRY_RESIZE:
+
+		case NeovimApi2::NEOVIM_FN_UI_TRY_RESIZE:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for ui_try_resize");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for ui_try_resize");
 				return;
-			} else {
-				emit on_ui_try_resize(data);
 			}
 
+			emit on_ui_try_resize(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_VIM_COMMAND:
+
+		case NeovimApi2::NEOVIM_FN_VIM_COMMAND:
 		{
 			emit on_vim_command();
-
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_VIM_FEEDKEYS:
+
+		case NeovimApi2::NEOVIM_FN_VIM_FEEDKEYS:
 		{
 			emit on_vim_feedkeys();
-
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_VIM_INPUT:
+
+		case NeovimApi2::NEOVIM_FN_VIM_INPUT:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_input");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_input");
 				return;
-			} else {
-				emit on_vim_input(data);
 			}
 
+			emit on_vim_input(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_VIM_REPLACE_TERMCODES:
+
+		case NeovimApi2::NEOVIM_FN_VIM_REPLACE_TERMCODES:
 		{
 			QByteArray data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_replace_termcodes");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_replace_termcodes");
 				return;
-			} else {
-				emit on_vim_replace_termcodes(data);
 			}
 
+			emit on_vim_replace_termcodes(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_VIM_COMMAND_OUTPUT:
+
+		case NeovimApi2::NEOVIM_FN_VIM_COMMAND_OUTPUT:
 		{
 			QByteArray data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_command_output");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_command_output");
 				return;
-			} else {
-				emit on_vim_command_output(data);
 			}
 
+			emit on_vim_command_output(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_VIM_EVAL:
+
+		case NeovimApi2::NEOVIM_FN_VIM_EVAL:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_eval");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_eval");
 				return;
-			} else {
-				emit on_vim_eval(data);
 			}
 
+			emit on_vim_eval(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_VIM_CALL_FUNCTION:
+
+		case NeovimApi2::NEOVIM_FN_VIM_CALL_FUNCTION:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_call_function");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_call_function");
 				return;
-			} else {
-				emit on_vim_call_function(data);
 			}
 
+			emit on_vim_call_function(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_VIM_STRWIDTH:
+
+		case NeovimApi2::NEOVIM_FN_VIM_STRWIDTH:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_strwidth");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_strwidth");
 				return;
-			} else {
-				emit on_vim_strwidth(data);
 			}
 
+			emit on_vim_strwidth(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_VIM_LIST_RUNTIME_PATHS:
+
+		case NeovimApi2::NEOVIM_FN_VIM_LIST_RUNTIME_PATHS:
 		{
 			QList<QByteArray> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_list_runtime_paths");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_list_runtime_paths");
 				return;
-			} else {
-				emit on_vim_list_runtime_paths(data);
 			}
 
+			emit on_vim_list_runtime_paths(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_VIM_CHANGE_DIRECTORY:
+
+		case NeovimApi2::NEOVIM_FN_VIM_CHANGE_DIRECTORY:
 		{
 			emit on_vim_change_directory();
-
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_VIM_GET_CURRENT_LINE:
+
+		case NeovimApi2::NEOVIM_FN_VIM_GET_CURRENT_LINE:
 		{
 			QByteArray data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_current_line");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_current_line");
 				return;
-			} else {
-				emit on_vim_get_current_line(data);
 			}
 
+			emit on_vim_get_current_line(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_VIM_SET_CURRENT_LINE:
+
+		case NeovimApi2::NEOVIM_FN_VIM_SET_CURRENT_LINE:
 		{
 			emit on_vim_set_current_line();
-
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_VIM_DEL_CURRENT_LINE:
+
+		case NeovimApi2::NEOVIM_FN_VIM_DEL_CURRENT_LINE:
 		{
 			emit on_vim_del_current_line();
-
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_VIM_GET_VAR:
+
+		case NeovimApi2::NEOVIM_FN_VIM_GET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_var");
 				return;
-			} else {
-				emit on_vim_get_var(data);
 			}
 
+			emit on_vim_get_var(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_VIM_GET_VVAR:
+
+		case NeovimApi2::NEOVIM_FN_VIM_GET_VVAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_vvar");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_vvar");
 				return;
-			} else {
-				emit on_vim_get_vvar(data);
 			}
 
+			emit on_vim_get_vvar(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_VIM_GET_OPTION:
+
+		case NeovimApi2::NEOVIM_FN_VIM_GET_OPTION:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_option");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_option");
 				return;
-			} else {
-				emit on_vim_get_option(data);
 			}
 
+			emit on_vim_get_option(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_VIM_SET_OPTION:
+
+		case NeovimApi2::NEOVIM_FN_VIM_SET_OPTION:
 		{
 			emit on_vim_set_option();
-
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_VIM_OUT_WRITE:
+
+		case NeovimApi2::NEOVIM_FN_VIM_OUT_WRITE:
 		{
 			emit on_vim_out_write();
-
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_VIM_ERR_WRITE:
+
+		case NeovimApi2::NEOVIM_FN_VIM_ERR_WRITE:
 		{
 			emit on_vim_err_write();
-
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_VIM_REPORT_ERROR:
+
+		case NeovimApi2::NEOVIM_FN_VIM_REPORT_ERROR:
 		{
 			emit on_vim_report_error();
-
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_VIM_GET_BUFFERS:
+
+		case NeovimApi2::NEOVIM_FN_VIM_GET_BUFFERS:
 		{
 			QList<int64_t> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_buffers");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_buffers");
 				return;
-			} else {
-				emit on_vim_get_buffers(data);
 			}
 
+			emit on_vim_get_buffers(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_VIM_GET_CURRENT_BUFFER:
+
+		case NeovimApi2::NEOVIM_FN_VIM_GET_CURRENT_BUFFER:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_current_buffer");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_current_buffer");
 				return;
-			} else {
-				emit on_vim_get_current_buffer(data);
 			}
 
+			emit on_vim_get_current_buffer(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_VIM_SET_CURRENT_BUFFER:
+
+		case NeovimApi2::NEOVIM_FN_VIM_SET_CURRENT_BUFFER:
 		{
 			emit on_vim_set_current_buffer();
-
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_VIM_GET_WINDOWS:
+
+		case NeovimApi2::NEOVIM_FN_VIM_GET_WINDOWS:
 		{
 			QList<int64_t> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_windows");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_windows");
 				return;
-			} else {
-				emit on_vim_get_windows(data);
 			}
 
+			emit on_vim_get_windows(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_VIM_GET_CURRENT_WINDOW:
+
+		case NeovimApi2::NEOVIM_FN_VIM_GET_CURRENT_WINDOW:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_current_window");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_current_window");
 				return;
-			} else {
-				emit on_vim_get_current_window(data);
 			}
 
+			emit on_vim_get_current_window(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_VIM_SET_CURRENT_WINDOW:
+
+		case NeovimApi2::NEOVIM_FN_VIM_SET_CURRENT_WINDOW:
 		{
 			emit on_vim_set_current_window();
-
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_VIM_GET_TABPAGES:
+
+		case NeovimApi2::NEOVIM_FN_VIM_GET_TABPAGES:
 		{
 			QList<int64_t> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_tabpages");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_tabpages");
 				return;
-			} else {
-				emit on_vim_get_tabpages(data);
 			}
 
+			emit on_vim_get_tabpages(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_VIM_GET_CURRENT_TABPAGE:
+
+		case NeovimApi2::NEOVIM_FN_VIM_GET_CURRENT_TABPAGE:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_current_tabpage");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_current_tabpage");
 				return;
-			} else {
-				emit on_vim_get_current_tabpage(data);
 			}
 
+			emit on_vim_get_current_tabpage(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_VIM_SET_CURRENT_TABPAGE:
+
+		case NeovimApi2::NEOVIM_FN_VIM_SET_CURRENT_TABPAGE:
 		{
 			emit on_vim_set_current_tabpage();
-
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_VIM_SUBSCRIBE:
+
+		case NeovimApi2::NEOVIM_FN_VIM_SUBSCRIBE:
 		{
 			emit on_vim_subscribe();
-
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_VIM_UNSUBSCRIBE:
+
+		case NeovimApi2::NEOVIM_FN_VIM_UNSUBSCRIBE:
 		{
 			emit on_vim_unsubscribe();
-
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_VIM_NAME_TO_COLOR:
+
+		case NeovimApi2::NEOVIM_FN_VIM_NAME_TO_COLOR:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_name_to_color");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_name_to_color");
 				return;
-			} else {
-				emit on_vim_name_to_color(data);
 			}
 
+			emit on_vim_name_to_color(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_VIM_GET_COLOR_MAP:
+
+		case NeovimApi2::NEOVIM_FN_VIM_GET_COLOR_MAP:
 		{
 			QVariantMap data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_color_map");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_color_map");
 				return;
-			} else {
-				emit on_vim_get_color_map(data);
 			}
 
+			emit on_vim_get_color_map(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_WINDOW_GET_BUFFER:
+
+		case NeovimApi2::NEOVIM_FN_WINDOW_GET_BUFFER:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_buffer");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_buffer");
 				return;
-			} else {
-				emit on_window_get_buffer(data);
 			}
 
+			emit on_window_get_buffer(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_WINDOW_GET_CURSOR:
+
+		case NeovimApi2::NEOVIM_FN_WINDOW_GET_CURSOR:
 		{
 			QPoint data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_cursor");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_cursor");
 				return;
-			} else {
-				emit on_window_get_cursor(data);
 			}
 
+			emit on_window_get_cursor(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_WINDOW_SET_CURSOR:
+
+		case NeovimApi2::NEOVIM_FN_WINDOW_SET_CURSOR:
 		{
 			emit on_window_set_cursor();
-
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_WINDOW_GET_HEIGHT:
+
+		case NeovimApi2::NEOVIM_FN_WINDOW_GET_HEIGHT:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_height");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_height");
 				return;
-			} else {
-				emit on_window_get_height(data);
 			}
 
+			emit on_window_get_height(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_WINDOW_SET_HEIGHT:
+
+		case NeovimApi2::NEOVIM_FN_WINDOW_SET_HEIGHT:
 		{
 			emit on_window_set_height();
-
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_WINDOW_GET_WIDTH:
+
+		case NeovimApi2::NEOVIM_FN_WINDOW_GET_WIDTH:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_width");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_width");
 				return;
-			} else {
-				emit on_window_get_width(data);
 			}
 
+			emit on_window_get_width(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_WINDOW_SET_WIDTH:
+
+		case NeovimApi2::NEOVIM_FN_WINDOW_SET_WIDTH:
 		{
 			emit on_window_set_width();
-
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_WINDOW_GET_VAR:
+
+		case NeovimApi2::NEOVIM_FN_WINDOW_GET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_var");
 				return;
-			} else {
-				emit on_window_get_var(data);
 			}
 
+			emit on_window_get_var(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_WINDOW_GET_OPTION:
+
+		case NeovimApi2::NEOVIM_FN_WINDOW_GET_OPTION:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_option");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_option");
 				return;
-			} else {
-				emit on_window_get_option(data);
 			}
 
+			emit on_window_get_option(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_WINDOW_SET_OPTION:
+
+		case NeovimApi2::NEOVIM_FN_WINDOW_SET_OPTION:
 		{
 			emit on_window_set_option();
-
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_WINDOW_GET_POSITION:
+
+		case NeovimApi2::NEOVIM_FN_WINDOW_GET_POSITION:
 		{
 			QPoint data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_position");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_position");
 				return;
-			} else {
-				emit on_window_get_position(data);
 			}
 
+			emit on_window_get_position(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_WINDOW_GET_TABPAGE:
+
+		case NeovimApi2::NEOVIM_FN_WINDOW_GET_TABPAGE:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_tabpage");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_tabpage");
 				return;
-			} else {
-				emit on_window_get_tabpage(data);
 			}
 
+			emit on_window_get_tabpage(data);
 		}
 		break;
-	case NeovimApi2::NEOVIM_FN_WINDOW_IS_VALID:
+
+		case NeovimApi2::NEOVIM_FN_WINDOW_IS_VALID:
 		{
 			bool data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_is_valid");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_is_valid");
 				return;
-			} else {
-				emit on_window_is_valid(data);
 			}
 
+			emit on_window_is_valid(data);
 		}
 		break;
+
 	default:
 		qWarning() << "Received unexpected response";
 	}
@@ -3670,750 +3839,1231 @@ void NeovimApi2::handleResponse(quint32 msgid, quint64 fun, const QVariant& res)
  *
  * Returns false if there is an API mismatch
  */
-bool NeovimApi2::checkFunctions(const QVariantList& ftable)
+/*static*/ bool NeovimApi2::checkFunctions(const QVariantList& ftable) noexcept
 {
-
-	QList<Function> required;
-	required
-		<< Function("Integer", "nvim_buf_line_count",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("String", "buffer_get_line",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						, false)
-		<< Function("void", "buffer_set_line",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("String")
-						, false)
-		<< Function("void", "buffer_del_line",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						, false)
-		<< Function("ArrayOf(String)", "buffer_get_line_slice",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Boolean")
-						<< QString("Boolean")
-						, false)
-		<< Function("ArrayOf(String)", "nvim_buf_get_lines",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Boolean")
-						, false)
-		<< Function("void", "buffer_set_line_slice",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Boolean")
-						<< QString("Boolean")
-						<< QString("ArrayOf(String)")
-						, false)
-		<< Function("void", "nvim_buf_set_lines",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Boolean")
-						<< QString("ArrayOf(String)")
-						, false)
-		<< Function("Object", "nvim_buf_get_var",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("Integer", "nvim_buf_get_changedtick",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("void", "nvim_buf_set_var",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("void", "nvim_buf_del_var",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("Object", "buffer_set_var",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("Object", "buffer_del_var",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("Object", "nvim_buf_get_option",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_buf_set_option",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("Integer", "nvim_buf_get_number",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("String", "nvim_buf_get_name",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("void", "nvim_buf_set_name",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("Boolean", "nvim_buf_is_valid",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("void", "buffer_insert",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("ArrayOf(String)")
-						, false)
-		<< Function("ArrayOf(Integer, 2)", "nvim_buf_get_mark",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("Integer", "nvim_buf_add_highlight",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("String")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Integer")
-						, false)
-		<< Function("void", "nvim_buf_clear_highlight",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Integer")
-						, false)
-		<< Function("ArrayOf(Window)", "nvim_tabpage_list_wins",
-			QList<QString>()
-						<< QString("Tabpage")
-						, false)
-		<< Function("Object", "nvim_tabpage_get_var",
-			QList<QString>()
-						<< QString("Tabpage")
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_tabpage_set_var",
-			QList<QString>()
-						<< QString("Tabpage")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("void", "nvim_tabpage_del_var",
-			QList<QString>()
-						<< QString("Tabpage")
-						<< QString("String")
-						, false)
-		<< Function("Object", "tabpage_set_var",
-			QList<QString>()
-						<< QString("Tabpage")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("Object", "tabpage_del_var",
-			QList<QString>()
-						<< QString("Tabpage")
-						<< QString("String")
-						, false)
-		<< Function("Window", "nvim_tabpage_get_win",
-			QList<QString>()
-						<< QString("Tabpage")
-						, false)
-		<< Function("Integer", "nvim_tabpage_get_number",
-			QList<QString>()
-						<< QString("Tabpage")
-						, false)
-		<< Function("Boolean", "nvim_tabpage_is_valid",
-			QList<QString>()
-						<< QString("Tabpage")
-						, false)
-		<< Function("void", "nvim_ui_attach",
-			QList<QString>()
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Dictionary")
-						, false)
-		<< Function("void", "ui_attach",
-			QList<QString>()
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Boolean")
-						, false)
-		<< Function("void", "nvim_ui_detach",
-			QList<QString>()
-						, false)
-		<< Function("void", "nvim_ui_try_resize",
-			QList<QString>()
-						<< QString("Integer")
-						<< QString("Integer")
-						, false)
-		<< Function("void", "nvim_ui_set_option",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("void", "nvim_command",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_feedkeys",
-			QList<QString>()
-						<< QString("String")
-						<< QString("String")
-						<< QString("Boolean")
-						, false)
-		<< Function("Integer", "nvim_input",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("String", "nvim_replace_termcodes",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Boolean")
-						<< QString("Boolean")
-						<< QString("Boolean")
-						, false)
-		<< Function("String", "nvim_command_output",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Object", "nvim_eval",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Object", "nvim_call_function",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Array")
-						, false)
-		<< Function("Integer", "nvim_strwidth",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("ArrayOf(String)", "nvim_list_runtime_paths",
-			QList<QString>()
-						, false)
-		<< Function("void", "nvim_set_current_dir",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("String", "nvim_get_current_line",
-			QList<QString>()
-						, false)
-		<< Function("void", "nvim_set_current_line",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_del_current_line",
-			QList<QString>()
-						, false)
-		<< Function("Object", "nvim_get_var",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_set_var",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("void", "nvim_del_var",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Object", "vim_set_var",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("Object", "vim_del_var",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Object", "nvim_get_vvar",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Object", "nvim_get_option",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_set_option",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("void", "nvim_out_write",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_err_write",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_err_writeln",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("ArrayOf(Buffer)", "nvim_list_bufs",
-			QList<QString>()
-						, false)
-		<< Function("Buffer", "nvim_get_current_buf",
-			QList<QString>()
-						, false)
-		<< Function("void", "nvim_set_current_buf",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("ArrayOf(Window)", "nvim_list_wins",
-			QList<QString>()
-						, false)
-		<< Function("Window", "nvim_get_current_win",
-			QList<QString>()
-						, false)
-		<< Function("void", "nvim_set_current_win",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("ArrayOf(Tabpage)", "nvim_list_tabpages",
-			QList<QString>()
-						, false)
-		<< Function("Tabpage", "nvim_get_current_tabpage",
-			QList<QString>()
-						, false)
-		<< Function("void", "nvim_set_current_tabpage",
-			QList<QString>()
-						<< QString("Tabpage")
-						, false)
-		<< Function("void", "nvim_subscribe",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_unsubscribe",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Integer", "nvim_get_color_by_name",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Dictionary", "nvim_get_color_map",
-			QList<QString>()
-						, false)
-		<< Function("Dictionary", "nvim_get_mode",
-			QList<QString>()
-						, false)
-		<< Function("Array", "nvim_get_api_info",
-			QList<QString>()
-						, false)
-		<< Function("Array", "nvim_call_atomic",
-			QList<QString>()
-						<< QString("Array")
-						, false)
-		<< Function("Buffer", "nvim_win_get_buf",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("ArrayOf(Integer, 2)", "nvim_win_get_cursor",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("void", "nvim_win_set_cursor",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("ArrayOf(Integer, 2)")
-						, false)
-		<< Function("Integer", "nvim_win_get_height",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("void", "nvim_win_set_height",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("Integer")
-						, false)
-		<< Function("Integer", "nvim_win_get_width",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("void", "nvim_win_set_width",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("Integer")
-						, false)
-		<< Function("Object", "nvim_win_get_var",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_win_set_var",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("void", "nvim_win_del_var",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						, false)
-		<< Function("Object", "window_set_var",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("Object", "window_del_var",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						, false)
-		<< Function("Object", "nvim_win_get_option",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_win_set_option",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("ArrayOf(Integer, 2)", "nvim_win_get_position",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("Tabpage", "nvim_win_get_tabpage",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("Integer", "nvim_win_get_number",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("Boolean", "nvim_win_is_valid",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("Integer", "buffer_line_count",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("ArrayOf(String)", "buffer_get_lines",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Boolean")
-						, false)
-		<< Function("void", "buffer_set_lines",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Boolean")
-						<< QString("ArrayOf(String)")
-						, false)
-		<< Function("Object", "buffer_get_var",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("Object", "buffer_get_option",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("void", "buffer_set_option",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("Integer", "buffer_get_number",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("String", "buffer_get_name",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("void", "buffer_set_name",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("Boolean", "buffer_is_valid",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("ArrayOf(Integer, 2)", "buffer_get_mark",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("Integer", "buffer_add_highlight",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("String")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Integer")
-						, false)
-		<< Function("void", "buffer_clear_highlight",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Integer")
-						, false)
-		<< Function("ArrayOf(Window)", "tabpage_get_windows",
-			QList<QString>()
-						<< QString("Tabpage")
-						, false)
-		<< Function("Object", "tabpage_get_var",
-			QList<QString>()
-						<< QString("Tabpage")
-						<< QString("String")
-						, false)
-		<< Function("Window", "tabpage_get_window",
-			QList<QString>()
-						<< QString("Tabpage")
-						, false)
-		<< Function("Boolean", "tabpage_is_valid",
-			QList<QString>()
-						<< QString("Tabpage")
-						, false)
-		<< Function("void", "ui_detach",
-			QList<QString>()
-						, false)
-		<< Function("Object", "ui_try_resize",
-			QList<QString>()
-						<< QString("Integer")
-						<< QString("Integer")
-						, false)
-		<< Function("void", "vim_command",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "vim_feedkeys",
-			QList<QString>()
-						<< QString("String")
-						<< QString("String")
-						<< QString("Boolean")
-						, false)
-		<< Function("Integer", "vim_input",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("String", "vim_replace_termcodes",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Boolean")
-						<< QString("Boolean")
-						<< QString("Boolean")
-						, false)
-		<< Function("String", "vim_command_output",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Object", "vim_eval",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Object", "vim_call_function",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Array")
-						, false)
-		<< Function("Integer", "vim_strwidth",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("ArrayOf(String)", "vim_list_runtime_paths",
-			QList<QString>()
-						, false)
-		<< Function("void", "vim_change_directory",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("String", "vim_get_current_line",
-			QList<QString>()
-						, false)
-		<< Function("void", "vim_set_current_line",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "vim_del_current_line",
-			QList<QString>()
-						, false)
-		<< Function("Object", "vim_get_var",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Object", "vim_get_vvar",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Object", "vim_get_option",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "vim_set_option",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("void", "vim_out_write",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "vim_err_write",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "vim_report_error",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("ArrayOf(Buffer)", "vim_get_buffers",
-			QList<QString>()
-						, false)
-		<< Function("Buffer", "vim_get_current_buffer",
-			QList<QString>()
-						, false)
-		<< Function("void", "vim_set_current_buffer",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("ArrayOf(Window)", "vim_get_windows",
-			QList<QString>()
-						, false)
-		<< Function("Window", "vim_get_current_window",
-			QList<QString>()
-						, false)
-		<< Function("void", "vim_set_current_window",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("ArrayOf(Tabpage)", "vim_get_tabpages",
-			QList<QString>()
-						, false)
-		<< Function("Tabpage", "vim_get_current_tabpage",
-			QList<QString>()
-						, false)
-		<< Function("void", "vim_set_current_tabpage",
-			QList<QString>()
-						<< QString("Tabpage")
-						, false)
-		<< Function("void", "vim_subscribe",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "vim_unsubscribe",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Integer", "vim_name_to_color",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Dictionary", "vim_get_color_map",
-			QList<QString>()
-						, false)
-		<< Function("Buffer", "window_get_buffer",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("ArrayOf(Integer, 2)", "window_get_cursor",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("void", "window_set_cursor",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("ArrayOf(Integer, 2)")
-						, false)
-		<< Function("Integer", "window_get_height",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("void", "window_set_height",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("Integer")
-						, false)
-		<< Function("Integer", "window_get_width",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("void", "window_set_width",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("Integer")
-						, false)
-		<< Function("Object", "window_get_var",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						, false)
-		<< Function("Object", "window_get_option",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						, false)
-		<< Function("void", "window_set_option",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("ArrayOf(Integer, 2)", "window_get_position",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("Tabpage", "window_get_tabpage",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("Boolean", "window_is_valid",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		;
-
+	static const QList<Function> required{
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_buf_line_count"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("String"),
+				QStringLiteral("buffer_get_line"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("buffer_set_line"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("buffer_del_line"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(String)"),
+				QStringLiteral("buffer_get_line_slice"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(String)"),
+				QStringLiteral("nvim_buf_get_lines"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("buffer_set_line_slice"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("ArrayOf(String)"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_buf_set_lines"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("ArrayOf(String)"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_buf_get_var"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_buf_get_changedtick"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_buf_set_var"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_buf_del_var"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("buffer_set_var"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("buffer_del_var"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_buf_get_option"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_buf_set_option"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_buf_get_number"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("String"),
+				QStringLiteral("nvim_buf_get_name"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_buf_set_name"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Boolean"),
+				QStringLiteral("nvim_buf_is_valid"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("buffer_insert"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("ArrayOf(String)"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Integer, 2)"),
+				QStringLiteral("nvim_buf_get_mark"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_buf_add_highlight"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("String"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_buf_clear_highlight"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Window)"),
+				QStringLiteral("nvim_tabpage_list_wins"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_tabpage_get_var"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_tabpage_set_var"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_tabpage_del_var"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("tabpage_set_var"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("tabpage_del_var"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Window"),
+				QStringLiteral("nvim_tabpage_get_win"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_tabpage_get_number"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Boolean"),
+				QStringLiteral("nvim_tabpage_is_valid"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_ui_attach"),
+				QStringList{
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Dictionary"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("ui_attach"),
+				QStringList{
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_ui_detach"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_ui_try_resize"),
+				QStringList{
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_ui_set_option"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_command"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_feedkeys"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("String"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_input"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("String"),
+				QStringLiteral("nvim_replace_termcodes"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("String"),
+				QStringLiteral("nvim_command_output"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_eval"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_call_function"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Array"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_strwidth"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(String)"),
+				QStringLiteral("nvim_list_runtime_paths"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_set_current_dir"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("String"),
+				QStringLiteral("nvim_get_current_line"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_set_current_line"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_del_current_line"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_get_var"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_set_var"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_del_var"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("vim_set_var"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("vim_del_var"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_get_vvar"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_get_option"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_set_option"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_out_write"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_err_write"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_err_writeln"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Buffer)"),
+				QStringLiteral("nvim_list_bufs"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Buffer"),
+				QStringLiteral("nvim_get_current_buf"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_set_current_buf"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Window)"),
+				QStringLiteral("nvim_list_wins"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Window"),
+				QStringLiteral("nvim_get_current_win"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_set_current_win"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Tabpage)"),
+				QStringLiteral("nvim_list_tabpages"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Tabpage"),
+				QStringLiteral("nvim_get_current_tabpage"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_set_current_tabpage"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_subscribe"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_unsubscribe"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_get_color_by_name"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Dictionary"),
+				QStringLiteral("nvim_get_color_map"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Dictionary"),
+				QStringLiteral("nvim_get_mode"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Array"),
+				QStringLiteral("nvim_get_api_info"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Array"),
+				QStringLiteral("nvim_call_atomic"),
+				QStringList{
+					QStringLiteral("Array"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Buffer"),
+				QStringLiteral("nvim_win_get_buf"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Integer, 2)"),
+				QStringLiteral("nvim_win_get_cursor"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_win_set_cursor"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("ArrayOf(Integer, 2)"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_win_get_height"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_win_set_height"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_win_get_width"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_win_set_width"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_win_get_var"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_win_set_var"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_win_del_var"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("window_set_var"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("window_del_var"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_win_get_option"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_win_set_option"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Integer, 2)"),
+				QStringLiteral("nvim_win_get_position"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Tabpage"),
+				QStringLiteral("nvim_win_get_tabpage"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_win_get_number"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Boolean"),
+				QStringLiteral("nvim_win_is_valid"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("buffer_line_count"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(String)"),
+				QStringLiteral("buffer_get_lines"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("buffer_set_lines"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("ArrayOf(String)"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("buffer_get_var"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("buffer_get_option"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("buffer_set_option"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("buffer_get_number"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("String"),
+				QStringLiteral("buffer_get_name"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("buffer_set_name"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Boolean"),
+				QStringLiteral("buffer_is_valid"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Integer, 2)"),
+				QStringLiteral("buffer_get_mark"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("buffer_add_highlight"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("String"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("buffer_clear_highlight"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Window)"),
+				QStringLiteral("tabpage_get_windows"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("tabpage_get_var"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Window"),
+				QStringLiteral("tabpage_get_window"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Boolean"),
+				QStringLiteral("tabpage_is_valid"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("ui_detach"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("ui_try_resize"),
+				QStringList{
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_command"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_feedkeys"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("String"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("vim_input"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("String"),
+				QStringLiteral("vim_replace_termcodes"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("String"),
+				QStringLiteral("vim_command_output"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("vim_eval"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("vim_call_function"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Array"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("vim_strwidth"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(String)"),
+				QStringLiteral("vim_list_runtime_paths"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_change_directory"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("String"),
+				QStringLiteral("vim_get_current_line"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_set_current_line"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_del_current_line"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("vim_get_var"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("vim_get_vvar"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("vim_get_option"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_set_option"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_out_write"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_err_write"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_report_error"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Buffer)"),
+				QStringLiteral("vim_get_buffers"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Buffer"),
+				QStringLiteral("vim_get_current_buffer"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_set_current_buffer"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Window)"),
+				QStringLiteral("vim_get_windows"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Window"),
+				QStringLiteral("vim_get_current_window"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_set_current_window"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Tabpage)"),
+				QStringLiteral("vim_get_tabpages"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Tabpage"),
+				QStringLiteral("vim_get_current_tabpage"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_set_current_tabpage"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_subscribe"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_unsubscribe"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("vim_name_to_color"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Dictionary"),
+				QStringLiteral("vim_get_color_map"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Buffer"),
+				QStringLiteral("window_get_buffer"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Integer, 2)"),
+				QStringLiteral("window_get_cursor"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("window_set_cursor"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("ArrayOf(Integer, 2)"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("window_get_height"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("window_set_height"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("window_get_width"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("window_set_width"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("window_get_var"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("window_get_option"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("window_set_option"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Integer, 2)"),
+				QStringLiteral("window_get_position"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Tabpage"),
+				QStringLiteral("window_get_tabpage"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Boolean"),
+				QStringLiteral("window_is_valid"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+		};
 
 	QList<Function> supported;
-	foreach(const QVariant& val, ftable) {
+	supported.reserve(ftable.size());
+	for(const auto& val : ftable) {
 		auto f = Function::fromVariant(val);
 		if (!f.isValid()) {
 			qDebug() << "Invalid function in metadata" << f;
@@ -4427,7 +5077,7 @@ bool NeovimApi2::checkFunctions(const QVariantList& ftable)
 	}
 
 	bool ok = true;
-	foreach(const Function& f, required) {
+	for(const auto& f : required) {
 		if (!supported.contains(f)) {
 			qDebug() << "- instance DOES NOT support API2:" << f;
 			ok = false;

--- a/src/auto/neovimapi2.h
+++ b/src/auto/neovimapi2.h
@@ -1,4 +1,4 @@
-// Auto generated 2020-09-09 13:30:54.082476 from nvim API level:2
+// Auto generated 2020-09-09 15:16:42.733351 from nvim API level:2
 #pragma once
 
 #include <QObject>

--- a/src/auto/neovimapi2.h
+++ b/src/auto/neovimapi2.h
@@ -1,604 +1,692 @@
-// Auto generated 2017-10-31 14:35:34.288640 from nvim API level:2
-#ifndef NEOVIM_QT_NEOVIMAPI2
-#define NEOVIM_QT_NEOVIMAPI2
-#include "msgpack.h"
+// Auto generated 2020-09-09 13:30:54.082476 from nvim API level:2
+#pragma once
+
 #include <QObject>
-#include <QVariant>
 #include <QPoint>
+#include <QVariant>
+
 #include "function.h"
+#include "msgpack.h"
 
 namespace NeovimQt {
+
 class NeovimConnector;
 class MsgpackRequest;
 
-class NeovimApi2: public QObject
+class NeovimApi2 : public QObject
 {
 	Q_OBJECT
-	Q_ENUMS(FunctionId)
 
 public:
-
 	enum FunctionId {
-		NEOVIM_FN_NULL=0,
-				NEOVIM_FN_NVIM_BUF_LINE_COUNT,
-				NEOVIM_FN_BUFFER_GET_LINE,
-				NEOVIM_FN_BUFFER_SET_LINE,
-				NEOVIM_FN_BUFFER_DEL_LINE,
-				NEOVIM_FN_BUFFER_GET_LINE_SLICE,
-				NEOVIM_FN_NVIM_BUF_GET_LINES,
-				NEOVIM_FN_BUFFER_SET_LINE_SLICE,
-				NEOVIM_FN_NVIM_BUF_SET_LINES,
-				NEOVIM_FN_NVIM_BUF_GET_VAR,
-				NEOVIM_FN_NVIM_BUF_GET_CHANGEDTICK,
-				NEOVIM_FN_NVIM_BUF_SET_VAR,
-				NEOVIM_FN_NVIM_BUF_DEL_VAR,
-				NEOVIM_FN_BUFFER_SET_VAR,
-				NEOVIM_FN_BUFFER_DEL_VAR,
-				NEOVIM_FN_NVIM_BUF_GET_OPTION,
-				NEOVIM_FN_NVIM_BUF_SET_OPTION,
-				NEOVIM_FN_NVIM_BUF_GET_NUMBER,
-				NEOVIM_FN_NVIM_BUF_GET_NAME,
-				NEOVIM_FN_NVIM_BUF_SET_NAME,
-				NEOVIM_FN_NVIM_BUF_IS_VALID,
-				NEOVIM_FN_BUFFER_INSERT,
-				NEOVIM_FN_NVIM_BUF_GET_MARK,
-				NEOVIM_FN_NVIM_BUF_ADD_HIGHLIGHT,
-				NEOVIM_FN_NVIM_BUF_CLEAR_HIGHLIGHT,
-				NEOVIM_FN_NVIM_TABPAGE_LIST_WINS,
-				NEOVIM_FN_NVIM_TABPAGE_GET_VAR,
-				NEOVIM_FN_NVIM_TABPAGE_SET_VAR,
-				NEOVIM_FN_NVIM_TABPAGE_DEL_VAR,
-				NEOVIM_FN_TABPAGE_SET_VAR,
-				NEOVIM_FN_TABPAGE_DEL_VAR,
-				NEOVIM_FN_NVIM_TABPAGE_GET_WIN,
-				NEOVIM_FN_NVIM_TABPAGE_GET_NUMBER,
-				NEOVIM_FN_NVIM_TABPAGE_IS_VALID,
-				NEOVIM_FN_NVIM_UI_ATTACH,
-				NEOVIM_FN_UI_ATTACH,
-				NEOVIM_FN_NVIM_UI_DETACH,
-				NEOVIM_FN_NVIM_UI_TRY_RESIZE,
-				NEOVIM_FN_NVIM_UI_SET_OPTION,
-				NEOVIM_FN_NVIM_COMMAND,
-				NEOVIM_FN_NVIM_FEEDKEYS,
-				NEOVIM_FN_NVIM_INPUT,
-				NEOVIM_FN_NVIM_REPLACE_TERMCODES,
-				NEOVIM_FN_NVIM_COMMAND_OUTPUT,
-				NEOVIM_FN_NVIM_EVAL,
-				NEOVIM_FN_NVIM_CALL_FUNCTION,
-				NEOVIM_FN_NVIM_STRWIDTH,
-				NEOVIM_FN_NVIM_LIST_RUNTIME_PATHS,
-				NEOVIM_FN_NVIM_SET_CURRENT_DIR,
-				NEOVIM_FN_NVIM_GET_CURRENT_LINE,
-				NEOVIM_FN_NVIM_SET_CURRENT_LINE,
-				NEOVIM_FN_NVIM_DEL_CURRENT_LINE,
-				NEOVIM_FN_NVIM_GET_VAR,
-				NEOVIM_FN_NVIM_SET_VAR,
-				NEOVIM_FN_NVIM_DEL_VAR,
-				NEOVIM_FN_VIM_SET_VAR,
-				NEOVIM_FN_VIM_DEL_VAR,
-				NEOVIM_FN_NVIM_GET_VVAR,
-				NEOVIM_FN_NVIM_GET_OPTION,
-				NEOVIM_FN_NVIM_SET_OPTION,
-				NEOVIM_FN_NVIM_OUT_WRITE,
-				NEOVIM_FN_NVIM_ERR_WRITE,
-				NEOVIM_FN_NVIM_ERR_WRITELN,
-				NEOVIM_FN_NVIM_LIST_BUFS,
-				NEOVIM_FN_NVIM_GET_CURRENT_BUF,
-				NEOVIM_FN_NVIM_SET_CURRENT_BUF,
-				NEOVIM_FN_NVIM_LIST_WINS,
-				NEOVIM_FN_NVIM_GET_CURRENT_WIN,
-				NEOVIM_FN_NVIM_SET_CURRENT_WIN,
-				NEOVIM_FN_NVIM_LIST_TABPAGES,
-				NEOVIM_FN_NVIM_GET_CURRENT_TABPAGE,
-				NEOVIM_FN_NVIM_SET_CURRENT_TABPAGE,
-				NEOVIM_FN_NVIM_SUBSCRIBE,
-				NEOVIM_FN_NVIM_UNSUBSCRIBE,
-				NEOVIM_FN_NVIM_GET_COLOR_BY_NAME,
-				NEOVIM_FN_NVIM_GET_COLOR_MAP,
-				NEOVIM_FN_NVIM_GET_MODE,
-				NEOVIM_FN_NVIM_GET_API_INFO,
-				NEOVIM_FN_NVIM_CALL_ATOMIC,
-				NEOVIM_FN_NVIM_WIN_GET_BUF,
-				NEOVIM_FN_NVIM_WIN_GET_CURSOR,
-				NEOVIM_FN_NVIM_WIN_SET_CURSOR,
-				NEOVIM_FN_NVIM_WIN_GET_HEIGHT,
-				NEOVIM_FN_NVIM_WIN_SET_HEIGHT,
-				NEOVIM_FN_NVIM_WIN_GET_WIDTH,
-				NEOVIM_FN_NVIM_WIN_SET_WIDTH,
-				NEOVIM_FN_NVIM_WIN_GET_VAR,
-				NEOVIM_FN_NVIM_WIN_SET_VAR,
-				NEOVIM_FN_NVIM_WIN_DEL_VAR,
-				NEOVIM_FN_WINDOW_SET_VAR,
-				NEOVIM_FN_WINDOW_DEL_VAR,
-				NEOVIM_FN_NVIM_WIN_GET_OPTION,
-				NEOVIM_FN_NVIM_WIN_SET_OPTION,
-				NEOVIM_FN_NVIM_WIN_GET_POSITION,
-				NEOVIM_FN_NVIM_WIN_GET_TABPAGE,
-				NEOVIM_FN_NVIM_WIN_GET_NUMBER,
-				NEOVIM_FN_NVIM_WIN_IS_VALID,
-				NEOVIM_FN_BUFFER_LINE_COUNT,
-				NEOVIM_FN_BUFFER_GET_LINES,
-				NEOVIM_FN_BUFFER_SET_LINES,
-				NEOVIM_FN_BUFFER_GET_VAR,
-				NEOVIM_FN_BUFFER_GET_OPTION,
-				NEOVIM_FN_BUFFER_SET_OPTION,
-				NEOVIM_FN_BUFFER_GET_NUMBER,
-				NEOVIM_FN_BUFFER_GET_NAME,
-				NEOVIM_FN_BUFFER_SET_NAME,
-				NEOVIM_FN_BUFFER_IS_VALID,
-				NEOVIM_FN_BUFFER_GET_MARK,
-				NEOVIM_FN_BUFFER_ADD_HIGHLIGHT,
-				NEOVIM_FN_BUFFER_CLEAR_HIGHLIGHT,
-				NEOVIM_FN_TABPAGE_GET_WINDOWS,
-				NEOVIM_FN_TABPAGE_GET_VAR,
-				NEOVIM_FN_TABPAGE_GET_WINDOW,
-				NEOVIM_FN_TABPAGE_IS_VALID,
-				NEOVIM_FN_UI_DETACH,
-				NEOVIM_FN_UI_TRY_RESIZE,
-				NEOVIM_FN_VIM_COMMAND,
-				NEOVIM_FN_VIM_FEEDKEYS,
-				NEOVIM_FN_VIM_INPUT,
-				NEOVIM_FN_VIM_REPLACE_TERMCODES,
-				NEOVIM_FN_VIM_COMMAND_OUTPUT,
-				NEOVIM_FN_VIM_EVAL,
-				NEOVIM_FN_VIM_CALL_FUNCTION,
-				NEOVIM_FN_VIM_STRWIDTH,
-				NEOVIM_FN_VIM_LIST_RUNTIME_PATHS,
-				NEOVIM_FN_VIM_CHANGE_DIRECTORY,
-				NEOVIM_FN_VIM_GET_CURRENT_LINE,
-				NEOVIM_FN_VIM_SET_CURRENT_LINE,
-				NEOVIM_FN_VIM_DEL_CURRENT_LINE,
-				NEOVIM_FN_VIM_GET_VAR,
-				NEOVIM_FN_VIM_GET_VVAR,
-				NEOVIM_FN_VIM_GET_OPTION,
-				NEOVIM_FN_VIM_SET_OPTION,
-				NEOVIM_FN_VIM_OUT_WRITE,
-				NEOVIM_FN_VIM_ERR_WRITE,
-				NEOVIM_FN_VIM_REPORT_ERROR,
-				NEOVIM_FN_VIM_GET_BUFFERS,
-				NEOVIM_FN_VIM_GET_CURRENT_BUFFER,
-				NEOVIM_FN_VIM_SET_CURRENT_BUFFER,
-				NEOVIM_FN_VIM_GET_WINDOWS,
-				NEOVIM_FN_VIM_GET_CURRENT_WINDOW,
-				NEOVIM_FN_VIM_SET_CURRENT_WINDOW,
-				NEOVIM_FN_VIM_GET_TABPAGES,
-				NEOVIM_FN_VIM_GET_CURRENT_TABPAGE,
-				NEOVIM_FN_VIM_SET_CURRENT_TABPAGE,
-				NEOVIM_FN_VIM_SUBSCRIBE,
-				NEOVIM_FN_VIM_UNSUBSCRIBE,
-				NEOVIM_FN_VIM_NAME_TO_COLOR,
-				NEOVIM_FN_VIM_GET_COLOR_MAP,
-				NEOVIM_FN_WINDOW_GET_BUFFER,
-				NEOVIM_FN_WINDOW_GET_CURSOR,
-				NEOVIM_FN_WINDOW_SET_CURSOR,
-				NEOVIM_FN_WINDOW_GET_HEIGHT,
-				NEOVIM_FN_WINDOW_SET_HEIGHT,
-				NEOVIM_FN_WINDOW_GET_WIDTH,
-				NEOVIM_FN_WINDOW_SET_WIDTH,
-				NEOVIM_FN_WINDOW_GET_VAR,
-				NEOVIM_FN_WINDOW_GET_OPTION,
-				NEOVIM_FN_WINDOW_SET_OPTION,
-				NEOVIM_FN_WINDOW_GET_POSITION,
-				NEOVIM_FN_WINDOW_GET_TABPAGE,
-				NEOVIM_FN_WINDOW_IS_VALID,
+		NEOVIM_FN_NULL,
+		NEOVIM_FN_NVIM_BUF_LINE_COUNT,
+		NEOVIM_FN_BUFFER_GET_LINE,
+		NEOVIM_FN_BUFFER_SET_LINE,
+		NEOVIM_FN_BUFFER_DEL_LINE,
+		NEOVIM_FN_BUFFER_GET_LINE_SLICE,
+		NEOVIM_FN_NVIM_BUF_GET_LINES,
+		NEOVIM_FN_BUFFER_SET_LINE_SLICE,
+		NEOVIM_FN_NVIM_BUF_SET_LINES,
+		NEOVIM_FN_NVIM_BUF_GET_VAR,
+		NEOVIM_FN_NVIM_BUF_GET_CHANGEDTICK,
+		NEOVIM_FN_NVIM_BUF_SET_VAR,
+		NEOVIM_FN_NVIM_BUF_DEL_VAR,
+		NEOVIM_FN_BUFFER_SET_VAR,
+		NEOVIM_FN_BUFFER_DEL_VAR,
+		NEOVIM_FN_NVIM_BUF_GET_OPTION,
+		NEOVIM_FN_NVIM_BUF_SET_OPTION,
+		NEOVIM_FN_NVIM_BUF_GET_NUMBER,
+		NEOVIM_FN_NVIM_BUF_GET_NAME,
+		NEOVIM_FN_NVIM_BUF_SET_NAME,
+		NEOVIM_FN_NVIM_BUF_IS_VALID,
+		NEOVIM_FN_BUFFER_INSERT,
+		NEOVIM_FN_NVIM_BUF_GET_MARK,
+		NEOVIM_FN_NVIM_BUF_ADD_HIGHLIGHT,
+		NEOVIM_FN_NVIM_BUF_CLEAR_HIGHLIGHT,
+		NEOVIM_FN_NVIM_TABPAGE_LIST_WINS,
+		NEOVIM_FN_NVIM_TABPAGE_GET_VAR,
+		NEOVIM_FN_NVIM_TABPAGE_SET_VAR,
+		NEOVIM_FN_NVIM_TABPAGE_DEL_VAR,
+		NEOVIM_FN_TABPAGE_SET_VAR,
+		NEOVIM_FN_TABPAGE_DEL_VAR,
+		NEOVIM_FN_NVIM_TABPAGE_GET_WIN,
+		NEOVIM_FN_NVIM_TABPAGE_GET_NUMBER,
+		NEOVIM_FN_NVIM_TABPAGE_IS_VALID,
+		NEOVIM_FN_NVIM_UI_ATTACH,
+		NEOVIM_FN_UI_ATTACH,
+		NEOVIM_FN_NVIM_UI_DETACH,
+		NEOVIM_FN_NVIM_UI_TRY_RESIZE,
+		NEOVIM_FN_NVIM_UI_SET_OPTION,
+		NEOVIM_FN_NVIM_COMMAND,
+		NEOVIM_FN_NVIM_FEEDKEYS,
+		NEOVIM_FN_NVIM_INPUT,
+		NEOVIM_FN_NVIM_REPLACE_TERMCODES,
+		NEOVIM_FN_NVIM_COMMAND_OUTPUT,
+		NEOVIM_FN_NVIM_EVAL,
+		NEOVIM_FN_NVIM_CALL_FUNCTION,
+		NEOVIM_FN_NVIM_STRWIDTH,
+		NEOVIM_FN_NVIM_LIST_RUNTIME_PATHS,
+		NEOVIM_FN_NVIM_SET_CURRENT_DIR,
+		NEOVIM_FN_NVIM_GET_CURRENT_LINE,
+		NEOVIM_FN_NVIM_SET_CURRENT_LINE,
+		NEOVIM_FN_NVIM_DEL_CURRENT_LINE,
+		NEOVIM_FN_NVIM_GET_VAR,
+		NEOVIM_FN_NVIM_SET_VAR,
+		NEOVIM_FN_NVIM_DEL_VAR,
+		NEOVIM_FN_VIM_SET_VAR,
+		NEOVIM_FN_VIM_DEL_VAR,
+		NEOVIM_FN_NVIM_GET_VVAR,
+		NEOVIM_FN_NVIM_GET_OPTION,
+		NEOVIM_FN_NVIM_SET_OPTION,
+		NEOVIM_FN_NVIM_OUT_WRITE,
+		NEOVIM_FN_NVIM_ERR_WRITE,
+		NEOVIM_FN_NVIM_ERR_WRITELN,
+		NEOVIM_FN_NVIM_LIST_BUFS,
+		NEOVIM_FN_NVIM_GET_CURRENT_BUF,
+		NEOVIM_FN_NVIM_SET_CURRENT_BUF,
+		NEOVIM_FN_NVIM_LIST_WINS,
+		NEOVIM_FN_NVIM_GET_CURRENT_WIN,
+		NEOVIM_FN_NVIM_SET_CURRENT_WIN,
+		NEOVIM_FN_NVIM_LIST_TABPAGES,
+		NEOVIM_FN_NVIM_GET_CURRENT_TABPAGE,
+		NEOVIM_FN_NVIM_SET_CURRENT_TABPAGE,
+		NEOVIM_FN_NVIM_SUBSCRIBE,
+		NEOVIM_FN_NVIM_UNSUBSCRIBE,
+		NEOVIM_FN_NVIM_GET_COLOR_BY_NAME,
+		NEOVIM_FN_NVIM_GET_COLOR_MAP,
+		NEOVIM_FN_NVIM_GET_MODE,
+		NEOVIM_FN_NVIM_GET_API_INFO,
+		NEOVIM_FN_NVIM_CALL_ATOMIC,
+		NEOVIM_FN_NVIM_WIN_GET_BUF,
+		NEOVIM_FN_NVIM_WIN_GET_CURSOR,
+		NEOVIM_FN_NVIM_WIN_SET_CURSOR,
+		NEOVIM_FN_NVIM_WIN_GET_HEIGHT,
+		NEOVIM_FN_NVIM_WIN_SET_HEIGHT,
+		NEOVIM_FN_NVIM_WIN_GET_WIDTH,
+		NEOVIM_FN_NVIM_WIN_SET_WIDTH,
+		NEOVIM_FN_NVIM_WIN_GET_VAR,
+		NEOVIM_FN_NVIM_WIN_SET_VAR,
+		NEOVIM_FN_NVIM_WIN_DEL_VAR,
+		NEOVIM_FN_WINDOW_SET_VAR,
+		NEOVIM_FN_WINDOW_DEL_VAR,
+		NEOVIM_FN_NVIM_WIN_GET_OPTION,
+		NEOVIM_FN_NVIM_WIN_SET_OPTION,
+		NEOVIM_FN_NVIM_WIN_GET_POSITION,
+		NEOVIM_FN_NVIM_WIN_GET_TABPAGE,
+		NEOVIM_FN_NVIM_WIN_GET_NUMBER,
+		NEOVIM_FN_NVIM_WIN_IS_VALID,
+		NEOVIM_FN_BUFFER_LINE_COUNT,
+		NEOVIM_FN_BUFFER_GET_LINES,
+		NEOVIM_FN_BUFFER_SET_LINES,
+		NEOVIM_FN_BUFFER_GET_VAR,
+		NEOVIM_FN_BUFFER_GET_OPTION,
+		NEOVIM_FN_BUFFER_SET_OPTION,
+		NEOVIM_FN_BUFFER_GET_NUMBER,
+		NEOVIM_FN_BUFFER_GET_NAME,
+		NEOVIM_FN_BUFFER_SET_NAME,
+		NEOVIM_FN_BUFFER_IS_VALID,
+		NEOVIM_FN_BUFFER_GET_MARK,
+		NEOVIM_FN_BUFFER_ADD_HIGHLIGHT,
+		NEOVIM_FN_BUFFER_CLEAR_HIGHLIGHT,
+		NEOVIM_FN_TABPAGE_GET_WINDOWS,
+		NEOVIM_FN_TABPAGE_GET_VAR,
+		NEOVIM_FN_TABPAGE_GET_WINDOW,
+		NEOVIM_FN_TABPAGE_IS_VALID,
+		NEOVIM_FN_UI_DETACH,
+		NEOVIM_FN_UI_TRY_RESIZE,
+		NEOVIM_FN_VIM_COMMAND,
+		NEOVIM_FN_VIM_FEEDKEYS,
+		NEOVIM_FN_VIM_INPUT,
+		NEOVIM_FN_VIM_REPLACE_TERMCODES,
+		NEOVIM_FN_VIM_COMMAND_OUTPUT,
+		NEOVIM_FN_VIM_EVAL,
+		NEOVIM_FN_VIM_CALL_FUNCTION,
+		NEOVIM_FN_VIM_STRWIDTH,
+		NEOVIM_FN_VIM_LIST_RUNTIME_PATHS,
+		NEOVIM_FN_VIM_CHANGE_DIRECTORY,
+		NEOVIM_FN_VIM_GET_CURRENT_LINE,
+		NEOVIM_FN_VIM_SET_CURRENT_LINE,
+		NEOVIM_FN_VIM_DEL_CURRENT_LINE,
+		NEOVIM_FN_VIM_GET_VAR,
+		NEOVIM_FN_VIM_GET_VVAR,
+		NEOVIM_FN_VIM_GET_OPTION,
+		NEOVIM_FN_VIM_SET_OPTION,
+		NEOVIM_FN_VIM_OUT_WRITE,
+		NEOVIM_FN_VIM_ERR_WRITE,
+		NEOVIM_FN_VIM_REPORT_ERROR,
+		NEOVIM_FN_VIM_GET_BUFFERS,
+		NEOVIM_FN_VIM_GET_CURRENT_BUFFER,
+		NEOVIM_FN_VIM_SET_CURRENT_BUFFER,
+		NEOVIM_FN_VIM_GET_WINDOWS,
+		NEOVIM_FN_VIM_GET_CURRENT_WINDOW,
+		NEOVIM_FN_VIM_SET_CURRENT_WINDOW,
+		NEOVIM_FN_VIM_GET_TABPAGES,
+		NEOVIM_FN_VIM_GET_CURRENT_TABPAGE,
+		NEOVIM_FN_VIM_SET_CURRENT_TABPAGE,
+		NEOVIM_FN_VIM_SUBSCRIBE,
+		NEOVIM_FN_VIM_UNSUBSCRIBE,
+		NEOVIM_FN_VIM_NAME_TO_COLOR,
+		NEOVIM_FN_VIM_GET_COLOR_MAP,
+		NEOVIM_FN_WINDOW_GET_BUFFER,
+		NEOVIM_FN_WINDOW_GET_CURSOR,
+		NEOVIM_FN_WINDOW_SET_CURSOR,
+		NEOVIM_FN_WINDOW_GET_HEIGHT,
+		NEOVIM_FN_WINDOW_SET_HEIGHT,
+		NEOVIM_FN_WINDOW_GET_WIDTH,
+		NEOVIM_FN_WINDOW_SET_WIDTH,
+		NEOVIM_FN_WINDOW_GET_VAR,
+		NEOVIM_FN_WINDOW_GET_OPTION,
+		NEOVIM_FN_WINDOW_SET_OPTION,
+		NEOVIM_FN_WINDOW_GET_POSITION,
+		NEOVIM_FN_WINDOW_GET_TABPAGE,
+		NEOVIM_FN_WINDOW_IS_VALID,
 			};
+	Q_ENUM(FunctionId)
 
-	static bool checkFunctions(const QVariantList& ftable);
-	static FunctionId functionId(const Function& f);
+	static bool checkFunctions(const QVariantList& ftable) noexcept;
 
-	NeovimApi2(NeovimConnector *);
+	static FunctionId functionId(const Function& f) noexcept;
+
+	NeovimApi2(NeovimConnector* c) noexcept;
+
 protected slots:
-	void handleResponse(quint32 id, quint64 fun, const QVariant&);
-	void handleResponseError(quint32 id, quint64 fun, const QVariant&);
+	void handleResponse(uint32_t id, uint64_t fun, const QVariant&);
+
+	void handleResponseError(uint32_t id, uint64_t fun, const QVariant&);
+
 signals:
 	void error(const QString& errmsg, const QVariant& errObj);
+
 	void neovimNotification(const QByteArray &name, const QVariantList& args);
+
 private:
-	NeovimConnector *m_c;
+	NeovimConnector* m_connector;
+
 public slots:
-	// Integer nvim_buf_line_count(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_line_count(int64_t buffer);
-	// DEPRECATED
-	// String buffer_get_line(Buffer buffer, Integer index, ) 
-	MsgpackRequest* buffer_get_line(int64_t buffer, int64_t index);
-	// DEPRECATED
-	// void buffer_set_line(Buffer buffer, Integer index, String line, ) 
-	MsgpackRequest* buffer_set_line(int64_t buffer, int64_t index, QByteArray line);
-	// DEPRECATED
-	// void buffer_del_line(Buffer buffer, Integer index, ) 
-	MsgpackRequest* buffer_del_line(int64_t buffer, int64_t index);
-	// DEPRECATED
-	// ArrayOf(String) buffer_get_line_slice(Buffer buffer, Integer start, Integer end, Boolean include_start, Boolean include_end, ) 
-	MsgpackRequest* buffer_get_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end);
-	// ArrayOf(String) nvim_buf_get_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ) 
-	MsgpackRequest* nvim_buf_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing);
-	// DEPRECATED
-	// void buffer_set_line_slice(Buffer buffer, Integer start, Integer end, Boolean include_start, Boolean include_end, ArrayOf(String) replacement, ) 
-	MsgpackRequest* buffer_set_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end, QList<QByteArray> replacement);
-	// void nvim_buf_set_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ArrayOf(String) replacement, ) 
-	MsgpackRequest* nvim_buf_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement);
-	// Object nvim_buf_get_var(Buffer buffer, String name, ) 
-	MsgpackRequest* nvim_buf_get_var(int64_t buffer, QByteArray name);
-	// Integer nvim_buf_get_changedtick(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_get_changedtick(int64_t buffer);
-	// void nvim_buf_set_var(Buffer buffer, String name, Object value, ) 
-	MsgpackRequest* nvim_buf_set_var(int64_t buffer, QByteArray name, QVariant value);
-	// void nvim_buf_del_var(Buffer buffer, String name, ) 
-	MsgpackRequest* nvim_buf_del_var(int64_t buffer, QByteArray name);
-	// DEPRECATED
-	// Object buffer_set_var(Buffer buffer, String name, Object value, ) 
-	MsgpackRequest* buffer_set_var(int64_t buffer, QByteArray name, QVariant value);
-	// DEPRECATED
-	// Object buffer_del_var(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_del_var(int64_t buffer, QByteArray name);
-	// Object nvim_buf_get_option(Buffer buffer, String name, ) 
-	MsgpackRequest* nvim_buf_get_option(int64_t buffer, QByteArray name);
-	// void nvim_buf_set_option(Buffer buffer, String name, Object value, ) 
-	MsgpackRequest* nvim_buf_set_option(int64_t buffer, QByteArray name, QVariant value);
-	// DEPRECATED
-	// Integer nvim_buf_get_number(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_get_number(int64_t buffer);
-	// String nvim_buf_get_name(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_get_name(int64_t buffer);
-	// void nvim_buf_set_name(Buffer buffer, String name, ) 
-	MsgpackRequest* nvim_buf_set_name(int64_t buffer, QByteArray name);
-	// Boolean nvim_buf_is_valid(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_is_valid(int64_t buffer);
-	// DEPRECATED
-	// void buffer_insert(Buffer buffer, Integer lnum, ArrayOf(String) lines, ) 
-	MsgpackRequest* buffer_insert(int64_t buffer, int64_t lnum, QList<QByteArray> lines);
-	// ArrayOf(Integer, 2) nvim_buf_get_mark(Buffer buffer, String name, ) 
-	MsgpackRequest* nvim_buf_get_mark(int64_t buffer, QByteArray name);
-	// Integer nvim_buf_add_highlight(Buffer buffer, Integer src_id, String hl_group, Integer line, Integer col_start, Integer col_end, ) 
-	MsgpackRequest* nvim_buf_add_highlight(int64_t buffer, int64_t src_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end);
-	// void nvim_buf_clear_highlight(Buffer buffer, Integer src_id, Integer line_start, Integer line_end, ) 
-	MsgpackRequest* nvim_buf_clear_highlight(int64_t buffer, int64_t src_id, int64_t line_start, int64_t line_end);
-	// ArrayOf(Window) nvim_tabpage_list_wins(Tabpage tabpage, ) 
-	MsgpackRequest* nvim_tabpage_list_wins(int64_t tabpage);
-	// Object nvim_tabpage_get_var(Tabpage tabpage, String name, ) 
-	MsgpackRequest* nvim_tabpage_get_var(int64_t tabpage, QByteArray name);
-	// void nvim_tabpage_set_var(Tabpage tabpage, String name, Object value, ) 
-	MsgpackRequest* nvim_tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value);
-	// void nvim_tabpage_del_var(Tabpage tabpage, String name, ) 
-	MsgpackRequest* nvim_tabpage_del_var(int64_t tabpage, QByteArray name);
-	// DEPRECATED
-	// Object tabpage_set_var(Tabpage tabpage, String name, Object value, ) 
-	MsgpackRequest* tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value);
-	// DEPRECATED
-	// Object tabpage_del_var(Tabpage tabpage, String name, ) 
-	MsgpackRequest* tabpage_del_var(int64_t tabpage, QByteArray name);
-	// Window nvim_tabpage_get_win(Tabpage tabpage, ) 
-	MsgpackRequest* nvim_tabpage_get_win(int64_t tabpage);
-	// Integer nvim_tabpage_get_number(Tabpage tabpage, ) 
-	MsgpackRequest* nvim_tabpage_get_number(int64_t tabpage);
-	// Boolean nvim_tabpage_is_valid(Tabpage tabpage, ) 
-	MsgpackRequest* nvim_tabpage_is_valid(int64_t tabpage);
-	// void nvim_ui_attach(Integer width, Integer height, Dictionary options, ) 
-	MsgpackRequest* nvim_ui_attach(int64_t width, int64_t height, QVariantMap options);
-	// DEPRECATED
-	// void ui_attach(Integer width, Integer height, Boolean enable_rgb, ) 
-	MsgpackRequest* ui_attach(int64_t width, int64_t height, bool enable_rgb);
-	// void nvim_ui_detach() 
-	MsgpackRequest* nvim_ui_detach();
-	// void nvim_ui_try_resize(Integer width, Integer height, ) 
-	MsgpackRequest* nvim_ui_try_resize(int64_t width, int64_t height);
-	// void nvim_ui_set_option(String name, Object value, ) 
-	MsgpackRequest* nvim_ui_set_option(QByteArray name, QVariant value);
-	// void nvim_command(String command, ) 
-	MsgpackRequest* nvim_command(QByteArray command);
-	// void nvim_feedkeys(String keys, String mode, Boolean escape_csi, ) 
-	MsgpackRequest* nvim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi);
-	// Integer nvim_input(String keys, ) 
-	MsgpackRequest* nvim_input(QByteArray keys);
-	// String nvim_replace_termcodes(String str, Boolean from_part, Boolean do_lt, Boolean special, ) 
-	MsgpackRequest* nvim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special);
-	// String nvim_command_output(String str, ) 
-	MsgpackRequest* nvim_command_output(QByteArray str);
-	// Object nvim_eval(String expr, ) 
-	MsgpackRequest* nvim_eval(QByteArray expr);
-	// Object nvim_call_function(String fname, Array args, ) 
-	MsgpackRequest* nvim_call_function(QByteArray fname, QVariantList args);
-	// Integer nvim_strwidth(String str, ) 
-	MsgpackRequest* nvim_strwidth(QByteArray str);
-	// ArrayOf(String) nvim_list_runtime_paths() 
-	MsgpackRequest* nvim_list_runtime_paths();
-	// void nvim_set_current_dir(String dir, ) 
-	MsgpackRequest* nvim_set_current_dir(QByteArray dir);
-	// String nvim_get_current_line() 
-	MsgpackRequest* nvim_get_current_line();
-	// void nvim_set_current_line(String line, ) 
-	MsgpackRequest* nvim_set_current_line(QByteArray line);
-	// void nvim_del_current_line() 
-	MsgpackRequest* nvim_del_current_line();
-	// Object nvim_get_var(String name, ) 
-	MsgpackRequest* nvim_get_var(QByteArray name);
-	// void nvim_set_var(String name, Object value, ) 
-	MsgpackRequest* nvim_set_var(QByteArray name, QVariant value);
-	// void nvim_del_var(String name, ) 
-	MsgpackRequest* nvim_del_var(QByteArray name);
-	// DEPRECATED
-	// Object vim_set_var(String name, Object value, ) 
-	MsgpackRequest* vim_set_var(QByteArray name, QVariant value);
-	// DEPRECATED
-	// Object vim_del_var(String name, ) 
-	MsgpackRequest* vim_del_var(QByteArray name);
-	// Object nvim_get_vvar(String name, ) 
-	MsgpackRequest* nvim_get_vvar(QByteArray name);
-	// Object nvim_get_option(String name, ) 
-	MsgpackRequest* nvim_get_option(QByteArray name);
-	// void nvim_set_option(String name, Object value, ) 
-	MsgpackRequest* nvim_set_option(QByteArray name, QVariant value);
-	// void nvim_out_write(String str, ) 
-	MsgpackRequest* nvim_out_write(QByteArray str);
-	// void nvim_err_write(String str, ) 
-	MsgpackRequest* nvim_err_write(QByteArray str);
-	// void nvim_err_writeln(String str, ) 
-	MsgpackRequest* nvim_err_writeln(QByteArray str);
-	// ArrayOf(Buffer) nvim_list_bufs() 
-	MsgpackRequest* nvim_list_bufs();
-	// Buffer nvim_get_current_buf() 
-	MsgpackRequest* nvim_get_current_buf();
-	// void nvim_set_current_buf(Buffer buffer, ) 
-	MsgpackRequest* nvim_set_current_buf(int64_t buffer);
-	// ArrayOf(Window) nvim_list_wins() 
-	MsgpackRequest* nvim_list_wins();
-	// Window nvim_get_current_win() 
-	MsgpackRequest* nvim_get_current_win();
-	// void nvim_set_current_win(Window window, ) 
-	MsgpackRequest* nvim_set_current_win(int64_t window);
-	// ArrayOf(Tabpage) nvim_list_tabpages() 
-	MsgpackRequest* nvim_list_tabpages();
-	// Tabpage nvim_get_current_tabpage() 
-	MsgpackRequest* nvim_get_current_tabpage();
-	// void nvim_set_current_tabpage(Tabpage tabpage, ) 
-	MsgpackRequest* nvim_set_current_tabpage(int64_t tabpage);
-	// void nvim_subscribe(String event, ) 
-	MsgpackRequest* nvim_subscribe(QByteArray event);
-	// void nvim_unsubscribe(String event, ) 
-	MsgpackRequest* nvim_unsubscribe(QByteArray event);
-	// Integer nvim_get_color_by_name(String name, ) 
-	MsgpackRequest* nvim_get_color_by_name(QByteArray name);
-	// Dictionary nvim_get_color_map() 
-	MsgpackRequest* nvim_get_color_map();
-	// Dictionary nvim_get_mode() 
-	MsgpackRequest* nvim_get_mode();
-	// Array nvim_get_api_info() 
-	MsgpackRequest* nvim_get_api_info();
-	// Array nvim_call_atomic(Array calls, ) 
-	MsgpackRequest* nvim_call_atomic(QVariantList calls);
-	// Buffer nvim_win_get_buf(Window window, ) 
-	MsgpackRequest* nvim_win_get_buf(int64_t window);
-	// ArrayOf(Integer, 2) nvim_win_get_cursor(Window window, ) 
-	MsgpackRequest* nvim_win_get_cursor(int64_t window);
-	// void nvim_win_set_cursor(Window window, ArrayOf(Integer, 2) pos, ) 
-	MsgpackRequest* nvim_win_set_cursor(int64_t window, QPoint pos);
-	// Integer nvim_win_get_height(Window window, ) 
-	MsgpackRequest* nvim_win_get_height(int64_t window);
-	// void nvim_win_set_height(Window window, Integer height, ) 
-	MsgpackRequest* nvim_win_set_height(int64_t window, int64_t height);
-	// Integer nvim_win_get_width(Window window, ) 
-	MsgpackRequest* nvim_win_get_width(int64_t window);
-	// void nvim_win_set_width(Window window, Integer width, ) 
-	MsgpackRequest* nvim_win_set_width(int64_t window, int64_t width);
-	// Object nvim_win_get_var(Window window, String name, ) 
-	MsgpackRequest* nvim_win_get_var(int64_t window, QByteArray name);
-	// void nvim_win_set_var(Window window, String name, Object value, ) 
-	MsgpackRequest* nvim_win_set_var(int64_t window, QByteArray name, QVariant value);
-	// void nvim_win_del_var(Window window, String name, ) 
-	MsgpackRequest* nvim_win_del_var(int64_t window, QByteArray name);
-	// DEPRECATED
-	// Object window_set_var(Window window, String name, Object value, ) 
-	MsgpackRequest* window_set_var(int64_t window, QByteArray name, QVariant value);
-	// DEPRECATED
-	// Object window_del_var(Window window, String name, ) 
-	MsgpackRequest* window_del_var(int64_t window, QByteArray name);
-	// Object nvim_win_get_option(Window window, String name, ) 
-	MsgpackRequest* nvim_win_get_option(int64_t window, QByteArray name);
-	// void nvim_win_set_option(Window window, String name, Object value, ) 
-	MsgpackRequest* nvim_win_set_option(int64_t window, QByteArray name, QVariant value);
-	// ArrayOf(Integer, 2) nvim_win_get_position(Window window, ) 
-	MsgpackRequest* nvim_win_get_position(int64_t window);
-	// Tabpage nvim_win_get_tabpage(Window window, ) 
-	MsgpackRequest* nvim_win_get_tabpage(int64_t window);
-	// Integer nvim_win_get_number(Window window, ) 
-	MsgpackRequest* nvim_win_get_number(int64_t window);
-	// Boolean nvim_win_is_valid(Window window, ) 
-	MsgpackRequest* nvim_win_is_valid(int64_t window);
-	// DEPRECATED
-	// Integer buffer_line_count(Buffer buffer, ) 
-	MsgpackRequest* buffer_line_count(int64_t buffer);
-	// DEPRECATED
-	// ArrayOf(String) buffer_get_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ) 
-	MsgpackRequest* buffer_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing);
-	// DEPRECATED
-	// void buffer_set_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ArrayOf(String) replacement, ) 
-	MsgpackRequest* buffer_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement);
-	// DEPRECATED
-	// Object buffer_get_var(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_get_var(int64_t buffer, QByteArray name);
-	// DEPRECATED
-	// Object buffer_get_option(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_get_option(int64_t buffer, QByteArray name);
-	// DEPRECATED
-	// void buffer_set_option(Buffer buffer, String name, Object value, ) 
-	MsgpackRequest* buffer_set_option(int64_t buffer, QByteArray name, QVariant value);
-	// DEPRECATED
-	// Integer buffer_get_number(Buffer buffer, ) 
-	MsgpackRequest* buffer_get_number(int64_t buffer);
-	// DEPRECATED
-	// String buffer_get_name(Buffer buffer, ) 
-	MsgpackRequest* buffer_get_name(int64_t buffer);
-	// DEPRECATED
-	// void buffer_set_name(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_set_name(int64_t buffer, QByteArray name);
-	// DEPRECATED
-	// Boolean buffer_is_valid(Buffer buffer, ) 
-	MsgpackRequest* buffer_is_valid(int64_t buffer);
-	// DEPRECATED
-	// ArrayOf(Integer, 2) buffer_get_mark(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_get_mark(int64_t buffer, QByteArray name);
-	// DEPRECATED
-	// Integer buffer_add_highlight(Buffer buffer, Integer src_id, String hl_group, Integer line, Integer col_start, Integer col_end, ) 
-	MsgpackRequest* buffer_add_highlight(int64_t buffer, int64_t src_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end);
-	// DEPRECATED
-	// void buffer_clear_highlight(Buffer buffer, Integer src_id, Integer line_start, Integer line_end, ) 
-	MsgpackRequest* buffer_clear_highlight(int64_t buffer, int64_t src_id, int64_t line_start, int64_t line_end);
-	// DEPRECATED
-	// ArrayOf(Window) tabpage_get_windows(Tabpage tabpage, ) 
-	MsgpackRequest* tabpage_get_windows(int64_t tabpage);
-	// DEPRECATED
-	// Object tabpage_get_var(Tabpage tabpage, String name, ) 
-	MsgpackRequest* tabpage_get_var(int64_t tabpage, QByteArray name);
-	// DEPRECATED
-	// Window tabpage_get_window(Tabpage tabpage, ) 
-	MsgpackRequest* tabpage_get_window(int64_t tabpage);
-	// DEPRECATED
-	// Boolean tabpage_is_valid(Tabpage tabpage, ) 
-	MsgpackRequest* tabpage_is_valid(int64_t tabpage);
-	// DEPRECATED
-	// void ui_detach() 
-	MsgpackRequest* ui_detach();
-	// DEPRECATED
-	// Object ui_try_resize(Integer width, Integer height, ) 
-	MsgpackRequest* ui_try_resize(int64_t width, int64_t height);
-	// DEPRECATED
-	// void vim_command(String command, ) 
-	MsgpackRequest* vim_command(QByteArray command);
-	// DEPRECATED
-	// void vim_feedkeys(String keys, String mode, Boolean escape_csi, ) 
-	MsgpackRequest* vim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi);
-	// DEPRECATED
-	// Integer vim_input(String keys, ) 
-	MsgpackRequest* vim_input(QByteArray keys);
-	// DEPRECATED
-	// String vim_replace_termcodes(String str, Boolean from_part, Boolean do_lt, Boolean special, ) 
-	MsgpackRequest* vim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special);
-	// DEPRECATED
-	// String vim_command_output(String str, ) 
-	MsgpackRequest* vim_command_output(QByteArray str);
-	// DEPRECATED
-	// Object vim_eval(String expr, ) 
-	MsgpackRequest* vim_eval(QByteArray expr);
-	// DEPRECATED
-	// Object vim_call_function(String fname, Array args, ) 
-	MsgpackRequest* vim_call_function(QByteArray fname, QVariantList args);
-	// DEPRECATED
-	// Integer vim_strwidth(String str, ) 
-	MsgpackRequest* vim_strwidth(QByteArray str);
-	// DEPRECATED
-	// ArrayOf(String) vim_list_runtime_paths() 
-	MsgpackRequest* vim_list_runtime_paths();
-	// DEPRECATED
-	// void vim_change_directory(String dir, ) 
-	MsgpackRequest* vim_change_directory(QByteArray dir);
-	// DEPRECATED
-	// String vim_get_current_line() 
-	MsgpackRequest* vim_get_current_line();
-	// DEPRECATED
-	// void vim_set_current_line(String line, ) 
-	MsgpackRequest* vim_set_current_line(QByteArray line);
-	// DEPRECATED
-	// void vim_del_current_line() 
-	MsgpackRequest* vim_del_current_line();
-	// DEPRECATED
-	// Object vim_get_var(String name, ) 
-	MsgpackRequest* vim_get_var(QByteArray name);
-	// DEPRECATED
-	// Object vim_get_vvar(String name, ) 
-	MsgpackRequest* vim_get_vvar(QByteArray name);
-	// DEPRECATED
-	// Object vim_get_option(String name, ) 
-	MsgpackRequest* vim_get_option(QByteArray name);
-	// DEPRECATED
-	// void vim_set_option(String name, Object value, ) 
-	MsgpackRequest* vim_set_option(QByteArray name, QVariant value);
-	// DEPRECATED
-	// void vim_out_write(String str, ) 
-	MsgpackRequest* vim_out_write(QByteArray str);
-	// DEPRECATED
-	// void vim_err_write(String str, ) 
-	MsgpackRequest* vim_err_write(QByteArray str);
-	// DEPRECATED
-	// void vim_report_error(String str, ) 
-	MsgpackRequest* vim_report_error(QByteArray str);
-	// DEPRECATED
-	// ArrayOf(Buffer) vim_get_buffers() 
-	MsgpackRequest* vim_get_buffers();
-	// DEPRECATED
-	// Buffer vim_get_current_buffer() 
-	MsgpackRequest* vim_get_current_buffer();
-	// DEPRECATED
-	// void vim_set_current_buffer(Buffer buffer, ) 
-	MsgpackRequest* vim_set_current_buffer(int64_t buffer);
-	// DEPRECATED
-	// ArrayOf(Window) vim_get_windows() 
-	MsgpackRequest* vim_get_windows();
-	// DEPRECATED
-	// Window vim_get_current_window() 
-	MsgpackRequest* vim_get_current_window();
-	// DEPRECATED
-	// void vim_set_current_window(Window window, ) 
-	MsgpackRequest* vim_set_current_window(int64_t window);
-	// DEPRECATED
-	// ArrayOf(Tabpage) vim_get_tabpages() 
-	MsgpackRequest* vim_get_tabpages();
-	// DEPRECATED
-	// Tabpage vim_get_current_tabpage() 
-	MsgpackRequest* vim_get_current_tabpage();
-	// DEPRECATED
-	// void vim_set_current_tabpage(Tabpage tabpage, ) 
-	MsgpackRequest* vim_set_current_tabpage(int64_t tabpage);
-	// DEPRECATED
-	// void vim_subscribe(String event, ) 
-	MsgpackRequest* vim_subscribe(QByteArray event);
-	// DEPRECATED
-	// void vim_unsubscribe(String event, ) 
-	MsgpackRequest* vim_unsubscribe(QByteArray event);
-	// DEPRECATED
-	// Integer vim_name_to_color(String name, ) 
-	MsgpackRequest* vim_name_to_color(QByteArray name);
-	// DEPRECATED
-	// Dictionary vim_get_color_map() 
-	MsgpackRequest* vim_get_color_map();
-	// DEPRECATED
-	// Buffer window_get_buffer(Window window, ) 
-	MsgpackRequest* window_get_buffer(int64_t window);
-	// DEPRECATED
-	// ArrayOf(Integer, 2) window_get_cursor(Window window, ) 
-	MsgpackRequest* window_get_cursor(int64_t window);
-	// DEPRECATED
-	// void window_set_cursor(Window window, ArrayOf(Integer, 2) pos, ) 
-	MsgpackRequest* window_set_cursor(int64_t window, QPoint pos);
-	// DEPRECATED
-	// Integer window_get_height(Window window, ) 
-	MsgpackRequest* window_get_height(int64_t window);
-	// DEPRECATED
-	// void window_set_height(Window window, Integer height, ) 
-	MsgpackRequest* window_set_height(int64_t window, int64_t height);
-	// DEPRECATED
-	// Integer window_get_width(Window window, ) 
-	MsgpackRequest* window_get_width(int64_t window);
-	// DEPRECATED
-	// void window_set_width(Window window, Integer width, ) 
-	MsgpackRequest* window_set_width(int64_t window, int64_t width);
-	// DEPRECATED
-	// Object window_get_var(Window window, String name, ) 
-	MsgpackRequest* window_get_var(int64_t window, QByteArray name);
-	// DEPRECATED
-	// Object window_get_option(Window window, String name, ) 
-	MsgpackRequest* window_get_option(int64_t window, QByteArray name);
-	// DEPRECATED
-	// void window_set_option(Window window, String name, Object value, ) 
-	MsgpackRequest* window_set_option(int64_t window, QByteArray name, QVariant value);
-	// DEPRECATED
-	// ArrayOf(Integer, 2) window_get_position(Window window, ) 
-	MsgpackRequest* window_get_position(int64_t window);
-	// DEPRECATED
-	// Tabpage window_get_tabpage(Window window, ) 
-	MsgpackRequest* window_get_tabpage(int64_t window);
-	// DEPRECATED
-	// Boolean window_is_valid(Window window, ) 
-	MsgpackRequest* window_is_valid(int64_t window);
+	/// Integer nvim_buf_line_count(Buffer buffer, )
+	NeovimQt::MsgpackRequest* nvim_buf_line_count(int64_t buffer);
+
+	/// DEPRECATED: String buffer_get_line(Buffer buffer, Integer index, )
+	NeovimQt::MsgpackRequest* buffer_get_line(int64_t buffer, int64_t index);
+
+	/// DEPRECATED: void buffer_set_line(Buffer buffer, Integer index, String line, )
+	NeovimQt::MsgpackRequest* buffer_set_line(int64_t buffer, int64_t index, QByteArray line);
+
+	/// DEPRECATED: void buffer_del_line(Buffer buffer, Integer index, )
+	NeovimQt::MsgpackRequest* buffer_del_line(int64_t buffer, int64_t index);
+
+	/// DEPRECATED: ArrayOf(String) buffer_get_line_slice(Buffer buffer, Integer start, Integer end, Boolean include_start, Boolean include_end, )
+	NeovimQt::MsgpackRequest* buffer_get_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end);
+
+	/// ArrayOf(String) nvim_buf_get_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, )
+	NeovimQt::MsgpackRequest* nvim_buf_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing);
+
+	/// DEPRECATED: void buffer_set_line_slice(Buffer buffer, Integer start, Integer end, Boolean include_start, Boolean include_end, ArrayOf(String) replacement, )
+	NeovimQt::MsgpackRequest* buffer_set_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end, QList<QByteArray> replacement);
+
+	/// void nvim_buf_set_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ArrayOf(String) replacement, )
+	NeovimQt::MsgpackRequest* nvim_buf_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement);
+
+	/// Object nvim_buf_get_var(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* nvim_buf_get_var(int64_t buffer, QByteArray name);
+
+	/// Integer nvim_buf_get_changedtick(Buffer buffer, )
+	NeovimQt::MsgpackRequest* nvim_buf_get_changedtick(int64_t buffer);
+
+	/// void nvim_buf_set_var(Buffer buffer, String name, Object value, )
+	NeovimQt::MsgpackRequest* nvim_buf_set_var(int64_t buffer, QByteArray name, QVariant value);
+
+	/// void nvim_buf_del_var(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* nvim_buf_del_var(int64_t buffer, QByteArray name);
+
+	/// DEPRECATED: Object buffer_set_var(Buffer buffer, String name, Object value, )
+	NeovimQt::MsgpackRequest* buffer_set_var(int64_t buffer, QByteArray name, QVariant value);
+
+	/// DEPRECATED: Object buffer_del_var(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* buffer_del_var(int64_t buffer, QByteArray name);
+
+	/// Object nvim_buf_get_option(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* nvim_buf_get_option(int64_t buffer, QByteArray name);
+
+	/// void nvim_buf_set_option(Buffer buffer, String name, Object value, )
+	NeovimQt::MsgpackRequest* nvim_buf_set_option(int64_t buffer, QByteArray name, QVariant value);
+
+	/// DEPRECATED: Integer nvim_buf_get_number(Buffer buffer, )
+	NeovimQt::MsgpackRequest* nvim_buf_get_number(int64_t buffer);
+
+	/// String nvim_buf_get_name(Buffer buffer, )
+	NeovimQt::MsgpackRequest* nvim_buf_get_name(int64_t buffer);
+
+	/// void nvim_buf_set_name(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* nvim_buf_set_name(int64_t buffer, QByteArray name);
+
+	/// Boolean nvim_buf_is_valid(Buffer buffer, )
+	NeovimQt::MsgpackRequest* nvim_buf_is_valid(int64_t buffer);
+
+	/// DEPRECATED: void buffer_insert(Buffer buffer, Integer lnum, ArrayOf(String) lines, )
+	NeovimQt::MsgpackRequest* buffer_insert(int64_t buffer, int64_t lnum, QList<QByteArray> lines);
+
+	/// ArrayOf(Integer, 2) nvim_buf_get_mark(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* nvim_buf_get_mark(int64_t buffer, QByteArray name);
+
+	/// Integer nvim_buf_add_highlight(Buffer buffer, Integer src_id, String hl_group, Integer line, Integer col_start, Integer col_end, )
+	NeovimQt::MsgpackRequest* nvim_buf_add_highlight(int64_t buffer, int64_t src_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end);
+
+	/// void nvim_buf_clear_highlight(Buffer buffer, Integer src_id, Integer line_start, Integer line_end, )
+	NeovimQt::MsgpackRequest* nvim_buf_clear_highlight(int64_t buffer, int64_t src_id, int64_t line_start, int64_t line_end);
+
+	/// ArrayOf(Window) nvim_tabpage_list_wins(Tabpage tabpage, )
+	NeovimQt::MsgpackRequest* nvim_tabpage_list_wins(int64_t tabpage);
+
+	/// Object nvim_tabpage_get_var(Tabpage tabpage, String name, )
+	NeovimQt::MsgpackRequest* nvim_tabpage_get_var(int64_t tabpage, QByteArray name);
+
+	/// void nvim_tabpage_set_var(Tabpage tabpage, String name, Object value, )
+	NeovimQt::MsgpackRequest* nvim_tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value);
+
+	/// void nvim_tabpage_del_var(Tabpage tabpage, String name, )
+	NeovimQt::MsgpackRequest* nvim_tabpage_del_var(int64_t tabpage, QByteArray name);
+
+	/// DEPRECATED: Object tabpage_set_var(Tabpage tabpage, String name, Object value, )
+	NeovimQt::MsgpackRequest* tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value);
+
+	/// DEPRECATED: Object tabpage_del_var(Tabpage tabpage, String name, )
+	NeovimQt::MsgpackRequest* tabpage_del_var(int64_t tabpage, QByteArray name);
+
+	/// Window nvim_tabpage_get_win(Tabpage tabpage, )
+	NeovimQt::MsgpackRequest* nvim_tabpage_get_win(int64_t tabpage);
+
+	/// Integer nvim_tabpage_get_number(Tabpage tabpage, )
+	NeovimQt::MsgpackRequest* nvim_tabpage_get_number(int64_t tabpage);
+
+	/// Boolean nvim_tabpage_is_valid(Tabpage tabpage, )
+	NeovimQt::MsgpackRequest* nvim_tabpage_is_valid(int64_t tabpage);
+
+	/// void nvim_ui_attach(Integer width, Integer height, Dictionary options, )
+	NeovimQt::MsgpackRequest* nvim_ui_attach(int64_t width, int64_t height, QVariantMap options);
+
+	/// DEPRECATED: void ui_attach(Integer width, Integer height, Boolean enable_rgb, )
+	NeovimQt::MsgpackRequest* ui_attach(int64_t width, int64_t height, bool enable_rgb);
+
+	/// void nvim_ui_detach()
+	NeovimQt::MsgpackRequest* nvim_ui_detach();
+
+	/// void nvim_ui_try_resize(Integer width, Integer height, )
+	NeovimQt::MsgpackRequest* nvim_ui_try_resize(int64_t width, int64_t height);
+
+	/// void nvim_ui_set_option(String name, Object value, )
+	NeovimQt::MsgpackRequest* nvim_ui_set_option(QByteArray name, QVariant value);
+
+	/// void nvim_command(String command, )
+	NeovimQt::MsgpackRequest* nvim_command(QByteArray command);
+
+	/// void nvim_feedkeys(String keys, String mode, Boolean escape_csi, )
+	NeovimQt::MsgpackRequest* nvim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi);
+
+	/// Integer nvim_input(String keys, )
+	NeovimQt::MsgpackRequest* nvim_input(QByteArray keys);
+
+	/// String nvim_replace_termcodes(String str, Boolean from_part, Boolean do_lt, Boolean special, )
+	NeovimQt::MsgpackRequest* nvim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special);
+
+	/// String nvim_command_output(String str, )
+	NeovimQt::MsgpackRequest* nvim_command_output(QByteArray str);
+
+	/// Object nvim_eval(String expr, )
+	NeovimQt::MsgpackRequest* nvim_eval(QByteArray expr);
+
+	/// Object nvim_call_function(String fname, Array args, )
+	NeovimQt::MsgpackRequest* nvim_call_function(QByteArray fname, QVariantList args);
+
+	/// Integer nvim_strwidth(String str, )
+	NeovimQt::MsgpackRequest* nvim_strwidth(QByteArray str);
+
+	/// ArrayOf(String) nvim_list_runtime_paths()
+	NeovimQt::MsgpackRequest* nvim_list_runtime_paths();
+
+	/// void nvim_set_current_dir(String dir, )
+	NeovimQt::MsgpackRequest* nvim_set_current_dir(QByteArray dir);
+
+	/// String nvim_get_current_line()
+	NeovimQt::MsgpackRequest* nvim_get_current_line();
+
+	/// void nvim_set_current_line(String line, )
+	NeovimQt::MsgpackRequest* nvim_set_current_line(QByteArray line);
+
+	/// void nvim_del_current_line()
+	NeovimQt::MsgpackRequest* nvim_del_current_line();
+
+	/// Object nvim_get_var(String name, )
+	NeovimQt::MsgpackRequest* nvim_get_var(QByteArray name);
+
+	/// void nvim_set_var(String name, Object value, )
+	NeovimQt::MsgpackRequest* nvim_set_var(QByteArray name, QVariant value);
+
+	/// void nvim_del_var(String name, )
+	NeovimQt::MsgpackRequest* nvim_del_var(QByteArray name);
+
+	/// DEPRECATED: Object vim_set_var(String name, Object value, )
+	NeovimQt::MsgpackRequest* vim_set_var(QByteArray name, QVariant value);
+
+	/// DEPRECATED: Object vim_del_var(String name, )
+	NeovimQt::MsgpackRequest* vim_del_var(QByteArray name);
+
+	/// Object nvim_get_vvar(String name, )
+	NeovimQt::MsgpackRequest* nvim_get_vvar(QByteArray name);
+
+	/// Object nvim_get_option(String name, )
+	NeovimQt::MsgpackRequest* nvim_get_option(QByteArray name);
+
+	/// void nvim_set_option(String name, Object value, )
+	NeovimQt::MsgpackRequest* nvim_set_option(QByteArray name, QVariant value);
+
+	/// void nvim_out_write(String str, )
+	NeovimQt::MsgpackRequest* nvim_out_write(QByteArray str);
+
+	/// void nvim_err_write(String str, )
+	NeovimQt::MsgpackRequest* nvim_err_write(QByteArray str);
+
+	/// void nvim_err_writeln(String str, )
+	NeovimQt::MsgpackRequest* nvim_err_writeln(QByteArray str);
+
+	/// ArrayOf(Buffer) nvim_list_bufs()
+	NeovimQt::MsgpackRequest* nvim_list_bufs();
+
+	/// Buffer nvim_get_current_buf()
+	NeovimQt::MsgpackRequest* nvim_get_current_buf();
+
+	/// void nvim_set_current_buf(Buffer buffer, )
+	NeovimQt::MsgpackRequest* nvim_set_current_buf(int64_t buffer);
+
+	/// ArrayOf(Window) nvim_list_wins()
+	NeovimQt::MsgpackRequest* nvim_list_wins();
+
+	/// Window nvim_get_current_win()
+	NeovimQt::MsgpackRequest* nvim_get_current_win();
+
+	/// void nvim_set_current_win(Window window, )
+	NeovimQt::MsgpackRequest* nvim_set_current_win(int64_t window);
+
+	/// ArrayOf(Tabpage) nvim_list_tabpages()
+	NeovimQt::MsgpackRequest* nvim_list_tabpages();
+
+	/// Tabpage nvim_get_current_tabpage()
+	NeovimQt::MsgpackRequest* nvim_get_current_tabpage();
+
+	/// void nvim_set_current_tabpage(Tabpage tabpage, )
+	NeovimQt::MsgpackRequest* nvim_set_current_tabpage(int64_t tabpage);
+
+	/// void nvim_subscribe(String event, )
+	NeovimQt::MsgpackRequest* nvim_subscribe(QByteArray event);
+
+	/// void nvim_unsubscribe(String event, )
+	NeovimQt::MsgpackRequest* nvim_unsubscribe(QByteArray event);
+
+	/// Integer nvim_get_color_by_name(String name, )
+	NeovimQt::MsgpackRequest* nvim_get_color_by_name(QByteArray name);
+
+	/// Dictionary nvim_get_color_map()
+	NeovimQt::MsgpackRequest* nvim_get_color_map();
+
+	/// Dictionary nvim_get_mode()
+	NeovimQt::MsgpackRequest* nvim_get_mode();
+
+	/// Array nvim_get_api_info()
+	NeovimQt::MsgpackRequest* nvim_get_api_info();
+
+	/// Array nvim_call_atomic(Array calls, )
+	NeovimQt::MsgpackRequest* nvim_call_atomic(QVariantList calls);
+
+	/// Buffer nvim_win_get_buf(Window window, )
+	NeovimQt::MsgpackRequest* nvim_win_get_buf(int64_t window);
+
+	/// ArrayOf(Integer, 2) nvim_win_get_cursor(Window window, )
+	NeovimQt::MsgpackRequest* nvim_win_get_cursor(int64_t window);
+
+	/// void nvim_win_set_cursor(Window window, ArrayOf(Integer, 2) pos, )
+	NeovimQt::MsgpackRequest* nvim_win_set_cursor(int64_t window, QPoint pos);
+
+	/// Integer nvim_win_get_height(Window window, )
+	NeovimQt::MsgpackRequest* nvim_win_get_height(int64_t window);
+
+	/// void nvim_win_set_height(Window window, Integer height, )
+	NeovimQt::MsgpackRequest* nvim_win_set_height(int64_t window, int64_t height);
+
+	/// Integer nvim_win_get_width(Window window, )
+	NeovimQt::MsgpackRequest* nvim_win_get_width(int64_t window);
+
+	/// void nvim_win_set_width(Window window, Integer width, )
+	NeovimQt::MsgpackRequest* nvim_win_set_width(int64_t window, int64_t width);
+
+	/// Object nvim_win_get_var(Window window, String name, )
+	NeovimQt::MsgpackRequest* nvim_win_get_var(int64_t window, QByteArray name);
+
+	/// void nvim_win_set_var(Window window, String name, Object value, )
+	NeovimQt::MsgpackRequest* nvim_win_set_var(int64_t window, QByteArray name, QVariant value);
+
+	/// void nvim_win_del_var(Window window, String name, )
+	NeovimQt::MsgpackRequest* nvim_win_del_var(int64_t window, QByteArray name);
+
+	/// DEPRECATED: Object window_set_var(Window window, String name, Object value, )
+	NeovimQt::MsgpackRequest* window_set_var(int64_t window, QByteArray name, QVariant value);
+
+	/// DEPRECATED: Object window_del_var(Window window, String name, )
+	NeovimQt::MsgpackRequest* window_del_var(int64_t window, QByteArray name);
+
+	/// Object nvim_win_get_option(Window window, String name, )
+	NeovimQt::MsgpackRequest* nvim_win_get_option(int64_t window, QByteArray name);
+
+	/// void nvim_win_set_option(Window window, String name, Object value, )
+	NeovimQt::MsgpackRequest* nvim_win_set_option(int64_t window, QByteArray name, QVariant value);
+
+	/// ArrayOf(Integer, 2) nvim_win_get_position(Window window, )
+	NeovimQt::MsgpackRequest* nvim_win_get_position(int64_t window);
+
+	/// Tabpage nvim_win_get_tabpage(Window window, )
+	NeovimQt::MsgpackRequest* nvim_win_get_tabpage(int64_t window);
+
+	/// Integer nvim_win_get_number(Window window, )
+	NeovimQt::MsgpackRequest* nvim_win_get_number(int64_t window);
+
+	/// Boolean nvim_win_is_valid(Window window, )
+	NeovimQt::MsgpackRequest* nvim_win_is_valid(int64_t window);
+
+	/// DEPRECATED: Integer buffer_line_count(Buffer buffer, )
+	NeovimQt::MsgpackRequest* buffer_line_count(int64_t buffer);
+
+	/// DEPRECATED: ArrayOf(String) buffer_get_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, )
+	NeovimQt::MsgpackRequest* buffer_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing);
+
+	/// DEPRECATED: void buffer_set_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ArrayOf(String) replacement, )
+	NeovimQt::MsgpackRequest* buffer_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement);
+
+	/// DEPRECATED: Object buffer_get_var(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* buffer_get_var(int64_t buffer, QByteArray name);
+
+	/// DEPRECATED: Object buffer_get_option(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* buffer_get_option(int64_t buffer, QByteArray name);
+
+	/// DEPRECATED: void buffer_set_option(Buffer buffer, String name, Object value, )
+	NeovimQt::MsgpackRequest* buffer_set_option(int64_t buffer, QByteArray name, QVariant value);
+
+	/// DEPRECATED: Integer buffer_get_number(Buffer buffer, )
+	NeovimQt::MsgpackRequest* buffer_get_number(int64_t buffer);
+
+	/// DEPRECATED: String buffer_get_name(Buffer buffer, )
+	NeovimQt::MsgpackRequest* buffer_get_name(int64_t buffer);
+
+	/// DEPRECATED: void buffer_set_name(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* buffer_set_name(int64_t buffer, QByteArray name);
+
+	/// DEPRECATED: Boolean buffer_is_valid(Buffer buffer, )
+	NeovimQt::MsgpackRequest* buffer_is_valid(int64_t buffer);
+
+	/// DEPRECATED: ArrayOf(Integer, 2) buffer_get_mark(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* buffer_get_mark(int64_t buffer, QByteArray name);
+
+	/// DEPRECATED: Integer buffer_add_highlight(Buffer buffer, Integer src_id, String hl_group, Integer line, Integer col_start, Integer col_end, )
+	NeovimQt::MsgpackRequest* buffer_add_highlight(int64_t buffer, int64_t src_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end);
+
+	/// DEPRECATED: void buffer_clear_highlight(Buffer buffer, Integer src_id, Integer line_start, Integer line_end, )
+	NeovimQt::MsgpackRequest* buffer_clear_highlight(int64_t buffer, int64_t src_id, int64_t line_start, int64_t line_end);
+
+	/// DEPRECATED: ArrayOf(Window) tabpage_get_windows(Tabpage tabpage, )
+	NeovimQt::MsgpackRequest* tabpage_get_windows(int64_t tabpage);
+
+	/// DEPRECATED: Object tabpage_get_var(Tabpage tabpage, String name, )
+	NeovimQt::MsgpackRequest* tabpage_get_var(int64_t tabpage, QByteArray name);
+
+	/// DEPRECATED: Window tabpage_get_window(Tabpage tabpage, )
+	NeovimQt::MsgpackRequest* tabpage_get_window(int64_t tabpage);
+
+	/// DEPRECATED: Boolean tabpage_is_valid(Tabpage tabpage, )
+	NeovimQt::MsgpackRequest* tabpage_is_valid(int64_t tabpage);
+
+	/// DEPRECATED: void ui_detach()
+	NeovimQt::MsgpackRequest* ui_detach();
+
+	/// DEPRECATED: Object ui_try_resize(Integer width, Integer height, )
+	NeovimQt::MsgpackRequest* ui_try_resize(int64_t width, int64_t height);
+
+	/// DEPRECATED: void vim_command(String command, )
+	NeovimQt::MsgpackRequest* vim_command(QByteArray command);
+
+	/// DEPRECATED: void vim_feedkeys(String keys, String mode, Boolean escape_csi, )
+	NeovimQt::MsgpackRequest* vim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi);
+
+	/// DEPRECATED: Integer vim_input(String keys, )
+	NeovimQt::MsgpackRequest* vim_input(QByteArray keys);
+
+	/// DEPRECATED: String vim_replace_termcodes(String str, Boolean from_part, Boolean do_lt, Boolean special, )
+	NeovimQt::MsgpackRequest* vim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special);
+
+	/// DEPRECATED: String vim_command_output(String str, )
+	NeovimQt::MsgpackRequest* vim_command_output(QByteArray str);
+
+	/// DEPRECATED: Object vim_eval(String expr, )
+	NeovimQt::MsgpackRequest* vim_eval(QByteArray expr);
+
+	/// DEPRECATED: Object vim_call_function(String fname, Array args, )
+	NeovimQt::MsgpackRequest* vim_call_function(QByteArray fname, QVariantList args);
+
+	/// DEPRECATED: Integer vim_strwidth(String str, )
+	NeovimQt::MsgpackRequest* vim_strwidth(QByteArray str);
+
+	/// DEPRECATED: ArrayOf(String) vim_list_runtime_paths()
+	NeovimQt::MsgpackRequest* vim_list_runtime_paths();
+
+	/// DEPRECATED: void vim_change_directory(String dir, )
+	NeovimQt::MsgpackRequest* vim_change_directory(QByteArray dir);
+
+	/// DEPRECATED: String vim_get_current_line()
+	NeovimQt::MsgpackRequest* vim_get_current_line();
+
+	/// DEPRECATED: void vim_set_current_line(String line, )
+	NeovimQt::MsgpackRequest* vim_set_current_line(QByteArray line);
+
+	/// DEPRECATED: void vim_del_current_line()
+	NeovimQt::MsgpackRequest* vim_del_current_line();
+
+	/// DEPRECATED: Object vim_get_var(String name, )
+	NeovimQt::MsgpackRequest* vim_get_var(QByteArray name);
+
+	/// DEPRECATED: Object vim_get_vvar(String name, )
+	NeovimQt::MsgpackRequest* vim_get_vvar(QByteArray name);
+
+	/// DEPRECATED: Object vim_get_option(String name, )
+	NeovimQt::MsgpackRequest* vim_get_option(QByteArray name);
+
+	/// DEPRECATED: void vim_set_option(String name, Object value, )
+	NeovimQt::MsgpackRequest* vim_set_option(QByteArray name, QVariant value);
+
+	/// DEPRECATED: void vim_out_write(String str, )
+	NeovimQt::MsgpackRequest* vim_out_write(QByteArray str);
+
+	/// DEPRECATED: void vim_err_write(String str, )
+	NeovimQt::MsgpackRequest* vim_err_write(QByteArray str);
+
+	/// DEPRECATED: void vim_report_error(String str, )
+	NeovimQt::MsgpackRequest* vim_report_error(QByteArray str);
+
+	/// DEPRECATED: ArrayOf(Buffer) vim_get_buffers()
+	NeovimQt::MsgpackRequest* vim_get_buffers();
+
+	/// DEPRECATED: Buffer vim_get_current_buffer()
+	NeovimQt::MsgpackRequest* vim_get_current_buffer();
+
+	/// DEPRECATED: void vim_set_current_buffer(Buffer buffer, )
+	NeovimQt::MsgpackRequest* vim_set_current_buffer(int64_t buffer);
+
+	/// DEPRECATED: ArrayOf(Window) vim_get_windows()
+	NeovimQt::MsgpackRequest* vim_get_windows();
+
+	/// DEPRECATED: Window vim_get_current_window()
+	NeovimQt::MsgpackRequest* vim_get_current_window();
+
+	/// DEPRECATED: void vim_set_current_window(Window window, )
+	NeovimQt::MsgpackRequest* vim_set_current_window(int64_t window);
+
+	/// DEPRECATED: ArrayOf(Tabpage) vim_get_tabpages()
+	NeovimQt::MsgpackRequest* vim_get_tabpages();
+
+	/// DEPRECATED: Tabpage vim_get_current_tabpage()
+	NeovimQt::MsgpackRequest* vim_get_current_tabpage();
+
+	/// DEPRECATED: void vim_set_current_tabpage(Tabpage tabpage, )
+	NeovimQt::MsgpackRequest* vim_set_current_tabpage(int64_t tabpage);
+
+	/// DEPRECATED: void vim_subscribe(String event, )
+	NeovimQt::MsgpackRequest* vim_subscribe(QByteArray event);
+
+	/// DEPRECATED: void vim_unsubscribe(String event, )
+	NeovimQt::MsgpackRequest* vim_unsubscribe(QByteArray event);
+
+	/// DEPRECATED: Integer vim_name_to_color(String name, )
+	NeovimQt::MsgpackRequest* vim_name_to_color(QByteArray name);
+
+	/// DEPRECATED: Dictionary vim_get_color_map()
+	NeovimQt::MsgpackRequest* vim_get_color_map();
+
+	/// DEPRECATED: Buffer window_get_buffer(Window window, )
+	NeovimQt::MsgpackRequest* window_get_buffer(int64_t window);
+
+	/// DEPRECATED: ArrayOf(Integer, 2) window_get_cursor(Window window, )
+	NeovimQt::MsgpackRequest* window_get_cursor(int64_t window);
+
+	/// DEPRECATED: void window_set_cursor(Window window, ArrayOf(Integer, 2) pos, )
+	NeovimQt::MsgpackRequest* window_set_cursor(int64_t window, QPoint pos);
+
+	/// DEPRECATED: Integer window_get_height(Window window, )
+	NeovimQt::MsgpackRequest* window_get_height(int64_t window);
+
+	/// DEPRECATED: void window_set_height(Window window, Integer height, )
+	NeovimQt::MsgpackRequest* window_set_height(int64_t window, int64_t height);
+
+	/// DEPRECATED: Integer window_get_width(Window window, )
+	NeovimQt::MsgpackRequest* window_get_width(int64_t window);
+
+	/// DEPRECATED: void window_set_width(Window window, Integer width, )
+	NeovimQt::MsgpackRequest* window_set_width(int64_t window, int64_t width);
+
+	/// DEPRECATED: Object window_get_var(Window window, String name, )
+	NeovimQt::MsgpackRequest* window_get_var(int64_t window, QByteArray name);
+
+	/// DEPRECATED: Object window_get_option(Window window, String name, )
+	NeovimQt::MsgpackRequest* window_get_option(int64_t window, QByteArray name);
+
+	/// DEPRECATED: void window_set_option(Window window, String name, Object value, )
+	NeovimQt::MsgpackRequest* window_set_option(int64_t window, QByteArray name, QVariant value);
+
+	/// DEPRECATED: ArrayOf(Integer, 2) window_get_position(Window window, )
+	NeovimQt::MsgpackRequest* window_get_position(int64_t window);
+
+	/// DEPRECATED: Tabpage window_get_tabpage(Window window, )
+	NeovimQt::MsgpackRequest* window_get_tabpage(int64_t window);
+
+	/// DEPRECATED: Boolean window_is_valid(Window window, )
+	NeovimQt::MsgpackRequest* window_is_valid(int64_t window);
+
 
 signals:
 	void on_nvim_buf_line_count(int64_t);
@@ -1085,5 +1173,5 @@ signals:
 	void err_window_is_valid(const QString&, const QVariant&);
 
 };
-} // namespace
-#endif
+
+} // namespace NeovimQt

--- a/src/auto/neovimapi3.cpp
+++ b/src/auto/neovimapi3.cpp
@@ -1,15 +1,15 @@
-// Auto generated 2018-08-08 20:42:42.062086 from nvim API level:3
+// Auto generated 2020-09-09 13:30:54.149809 from nvim API level:3
 #include "auto/neovimapi3.h"
-#include "neovimconnector.h"
-#include "msgpackrequest.h"
 #include "msgpackiodevice.h"
+#include "msgpackrequest.h"
+#include "neovimconnector.h"
 #include "util.h"
 
 namespace NeovimQt {
 /* Unpack Neovim EXT types Window, Buffer Tabpage which are all
  * uint64_t see Neovim:msgpack_rpc_to_
  */
-QVariant unpackBufferApi3(MsgpackIODevice *dev, const char* in, quint32 size)
+static QVariant unpackBufferApi3(MsgpackIODevice *dev, const char* in, uint32_t size) noexcept
 {
 	msgpack_unpacked result;
 	msgpack_unpacked_init(&result);
@@ -20,10 +20,10 @@ QVariant unpackBufferApi3(MsgpackIODevice *dev, const char* in, quint32 size)
 	if (ret == MSGPACK_UNPACK_SUCCESS) {
 		switch (result.data.type) {
 			case MSGPACK_OBJECT_NEGATIVE_INTEGER:
-				variant = (qint64)result.data.via.i64;
+				variant.setValue<int64_t>(result.data.via.i64);
 				break;
 			case MSGPACK_OBJECT_POSITIVE_INTEGER:
-				variant = (quint64)result.data.via.u64;
+				variant.setValue<uint64_t>(result.data.via.u64);
 				break;
 			default:
 				// TODO it would be nice if we could call back MsgpackIoDevice method or primitive types here
@@ -34,1613 +34,1787 @@ QVariant unpackBufferApi3(MsgpackIODevice *dev, const char* in, quint32 size)
 	msgpack_unpacked_destroy(&result);
 	return variant;
 }
-#define unpackWindowApi3 unpackBufferApi3
-#define unpackTabpageApi3 unpackBufferApi3
 
-NeovimApi3::NeovimApi3(NeovimConnector *c)
-:m_c(c)
+static QVariant unpackWindowApi3(MsgpackIODevice *dev, const char* in, uint32_t size) noexcept
+{
+	return unpackBufferApi3(dev, in, size);
+}
+
+static QVariant unpackTabpageApi3(MsgpackIODevice *dev, const char* in, uint32_t size) noexcept
+{
+	return unpackBufferApi3(dev, in, size);
+}
+
+NeovimApi3::NeovimApi3(NeovimConnector *c) noexcept
+	: m_connector{ c }
 {
 	// EXT types
-		m_c->m_dev->registerExtType(0, unpackBufferApi3);
-		m_c->m_dev->registerExtType(1, unpackWindowApi3);
-		m_c->m_dev->registerExtType(2, unpackTabpageApi3);
-		connect(m_c->m_dev, &MsgpackIODevice::notification,
-			this, &NeovimApi3::neovimNotification);
+	m_connector->m_dev->registerExtType(0, unpackBufferApi3);
+	m_connector->m_dev->registerExtType(1, unpackWindowApi3);
+	m_connector->m_dev->registerExtType(2, unpackTabpageApi3);
+	connect(m_connector->m_dev, &MsgpackIODevice::notification,
+		this, &NeovimApi3::neovimNotification);
 }
 
 // Slots
 MsgpackRequest* NeovimApi3::nvim_buf_line_count(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_line_count", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_line_count", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_BUF_LINE_COUNT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::buffer_get_line(int64_t buffer, int64_t index)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_line", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_get_line", 2) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_BUFFER_GET_LINE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(index);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(index);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::buffer_set_line(int64_t buffer, int64_t index, QByteArray line)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_set_line", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_set_line", 3) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_BUFFER_SET_LINE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(index);
-	m_c->m_dev->send(line);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(index);
+	m_connector->m_dev->send(line);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::buffer_del_line(int64_t buffer, int64_t index)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_del_line", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_del_line", 2) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_BUFFER_DEL_LINE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(index);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(index);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::buffer_get_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_line_slice", 5);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_get_line_slice", 5) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_BUFFER_GET_LINE_SLICE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(start);
-	m_c->m_dev->send(end);
-	m_c->m_dev->send(include_start);
-	m_c->m_dev->send(include_end);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(start);
+	m_connector->m_dev->send(end);
+	m_connector->m_dev->send(include_start);
+	m_connector->m_dev->send(include_end);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_buf_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_get_lines", 4);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_get_lines", 4) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_BUF_GET_LINES);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(start);
-	m_c->m_dev->send(end);
-	m_c->m_dev->send(strict_indexing);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(start);
+	m_connector->m_dev->send(end);
+	m_connector->m_dev->send(strict_indexing);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::buffer_set_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end, QList<QByteArray> replacement)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_set_line_slice", 6);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_set_line_slice", 6) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_BUFFER_SET_LINE_SLICE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(start);
-	m_c->m_dev->send(end);
-	m_c->m_dev->send(include_start);
-	m_c->m_dev->send(include_end);
-	m_c->m_dev->sendArrayOf(replacement);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(start);
+	m_connector->m_dev->send(end);
+	m_connector->m_dev->send(include_start);
+	m_connector->m_dev->send(include_end);
+	m_connector->m_dev->sendArrayOf(replacement);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_buf_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_set_lines", 5);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_set_lines", 5) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_BUF_SET_LINES);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(start);
-	m_c->m_dev->send(end);
-	m_c->m_dev->send(strict_indexing);
-	m_c->m_dev->sendArrayOf(replacement);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(start);
+	m_connector->m_dev->send(end);
+	m_connector->m_dev->send(strict_indexing);
+	m_connector->m_dev->sendArrayOf(replacement);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_buf_get_var(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_get_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_get_var", 2) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_BUF_GET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_buf_get_changedtick(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_get_changedtick", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_get_changedtick", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_BUF_GET_CHANGEDTICK);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_buf_get_keymap(int64_t buffer, QByteArray mode)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_get_keymap", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_get_keymap", 2) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_BUF_GET_KEYMAP);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(mode);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(mode);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_buf_set_var(int64_t buffer, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_set_var", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_set_var", 3) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_BUF_SET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_buf_del_var(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_del_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_del_var", 2) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_BUF_DEL_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::buffer_set_var(int64_t buffer, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_set_var", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_set_var", 3) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_BUFFER_SET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::buffer_del_var(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_del_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_del_var", 2) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_BUFFER_DEL_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_buf_get_option(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_get_option", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_get_option", 2) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_BUF_GET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_buf_set_option(int64_t buffer, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_set_option", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_set_option", 3) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_BUF_SET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_buf_get_number(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_get_number", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_get_number", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_BUF_GET_NUMBER);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_buf_get_name(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_get_name", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_get_name", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_BUF_GET_NAME);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_buf_set_name(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_set_name", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_set_name", 2) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_BUF_SET_NAME);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_buf_is_valid(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_is_valid", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_is_valid", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_BUF_IS_VALID);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::buffer_insert(int64_t buffer, int64_t lnum, QList<QByteArray> lines)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_insert", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_insert", 3) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_BUFFER_INSERT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(lnum);
-	m_c->m_dev->sendArrayOf(lines);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(lnum);
+	m_connector->m_dev->sendArrayOf(lines);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_buf_get_mark(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_get_mark", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_get_mark", 2) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_BUF_GET_MARK);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_buf_add_highlight(int64_t buffer, int64_t src_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_add_highlight", 6);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_add_highlight", 6) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_BUF_ADD_HIGHLIGHT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(src_id);
-	m_c->m_dev->send(hl_group);
-	m_c->m_dev->send(line);
-	m_c->m_dev->send(col_start);
-	m_c->m_dev->send(col_end);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(src_id);
+	m_connector->m_dev->send(hl_group);
+	m_connector->m_dev->send(line);
+	m_connector->m_dev->send(col_start);
+	m_connector->m_dev->send(col_end);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_buf_clear_highlight(int64_t buffer, int64_t src_id, int64_t line_start, int64_t line_end)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_clear_highlight", 4);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_clear_highlight", 4) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_BUF_CLEAR_HIGHLIGHT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(src_id);
-	m_c->m_dev->send(line_start);
-	m_c->m_dev->send(line_end);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(src_id);
+	m_connector->m_dev->send(line_start);
+	m_connector->m_dev->send(line_end);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_tabpage_list_wins(int64_t tabpage)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_tabpage_list_wins", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_tabpage_list_wins", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_TABPAGE_LIST_WINS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(tabpage);
+	m_connector->m_dev->send(tabpage);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_tabpage_get_var(int64_t tabpage, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_tabpage_get_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_tabpage_get_var", 2) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_TABPAGE_GET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(tabpage);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(tabpage);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_tabpage_set_var", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_tabpage_set_var", 3) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_TABPAGE_SET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(tabpage);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(tabpage);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_tabpage_del_var(int64_t tabpage, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_tabpage_del_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_tabpage_del_var", 2) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_TABPAGE_DEL_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(tabpage);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(tabpage);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("tabpage_set_var", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("tabpage_set_var", 3) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_TABPAGE_SET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(tabpage);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(tabpage);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::tabpage_del_var(int64_t tabpage, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("tabpage_del_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("tabpage_del_var", 2) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_TABPAGE_DEL_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(tabpage);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(tabpage);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_tabpage_get_win(int64_t tabpage)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_tabpage_get_win", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_tabpage_get_win", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_TABPAGE_GET_WIN);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(tabpage);
+	m_connector->m_dev->send(tabpage);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_tabpage_get_number(int64_t tabpage)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_tabpage_get_number", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_tabpage_get_number", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_TABPAGE_GET_NUMBER);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(tabpage);
+	m_connector->m_dev->send(tabpage);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_tabpage_is_valid(int64_t tabpage)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_tabpage_is_valid", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_tabpage_is_valid", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_TABPAGE_IS_VALID);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(tabpage);
+	m_connector->m_dev->send(tabpage);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_ui_attach(int64_t width, int64_t height, QVariantMap options)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_ui_attach", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_ui_attach", 3) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_UI_ATTACH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(width);
-	m_c->m_dev->send(height);
-	m_c->m_dev->send(options);
+	m_connector->m_dev->send(width);
+	m_connector->m_dev->send(height);
+	m_connector->m_dev->send(options);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::ui_attach(int64_t width, int64_t height, bool enable_rgb)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("ui_attach", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("ui_attach", 3) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_UI_ATTACH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(width);
-	m_c->m_dev->send(height);
-	m_c->m_dev->send(enable_rgb);
+	m_connector->m_dev->send(width);
+	m_connector->m_dev->send(height);
+	m_connector->m_dev->send(enable_rgb);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_ui_detach()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_ui_detach", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_ui_detach", 0) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_UI_DETACH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_ui_try_resize(int64_t width, int64_t height)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_ui_try_resize", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_ui_try_resize", 2) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_UI_TRY_RESIZE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(width);
-	m_c->m_dev->send(height);
+	m_connector->m_dev->send(width);
+	m_connector->m_dev->send(height);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_ui_set_option(QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_ui_set_option", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_ui_set_option", 2) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_UI_SET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_command(QByteArray command)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_command", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_command", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_COMMAND);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(command);
+	m_connector->m_dev->send(command);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_get_hl_by_name(QByteArray name, bool rgb)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_hl_by_name", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_hl_by_name", 2) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_GET_HL_BY_NAME);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(rgb);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(rgb);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_get_hl_by_id(int64_t hl_id, bool rgb)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_hl_by_id", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_hl_by_id", 2) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_GET_HL_BY_ID);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(hl_id);
-	m_c->m_dev->send(rgb);
+	m_connector->m_dev->send(hl_id);
+	m_connector->m_dev->send(rgb);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_feedkeys", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_feedkeys", 3) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_FEEDKEYS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(keys);
-	m_c->m_dev->send(mode);
-	m_c->m_dev->send(escape_csi);
+	m_connector->m_dev->send(keys);
+	m_connector->m_dev->send(mode);
+	m_connector->m_dev->send(escape_csi);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_input(QByteArray keys)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_input", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_input", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_INPUT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(keys);
+	m_connector->m_dev->send(keys);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_replace_termcodes", 4);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_replace_termcodes", 4) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_REPLACE_TERMCODES);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(str);
-	m_c->m_dev->send(from_part);
-	m_c->m_dev->send(do_lt);
-	m_c->m_dev->send(special);
+	m_connector->m_dev->send(str);
+	m_connector->m_dev->send(from_part);
+	m_connector->m_dev->send(do_lt);
+	m_connector->m_dev->send(special);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_command_output(QByteArray str)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_command_output", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_command_output", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_COMMAND_OUTPUT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(str);
+	m_connector->m_dev->send(str);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_eval(QByteArray expr)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_eval", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_eval", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_EVAL);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(expr);
+	m_connector->m_dev->send(expr);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_call_function(QByteArray fname, QVariantList args)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_call_function", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_call_function", 2) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_CALL_FUNCTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(fname);
-	m_c->m_dev->send(args);
+	m_connector->m_dev->send(fname);
+	m_connector->m_dev->send(args);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_execute_lua(QByteArray code, QVariantList args)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_execute_lua", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_execute_lua", 2) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_EXECUTE_LUA);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(code);
-	m_c->m_dev->send(args);
+	m_connector->m_dev->send(code);
+	m_connector->m_dev->send(args);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_strwidth(QByteArray text)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_strwidth", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_strwidth", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_STRWIDTH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(text);
+	m_connector->m_dev->send(text);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_list_runtime_paths()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_list_runtime_paths", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_list_runtime_paths", 0) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_LIST_RUNTIME_PATHS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_set_current_dir(QByteArray dir)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_set_current_dir", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_set_current_dir", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_SET_CURRENT_DIR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(dir);
+	m_connector->m_dev->send(dir);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_get_current_line()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_current_line", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_current_line", 0) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_GET_CURRENT_LINE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_set_current_line(QByteArray line)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_set_current_line", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_set_current_line", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_SET_CURRENT_LINE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(line);
+	m_connector->m_dev->send(line);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_del_current_line()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_del_current_line", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_del_current_line", 0) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_DEL_CURRENT_LINE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_get_var(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_var", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_var", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_GET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_set_var(QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_set_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_set_var", 2) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_SET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_del_var(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_del_var", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_del_var", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_DEL_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::vim_set_var(QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_set_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_set_var", 2) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_VIM_SET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::vim_del_var(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_del_var", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_del_var", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_VIM_DEL_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_get_vvar(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_vvar", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_vvar", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_GET_VVAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_get_option(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_option", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_option", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_GET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_set_option(QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_set_option", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_set_option", 2) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_SET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_out_write(QByteArray str)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_out_write", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_out_write", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_OUT_WRITE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(str);
+	m_connector->m_dev->send(str);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_err_write(QByteArray str)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_err_write", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_err_write", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_ERR_WRITE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(str);
+	m_connector->m_dev->send(str);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_err_writeln(QByteArray str)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_err_writeln", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_err_writeln", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_ERR_WRITELN);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(str);
+	m_connector->m_dev->send(str);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_list_bufs()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_list_bufs", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_list_bufs", 0) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_LIST_BUFS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_get_current_buf()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_current_buf", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_current_buf", 0) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_GET_CURRENT_BUF);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_set_current_buf(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_set_current_buf", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_set_current_buf", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_SET_CURRENT_BUF);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_list_wins()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_list_wins", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_list_wins", 0) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_LIST_WINS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_get_current_win()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_current_win", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_current_win", 0) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_GET_CURRENT_WIN);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_set_current_win(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_set_current_win", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_set_current_win", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_SET_CURRENT_WIN);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_list_tabpages()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_list_tabpages", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_list_tabpages", 0) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_LIST_TABPAGES);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_get_current_tabpage()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_current_tabpage", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_current_tabpage", 0) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_GET_CURRENT_TABPAGE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_set_current_tabpage(int64_t tabpage)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_set_current_tabpage", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_set_current_tabpage", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_SET_CURRENT_TABPAGE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(tabpage);
+	m_connector->m_dev->send(tabpage);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_subscribe(QByteArray event)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_subscribe", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_subscribe", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_SUBSCRIBE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(event);
+	m_connector->m_dev->send(event);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_unsubscribe(QByteArray event)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_unsubscribe", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_unsubscribe", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_UNSUBSCRIBE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(event);
+	m_connector->m_dev->send(event);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_get_color_by_name(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_color_by_name", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_color_by_name", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_GET_COLOR_BY_NAME);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_get_color_map()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_color_map", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_color_map", 0) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_GET_COLOR_MAP);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_get_mode()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_mode", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_mode", 0) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_GET_MODE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_get_keymap(QByteArray mode)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_keymap", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_keymap", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_GET_KEYMAP);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(mode);
+	m_connector->m_dev->send(mode);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_get_api_info()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_api_info", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_api_info", 0) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_GET_API_INFO);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_call_atomic(QVariantList calls)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_call_atomic", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_call_atomic", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_CALL_ATOMIC);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(calls);
+	m_connector->m_dev->send(calls);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_win_get_buf(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_buf", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_get_buf", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_WIN_GET_BUF);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_win_get_cursor(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_cursor", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_get_cursor", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_WIN_GET_CURSOR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_win_set_cursor(int64_t window, QPoint pos)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_set_cursor", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_set_cursor", 2) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_WIN_SET_CURSOR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(pos);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(pos);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_win_get_height(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_height", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_get_height", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_WIN_GET_HEIGHT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_win_set_height(int64_t window, int64_t height)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_set_height", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_set_height", 2) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_WIN_SET_HEIGHT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(height);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(height);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_win_get_width(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_width", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_get_width", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_WIN_GET_WIDTH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_win_set_width(int64_t window, int64_t width)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_set_width", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_set_width", 2) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_WIN_SET_WIDTH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(width);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(width);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_win_get_var(int64_t window, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_get_var", 2) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_WIN_GET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_win_set_var(int64_t window, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_set_var", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_set_var", 3) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_WIN_SET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_win_del_var(int64_t window, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_del_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_del_var", 2) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_WIN_DEL_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::window_set_var(int64_t window, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_set_var", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_set_var", 3) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_WINDOW_SET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::window_del_var(int64_t window, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_del_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_del_var", 2) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_WINDOW_DEL_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_win_get_option(int64_t window, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_option", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_get_option", 2) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_WIN_GET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_win_set_option(int64_t window, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_set_option", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_set_option", 3) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_WIN_SET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_win_get_position(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_position", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_get_position", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_WIN_GET_POSITION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_win_get_tabpage(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_tabpage", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_get_tabpage", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_WIN_GET_TABPAGE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_win_get_number(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_number", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_get_number", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_WIN_GET_NUMBER);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::nvim_win_is_valid(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_is_valid", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_is_valid", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_NVIM_WIN_IS_VALID);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::buffer_line_count(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_line_count", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_line_count", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_BUFFER_LINE_COUNT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::buffer_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_lines", 4);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_get_lines", 4) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_BUFFER_GET_LINES);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(start);
-	m_c->m_dev->send(end);
-	m_c->m_dev->send(strict_indexing);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(start);
+	m_connector->m_dev->send(end);
+	m_connector->m_dev->send(strict_indexing);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::buffer_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_set_lines", 5);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_set_lines", 5) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_BUFFER_SET_LINES);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(start);
-	m_c->m_dev->send(end);
-	m_c->m_dev->send(strict_indexing);
-	m_c->m_dev->sendArrayOf(replacement);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(start);
+	m_connector->m_dev->send(end);
+	m_connector->m_dev->send(strict_indexing);
+	m_connector->m_dev->sendArrayOf(replacement);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::buffer_get_var(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_get_var", 2) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_BUFFER_GET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::buffer_get_option(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_option", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_get_option", 2) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_BUFFER_GET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::buffer_set_option(int64_t buffer, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_set_option", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_set_option", 3) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_BUFFER_SET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::buffer_get_number(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_number", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_get_number", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_BUFFER_GET_NUMBER);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::buffer_get_name(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_name", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_get_name", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_BUFFER_GET_NAME);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::buffer_set_name(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_set_name", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_set_name", 2) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_BUFFER_SET_NAME);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::buffer_is_valid(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_is_valid", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_is_valid", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_BUFFER_IS_VALID);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::buffer_get_mark(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_mark", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_get_mark", 2) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_BUFFER_GET_MARK);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::buffer_add_highlight(int64_t buffer, int64_t src_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_add_highlight", 6);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_add_highlight", 6) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_BUFFER_ADD_HIGHLIGHT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(src_id);
-	m_c->m_dev->send(hl_group);
-	m_c->m_dev->send(line);
-	m_c->m_dev->send(col_start);
-	m_c->m_dev->send(col_end);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(src_id);
+	m_connector->m_dev->send(hl_group);
+	m_connector->m_dev->send(line);
+	m_connector->m_dev->send(col_start);
+	m_connector->m_dev->send(col_end);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::buffer_clear_highlight(int64_t buffer, int64_t src_id, int64_t line_start, int64_t line_end)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_clear_highlight", 4);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_clear_highlight", 4) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_BUFFER_CLEAR_HIGHLIGHT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(src_id);
-	m_c->m_dev->send(line_start);
-	m_c->m_dev->send(line_end);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(src_id);
+	m_connector->m_dev->send(line_start);
+	m_connector->m_dev->send(line_end);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::tabpage_get_windows(int64_t tabpage)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("tabpage_get_windows", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("tabpage_get_windows", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_TABPAGE_GET_WINDOWS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(tabpage);
+	m_connector->m_dev->send(tabpage);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::tabpage_get_var(int64_t tabpage, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("tabpage_get_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("tabpage_get_var", 2) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_TABPAGE_GET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(tabpage);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(tabpage);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::tabpage_get_window(int64_t tabpage)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("tabpage_get_window", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("tabpage_get_window", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_TABPAGE_GET_WINDOW);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(tabpage);
+	m_connector->m_dev->send(tabpage);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::tabpage_is_valid(int64_t tabpage)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("tabpage_is_valid", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("tabpage_is_valid", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_TABPAGE_IS_VALID);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(tabpage);
+	m_connector->m_dev->send(tabpage);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::ui_detach()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("ui_detach", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("ui_detach", 0) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_UI_DETACH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::ui_try_resize(int64_t width, int64_t height)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("ui_try_resize", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("ui_try_resize", 2) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_UI_TRY_RESIZE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(width);
-	m_c->m_dev->send(height);
+	m_connector->m_dev->send(width);
+	m_connector->m_dev->send(height);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::vim_command(QByteArray command)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_command", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_command", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_VIM_COMMAND);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(command);
+	m_connector->m_dev->send(command);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::vim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_feedkeys", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_feedkeys", 3) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_VIM_FEEDKEYS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(keys);
-	m_c->m_dev->send(mode);
-	m_c->m_dev->send(escape_csi);
+	m_connector->m_dev->send(keys);
+	m_connector->m_dev->send(mode);
+	m_connector->m_dev->send(escape_csi);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::vim_input(QByteArray keys)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_input", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_input", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_VIM_INPUT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(keys);
+	m_connector->m_dev->send(keys);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::vim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_replace_termcodes", 4);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_replace_termcodes", 4) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_VIM_REPLACE_TERMCODES);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(str);
-	m_c->m_dev->send(from_part);
-	m_c->m_dev->send(do_lt);
-	m_c->m_dev->send(special);
+	m_connector->m_dev->send(str);
+	m_connector->m_dev->send(from_part);
+	m_connector->m_dev->send(do_lt);
+	m_connector->m_dev->send(special);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::vim_command_output(QByteArray str)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_command_output", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_command_output", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_VIM_COMMAND_OUTPUT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(str);
+	m_connector->m_dev->send(str);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::vim_eval(QByteArray expr)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_eval", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_eval", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_VIM_EVAL);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(expr);
+	m_connector->m_dev->send(expr);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::vim_call_function(QByteArray fname, QVariantList args)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_call_function", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_call_function", 2) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_VIM_CALL_FUNCTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(fname);
-	m_c->m_dev->send(args);
+	m_connector->m_dev->send(fname);
+	m_connector->m_dev->send(args);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::vim_strwidth(QByteArray text)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_strwidth", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_strwidth", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_VIM_STRWIDTH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(text);
+	m_connector->m_dev->send(text);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::vim_list_runtime_paths()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_list_runtime_paths", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_list_runtime_paths", 0) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_VIM_LIST_RUNTIME_PATHS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::vim_change_directory(QByteArray dir)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_change_directory", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_change_directory", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_VIM_CHANGE_DIRECTORY);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(dir);
+	m_connector->m_dev->send(dir);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::vim_get_current_line()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_current_line", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_current_line", 0) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_VIM_GET_CURRENT_LINE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::vim_set_current_line(QByteArray line)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_set_current_line", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_set_current_line", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_VIM_SET_CURRENT_LINE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(line);
+	m_connector->m_dev->send(line);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::vim_del_current_line()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_del_current_line", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_del_current_line", 0) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_VIM_DEL_CURRENT_LINE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::vim_get_var(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_var", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_var", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_VIM_GET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::vim_get_vvar(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_vvar", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_vvar", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_VIM_GET_VVAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::vim_get_option(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_option", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_option", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_VIM_GET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::vim_set_option(QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_set_option", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_set_option", 2) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_VIM_SET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::vim_out_write(QByteArray str)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_out_write", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_out_write", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_VIM_OUT_WRITE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(str);
+	m_connector->m_dev->send(str);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::vim_err_write(QByteArray str)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_err_write", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_err_write", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_VIM_ERR_WRITE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(str);
+	m_connector->m_dev->send(str);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::vim_report_error(QByteArray str)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_report_error", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_report_error", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_VIM_REPORT_ERROR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(str);
+	m_connector->m_dev->send(str);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::vim_get_buffers()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_buffers", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_buffers", 0) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_VIM_GET_BUFFERS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::vim_get_current_buffer()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_current_buffer", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_current_buffer", 0) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_VIM_GET_CURRENT_BUFFER);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::vim_set_current_buffer(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_set_current_buffer", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_set_current_buffer", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_VIM_SET_CURRENT_BUFFER);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::vim_get_windows()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_windows", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_windows", 0) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_VIM_GET_WINDOWS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::vim_get_current_window()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_current_window", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_current_window", 0) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_VIM_GET_CURRENT_WINDOW);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::vim_set_current_window(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_set_current_window", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_set_current_window", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_VIM_SET_CURRENT_WINDOW);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::vim_get_tabpages()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_tabpages", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_tabpages", 0) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_VIM_GET_TABPAGES);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::vim_get_current_tabpage()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_current_tabpage", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_current_tabpage", 0) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_VIM_GET_CURRENT_TABPAGE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::vim_set_current_tabpage(int64_t tabpage)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_set_current_tabpage", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_set_current_tabpage", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_VIM_SET_CURRENT_TABPAGE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(tabpage);
+	m_connector->m_dev->send(tabpage);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::vim_subscribe(QByteArray event)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_subscribe", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_subscribe", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_VIM_SUBSCRIBE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(event);
+	m_connector->m_dev->send(event);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::vim_unsubscribe(QByteArray event)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_unsubscribe", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_unsubscribe", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_VIM_UNSUBSCRIBE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(event);
+	m_connector->m_dev->send(event);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::vim_name_to_color(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_name_to_color", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_name_to_color", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_VIM_NAME_TO_COLOR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::vim_get_color_map()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_color_map", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_color_map", 0) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_VIM_GET_COLOR_MAP);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::window_get_buffer(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_buffer", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_get_buffer", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_WINDOW_GET_BUFFER);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::window_get_cursor(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_cursor", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_get_cursor", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_WINDOW_GET_CURSOR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::window_set_cursor(int64_t window, QPoint pos)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_set_cursor", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_set_cursor", 2) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_WINDOW_SET_CURSOR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(pos);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(pos);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::window_get_height(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_height", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_get_height", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_WINDOW_GET_HEIGHT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::window_set_height(int64_t window, int64_t height)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_set_height", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_set_height", 2) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_WINDOW_SET_HEIGHT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(height);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(height);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::window_get_width(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_width", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_get_width", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_WINDOW_GET_WIDTH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::window_set_width(int64_t window, int64_t width)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_set_width", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_set_width", 2) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_WINDOW_SET_WIDTH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(width);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(width);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::window_get_var(int64_t window, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_get_var", 2) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_WINDOW_GET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::window_get_option(int64_t window, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_option", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_get_option", 2) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_WINDOW_GET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::window_set_option(int64_t window, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_set_option", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_set_option", 3) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_WINDOW_SET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::window_get_position(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_position", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_get_position", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_WINDOW_GET_POSITION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::window_get_tabpage(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_tabpage", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_get_tabpage", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_WINDOW_GET_TABPAGE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi3::window_is_valid(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_is_valid", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_is_valid", 1) };
 	r->setFunction(NeovimApi3::NEOVIM_FN_WINDOW_IS_VALID);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi3::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi3::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
 
+
 // Handlers
 
-void NeovimApi3::handleResponseError(quint32 msgid, quint64 fun, const QVariant& res)
+void NeovimApi3::handleResponseError(uint32_t msgid, uint64_t fun, const QVariant& res)
 {
 
 	// TODO: support Neovim error types Exception/Validation/etc
@@ -1648,7 +1822,7 @@ void NeovimApi3::handleResponseError(quint32 msgid, quint64 fun, const QVariant&
 	const QVariantList asList = res.toList();
 	if (asList.size() >= 2) {
 		if (asList.at(1).canConvert<QByteArray>()) {
-			errMsg = m_c->m_dev->decode(asList.at(1).toByteArray());
+			errMsg = m_connector->m_dev->decode(asList.at(1).toByteArray());
 		} else {
 			errMsg = tr("Received unsupported Neovim error type");
 		}
@@ -2154,1633 +2328,1633 @@ void NeovimApi3::handleResponseError(quint32 msgid, quint64 fun, const QVariant&
 		emit err_window_is_valid(errMsg, res);
 		break;
 	default:
-		m_c->setError(NeovimConnector::RuntimeMsgpackError, QString("Received error for function that should not fail: %s").arg(fun));
+		m_connector->setError(NeovimConnector::RuntimeMsgpackError, QString("Received error for function that should not fail: %s").arg(fun));
 	}
 }
 
-void NeovimApi3::handleResponse(quint32 msgid, quint64 fun, const QVariant& res)
+void NeovimApi3::handleResponse(uint32_t msgid, uint64_t fun, const QVariant& res)
 {
 	switch(fun) {
-	case NeovimApi3::NEOVIM_FN_NVIM_BUF_LINE_COUNT:
+		case NeovimApi3::NEOVIM_FN_NVIM_BUF_LINE_COUNT:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_line_count");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_line_count");
 				return;
-			} else {
-				emit on_nvim_buf_line_count(data);
 			}
 
+			emit on_nvim_buf_line_count(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_BUFFER_GET_LINE:
+
+		case NeovimApi3::NEOVIM_FN_BUFFER_GET_LINE:
 		{
 			QByteArray data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_line");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_line");
 				return;
-			} else {
-				emit on_buffer_get_line(data);
 			}
 
+			emit on_buffer_get_line(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_BUFFER_SET_LINE:
+
+		case NeovimApi3::NEOVIM_FN_BUFFER_SET_LINE:
 		{
 			emit on_buffer_set_line();
-
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_BUFFER_DEL_LINE:
+
+		case NeovimApi3::NEOVIM_FN_BUFFER_DEL_LINE:
 		{
 			emit on_buffer_del_line();
-
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_BUFFER_GET_LINE_SLICE:
+
+		case NeovimApi3::NEOVIM_FN_BUFFER_GET_LINE_SLICE:
 		{
 			QList<QByteArray> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_line_slice");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_line_slice");
 				return;
-			} else {
-				emit on_buffer_get_line_slice(data);
 			}
 
+			emit on_buffer_get_line_slice(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_BUF_GET_LINES:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_BUF_GET_LINES:
 		{
 			QList<QByteArray> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_lines");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_lines");
 				return;
-			} else {
-				emit on_nvim_buf_get_lines(data);
 			}
 
+			emit on_nvim_buf_get_lines(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_BUFFER_SET_LINE_SLICE:
+
+		case NeovimApi3::NEOVIM_FN_BUFFER_SET_LINE_SLICE:
 		{
 			emit on_buffer_set_line_slice();
-
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_BUF_SET_LINES:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_BUF_SET_LINES:
 		{
 			emit on_nvim_buf_set_lines();
-
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_BUF_GET_VAR:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_BUF_GET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_var");
 				return;
-			} else {
-				emit on_nvim_buf_get_var(data);
 			}
 
+			emit on_nvim_buf_get_var(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_BUF_GET_CHANGEDTICK:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_BUF_GET_CHANGEDTICK:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_changedtick");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_changedtick");
 				return;
-			} else {
-				emit on_nvim_buf_get_changedtick(data);
 			}
 
+			emit on_nvim_buf_get_changedtick(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_BUF_GET_KEYMAP:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_BUF_GET_KEYMAP:
 		{
 			QList<QVariantMap> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_keymap");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_keymap");
 				return;
-			} else {
-				emit on_nvim_buf_get_keymap(data);
 			}
 
+			emit on_nvim_buf_get_keymap(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_BUF_SET_VAR:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_BUF_SET_VAR:
 		{
 			emit on_nvim_buf_set_var();
-
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_BUF_DEL_VAR:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_BUF_DEL_VAR:
 		{
 			emit on_nvim_buf_del_var();
-
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_BUFFER_SET_VAR:
+
+		case NeovimApi3::NEOVIM_FN_BUFFER_SET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_set_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_set_var");
 				return;
-			} else {
-				emit on_buffer_set_var(data);
 			}
 
+			emit on_buffer_set_var(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_BUFFER_DEL_VAR:
+
+		case NeovimApi3::NEOVIM_FN_BUFFER_DEL_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_del_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_del_var");
 				return;
-			} else {
-				emit on_buffer_del_var(data);
 			}
 
+			emit on_buffer_del_var(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_BUF_GET_OPTION:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_BUF_GET_OPTION:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_option");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_option");
 				return;
-			} else {
-				emit on_nvim_buf_get_option(data);
 			}
 
+			emit on_nvim_buf_get_option(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_BUF_SET_OPTION:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_BUF_SET_OPTION:
 		{
 			emit on_nvim_buf_set_option();
-
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_BUF_GET_NUMBER:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_BUF_GET_NUMBER:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_number");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_number");
 				return;
-			} else {
-				emit on_nvim_buf_get_number(data);
 			}
 
+			emit on_nvim_buf_get_number(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_BUF_GET_NAME:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_BUF_GET_NAME:
 		{
 			QByteArray data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_name");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_name");
 				return;
-			} else {
-				emit on_nvim_buf_get_name(data);
 			}
 
+			emit on_nvim_buf_get_name(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_BUF_SET_NAME:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_BUF_SET_NAME:
 		{
 			emit on_nvim_buf_set_name();
-
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_BUF_IS_VALID:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_BUF_IS_VALID:
 		{
 			bool data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_is_valid");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_is_valid");
 				return;
-			} else {
-				emit on_nvim_buf_is_valid(data);
 			}
 
+			emit on_nvim_buf_is_valid(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_BUFFER_INSERT:
+
+		case NeovimApi3::NEOVIM_FN_BUFFER_INSERT:
 		{
 			emit on_buffer_insert();
-
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_BUF_GET_MARK:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_BUF_GET_MARK:
 		{
 			QPoint data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_mark");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_mark");
 				return;
-			} else {
-				emit on_nvim_buf_get_mark(data);
 			}
 
+			emit on_nvim_buf_get_mark(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_BUF_ADD_HIGHLIGHT:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_BUF_ADD_HIGHLIGHT:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_add_highlight");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_add_highlight");
 				return;
-			} else {
-				emit on_nvim_buf_add_highlight(data);
 			}
 
+			emit on_nvim_buf_add_highlight(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_BUF_CLEAR_HIGHLIGHT:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_BUF_CLEAR_HIGHLIGHT:
 		{
 			emit on_nvim_buf_clear_highlight();
-
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_TABPAGE_LIST_WINS:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_TABPAGE_LIST_WINS:
 		{
 			QList<int64_t> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_list_wins");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_list_wins");
 				return;
-			} else {
-				emit on_nvim_tabpage_list_wins(data);
 			}
 
+			emit on_nvim_tabpage_list_wins(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_TABPAGE_GET_VAR:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_TABPAGE_GET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_get_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_get_var");
 				return;
-			} else {
-				emit on_nvim_tabpage_get_var(data);
 			}
 
+			emit on_nvim_tabpage_get_var(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_TABPAGE_SET_VAR:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_TABPAGE_SET_VAR:
 		{
 			emit on_nvim_tabpage_set_var();
-
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_TABPAGE_DEL_VAR:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_TABPAGE_DEL_VAR:
 		{
 			emit on_nvim_tabpage_del_var();
-
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_TABPAGE_SET_VAR:
+
+		case NeovimApi3::NEOVIM_FN_TABPAGE_SET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_set_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_set_var");
 				return;
-			} else {
-				emit on_tabpage_set_var(data);
 			}
 
+			emit on_tabpage_set_var(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_TABPAGE_DEL_VAR:
+
+		case NeovimApi3::NEOVIM_FN_TABPAGE_DEL_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_del_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_del_var");
 				return;
-			} else {
-				emit on_tabpage_del_var(data);
 			}
 
+			emit on_tabpage_del_var(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_TABPAGE_GET_WIN:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_TABPAGE_GET_WIN:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_get_win");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_get_win");
 				return;
-			} else {
-				emit on_nvim_tabpage_get_win(data);
 			}
 
+			emit on_nvim_tabpage_get_win(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_TABPAGE_GET_NUMBER:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_TABPAGE_GET_NUMBER:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_get_number");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_get_number");
 				return;
-			} else {
-				emit on_nvim_tabpage_get_number(data);
 			}
 
+			emit on_nvim_tabpage_get_number(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_TABPAGE_IS_VALID:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_TABPAGE_IS_VALID:
 		{
 			bool data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_is_valid");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_is_valid");
 				return;
-			} else {
-				emit on_nvim_tabpage_is_valid(data);
 			}
 
+			emit on_nvim_tabpage_is_valid(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_UI_ATTACH:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_UI_ATTACH:
 		{
 			emit on_nvim_ui_attach();
-
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_UI_ATTACH:
+
+		case NeovimApi3::NEOVIM_FN_UI_ATTACH:
 		{
 			emit on_ui_attach();
-
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_UI_DETACH:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_UI_DETACH:
 		{
 			emit on_nvim_ui_detach();
-
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_UI_TRY_RESIZE:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_UI_TRY_RESIZE:
 		{
 			emit on_nvim_ui_try_resize();
-
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_UI_SET_OPTION:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_UI_SET_OPTION:
 		{
 			emit on_nvim_ui_set_option();
-
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_COMMAND:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_COMMAND:
 		{
 			emit on_nvim_command();
-
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_GET_HL_BY_NAME:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_GET_HL_BY_NAME:
 		{
 			QVariantMap data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_hl_by_name");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_hl_by_name");
 				return;
-			} else {
-				emit on_nvim_get_hl_by_name(data);
 			}
 
+			emit on_nvim_get_hl_by_name(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_GET_HL_BY_ID:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_GET_HL_BY_ID:
 		{
 			QVariantMap data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_hl_by_id");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_hl_by_id");
 				return;
-			} else {
-				emit on_nvim_get_hl_by_id(data);
 			}
 
+			emit on_nvim_get_hl_by_id(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_FEEDKEYS:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_FEEDKEYS:
 		{
 			emit on_nvim_feedkeys();
-
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_INPUT:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_INPUT:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_input");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_input");
 				return;
-			} else {
-				emit on_nvim_input(data);
 			}
 
+			emit on_nvim_input(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_REPLACE_TERMCODES:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_REPLACE_TERMCODES:
 		{
 			QByteArray data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_replace_termcodes");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_replace_termcodes");
 				return;
-			} else {
-				emit on_nvim_replace_termcodes(data);
 			}
 
+			emit on_nvim_replace_termcodes(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_COMMAND_OUTPUT:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_COMMAND_OUTPUT:
 		{
 			QByteArray data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_command_output");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_command_output");
 				return;
-			} else {
-				emit on_nvim_command_output(data);
 			}
 
+			emit on_nvim_command_output(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_EVAL:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_EVAL:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_eval");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_eval");
 				return;
-			} else {
-				emit on_nvim_eval(data);
 			}
 
+			emit on_nvim_eval(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_CALL_FUNCTION:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_CALL_FUNCTION:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_call_function");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_call_function");
 				return;
-			} else {
-				emit on_nvim_call_function(data);
 			}
 
+			emit on_nvim_call_function(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_EXECUTE_LUA:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_EXECUTE_LUA:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_execute_lua");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_execute_lua");
 				return;
-			} else {
-				emit on_nvim_execute_lua(data);
 			}
 
+			emit on_nvim_execute_lua(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_STRWIDTH:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_STRWIDTH:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_strwidth");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_strwidth");
 				return;
-			} else {
-				emit on_nvim_strwidth(data);
 			}
 
+			emit on_nvim_strwidth(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_LIST_RUNTIME_PATHS:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_LIST_RUNTIME_PATHS:
 		{
 			QList<QByteArray> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_runtime_paths");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_runtime_paths");
 				return;
-			} else {
-				emit on_nvim_list_runtime_paths(data);
 			}
 
+			emit on_nvim_list_runtime_paths(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_SET_CURRENT_DIR:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_SET_CURRENT_DIR:
 		{
 			emit on_nvim_set_current_dir();
-
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_GET_CURRENT_LINE:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_GET_CURRENT_LINE:
 		{
 			QByteArray data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_current_line");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_current_line");
 				return;
-			} else {
-				emit on_nvim_get_current_line(data);
 			}
 
+			emit on_nvim_get_current_line(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_SET_CURRENT_LINE:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_SET_CURRENT_LINE:
 		{
 			emit on_nvim_set_current_line();
-
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_DEL_CURRENT_LINE:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_DEL_CURRENT_LINE:
 		{
 			emit on_nvim_del_current_line();
-
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_GET_VAR:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_GET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_var");
 				return;
-			} else {
-				emit on_nvim_get_var(data);
 			}
 
+			emit on_nvim_get_var(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_SET_VAR:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_SET_VAR:
 		{
 			emit on_nvim_set_var();
-
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_DEL_VAR:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_DEL_VAR:
 		{
 			emit on_nvim_del_var();
-
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_VIM_SET_VAR:
+
+		case NeovimApi3::NEOVIM_FN_VIM_SET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_set_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_set_var");
 				return;
-			} else {
-				emit on_vim_set_var(data);
 			}
 
+			emit on_vim_set_var(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_VIM_DEL_VAR:
+
+		case NeovimApi3::NEOVIM_FN_VIM_DEL_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_del_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_del_var");
 				return;
-			} else {
-				emit on_vim_del_var(data);
 			}
 
+			emit on_vim_del_var(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_GET_VVAR:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_GET_VVAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_vvar");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_vvar");
 				return;
-			} else {
-				emit on_nvim_get_vvar(data);
 			}
 
+			emit on_nvim_get_vvar(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_GET_OPTION:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_GET_OPTION:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_option");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_option");
 				return;
-			} else {
-				emit on_nvim_get_option(data);
 			}
 
+			emit on_nvim_get_option(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_SET_OPTION:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_SET_OPTION:
 		{
 			emit on_nvim_set_option();
-
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_OUT_WRITE:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_OUT_WRITE:
 		{
 			emit on_nvim_out_write();
-
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_ERR_WRITE:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_ERR_WRITE:
 		{
 			emit on_nvim_err_write();
-
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_ERR_WRITELN:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_ERR_WRITELN:
 		{
 			emit on_nvim_err_writeln();
-
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_LIST_BUFS:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_LIST_BUFS:
 		{
 			QList<int64_t> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_bufs");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_bufs");
 				return;
-			} else {
-				emit on_nvim_list_bufs(data);
 			}
 
+			emit on_nvim_list_bufs(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_GET_CURRENT_BUF:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_GET_CURRENT_BUF:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_current_buf");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_current_buf");
 				return;
-			} else {
-				emit on_nvim_get_current_buf(data);
 			}
 
+			emit on_nvim_get_current_buf(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_SET_CURRENT_BUF:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_SET_CURRENT_BUF:
 		{
 			emit on_nvim_set_current_buf();
-
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_LIST_WINS:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_LIST_WINS:
 		{
 			QList<int64_t> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_wins");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_wins");
 				return;
-			} else {
-				emit on_nvim_list_wins(data);
 			}
 
+			emit on_nvim_list_wins(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_GET_CURRENT_WIN:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_GET_CURRENT_WIN:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_current_win");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_current_win");
 				return;
-			} else {
-				emit on_nvim_get_current_win(data);
 			}
 
+			emit on_nvim_get_current_win(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_SET_CURRENT_WIN:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_SET_CURRENT_WIN:
 		{
 			emit on_nvim_set_current_win();
-
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_LIST_TABPAGES:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_LIST_TABPAGES:
 		{
 			QList<int64_t> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_tabpages");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_tabpages");
 				return;
-			} else {
-				emit on_nvim_list_tabpages(data);
 			}
 
+			emit on_nvim_list_tabpages(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_GET_CURRENT_TABPAGE:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_GET_CURRENT_TABPAGE:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_current_tabpage");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_current_tabpage");
 				return;
-			} else {
-				emit on_nvim_get_current_tabpage(data);
 			}
 
+			emit on_nvim_get_current_tabpage(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_SET_CURRENT_TABPAGE:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_SET_CURRENT_TABPAGE:
 		{
 			emit on_nvim_set_current_tabpage();
-
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_SUBSCRIBE:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_SUBSCRIBE:
 		{
 			emit on_nvim_subscribe();
-
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_UNSUBSCRIBE:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_UNSUBSCRIBE:
 		{
 			emit on_nvim_unsubscribe();
-
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_GET_COLOR_BY_NAME:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_GET_COLOR_BY_NAME:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_color_by_name");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_color_by_name");
 				return;
-			} else {
-				emit on_nvim_get_color_by_name(data);
 			}
 
+			emit on_nvim_get_color_by_name(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_GET_COLOR_MAP:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_GET_COLOR_MAP:
 		{
 			QVariantMap data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_color_map");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_color_map");
 				return;
-			} else {
-				emit on_nvim_get_color_map(data);
 			}
 
+			emit on_nvim_get_color_map(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_GET_MODE:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_GET_MODE:
 		{
 			QVariantMap data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_mode");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_mode");
 				return;
-			} else {
-				emit on_nvim_get_mode(data);
 			}
 
+			emit on_nvim_get_mode(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_GET_KEYMAP:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_GET_KEYMAP:
 		{
 			QList<QVariantMap> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_keymap");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_keymap");
 				return;
-			} else {
-				emit on_nvim_get_keymap(data);
 			}
 
+			emit on_nvim_get_keymap(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_GET_API_INFO:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_GET_API_INFO:
 		{
 			QVariantList data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_api_info");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_api_info");
 				return;
-			} else {
-				emit on_nvim_get_api_info(data);
 			}
 
+			emit on_nvim_get_api_info(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_CALL_ATOMIC:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_CALL_ATOMIC:
 		{
 			QVariantList data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_call_atomic");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_call_atomic");
 				return;
-			} else {
-				emit on_nvim_call_atomic(data);
 			}
 
+			emit on_nvim_call_atomic(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_WIN_GET_BUF:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_WIN_GET_BUF:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_buf");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_buf");
 				return;
-			} else {
-				emit on_nvim_win_get_buf(data);
 			}
 
+			emit on_nvim_win_get_buf(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_WIN_GET_CURSOR:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_WIN_GET_CURSOR:
 		{
 			QPoint data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_cursor");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_cursor");
 				return;
-			} else {
-				emit on_nvim_win_get_cursor(data);
 			}
 
+			emit on_nvim_win_get_cursor(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_WIN_SET_CURSOR:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_WIN_SET_CURSOR:
 		{
 			emit on_nvim_win_set_cursor();
-
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_WIN_GET_HEIGHT:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_WIN_GET_HEIGHT:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_height");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_height");
 				return;
-			} else {
-				emit on_nvim_win_get_height(data);
 			}
 
+			emit on_nvim_win_get_height(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_WIN_SET_HEIGHT:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_WIN_SET_HEIGHT:
 		{
 			emit on_nvim_win_set_height();
-
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_WIN_GET_WIDTH:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_WIN_GET_WIDTH:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_width");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_width");
 				return;
-			} else {
-				emit on_nvim_win_get_width(data);
 			}
 
+			emit on_nvim_win_get_width(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_WIN_SET_WIDTH:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_WIN_SET_WIDTH:
 		{
 			emit on_nvim_win_set_width();
-
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_WIN_GET_VAR:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_WIN_GET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_var");
 				return;
-			} else {
-				emit on_nvim_win_get_var(data);
 			}
 
+			emit on_nvim_win_get_var(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_WIN_SET_VAR:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_WIN_SET_VAR:
 		{
 			emit on_nvim_win_set_var();
-
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_WIN_DEL_VAR:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_WIN_DEL_VAR:
 		{
 			emit on_nvim_win_del_var();
-
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_WINDOW_SET_VAR:
+
+		case NeovimApi3::NEOVIM_FN_WINDOW_SET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_set_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_set_var");
 				return;
-			} else {
-				emit on_window_set_var(data);
 			}
 
+			emit on_window_set_var(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_WINDOW_DEL_VAR:
+
+		case NeovimApi3::NEOVIM_FN_WINDOW_DEL_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_del_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_del_var");
 				return;
-			} else {
-				emit on_window_del_var(data);
 			}
 
+			emit on_window_del_var(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_WIN_GET_OPTION:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_WIN_GET_OPTION:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_option");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_option");
 				return;
-			} else {
-				emit on_nvim_win_get_option(data);
 			}
 
+			emit on_nvim_win_get_option(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_WIN_SET_OPTION:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_WIN_SET_OPTION:
 		{
 			emit on_nvim_win_set_option();
-
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_WIN_GET_POSITION:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_WIN_GET_POSITION:
 		{
 			QPoint data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_position");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_position");
 				return;
-			} else {
-				emit on_nvim_win_get_position(data);
 			}
 
+			emit on_nvim_win_get_position(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_WIN_GET_TABPAGE:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_WIN_GET_TABPAGE:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_tabpage");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_tabpage");
 				return;
-			} else {
-				emit on_nvim_win_get_tabpage(data);
 			}
 
+			emit on_nvim_win_get_tabpage(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_WIN_GET_NUMBER:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_WIN_GET_NUMBER:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_number");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_number");
 				return;
-			} else {
-				emit on_nvim_win_get_number(data);
 			}
 
+			emit on_nvim_win_get_number(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_NVIM_WIN_IS_VALID:
+
+		case NeovimApi3::NEOVIM_FN_NVIM_WIN_IS_VALID:
 		{
 			bool data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_is_valid");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_is_valid");
 				return;
-			} else {
-				emit on_nvim_win_is_valid(data);
 			}
 
+			emit on_nvim_win_is_valid(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_BUFFER_LINE_COUNT:
+
+		case NeovimApi3::NEOVIM_FN_BUFFER_LINE_COUNT:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_line_count");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_line_count");
 				return;
-			} else {
-				emit on_buffer_line_count(data);
 			}
 
+			emit on_buffer_line_count(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_BUFFER_GET_LINES:
+
+		case NeovimApi3::NEOVIM_FN_BUFFER_GET_LINES:
 		{
 			QList<QByteArray> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_lines");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_lines");
 				return;
-			} else {
-				emit on_buffer_get_lines(data);
 			}
 
+			emit on_buffer_get_lines(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_BUFFER_SET_LINES:
+
+		case NeovimApi3::NEOVIM_FN_BUFFER_SET_LINES:
 		{
 			emit on_buffer_set_lines();
-
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_BUFFER_GET_VAR:
+
+		case NeovimApi3::NEOVIM_FN_BUFFER_GET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_var");
 				return;
-			} else {
-				emit on_buffer_get_var(data);
 			}
 
+			emit on_buffer_get_var(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_BUFFER_GET_OPTION:
+
+		case NeovimApi3::NEOVIM_FN_BUFFER_GET_OPTION:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_option");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_option");
 				return;
-			} else {
-				emit on_buffer_get_option(data);
 			}
 
+			emit on_buffer_get_option(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_BUFFER_SET_OPTION:
+
+		case NeovimApi3::NEOVIM_FN_BUFFER_SET_OPTION:
 		{
 			emit on_buffer_set_option();
-
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_BUFFER_GET_NUMBER:
+
+		case NeovimApi3::NEOVIM_FN_BUFFER_GET_NUMBER:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_number");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_number");
 				return;
-			} else {
-				emit on_buffer_get_number(data);
 			}
 
+			emit on_buffer_get_number(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_BUFFER_GET_NAME:
+
+		case NeovimApi3::NEOVIM_FN_BUFFER_GET_NAME:
 		{
 			QByteArray data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_name");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_name");
 				return;
-			} else {
-				emit on_buffer_get_name(data);
 			}
 
+			emit on_buffer_get_name(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_BUFFER_SET_NAME:
+
+		case NeovimApi3::NEOVIM_FN_BUFFER_SET_NAME:
 		{
 			emit on_buffer_set_name();
-
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_BUFFER_IS_VALID:
+
+		case NeovimApi3::NEOVIM_FN_BUFFER_IS_VALID:
 		{
 			bool data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_is_valid");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_is_valid");
 				return;
-			} else {
-				emit on_buffer_is_valid(data);
 			}
 
+			emit on_buffer_is_valid(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_BUFFER_GET_MARK:
+
+		case NeovimApi3::NEOVIM_FN_BUFFER_GET_MARK:
 		{
 			QPoint data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_mark");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_mark");
 				return;
-			} else {
-				emit on_buffer_get_mark(data);
 			}
 
+			emit on_buffer_get_mark(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_BUFFER_ADD_HIGHLIGHT:
+
+		case NeovimApi3::NEOVIM_FN_BUFFER_ADD_HIGHLIGHT:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_add_highlight");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_add_highlight");
 				return;
-			} else {
-				emit on_buffer_add_highlight(data);
 			}
 
+			emit on_buffer_add_highlight(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_BUFFER_CLEAR_HIGHLIGHT:
+
+		case NeovimApi3::NEOVIM_FN_BUFFER_CLEAR_HIGHLIGHT:
 		{
 			emit on_buffer_clear_highlight();
-
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_TABPAGE_GET_WINDOWS:
+
+		case NeovimApi3::NEOVIM_FN_TABPAGE_GET_WINDOWS:
 		{
 			QList<int64_t> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_get_windows");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_get_windows");
 				return;
-			} else {
-				emit on_tabpage_get_windows(data);
 			}
 
+			emit on_tabpage_get_windows(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_TABPAGE_GET_VAR:
+
+		case NeovimApi3::NEOVIM_FN_TABPAGE_GET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_get_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_get_var");
 				return;
-			} else {
-				emit on_tabpage_get_var(data);
 			}
 
+			emit on_tabpage_get_var(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_TABPAGE_GET_WINDOW:
+
+		case NeovimApi3::NEOVIM_FN_TABPAGE_GET_WINDOW:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_get_window");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_get_window");
 				return;
-			} else {
-				emit on_tabpage_get_window(data);
 			}
 
+			emit on_tabpage_get_window(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_TABPAGE_IS_VALID:
+
+		case NeovimApi3::NEOVIM_FN_TABPAGE_IS_VALID:
 		{
 			bool data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_is_valid");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_is_valid");
 				return;
-			} else {
-				emit on_tabpage_is_valid(data);
 			}
 
+			emit on_tabpage_is_valid(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_UI_DETACH:
+
+		case NeovimApi3::NEOVIM_FN_UI_DETACH:
 		{
 			emit on_ui_detach();
-
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_UI_TRY_RESIZE:
+
+		case NeovimApi3::NEOVIM_FN_UI_TRY_RESIZE:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for ui_try_resize");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for ui_try_resize");
 				return;
-			} else {
-				emit on_ui_try_resize(data);
 			}
 
+			emit on_ui_try_resize(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_VIM_COMMAND:
+
+		case NeovimApi3::NEOVIM_FN_VIM_COMMAND:
 		{
 			emit on_vim_command();
-
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_VIM_FEEDKEYS:
+
+		case NeovimApi3::NEOVIM_FN_VIM_FEEDKEYS:
 		{
 			emit on_vim_feedkeys();
-
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_VIM_INPUT:
+
+		case NeovimApi3::NEOVIM_FN_VIM_INPUT:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_input");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_input");
 				return;
-			} else {
-				emit on_vim_input(data);
 			}
 
+			emit on_vim_input(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_VIM_REPLACE_TERMCODES:
+
+		case NeovimApi3::NEOVIM_FN_VIM_REPLACE_TERMCODES:
 		{
 			QByteArray data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_replace_termcodes");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_replace_termcodes");
 				return;
-			} else {
-				emit on_vim_replace_termcodes(data);
 			}
 
+			emit on_vim_replace_termcodes(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_VIM_COMMAND_OUTPUT:
+
+		case NeovimApi3::NEOVIM_FN_VIM_COMMAND_OUTPUT:
 		{
 			QByteArray data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_command_output");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_command_output");
 				return;
-			} else {
-				emit on_vim_command_output(data);
 			}
 
+			emit on_vim_command_output(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_VIM_EVAL:
+
+		case NeovimApi3::NEOVIM_FN_VIM_EVAL:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_eval");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_eval");
 				return;
-			} else {
-				emit on_vim_eval(data);
 			}
 
+			emit on_vim_eval(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_VIM_CALL_FUNCTION:
+
+		case NeovimApi3::NEOVIM_FN_VIM_CALL_FUNCTION:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_call_function");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_call_function");
 				return;
-			} else {
-				emit on_vim_call_function(data);
 			}
 
+			emit on_vim_call_function(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_VIM_STRWIDTH:
+
+		case NeovimApi3::NEOVIM_FN_VIM_STRWIDTH:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_strwidth");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_strwidth");
 				return;
-			} else {
-				emit on_vim_strwidth(data);
 			}
 
+			emit on_vim_strwidth(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_VIM_LIST_RUNTIME_PATHS:
+
+		case NeovimApi3::NEOVIM_FN_VIM_LIST_RUNTIME_PATHS:
 		{
 			QList<QByteArray> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_list_runtime_paths");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_list_runtime_paths");
 				return;
-			} else {
-				emit on_vim_list_runtime_paths(data);
 			}
 
+			emit on_vim_list_runtime_paths(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_VIM_CHANGE_DIRECTORY:
+
+		case NeovimApi3::NEOVIM_FN_VIM_CHANGE_DIRECTORY:
 		{
 			emit on_vim_change_directory();
-
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_VIM_GET_CURRENT_LINE:
+
+		case NeovimApi3::NEOVIM_FN_VIM_GET_CURRENT_LINE:
 		{
 			QByteArray data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_current_line");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_current_line");
 				return;
-			} else {
-				emit on_vim_get_current_line(data);
 			}
 
+			emit on_vim_get_current_line(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_VIM_SET_CURRENT_LINE:
+
+		case NeovimApi3::NEOVIM_FN_VIM_SET_CURRENT_LINE:
 		{
 			emit on_vim_set_current_line();
-
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_VIM_DEL_CURRENT_LINE:
+
+		case NeovimApi3::NEOVIM_FN_VIM_DEL_CURRENT_LINE:
 		{
 			emit on_vim_del_current_line();
-
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_VIM_GET_VAR:
+
+		case NeovimApi3::NEOVIM_FN_VIM_GET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_var");
 				return;
-			} else {
-				emit on_vim_get_var(data);
 			}
 
+			emit on_vim_get_var(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_VIM_GET_VVAR:
+
+		case NeovimApi3::NEOVIM_FN_VIM_GET_VVAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_vvar");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_vvar");
 				return;
-			} else {
-				emit on_vim_get_vvar(data);
 			}
 
+			emit on_vim_get_vvar(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_VIM_GET_OPTION:
+
+		case NeovimApi3::NEOVIM_FN_VIM_GET_OPTION:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_option");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_option");
 				return;
-			} else {
-				emit on_vim_get_option(data);
 			}
 
+			emit on_vim_get_option(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_VIM_SET_OPTION:
+
+		case NeovimApi3::NEOVIM_FN_VIM_SET_OPTION:
 		{
 			emit on_vim_set_option();
-
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_VIM_OUT_WRITE:
+
+		case NeovimApi3::NEOVIM_FN_VIM_OUT_WRITE:
 		{
 			emit on_vim_out_write();
-
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_VIM_ERR_WRITE:
+
+		case NeovimApi3::NEOVIM_FN_VIM_ERR_WRITE:
 		{
 			emit on_vim_err_write();
-
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_VIM_REPORT_ERROR:
+
+		case NeovimApi3::NEOVIM_FN_VIM_REPORT_ERROR:
 		{
 			emit on_vim_report_error();
-
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_VIM_GET_BUFFERS:
+
+		case NeovimApi3::NEOVIM_FN_VIM_GET_BUFFERS:
 		{
 			QList<int64_t> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_buffers");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_buffers");
 				return;
-			} else {
-				emit on_vim_get_buffers(data);
 			}
 
+			emit on_vim_get_buffers(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_VIM_GET_CURRENT_BUFFER:
+
+		case NeovimApi3::NEOVIM_FN_VIM_GET_CURRENT_BUFFER:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_current_buffer");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_current_buffer");
 				return;
-			} else {
-				emit on_vim_get_current_buffer(data);
 			}
 
+			emit on_vim_get_current_buffer(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_VIM_SET_CURRENT_BUFFER:
+
+		case NeovimApi3::NEOVIM_FN_VIM_SET_CURRENT_BUFFER:
 		{
 			emit on_vim_set_current_buffer();
-
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_VIM_GET_WINDOWS:
+
+		case NeovimApi3::NEOVIM_FN_VIM_GET_WINDOWS:
 		{
 			QList<int64_t> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_windows");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_windows");
 				return;
-			} else {
-				emit on_vim_get_windows(data);
 			}
 
+			emit on_vim_get_windows(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_VIM_GET_CURRENT_WINDOW:
+
+		case NeovimApi3::NEOVIM_FN_VIM_GET_CURRENT_WINDOW:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_current_window");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_current_window");
 				return;
-			} else {
-				emit on_vim_get_current_window(data);
 			}
 
+			emit on_vim_get_current_window(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_VIM_SET_CURRENT_WINDOW:
+
+		case NeovimApi3::NEOVIM_FN_VIM_SET_CURRENT_WINDOW:
 		{
 			emit on_vim_set_current_window();
-
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_VIM_GET_TABPAGES:
+
+		case NeovimApi3::NEOVIM_FN_VIM_GET_TABPAGES:
 		{
 			QList<int64_t> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_tabpages");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_tabpages");
 				return;
-			} else {
-				emit on_vim_get_tabpages(data);
 			}
 
+			emit on_vim_get_tabpages(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_VIM_GET_CURRENT_TABPAGE:
+
+		case NeovimApi3::NEOVIM_FN_VIM_GET_CURRENT_TABPAGE:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_current_tabpage");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_current_tabpage");
 				return;
-			} else {
-				emit on_vim_get_current_tabpage(data);
 			}
 
+			emit on_vim_get_current_tabpage(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_VIM_SET_CURRENT_TABPAGE:
+
+		case NeovimApi3::NEOVIM_FN_VIM_SET_CURRENT_TABPAGE:
 		{
 			emit on_vim_set_current_tabpage();
-
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_VIM_SUBSCRIBE:
+
+		case NeovimApi3::NEOVIM_FN_VIM_SUBSCRIBE:
 		{
 			emit on_vim_subscribe();
-
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_VIM_UNSUBSCRIBE:
+
+		case NeovimApi3::NEOVIM_FN_VIM_UNSUBSCRIBE:
 		{
 			emit on_vim_unsubscribe();
-
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_VIM_NAME_TO_COLOR:
+
+		case NeovimApi3::NEOVIM_FN_VIM_NAME_TO_COLOR:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_name_to_color");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_name_to_color");
 				return;
-			} else {
-				emit on_vim_name_to_color(data);
 			}
 
+			emit on_vim_name_to_color(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_VIM_GET_COLOR_MAP:
+
+		case NeovimApi3::NEOVIM_FN_VIM_GET_COLOR_MAP:
 		{
 			QVariantMap data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_color_map");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_color_map");
 				return;
-			} else {
-				emit on_vim_get_color_map(data);
 			}
 
+			emit on_vim_get_color_map(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_WINDOW_GET_BUFFER:
+
+		case NeovimApi3::NEOVIM_FN_WINDOW_GET_BUFFER:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_buffer");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_buffer");
 				return;
-			} else {
-				emit on_window_get_buffer(data);
 			}
 
+			emit on_window_get_buffer(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_WINDOW_GET_CURSOR:
+
+		case NeovimApi3::NEOVIM_FN_WINDOW_GET_CURSOR:
 		{
 			QPoint data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_cursor");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_cursor");
 				return;
-			} else {
-				emit on_window_get_cursor(data);
 			}
 
+			emit on_window_get_cursor(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_WINDOW_SET_CURSOR:
+
+		case NeovimApi3::NEOVIM_FN_WINDOW_SET_CURSOR:
 		{
 			emit on_window_set_cursor();
-
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_WINDOW_GET_HEIGHT:
+
+		case NeovimApi3::NEOVIM_FN_WINDOW_GET_HEIGHT:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_height");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_height");
 				return;
-			} else {
-				emit on_window_get_height(data);
 			}
 
+			emit on_window_get_height(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_WINDOW_SET_HEIGHT:
+
+		case NeovimApi3::NEOVIM_FN_WINDOW_SET_HEIGHT:
 		{
 			emit on_window_set_height();
-
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_WINDOW_GET_WIDTH:
+
+		case NeovimApi3::NEOVIM_FN_WINDOW_GET_WIDTH:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_width");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_width");
 				return;
-			} else {
-				emit on_window_get_width(data);
 			}
 
+			emit on_window_get_width(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_WINDOW_SET_WIDTH:
+
+		case NeovimApi3::NEOVIM_FN_WINDOW_SET_WIDTH:
 		{
 			emit on_window_set_width();
-
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_WINDOW_GET_VAR:
+
+		case NeovimApi3::NEOVIM_FN_WINDOW_GET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_var");
 				return;
-			} else {
-				emit on_window_get_var(data);
 			}
 
+			emit on_window_get_var(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_WINDOW_GET_OPTION:
+
+		case NeovimApi3::NEOVIM_FN_WINDOW_GET_OPTION:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_option");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_option");
 				return;
-			} else {
-				emit on_window_get_option(data);
 			}
 
+			emit on_window_get_option(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_WINDOW_SET_OPTION:
+
+		case NeovimApi3::NEOVIM_FN_WINDOW_SET_OPTION:
 		{
 			emit on_window_set_option();
-
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_WINDOW_GET_POSITION:
+
+		case NeovimApi3::NEOVIM_FN_WINDOW_GET_POSITION:
 		{
 			QPoint data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_position");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_position");
 				return;
-			} else {
-				emit on_window_get_position(data);
 			}
 
+			emit on_window_get_position(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_WINDOW_GET_TABPAGE:
+
+		case NeovimApi3::NEOVIM_FN_WINDOW_GET_TABPAGE:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_tabpage");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_tabpage");
 				return;
-			} else {
-				emit on_window_get_tabpage(data);
 			}
 
+			emit on_window_get_tabpage(data);
 		}
 		break;
-	case NeovimApi3::NEOVIM_FN_WINDOW_IS_VALID:
+
+		case NeovimApi3::NEOVIM_FN_WINDOW_IS_VALID:
 		{
 			bool data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_is_valid");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_is_valid");
 				return;
-			} else {
-				emit on_window_is_valid(data);
 			}
 
+			emit on_window_is_valid(data);
 		}
 		break;
+
 	default:
 		qWarning() << "Received unexpected response";
 	}
@@ -3794,774 +3968,1270 @@ void NeovimApi3::handleResponse(quint32 msgid, quint64 fun, const QVariant& res)
  *
  * Returns false if there is an API mismatch
  */
-bool NeovimApi3::checkFunctions(const QVariantList& ftable)
+/*static*/ bool NeovimApi3::checkFunctions(const QVariantList& ftable) noexcept
 {
-
-	QList<Function> required;
-	required
-		<< Function("Integer", "nvim_buf_line_count",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("String", "buffer_get_line",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						, false)
-		<< Function("void", "buffer_set_line",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("String")
-						, false)
-		<< Function("void", "buffer_del_line",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						, false)
-		<< Function("ArrayOf(String)", "buffer_get_line_slice",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Boolean")
-						<< QString("Boolean")
-						, false)
-		<< Function("ArrayOf(String)", "nvim_buf_get_lines",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Boolean")
-						, false)
-		<< Function("void", "buffer_set_line_slice",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Boolean")
-						<< QString("Boolean")
-						<< QString("ArrayOf(String)")
-						, false)
-		<< Function("void", "nvim_buf_set_lines",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Boolean")
-						<< QString("ArrayOf(String)")
-						, false)
-		<< Function("Object", "nvim_buf_get_var",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("Integer", "nvim_buf_get_changedtick",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("ArrayOf(Dictionary)", "nvim_buf_get_keymap",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_buf_set_var",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("void", "nvim_buf_del_var",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("Object", "buffer_set_var",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("Object", "buffer_del_var",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("Object", "nvim_buf_get_option",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_buf_set_option",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("Integer", "nvim_buf_get_number",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("String", "nvim_buf_get_name",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("void", "nvim_buf_set_name",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("Boolean", "nvim_buf_is_valid",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("void", "buffer_insert",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("ArrayOf(String)")
-						, false)
-		<< Function("ArrayOf(Integer, 2)", "nvim_buf_get_mark",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("Integer", "nvim_buf_add_highlight",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("String")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Integer")
-						, false)
-		<< Function("void", "nvim_buf_clear_highlight",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Integer")
-						, false)
-		<< Function("ArrayOf(Window)", "nvim_tabpage_list_wins",
-			QList<QString>()
-						<< QString("Tabpage")
-						, false)
-		<< Function("Object", "nvim_tabpage_get_var",
-			QList<QString>()
-						<< QString("Tabpage")
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_tabpage_set_var",
-			QList<QString>()
-						<< QString("Tabpage")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("void", "nvim_tabpage_del_var",
-			QList<QString>()
-						<< QString("Tabpage")
-						<< QString("String")
-						, false)
-		<< Function("Object", "tabpage_set_var",
-			QList<QString>()
-						<< QString("Tabpage")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("Object", "tabpage_del_var",
-			QList<QString>()
-						<< QString("Tabpage")
-						<< QString("String")
-						, false)
-		<< Function("Window", "nvim_tabpage_get_win",
-			QList<QString>()
-						<< QString("Tabpage")
-						, false)
-		<< Function("Integer", "nvim_tabpage_get_number",
-			QList<QString>()
-						<< QString("Tabpage")
-						, false)
-		<< Function("Boolean", "nvim_tabpage_is_valid",
-			QList<QString>()
-						<< QString("Tabpage")
-						, false)
-		<< Function("void", "nvim_ui_attach",
-			QList<QString>()
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Dictionary")
-						, false)
-		<< Function("void", "ui_attach",
-			QList<QString>()
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Boolean")
-						, false)
-		<< Function("void", "nvim_ui_detach",
-			QList<QString>()
-						, false)
-		<< Function("void", "nvim_ui_try_resize",
-			QList<QString>()
-						<< QString("Integer")
-						<< QString("Integer")
-						, false)
-		<< Function("void", "nvim_ui_set_option",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("void", "nvim_command",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Dictionary", "nvim_get_hl_by_name",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Boolean")
-						, false)
-		<< Function("Dictionary", "nvim_get_hl_by_id",
-			QList<QString>()
-						<< QString("Integer")
-						<< QString("Boolean")
-						, false)
-		<< Function("void", "nvim_feedkeys",
-			QList<QString>()
-						<< QString("String")
-						<< QString("String")
-						<< QString("Boolean")
-						, false)
-		<< Function("Integer", "nvim_input",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("String", "nvim_replace_termcodes",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Boolean")
-						<< QString("Boolean")
-						<< QString("Boolean")
-						, false)
-		<< Function("String", "nvim_command_output",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Object", "nvim_eval",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Object", "nvim_call_function",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Array")
-						, false)
-		<< Function("Object", "nvim_execute_lua",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Array")
-						, false)
-		<< Function("Integer", "nvim_strwidth",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("ArrayOf(String)", "nvim_list_runtime_paths",
-			QList<QString>()
-						, false)
-		<< Function("void", "nvim_set_current_dir",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("String", "nvim_get_current_line",
-			QList<QString>()
-						, false)
-		<< Function("void", "nvim_set_current_line",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_del_current_line",
-			QList<QString>()
-						, false)
-		<< Function("Object", "nvim_get_var",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_set_var",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("void", "nvim_del_var",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Object", "vim_set_var",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("Object", "vim_del_var",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Object", "nvim_get_vvar",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Object", "nvim_get_option",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_set_option",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("void", "nvim_out_write",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_err_write",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_err_writeln",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("ArrayOf(Buffer)", "nvim_list_bufs",
-			QList<QString>()
-						, false)
-		<< Function("Buffer", "nvim_get_current_buf",
-			QList<QString>()
-						, false)
-		<< Function("void", "nvim_set_current_buf",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("ArrayOf(Window)", "nvim_list_wins",
-			QList<QString>()
-						, false)
-		<< Function("Window", "nvim_get_current_win",
-			QList<QString>()
-						, false)
-		<< Function("void", "nvim_set_current_win",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("ArrayOf(Tabpage)", "nvim_list_tabpages",
-			QList<QString>()
-						, false)
-		<< Function("Tabpage", "nvim_get_current_tabpage",
-			QList<QString>()
-						, false)
-		<< Function("void", "nvim_set_current_tabpage",
-			QList<QString>()
-						<< QString("Tabpage")
-						, false)
-		<< Function("void", "nvim_subscribe",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_unsubscribe",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Integer", "nvim_get_color_by_name",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Dictionary", "nvim_get_color_map",
-			QList<QString>()
-						, false)
-		<< Function("Dictionary", "nvim_get_mode",
-			QList<QString>()
-						, false)
-		<< Function("ArrayOf(Dictionary)", "nvim_get_keymap",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Array", "nvim_get_api_info",
-			QList<QString>()
-						, false)
-		<< Function("Array", "nvim_call_atomic",
-			QList<QString>()
-						<< QString("Array")
-						, false)
-		<< Function("Buffer", "nvim_win_get_buf",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("ArrayOf(Integer, 2)", "nvim_win_get_cursor",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("void", "nvim_win_set_cursor",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("ArrayOf(Integer, 2)")
-						, false)
-		<< Function("Integer", "nvim_win_get_height",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("void", "nvim_win_set_height",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("Integer")
-						, false)
-		<< Function("Integer", "nvim_win_get_width",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("void", "nvim_win_set_width",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("Integer")
-						, false)
-		<< Function("Object", "nvim_win_get_var",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_win_set_var",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("void", "nvim_win_del_var",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						, false)
-		<< Function("Object", "window_set_var",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("Object", "window_del_var",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						, false)
-		<< Function("Object", "nvim_win_get_option",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_win_set_option",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("ArrayOf(Integer, 2)", "nvim_win_get_position",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("Tabpage", "nvim_win_get_tabpage",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("Integer", "nvim_win_get_number",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("Boolean", "nvim_win_is_valid",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("Integer", "buffer_line_count",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("ArrayOf(String)", "buffer_get_lines",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Boolean")
-						, false)
-		<< Function("void", "buffer_set_lines",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Boolean")
-						<< QString("ArrayOf(String)")
-						, false)
-		<< Function("Object", "buffer_get_var",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("Object", "buffer_get_option",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("void", "buffer_set_option",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("Integer", "buffer_get_number",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("String", "buffer_get_name",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("void", "buffer_set_name",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("Boolean", "buffer_is_valid",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("ArrayOf(Integer, 2)", "buffer_get_mark",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("Integer", "buffer_add_highlight",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("String")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Integer")
-						, false)
-		<< Function("void", "buffer_clear_highlight",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Integer")
-						, false)
-		<< Function("ArrayOf(Window)", "tabpage_get_windows",
-			QList<QString>()
-						<< QString("Tabpage")
-						, false)
-		<< Function("Object", "tabpage_get_var",
-			QList<QString>()
-						<< QString("Tabpage")
-						<< QString("String")
-						, false)
-		<< Function("Window", "tabpage_get_window",
-			QList<QString>()
-						<< QString("Tabpage")
-						, false)
-		<< Function("Boolean", "tabpage_is_valid",
-			QList<QString>()
-						<< QString("Tabpage")
-						, false)
-		<< Function("void", "ui_detach",
-			QList<QString>()
-						, false)
-		<< Function("Object", "ui_try_resize",
-			QList<QString>()
-						<< QString("Integer")
-						<< QString("Integer")
-						, false)
-		<< Function("void", "vim_command",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "vim_feedkeys",
-			QList<QString>()
-						<< QString("String")
-						<< QString("String")
-						<< QString("Boolean")
-						, false)
-		<< Function("Integer", "vim_input",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("String", "vim_replace_termcodes",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Boolean")
-						<< QString("Boolean")
-						<< QString("Boolean")
-						, false)
-		<< Function("String", "vim_command_output",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Object", "vim_eval",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Object", "vim_call_function",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Array")
-						, false)
-		<< Function("Integer", "vim_strwidth",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("ArrayOf(String)", "vim_list_runtime_paths",
-			QList<QString>()
-						, false)
-		<< Function("void", "vim_change_directory",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("String", "vim_get_current_line",
-			QList<QString>()
-						, false)
-		<< Function("void", "vim_set_current_line",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "vim_del_current_line",
-			QList<QString>()
-						, false)
-		<< Function("Object", "vim_get_var",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Object", "vim_get_vvar",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Object", "vim_get_option",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "vim_set_option",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("void", "vim_out_write",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "vim_err_write",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "vim_report_error",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("ArrayOf(Buffer)", "vim_get_buffers",
-			QList<QString>()
-						, false)
-		<< Function("Buffer", "vim_get_current_buffer",
-			QList<QString>()
-						, false)
-		<< Function("void", "vim_set_current_buffer",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("ArrayOf(Window)", "vim_get_windows",
-			QList<QString>()
-						, false)
-		<< Function("Window", "vim_get_current_window",
-			QList<QString>()
-						, false)
-		<< Function("void", "vim_set_current_window",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("ArrayOf(Tabpage)", "vim_get_tabpages",
-			QList<QString>()
-						, false)
-		<< Function("Tabpage", "vim_get_current_tabpage",
-			QList<QString>()
-						, false)
-		<< Function("void", "vim_set_current_tabpage",
-			QList<QString>()
-						<< QString("Tabpage")
-						, false)
-		<< Function("void", "vim_subscribe",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "vim_unsubscribe",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Integer", "vim_name_to_color",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Dictionary", "vim_get_color_map",
-			QList<QString>()
-						, false)
-		<< Function("Buffer", "window_get_buffer",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("ArrayOf(Integer, 2)", "window_get_cursor",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("void", "window_set_cursor",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("ArrayOf(Integer, 2)")
-						, false)
-		<< Function("Integer", "window_get_height",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("void", "window_set_height",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("Integer")
-						, false)
-		<< Function("Integer", "window_get_width",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("void", "window_set_width",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("Integer")
-						, false)
-		<< Function("Object", "window_get_var",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						, false)
-		<< Function("Object", "window_get_option",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						, false)
-		<< Function("void", "window_set_option",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("ArrayOf(Integer, 2)", "window_get_position",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("Tabpage", "window_get_tabpage",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("Boolean", "window_is_valid",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		;
-
+	static const QList<Function> required{
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_buf_line_count"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("String"),
+				QStringLiteral("buffer_get_line"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("buffer_set_line"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("buffer_del_line"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(String)"),
+				QStringLiteral("buffer_get_line_slice"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(String)"),
+				QStringLiteral("nvim_buf_get_lines"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("buffer_set_line_slice"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("ArrayOf(String)"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_buf_set_lines"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("ArrayOf(String)"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_buf_get_var"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_buf_get_changedtick"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Dictionary)"),
+				QStringLiteral("nvim_buf_get_keymap"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_buf_set_var"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_buf_del_var"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("buffer_set_var"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("buffer_del_var"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_buf_get_option"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_buf_set_option"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_buf_get_number"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("String"),
+				QStringLiteral("nvim_buf_get_name"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_buf_set_name"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Boolean"),
+				QStringLiteral("nvim_buf_is_valid"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("buffer_insert"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("ArrayOf(String)"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Integer, 2)"),
+				QStringLiteral("nvim_buf_get_mark"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_buf_add_highlight"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("String"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_buf_clear_highlight"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Window)"),
+				QStringLiteral("nvim_tabpage_list_wins"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_tabpage_get_var"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_tabpage_set_var"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_tabpage_del_var"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("tabpage_set_var"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("tabpage_del_var"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Window"),
+				QStringLiteral("nvim_tabpage_get_win"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_tabpage_get_number"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Boolean"),
+				QStringLiteral("nvim_tabpage_is_valid"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_ui_attach"),
+				QStringList{
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Dictionary"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("ui_attach"),
+				QStringList{
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_ui_detach"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_ui_try_resize"),
+				QStringList{
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_ui_set_option"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_command"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Dictionary"),
+				QStringLiteral("nvim_get_hl_by_name"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Dictionary"),
+				QStringLiteral("nvim_get_hl_by_id"),
+				QStringList{
+					QStringLiteral("Integer"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_feedkeys"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("String"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_input"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("String"),
+				QStringLiteral("nvim_replace_termcodes"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("String"),
+				QStringLiteral("nvim_command_output"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_eval"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_call_function"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Array"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_execute_lua"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Array"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_strwidth"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(String)"),
+				QStringLiteral("nvim_list_runtime_paths"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_set_current_dir"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("String"),
+				QStringLiteral("nvim_get_current_line"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_set_current_line"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_del_current_line"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_get_var"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_set_var"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_del_var"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("vim_set_var"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("vim_del_var"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_get_vvar"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_get_option"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_set_option"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_out_write"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_err_write"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_err_writeln"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Buffer)"),
+				QStringLiteral("nvim_list_bufs"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Buffer"),
+				QStringLiteral("nvim_get_current_buf"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_set_current_buf"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Window)"),
+				QStringLiteral("nvim_list_wins"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Window"),
+				QStringLiteral("nvim_get_current_win"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_set_current_win"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Tabpage)"),
+				QStringLiteral("nvim_list_tabpages"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Tabpage"),
+				QStringLiteral("nvim_get_current_tabpage"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_set_current_tabpage"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_subscribe"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_unsubscribe"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_get_color_by_name"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Dictionary"),
+				QStringLiteral("nvim_get_color_map"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Dictionary"),
+				QStringLiteral("nvim_get_mode"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Dictionary)"),
+				QStringLiteral("nvim_get_keymap"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Array"),
+				QStringLiteral("nvim_get_api_info"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Array"),
+				QStringLiteral("nvim_call_atomic"),
+				QStringList{
+					QStringLiteral("Array"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Buffer"),
+				QStringLiteral("nvim_win_get_buf"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Integer, 2)"),
+				QStringLiteral("nvim_win_get_cursor"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_win_set_cursor"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("ArrayOf(Integer, 2)"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_win_get_height"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_win_set_height"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_win_get_width"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_win_set_width"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_win_get_var"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_win_set_var"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_win_del_var"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("window_set_var"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("window_del_var"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_win_get_option"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_win_set_option"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Integer, 2)"),
+				QStringLiteral("nvim_win_get_position"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Tabpage"),
+				QStringLiteral("nvim_win_get_tabpage"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_win_get_number"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Boolean"),
+				QStringLiteral("nvim_win_is_valid"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("buffer_line_count"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(String)"),
+				QStringLiteral("buffer_get_lines"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("buffer_set_lines"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("ArrayOf(String)"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("buffer_get_var"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("buffer_get_option"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("buffer_set_option"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("buffer_get_number"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("String"),
+				QStringLiteral("buffer_get_name"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("buffer_set_name"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Boolean"),
+				QStringLiteral("buffer_is_valid"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Integer, 2)"),
+				QStringLiteral("buffer_get_mark"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("buffer_add_highlight"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("String"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("buffer_clear_highlight"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Window)"),
+				QStringLiteral("tabpage_get_windows"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("tabpage_get_var"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Window"),
+				QStringLiteral("tabpage_get_window"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Boolean"),
+				QStringLiteral("tabpage_is_valid"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("ui_detach"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("ui_try_resize"),
+				QStringList{
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_command"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_feedkeys"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("String"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("vim_input"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("String"),
+				QStringLiteral("vim_replace_termcodes"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("String"),
+				QStringLiteral("vim_command_output"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("vim_eval"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("vim_call_function"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Array"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("vim_strwidth"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(String)"),
+				QStringLiteral("vim_list_runtime_paths"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_change_directory"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("String"),
+				QStringLiteral("vim_get_current_line"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_set_current_line"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_del_current_line"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("vim_get_var"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("vim_get_vvar"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("vim_get_option"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_set_option"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_out_write"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_err_write"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_report_error"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Buffer)"),
+				QStringLiteral("vim_get_buffers"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Buffer"),
+				QStringLiteral("vim_get_current_buffer"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_set_current_buffer"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Window)"),
+				QStringLiteral("vim_get_windows"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Window"),
+				QStringLiteral("vim_get_current_window"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_set_current_window"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Tabpage)"),
+				QStringLiteral("vim_get_tabpages"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Tabpage"),
+				QStringLiteral("vim_get_current_tabpage"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_set_current_tabpage"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_subscribe"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_unsubscribe"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("vim_name_to_color"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Dictionary"),
+				QStringLiteral("vim_get_color_map"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Buffer"),
+				QStringLiteral("window_get_buffer"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Integer, 2)"),
+				QStringLiteral("window_get_cursor"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("window_set_cursor"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("ArrayOf(Integer, 2)"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("window_get_height"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("window_set_height"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("window_get_width"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("window_set_width"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("window_get_var"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("window_get_option"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("window_set_option"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Integer, 2)"),
+				QStringLiteral("window_get_position"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Tabpage"),
+				QStringLiteral("window_get_tabpage"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Boolean"),
+				QStringLiteral("window_is_valid"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+		};
 
 	QList<Function> supported;
-	foreach(const QVariant& val, ftable) {
+	supported.reserve(ftable.size());
+	for(const auto& val : ftable) {
 		auto f = Function::fromVariant(val);
 		if (!f.isValid()) {
 			qDebug() << "Invalid function in metadata" << f;
@@ -4575,7 +5245,7 @@ bool NeovimApi3::checkFunctions(const QVariantList& ftable)
 	}
 
 	bool ok = true;
-	foreach(const Function& f, required) {
+	for(const auto& f : required) {
 		if (!supported.contains(f)) {
 			qDebug() << "- instance DOES NOT support API3:" << f;
 			ok = false;

--- a/src/auto/neovimapi3.cpp
+++ b/src/auto/neovimapi3.cpp
@@ -1,4 +1,4 @@
-// Auto generated 2020-09-09 13:30:54.149809 from nvim API level:3
+// Auto generated 2020-09-09 15:16:42.801442 from nvim API level:3
 #include "auto/neovimapi3.h"
 #include "msgpackiodevice.h"
 #include "msgpackrequest.h"
@@ -5229,7 +5229,7 @@ void NeovimApi3::handleResponse(uint32_t msgid, uint64_t fun, const QVariant& re
 				, false },
 		};
 
-	QList<Function> supported;
+	QVector<Function> supported;
 	supported.reserve(ftable.size());
 	for(const auto& val : ftable) {
 		auto f = Function::fromVariant(val);

--- a/src/auto/neovimapi3.h
+++ b/src/auto/neovimapi3.h
@@ -1,4 +1,4 @@
-// Auto generated 2020-09-09 13:30:54.167971 from nvim API level:3
+// Auto generated 2020-09-09 15:16:42.820006 from nvim API level:3
 #pragma once
 
 #include <QObject>

--- a/src/auto/neovimapi3.h
+++ b/src/auto/neovimapi3.h
@@ -1,619 +1,712 @@
-// Auto generated 2018-08-08 20:42:42.027594 from nvim API level:3
-#ifndef NEOVIM_QT_NEOVIMAPI3
-#define NEOVIM_QT_NEOVIMAPI3
-#include "msgpack.h"
+// Auto generated 2020-09-09 13:30:54.167971 from nvim API level:3
+#pragma once
+
 #include <QObject>
-#include <QVariant>
 #include <QPoint>
+#include <QVariant>
+
 #include "function.h"
+#include "msgpack.h"
 
 namespace NeovimQt {
+
 class NeovimConnector;
 class MsgpackRequest;
 
-class NeovimApi3: public QObject
+class NeovimApi3 : public QObject
 {
 	Q_OBJECT
-	Q_ENUMS(FunctionId)
 
 public:
-
 	enum FunctionId {
-		NEOVIM_FN_NULL=0,
-				NEOVIM_FN_NVIM_BUF_LINE_COUNT,
-				NEOVIM_FN_BUFFER_GET_LINE,
-				NEOVIM_FN_BUFFER_SET_LINE,
-				NEOVIM_FN_BUFFER_DEL_LINE,
-				NEOVIM_FN_BUFFER_GET_LINE_SLICE,
-				NEOVIM_FN_NVIM_BUF_GET_LINES,
-				NEOVIM_FN_BUFFER_SET_LINE_SLICE,
-				NEOVIM_FN_NVIM_BUF_SET_LINES,
-				NEOVIM_FN_NVIM_BUF_GET_VAR,
-				NEOVIM_FN_NVIM_BUF_GET_CHANGEDTICK,
-				NEOVIM_FN_NVIM_BUF_GET_KEYMAP,
-				NEOVIM_FN_NVIM_BUF_SET_VAR,
-				NEOVIM_FN_NVIM_BUF_DEL_VAR,
-				NEOVIM_FN_BUFFER_SET_VAR,
-				NEOVIM_FN_BUFFER_DEL_VAR,
-				NEOVIM_FN_NVIM_BUF_GET_OPTION,
-				NEOVIM_FN_NVIM_BUF_SET_OPTION,
-				NEOVIM_FN_NVIM_BUF_GET_NUMBER,
-				NEOVIM_FN_NVIM_BUF_GET_NAME,
-				NEOVIM_FN_NVIM_BUF_SET_NAME,
-				NEOVIM_FN_NVIM_BUF_IS_VALID,
-				NEOVIM_FN_BUFFER_INSERT,
-				NEOVIM_FN_NVIM_BUF_GET_MARK,
-				NEOVIM_FN_NVIM_BUF_ADD_HIGHLIGHT,
-				NEOVIM_FN_NVIM_BUF_CLEAR_HIGHLIGHT,
-				NEOVIM_FN_NVIM_TABPAGE_LIST_WINS,
-				NEOVIM_FN_NVIM_TABPAGE_GET_VAR,
-				NEOVIM_FN_NVIM_TABPAGE_SET_VAR,
-				NEOVIM_FN_NVIM_TABPAGE_DEL_VAR,
-				NEOVIM_FN_TABPAGE_SET_VAR,
-				NEOVIM_FN_TABPAGE_DEL_VAR,
-				NEOVIM_FN_NVIM_TABPAGE_GET_WIN,
-				NEOVIM_FN_NVIM_TABPAGE_GET_NUMBER,
-				NEOVIM_FN_NVIM_TABPAGE_IS_VALID,
-				NEOVIM_FN_NVIM_UI_ATTACH,
-				NEOVIM_FN_UI_ATTACH,
-				NEOVIM_FN_NVIM_UI_DETACH,
-				NEOVIM_FN_NVIM_UI_TRY_RESIZE,
-				NEOVIM_FN_NVIM_UI_SET_OPTION,
-				NEOVIM_FN_NVIM_COMMAND,
-				NEOVIM_FN_NVIM_GET_HL_BY_NAME,
-				NEOVIM_FN_NVIM_GET_HL_BY_ID,
-				NEOVIM_FN_NVIM_FEEDKEYS,
-				NEOVIM_FN_NVIM_INPUT,
-				NEOVIM_FN_NVIM_REPLACE_TERMCODES,
-				NEOVIM_FN_NVIM_COMMAND_OUTPUT,
-				NEOVIM_FN_NVIM_EVAL,
-				NEOVIM_FN_NVIM_CALL_FUNCTION,
-				NEOVIM_FN_NVIM_EXECUTE_LUA,
-				NEOVIM_FN_NVIM_STRWIDTH,
-				NEOVIM_FN_NVIM_LIST_RUNTIME_PATHS,
-				NEOVIM_FN_NVIM_SET_CURRENT_DIR,
-				NEOVIM_FN_NVIM_GET_CURRENT_LINE,
-				NEOVIM_FN_NVIM_SET_CURRENT_LINE,
-				NEOVIM_FN_NVIM_DEL_CURRENT_LINE,
-				NEOVIM_FN_NVIM_GET_VAR,
-				NEOVIM_FN_NVIM_SET_VAR,
-				NEOVIM_FN_NVIM_DEL_VAR,
-				NEOVIM_FN_VIM_SET_VAR,
-				NEOVIM_FN_VIM_DEL_VAR,
-				NEOVIM_FN_NVIM_GET_VVAR,
-				NEOVIM_FN_NVIM_GET_OPTION,
-				NEOVIM_FN_NVIM_SET_OPTION,
-				NEOVIM_FN_NVIM_OUT_WRITE,
-				NEOVIM_FN_NVIM_ERR_WRITE,
-				NEOVIM_FN_NVIM_ERR_WRITELN,
-				NEOVIM_FN_NVIM_LIST_BUFS,
-				NEOVIM_FN_NVIM_GET_CURRENT_BUF,
-				NEOVIM_FN_NVIM_SET_CURRENT_BUF,
-				NEOVIM_FN_NVIM_LIST_WINS,
-				NEOVIM_FN_NVIM_GET_CURRENT_WIN,
-				NEOVIM_FN_NVIM_SET_CURRENT_WIN,
-				NEOVIM_FN_NVIM_LIST_TABPAGES,
-				NEOVIM_FN_NVIM_GET_CURRENT_TABPAGE,
-				NEOVIM_FN_NVIM_SET_CURRENT_TABPAGE,
-				NEOVIM_FN_NVIM_SUBSCRIBE,
-				NEOVIM_FN_NVIM_UNSUBSCRIBE,
-				NEOVIM_FN_NVIM_GET_COLOR_BY_NAME,
-				NEOVIM_FN_NVIM_GET_COLOR_MAP,
-				NEOVIM_FN_NVIM_GET_MODE,
-				NEOVIM_FN_NVIM_GET_KEYMAP,
-				NEOVIM_FN_NVIM_GET_API_INFO,
-				NEOVIM_FN_NVIM_CALL_ATOMIC,
-				NEOVIM_FN_NVIM_WIN_GET_BUF,
-				NEOVIM_FN_NVIM_WIN_GET_CURSOR,
-				NEOVIM_FN_NVIM_WIN_SET_CURSOR,
-				NEOVIM_FN_NVIM_WIN_GET_HEIGHT,
-				NEOVIM_FN_NVIM_WIN_SET_HEIGHT,
-				NEOVIM_FN_NVIM_WIN_GET_WIDTH,
-				NEOVIM_FN_NVIM_WIN_SET_WIDTH,
-				NEOVIM_FN_NVIM_WIN_GET_VAR,
-				NEOVIM_FN_NVIM_WIN_SET_VAR,
-				NEOVIM_FN_NVIM_WIN_DEL_VAR,
-				NEOVIM_FN_WINDOW_SET_VAR,
-				NEOVIM_FN_WINDOW_DEL_VAR,
-				NEOVIM_FN_NVIM_WIN_GET_OPTION,
-				NEOVIM_FN_NVIM_WIN_SET_OPTION,
-				NEOVIM_FN_NVIM_WIN_GET_POSITION,
-				NEOVIM_FN_NVIM_WIN_GET_TABPAGE,
-				NEOVIM_FN_NVIM_WIN_GET_NUMBER,
-				NEOVIM_FN_NVIM_WIN_IS_VALID,
-				NEOVIM_FN_BUFFER_LINE_COUNT,
-				NEOVIM_FN_BUFFER_GET_LINES,
-				NEOVIM_FN_BUFFER_SET_LINES,
-				NEOVIM_FN_BUFFER_GET_VAR,
-				NEOVIM_FN_BUFFER_GET_OPTION,
-				NEOVIM_FN_BUFFER_SET_OPTION,
-				NEOVIM_FN_BUFFER_GET_NUMBER,
-				NEOVIM_FN_BUFFER_GET_NAME,
-				NEOVIM_FN_BUFFER_SET_NAME,
-				NEOVIM_FN_BUFFER_IS_VALID,
-				NEOVIM_FN_BUFFER_GET_MARK,
-				NEOVIM_FN_BUFFER_ADD_HIGHLIGHT,
-				NEOVIM_FN_BUFFER_CLEAR_HIGHLIGHT,
-				NEOVIM_FN_TABPAGE_GET_WINDOWS,
-				NEOVIM_FN_TABPAGE_GET_VAR,
-				NEOVIM_FN_TABPAGE_GET_WINDOW,
-				NEOVIM_FN_TABPAGE_IS_VALID,
-				NEOVIM_FN_UI_DETACH,
-				NEOVIM_FN_UI_TRY_RESIZE,
-				NEOVIM_FN_VIM_COMMAND,
-				NEOVIM_FN_VIM_FEEDKEYS,
-				NEOVIM_FN_VIM_INPUT,
-				NEOVIM_FN_VIM_REPLACE_TERMCODES,
-				NEOVIM_FN_VIM_COMMAND_OUTPUT,
-				NEOVIM_FN_VIM_EVAL,
-				NEOVIM_FN_VIM_CALL_FUNCTION,
-				NEOVIM_FN_VIM_STRWIDTH,
-				NEOVIM_FN_VIM_LIST_RUNTIME_PATHS,
-				NEOVIM_FN_VIM_CHANGE_DIRECTORY,
-				NEOVIM_FN_VIM_GET_CURRENT_LINE,
-				NEOVIM_FN_VIM_SET_CURRENT_LINE,
-				NEOVIM_FN_VIM_DEL_CURRENT_LINE,
-				NEOVIM_FN_VIM_GET_VAR,
-				NEOVIM_FN_VIM_GET_VVAR,
-				NEOVIM_FN_VIM_GET_OPTION,
-				NEOVIM_FN_VIM_SET_OPTION,
-				NEOVIM_FN_VIM_OUT_WRITE,
-				NEOVIM_FN_VIM_ERR_WRITE,
-				NEOVIM_FN_VIM_REPORT_ERROR,
-				NEOVIM_FN_VIM_GET_BUFFERS,
-				NEOVIM_FN_VIM_GET_CURRENT_BUFFER,
-				NEOVIM_FN_VIM_SET_CURRENT_BUFFER,
-				NEOVIM_FN_VIM_GET_WINDOWS,
-				NEOVIM_FN_VIM_GET_CURRENT_WINDOW,
-				NEOVIM_FN_VIM_SET_CURRENT_WINDOW,
-				NEOVIM_FN_VIM_GET_TABPAGES,
-				NEOVIM_FN_VIM_GET_CURRENT_TABPAGE,
-				NEOVIM_FN_VIM_SET_CURRENT_TABPAGE,
-				NEOVIM_FN_VIM_SUBSCRIBE,
-				NEOVIM_FN_VIM_UNSUBSCRIBE,
-				NEOVIM_FN_VIM_NAME_TO_COLOR,
-				NEOVIM_FN_VIM_GET_COLOR_MAP,
-				NEOVIM_FN_WINDOW_GET_BUFFER,
-				NEOVIM_FN_WINDOW_GET_CURSOR,
-				NEOVIM_FN_WINDOW_SET_CURSOR,
-				NEOVIM_FN_WINDOW_GET_HEIGHT,
-				NEOVIM_FN_WINDOW_SET_HEIGHT,
-				NEOVIM_FN_WINDOW_GET_WIDTH,
-				NEOVIM_FN_WINDOW_SET_WIDTH,
-				NEOVIM_FN_WINDOW_GET_VAR,
-				NEOVIM_FN_WINDOW_GET_OPTION,
-				NEOVIM_FN_WINDOW_SET_OPTION,
-				NEOVIM_FN_WINDOW_GET_POSITION,
-				NEOVIM_FN_WINDOW_GET_TABPAGE,
-				NEOVIM_FN_WINDOW_IS_VALID,
+		NEOVIM_FN_NULL,
+		NEOVIM_FN_NVIM_BUF_LINE_COUNT,
+		NEOVIM_FN_BUFFER_GET_LINE,
+		NEOVIM_FN_BUFFER_SET_LINE,
+		NEOVIM_FN_BUFFER_DEL_LINE,
+		NEOVIM_FN_BUFFER_GET_LINE_SLICE,
+		NEOVIM_FN_NVIM_BUF_GET_LINES,
+		NEOVIM_FN_BUFFER_SET_LINE_SLICE,
+		NEOVIM_FN_NVIM_BUF_SET_LINES,
+		NEOVIM_FN_NVIM_BUF_GET_VAR,
+		NEOVIM_FN_NVIM_BUF_GET_CHANGEDTICK,
+		NEOVIM_FN_NVIM_BUF_GET_KEYMAP,
+		NEOVIM_FN_NVIM_BUF_SET_VAR,
+		NEOVIM_FN_NVIM_BUF_DEL_VAR,
+		NEOVIM_FN_BUFFER_SET_VAR,
+		NEOVIM_FN_BUFFER_DEL_VAR,
+		NEOVIM_FN_NVIM_BUF_GET_OPTION,
+		NEOVIM_FN_NVIM_BUF_SET_OPTION,
+		NEOVIM_FN_NVIM_BUF_GET_NUMBER,
+		NEOVIM_FN_NVIM_BUF_GET_NAME,
+		NEOVIM_FN_NVIM_BUF_SET_NAME,
+		NEOVIM_FN_NVIM_BUF_IS_VALID,
+		NEOVIM_FN_BUFFER_INSERT,
+		NEOVIM_FN_NVIM_BUF_GET_MARK,
+		NEOVIM_FN_NVIM_BUF_ADD_HIGHLIGHT,
+		NEOVIM_FN_NVIM_BUF_CLEAR_HIGHLIGHT,
+		NEOVIM_FN_NVIM_TABPAGE_LIST_WINS,
+		NEOVIM_FN_NVIM_TABPAGE_GET_VAR,
+		NEOVIM_FN_NVIM_TABPAGE_SET_VAR,
+		NEOVIM_FN_NVIM_TABPAGE_DEL_VAR,
+		NEOVIM_FN_TABPAGE_SET_VAR,
+		NEOVIM_FN_TABPAGE_DEL_VAR,
+		NEOVIM_FN_NVIM_TABPAGE_GET_WIN,
+		NEOVIM_FN_NVIM_TABPAGE_GET_NUMBER,
+		NEOVIM_FN_NVIM_TABPAGE_IS_VALID,
+		NEOVIM_FN_NVIM_UI_ATTACH,
+		NEOVIM_FN_UI_ATTACH,
+		NEOVIM_FN_NVIM_UI_DETACH,
+		NEOVIM_FN_NVIM_UI_TRY_RESIZE,
+		NEOVIM_FN_NVIM_UI_SET_OPTION,
+		NEOVIM_FN_NVIM_COMMAND,
+		NEOVIM_FN_NVIM_GET_HL_BY_NAME,
+		NEOVIM_FN_NVIM_GET_HL_BY_ID,
+		NEOVIM_FN_NVIM_FEEDKEYS,
+		NEOVIM_FN_NVIM_INPUT,
+		NEOVIM_FN_NVIM_REPLACE_TERMCODES,
+		NEOVIM_FN_NVIM_COMMAND_OUTPUT,
+		NEOVIM_FN_NVIM_EVAL,
+		NEOVIM_FN_NVIM_CALL_FUNCTION,
+		NEOVIM_FN_NVIM_EXECUTE_LUA,
+		NEOVIM_FN_NVIM_STRWIDTH,
+		NEOVIM_FN_NVIM_LIST_RUNTIME_PATHS,
+		NEOVIM_FN_NVIM_SET_CURRENT_DIR,
+		NEOVIM_FN_NVIM_GET_CURRENT_LINE,
+		NEOVIM_FN_NVIM_SET_CURRENT_LINE,
+		NEOVIM_FN_NVIM_DEL_CURRENT_LINE,
+		NEOVIM_FN_NVIM_GET_VAR,
+		NEOVIM_FN_NVIM_SET_VAR,
+		NEOVIM_FN_NVIM_DEL_VAR,
+		NEOVIM_FN_VIM_SET_VAR,
+		NEOVIM_FN_VIM_DEL_VAR,
+		NEOVIM_FN_NVIM_GET_VVAR,
+		NEOVIM_FN_NVIM_GET_OPTION,
+		NEOVIM_FN_NVIM_SET_OPTION,
+		NEOVIM_FN_NVIM_OUT_WRITE,
+		NEOVIM_FN_NVIM_ERR_WRITE,
+		NEOVIM_FN_NVIM_ERR_WRITELN,
+		NEOVIM_FN_NVIM_LIST_BUFS,
+		NEOVIM_FN_NVIM_GET_CURRENT_BUF,
+		NEOVIM_FN_NVIM_SET_CURRENT_BUF,
+		NEOVIM_FN_NVIM_LIST_WINS,
+		NEOVIM_FN_NVIM_GET_CURRENT_WIN,
+		NEOVIM_FN_NVIM_SET_CURRENT_WIN,
+		NEOVIM_FN_NVIM_LIST_TABPAGES,
+		NEOVIM_FN_NVIM_GET_CURRENT_TABPAGE,
+		NEOVIM_FN_NVIM_SET_CURRENT_TABPAGE,
+		NEOVIM_FN_NVIM_SUBSCRIBE,
+		NEOVIM_FN_NVIM_UNSUBSCRIBE,
+		NEOVIM_FN_NVIM_GET_COLOR_BY_NAME,
+		NEOVIM_FN_NVIM_GET_COLOR_MAP,
+		NEOVIM_FN_NVIM_GET_MODE,
+		NEOVIM_FN_NVIM_GET_KEYMAP,
+		NEOVIM_FN_NVIM_GET_API_INFO,
+		NEOVIM_FN_NVIM_CALL_ATOMIC,
+		NEOVIM_FN_NVIM_WIN_GET_BUF,
+		NEOVIM_FN_NVIM_WIN_GET_CURSOR,
+		NEOVIM_FN_NVIM_WIN_SET_CURSOR,
+		NEOVIM_FN_NVIM_WIN_GET_HEIGHT,
+		NEOVIM_FN_NVIM_WIN_SET_HEIGHT,
+		NEOVIM_FN_NVIM_WIN_GET_WIDTH,
+		NEOVIM_FN_NVIM_WIN_SET_WIDTH,
+		NEOVIM_FN_NVIM_WIN_GET_VAR,
+		NEOVIM_FN_NVIM_WIN_SET_VAR,
+		NEOVIM_FN_NVIM_WIN_DEL_VAR,
+		NEOVIM_FN_WINDOW_SET_VAR,
+		NEOVIM_FN_WINDOW_DEL_VAR,
+		NEOVIM_FN_NVIM_WIN_GET_OPTION,
+		NEOVIM_FN_NVIM_WIN_SET_OPTION,
+		NEOVIM_FN_NVIM_WIN_GET_POSITION,
+		NEOVIM_FN_NVIM_WIN_GET_TABPAGE,
+		NEOVIM_FN_NVIM_WIN_GET_NUMBER,
+		NEOVIM_FN_NVIM_WIN_IS_VALID,
+		NEOVIM_FN_BUFFER_LINE_COUNT,
+		NEOVIM_FN_BUFFER_GET_LINES,
+		NEOVIM_FN_BUFFER_SET_LINES,
+		NEOVIM_FN_BUFFER_GET_VAR,
+		NEOVIM_FN_BUFFER_GET_OPTION,
+		NEOVIM_FN_BUFFER_SET_OPTION,
+		NEOVIM_FN_BUFFER_GET_NUMBER,
+		NEOVIM_FN_BUFFER_GET_NAME,
+		NEOVIM_FN_BUFFER_SET_NAME,
+		NEOVIM_FN_BUFFER_IS_VALID,
+		NEOVIM_FN_BUFFER_GET_MARK,
+		NEOVIM_FN_BUFFER_ADD_HIGHLIGHT,
+		NEOVIM_FN_BUFFER_CLEAR_HIGHLIGHT,
+		NEOVIM_FN_TABPAGE_GET_WINDOWS,
+		NEOVIM_FN_TABPAGE_GET_VAR,
+		NEOVIM_FN_TABPAGE_GET_WINDOW,
+		NEOVIM_FN_TABPAGE_IS_VALID,
+		NEOVIM_FN_UI_DETACH,
+		NEOVIM_FN_UI_TRY_RESIZE,
+		NEOVIM_FN_VIM_COMMAND,
+		NEOVIM_FN_VIM_FEEDKEYS,
+		NEOVIM_FN_VIM_INPUT,
+		NEOVIM_FN_VIM_REPLACE_TERMCODES,
+		NEOVIM_FN_VIM_COMMAND_OUTPUT,
+		NEOVIM_FN_VIM_EVAL,
+		NEOVIM_FN_VIM_CALL_FUNCTION,
+		NEOVIM_FN_VIM_STRWIDTH,
+		NEOVIM_FN_VIM_LIST_RUNTIME_PATHS,
+		NEOVIM_FN_VIM_CHANGE_DIRECTORY,
+		NEOVIM_FN_VIM_GET_CURRENT_LINE,
+		NEOVIM_FN_VIM_SET_CURRENT_LINE,
+		NEOVIM_FN_VIM_DEL_CURRENT_LINE,
+		NEOVIM_FN_VIM_GET_VAR,
+		NEOVIM_FN_VIM_GET_VVAR,
+		NEOVIM_FN_VIM_GET_OPTION,
+		NEOVIM_FN_VIM_SET_OPTION,
+		NEOVIM_FN_VIM_OUT_WRITE,
+		NEOVIM_FN_VIM_ERR_WRITE,
+		NEOVIM_FN_VIM_REPORT_ERROR,
+		NEOVIM_FN_VIM_GET_BUFFERS,
+		NEOVIM_FN_VIM_GET_CURRENT_BUFFER,
+		NEOVIM_FN_VIM_SET_CURRENT_BUFFER,
+		NEOVIM_FN_VIM_GET_WINDOWS,
+		NEOVIM_FN_VIM_GET_CURRENT_WINDOW,
+		NEOVIM_FN_VIM_SET_CURRENT_WINDOW,
+		NEOVIM_FN_VIM_GET_TABPAGES,
+		NEOVIM_FN_VIM_GET_CURRENT_TABPAGE,
+		NEOVIM_FN_VIM_SET_CURRENT_TABPAGE,
+		NEOVIM_FN_VIM_SUBSCRIBE,
+		NEOVIM_FN_VIM_UNSUBSCRIBE,
+		NEOVIM_FN_VIM_NAME_TO_COLOR,
+		NEOVIM_FN_VIM_GET_COLOR_MAP,
+		NEOVIM_FN_WINDOW_GET_BUFFER,
+		NEOVIM_FN_WINDOW_GET_CURSOR,
+		NEOVIM_FN_WINDOW_SET_CURSOR,
+		NEOVIM_FN_WINDOW_GET_HEIGHT,
+		NEOVIM_FN_WINDOW_SET_HEIGHT,
+		NEOVIM_FN_WINDOW_GET_WIDTH,
+		NEOVIM_FN_WINDOW_SET_WIDTH,
+		NEOVIM_FN_WINDOW_GET_VAR,
+		NEOVIM_FN_WINDOW_GET_OPTION,
+		NEOVIM_FN_WINDOW_SET_OPTION,
+		NEOVIM_FN_WINDOW_GET_POSITION,
+		NEOVIM_FN_WINDOW_GET_TABPAGE,
+		NEOVIM_FN_WINDOW_IS_VALID,
 			};
+	Q_ENUM(FunctionId)
 
-	static bool checkFunctions(const QVariantList& ftable);
-	static FunctionId functionId(const Function& f);
+	static bool checkFunctions(const QVariantList& ftable) noexcept;
 
-	NeovimApi3(NeovimConnector *);
+	static FunctionId functionId(const Function& f) noexcept;
+
+	NeovimApi3(NeovimConnector* c) noexcept;
+
 protected slots:
-	void handleResponse(quint32 id, quint64 fun, const QVariant&);
-	void handleResponseError(quint32 id, quint64 fun, const QVariant&);
+	void handleResponse(uint32_t id, uint64_t fun, const QVariant&);
+
+	void handleResponseError(uint32_t id, uint64_t fun, const QVariant&);
+
 signals:
 	void error(const QString& errmsg, const QVariant& errObj);
+
 	void neovimNotification(const QByteArray &name, const QVariantList& args);
+
 private:
-	NeovimConnector *m_c;
+	NeovimConnector* m_connector;
+
 public slots:
-	// Integer nvim_buf_line_count(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_line_count(int64_t buffer);
-	// DEPRECATED
-	// String buffer_get_line(Buffer buffer, Integer index, ) 
-	MsgpackRequest* buffer_get_line(int64_t buffer, int64_t index);
-	// DEPRECATED
-	// void buffer_set_line(Buffer buffer, Integer index, String line, ) 
-	MsgpackRequest* buffer_set_line(int64_t buffer, int64_t index, QByteArray line);
-	// DEPRECATED
-	// void buffer_del_line(Buffer buffer, Integer index, ) 
-	MsgpackRequest* buffer_del_line(int64_t buffer, int64_t index);
-	// DEPRECATED
-	// ArrayOf(String) buffer_get_line_slice(Buffer buffer, Integer start, Integer end, Boolean include_start, Boolean include_end, ) 
-	MsgpackRequest* buffer_get_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end);
-	// ArrayOf(String) nvim_buf_get_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ) 
-	MsgpackRequest* nvim_buf_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing);
-	// DEPRECATED
-	// void buffer_set_line_slice(Buffer buffer, Integer start, Integer end, Boolean include_start, Boolean include_end, ArrayOf(String) replacement, ) 
-	MsgpackRequest* buffer_set_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end, QList<QByteArray> replacement);
-	// void nvim_buf_set_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ArrayOf(String) replacement, ) 
-	MsgpackRequest* nvim_buf_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement);
-	// Object nvim_buf_get_var(Buffer buffer, String name, ) 
-	MsgpackRequest* nvim_buf_get_var(int64_t buffer, QByteArray name);
-	// Integer nvim_buf_get_changedtick(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_get_changedtick(int64_t buffer);
-	// ArrayOf(Dictionary) nvim_buf_get_keymap(Buffer buffer, String mode, ) 
-	MsgpackRequest* nvim_buf_get_keymap(int64_t buffer, QByteArray mode);
-	// void nvim_buf_set_var(Buffer buffer, String name, Object value, ) 
-	MsgpackRequest* nvim_buf_set_var(int64_t buffer, QByteArray name, QVariant value);
-	// void nvim_buf_del_var(Buffer buffer, String name, ) 
-	MsgpackRequest* nvim_buf_del_var(int64_t buffer, QByteArray name);
-	// DEPRECATED
-	// Object buffer_set_var(Buffer buffer, String name, Object value, ) 
-	MsgpackRequest* buffer_set_var(int64_t buffer, QByteArray name, QVariant value);
-	// DEPRECATED
-	// Object buffer_del_var(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_del_var(int64_t buffer, QByteArray name);
-	// Object nvim_buf_get_option(Buffer buffer, String name, ) 
-	MsgpackRequest* nvim_buf_get_option(int64_t buffer, QByteArray name);
-	// void nvim_buf_set_option(Buffer buffer, String name, Object value, ) 
-	MsgpackRequest* nvim_buf_set_option(int64_t buffer, QByteArray name, QVariant value);
-	// DEPRECATED
-	// Integer nvim_buf_get_number(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_get_number(int64_t buffer);
-	// String nvim_buf_get_name(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_get_name(int64_t buffer);
-	// void nvim_buf_set_name(Buffer buffer, String name, ) 
-	MsgpackRequest* nvim_buf_set_name(int64_t buffer, QByteArray name);
-	// Boolean nvim_buf_is_valid(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_is_valid(int64_t buffer);
-	// DEPRECATED
-	// void buffer_insert(Buffer buffer, Integer lnum, ArrayOf(String) lines, ) 
-	MsgpackRequest* buffer_insert(int64_t buffer, int64_t lnum, QList<QByteArray> lines);
-	// ArrayOf(Integer, 2) nvim_buf_get_mark(Buffer buffer, String name, ) 
-	MsgpackRequest* nvim_buf_get_mark(int64_t buffer, QByteArray name);
-	// Integer nvim_buf_add_highlight(Buffer buffer, Integer src_id, String hl_group, Integer line, Integer col_start, Integer col_end, ) 
-	MsgpackRequest* nvim_buf_add_highlight(int64_t buffer, int64_t src_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end);
-	// void nvim_buf_clear_highlight(Buffer buffer, Integer src_id, Integer line_start, Integer line_end, ) 
-	MsgpackRequest* nvim_buf_clear_highlight(int64_t buffer, int64_t src_id, int64_t line_start, int64_t line_end);
-	// ArrayOf(Window) nvim_tabpage_list_wins(Tabpage tabpage, ) 
-	MsgpackRequest* nvim_tabpage_list_wins(int64_t tabpage);
-	// Object nvim_tabpage_get_var(Tabpage tabpage, String name, ) 
-	MsgpackRequest* nvim_tabpage_get_var(int64_t tabpage, QByteArray name);
-	// void nvim_tabpage_set_var(Tabpage tabpage, String name, Object value, ) 
-	MsgpackRequest* nvim_tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value);
-	// void nvim_tabpage_del_var(Tabpage tabpage, String name, ) 
-	MsgpackRequest* nvim_tabpage_del_var(int64_t tabpage, QByteArray name);
-	// DEPRECATED
-	// Object tabpage_set_var(Tabpage tabpage, String name, Object value, ) 
-	MsgpackRequest* tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value);
-	// DEPRECATED
-	// Object tabpage_del_var(Tabpage tabpage, String name, ) 
-	MsgpackRequest* tabpage_del_var(int64_t tabpage, QByteArray name);
-	// Window nvim_tabpage_get_win(Tabpage tabpage, ) 
-	MsgpackRequest* nvim_tabpage_get_win(int64_t tabpage);
-	// Integer nvim_tabpage_get_number(Tabpage tabpage, ) 
-	MsgpackRequest* nvim_tabpage_get_number(int64_t tabpage);
-	// Boolean nvim_tabpage_is_valid(Tabpage tabpage, ) 
-	MsgpackRequest* nvim_tabpage_is_valid(int64_t tabpage);
-	// void nvim_ui_attach(Integer width, Integer height, Dictionary options, ) 
-	MsgpackRequest* nvim_ui_attach(int64_t width, int64_t height, QVariantMap options);
-	// DEPRECATED
-	// void ui_attach(Integer width, Integer height, Boolean enable_rgb, ) 
-	MsgpackRequest* ui_attach(int64_t width, int64_t height, bool enable_rgb);
-	// void nvim_ui_detach() 
-	MsgpackRequest* nvim_ui_detach();
-	// void nvim_ui_try_resize(Integer width, Integer height, ) 
-	MsgpackRequest* nvim_ui_try_resize(int64_t width, int64_t height);
-	// void nvim_ui_set_option(String name, Object value, ) 
-	MsgpackRequest* nvim_ui_set_option(QByteArray name, QVariant value);
-	// void nvim_command(String command, ) 
-	MsgpackRequest* nvim_command(QByteArray command);
-	// Dictionary nvim_get_hl_by_name(String name, Boolean rgb, ) 
-	MsgpackRequest* nvim_get_hl_by_name(QByteArray name, bool rgb);
-	// Dictionary nvim_get_hl_by_id(Integer hl_id, Boolean rgb, ) 
-	MsgpackRequest* nvim_get_hl_by_id(int64_t hl_id, bool rgb);
-	// void nvim_feedkeys(String keys, String mode, Boolean escape_csi, ) 
-	MsgpackRequest* nvim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi);
-	// Integer nvim_input(String keys, ) 
-	MsgpackRequest* nvim_input(QByteArray keys);
-	// String nvim_replace_termcodes(String str, Boolean from_part, Boolean do_lt, Boolean special, ) 
-	MsgpackRequest* nvim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special);
-	// String nvim_command_output(String str, ) 
-	MsgpackRequest* nvim_command_output(QByteArray str);
-	// Object nvim_eval(String expr, ) 
-	MsgpackRequest* nvim_eval(QByteArray expr);
-	// Object nvim_call_function(String fname, Array args, ) 
-	MsgpackRequest* nvim_call_function(QByteArray fname, QVariantList args);
-	// Object nvim_execute_lua(String code, Array args, ) 
-	MsgpackRequest* nvim_execute_lua(QByteArray code, QVariantList args);
-	// Integer nvim_strwidth(String text, ) 
-	MsgpackRequest* nvim_strwidth(QByteArray text);
-	// ArrayOf(String) nvim_list_runtime_paths() 
-	MsgpackRequest* nvim_list_runtime_paths();
-	// void nvim_set_current_dir(String dir, ) 
-	MsgpackRequest* nvim_set_current_dir(QByteArray dir);
-	// String nvim_get_current_line() 
-	MsgpackRequest* nvim_get_current_line();
-	// void nvim_set_current_line(String line, ) 
-	MsgpackRequest* nvim_set_current_line(QByteArray line);
-	// void nvim_del_current_line() 
-	MsgpackRequest* nvim_del_current_line();
-	// Object nvim_get_var(String name, ) 
-	MsgpackRequest* nvim_get_var(QByteArray name);
-	// void nvim_set_var(String name, Object value, ) 
-	MsgpackRequest* nvim_set_var(QByteArray name, QVariant value);
-	// void nvim_del_var(String name, ) 
-	MsgpackRequest* nvim_del_var(QByteArray name);
-	// DEPRECATED
-	// Object vim_set_var(String name, Object value, ) 
-	MsgpackRequest* vim_set_var(QByteArray name, QVariant value);
-	// DEPRECATED
-	// Object vim_del_var(String name, ) 
-	MsgpackRequest* vim_del_var(QByteArray name);
-	// Object nvim_get_vvar(String name, ) 
-	MsgpackRequest* nvim_get_vvar(QByteArray name);
-	// Object nvim_get_option(String name, ) 
-	MsgpackRequest* nvim_get_option(QByteArray name);
-	// void nvim_set_option(String name, Object value, ) 
-	MsgpackRequest* nvim_set_option(QByteArray name, QVariant value);
-	// void nvim_out_write(String str, ) 
-	MsgpackRequest* nvim_out_write(QByteArray str);
-	// void nvim_err_write(String str, ) 
-	MsgpackRequest* nvim_err_write(QByteArray str);
-	// void nvim_err_writeln(String str, ) 
-	MsgpackRequest* nvim_err_writeln(QByteArray str);
-	// ArrayOf(Buffer) nvim_list_bufs() 
-	MsgpackRequest* nvim_list_bufs();
-	// Buffer nvim_get_current_buf() 
-	MsgpackRequest* nvim_get_current_buf();
-	// void nvim_set_current_buf(Buffer buffer, ) 
-	MsgpackRequest* nvim_set_current_buf(int64_t buffer);
-	// ArrayOf(Window) nvim_list_wins() 
-	MsgpackRequest* nvim_list_wins();
-	// Window nvim_get_current_win() 
-	MsgpackRequest* nvim_get_current_win();
-	// void nvim_set_current_win(Window window, ) 
-	MsgpackRequest* nvim_set_current_win(int64_t window);
-	// ArrayOf(Tabpage) nvim_list_tabpages() 
-	MsgpackRequest* nvim_list_tabpages();
-	// Tabpage nvim_get_current_tabpage() 
-	MsgpackRequest* nvim_get_current_tabpage();
-	// void nvim_set_current_tabpage(Tabpage tabpage, ) 
-	MsgpackRequest* nvim_set_current_tabpage(int64_t tabpage);
-	// void nvim_subscribe(String event, ) 
-	MsgpackRequest* nvim_subscribe(QByteArray event);
-	// void nvim_unsubscribe(String event, ) 
-	MsgpackRequest* nvim_unsubscribe(QByteArray event);
-	// Integer nvim_get_color_by_name(String name, ) 
-	MsgpackRequest* nvim_get_color_by_name(QByteArray name);
-	// Dictionary nvim_get_color_map() 
-	MsgpackRequest* nvim_get_color_map();
-	// Dictionary nvim_get_mode() 
-	MsgpackRequest* nvim_get_mode();
-	// ArrayOf(Dictionary) nvim_get_keymap(String mode, ) 
-	MsgpackRequest* nvim_get_keymap(QByteArray mode);
-	// Array nvim_get_api_info() 
-	MsgpackRequest* nvim_get_api_info();
-	// Array nvim_call_atomic(Array calls, ) 
-	MsgpackRequest* nvim_call_atomic(QVariantList calls);
-	// Buffer nvim_win_get_buf(Window window, ) 
-	MsgpackRequest* nvim_win_get_buf(int64_t window);
-	// ArrayOf(Integer, 2) nvim_win_get_cursor(Window window, ) 
-	MsgpackRequest* nvim_win_get_cursor(int64_t window);
-	// void nvim_win_set_cursor(Window window, ArrayOf(Integer, 2) pos, ) 
-	MsgpackRequest* nvim_win_set_cursor(int64_t window, QPoint pos);
-	// Integer nvim_win_get_height(Window window, ) 
-	MsgpackRequest* nvim_win_get_height(int64_t window);
-	// void nvim_win_set_height(Window window, Integer height, ) 
-	MsgpackRequest* nvim_win_set_height(int64_t window, int64_t height);
-	// Integer nvim_win_get_width(Window window, ) 
-	MsgpackRequest* nvim_win_get_width(int64_t window);
-	// void nvim_win_set_width(Window window, Integer width, ) 
-	MsgpackRequest* nvim_win_set_width(int64_t window, int64_t width);
-	// Object nvim_win_get_var(Window window, String name, ) 
-	MsgpackRequest* nvim_win_get_var(int64_t window, QByteArray name);
-	// void nvim_win_set_var(Window window, String name, Object value, ) 
-	MsgpackRequest* nvim_win_set_var(int64_t window, QByteArray name, QVariant value);
-	// void nvim_win_del_var(Window window, String name, ) 
-	MsgpackRequest* nvim_win_del_var(int64_t window, QByteArray name);
-	// DEPRECATED
-	// Object window_set_var(Window window, String name, Object value, ) 
-	MsgpackRequest* window_set_var(int64_t window, QByteArray name, QVariant value);
-	// DEPRECATED
-	// Object window_del_var(Window window, String name, ) 
-	MsgpackRequest* window_del_var(int64_t window, QByteArray name);
-	// Object nvim_win_get_option(Window window, String name, ) 
-	MsgpackRequest* nvim_win_get_option(int64_t window, QByteArray name);
-	// void nvim_win_set_option(Window window, String name, Object value, ) 
-	MsgpackRequest* nvim_win_set_option(int64_t window, QByteArray name, QVariant value);
-	// ArrayOf(Integer, 2) nvim_win_get_position(Window window, ) 
-	MsgpackRequest* nvim_win_get_position(int64_t window);
-	// Tabpage nvim_win_get_tabpage(Window window, ) 
-	MsgpackRequest* nvim_win_get_tabpage(int64_t window);
-	// Integer nvim_win_get_number(Window window, ) 
-	MsgpackRequest* nvim_win_get_number(int64_t window);
-	// Boolean nvim_win_is_valid(Window window, ) 
-	MsgpackRequest* nvim_win_is_valid(int64_t window);
-	// DEPRECATED
-	// Integer buffer_line_count(Buffer buffer, ) 
-	MsgpackRequest* buffer_line_count(int64_t buffer);
-	// DEPRECATED
-	// ArrayOf(String) buffer_get_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ) 
-	MsgpackRequest* buffer_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing);
-	// DEPRECATED
-	// void buffer_set_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ArrayOf(String) replacement, ) 
-	MsgpackRequest* buffer_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement);
-	// DEPRECATED
-	// Object buffer_get_var(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_get_var(int64_t buffer, QByteArray name);
-	// DEPRECATED
-	// Object buffer_get_option(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_get_option(int64_t buffer, QByteArray name);
-	// DEPRECATED
-	// void buffer_set_option(Buffer buffer, String name, Object value, ) 
-	MsgpackRequest* buffer_set_option(int64_t buffer, QByteArray name, QVariant value);
-	// DEPRECATED
-	// Integer buffer_get_number(Buffer buffer, ) 
-	MsgpackRequest* buffer_get_number(int64_t buffer);
-	// DEPRECATED
-	// String buffer_get_name(Buffer buffer, ) 
-	MsgpackRequest* buffer_get_name(int64_t buffer);
-	// DEPRECATED
-	// void buffer_set_name(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_set_name(int64_t buffer, QByteArray name);
-	// DEPRECATED
-	// Boolean buffer_is_valid(Buffer buffer, ) 
-	MsgpackRequest* buffer_is_valid(int64_t buffer);
-	// DEPRECATED
-	// ArrayOf(Integer, 2) buffer_get_mark(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_get_mark(int64_t buffer, QByteArray name);
-	// DEPRECATED
-	// Integer buffer_add_highlight(Buffer buffer, Integer src_id, String hl_group, Integer line, Integer col_start, Integer col_end, ) 
-	MsgpackRequest* buffer_add_highlight(int64_t buffer, int64_t src_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end);
-	// DEPRECATED
-	// void buffer_clear_highlight(Buffer buffer, Integer src_id, Integer line_start, Integer line_end, ) 
-	MsgpackRequest* buffer_clear_highlight(int64_t buffer, int64_t src_id, int64_t line_start, int64_t line_end);
-	// DEPRECATED
-	// ArrayOf(Window) tabpage_get_windows(Tabpage tabpage, ) 
-	MsgpackRequest* tabpage_get_windows(int64_t tabpage);
-	// DEPRECATED
-	// Object tabpage_get_var(Tabpage tabpage, String name, ) 
-	MsgpackRequest* tabpage_get_var(int64_t tabpage, QByteArray name);
-	// DEPRECATED
-	// Window tabpage_get_window(Tabpage tabpage, ) 
-	MsgpackRequest* tabpage_get_window(int64_t tabpage);
-	// DEPRECATED
-	// Boolean tabpage_is_valid(Tabpage tabpage, ) 
-	MsgpackRequest* tabpage_is_valid(int64_t tabpage);
-	// DEPRECATED
-	// void ui_detach() 
-	MsgpackRequest* ui_detach();
-	// DEPRECATED
-	// Object ui_try_resize(Integer width, Integer height, ) 
-	MsgpackRequest* ui_try_resize(int64_t width, int64_t height);
-	// DEPRECATED
-	// void vim_command(String command, ) 
-	MsgpackRequest* vim_command(QByteArray command);
-	// DEPRECATED
-	// void vim_feedkeys(String keys, String mode, Boolean escape_csi, ) 
-	MsgpackRequest* vim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi);
-	// DEPRECATED
-	// Integer vim_input(String keys, ) 
-	MsgpackRequest* vim_input(QByteArray keys);
-	// DEPRECATED
-	// String vim_replace_termcodes(String str, Boolean from_part, Boolean do_lt, Boolean special, ) 
-	MsgpackRequest* vim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special);
-	// DEPRECATED
-	// String vim_command_output(String str, ) 
-	MsgpackRequest* vim_command_output(QByteArray str);
-	// DEPRECATED
-	// Object vim_eval(String expr, ) 
-	MsgpackRequest* vim_eval(QByteArray expr);
-	// DEPRECATED
-	// Object vim_call_function(String fname, Array args, ) 
-	MsgpackRequest* vim_call_function(QByteArray fname, QVariantList args);
-	// DEPRECATED
-	// Integer vim_strwidth(String text, ) 
-	MsgpackRequest* vim_strwidth(QByteArray text);
-	// DEPRECATED
-	// ArrayOf(String) vim_list_runtime_paths() 
-	MsgpackRequest* vim_list_runtime_paths();
-	// DEPRECATED
-	// void vim_change_directory(String dir, ) 
-	MsgpackRequest* vim_change_directory(QByteArray dir);
-	// DEPRECATED
-	// String vim_get_current_line() 
-	MsgpackRequest* vim_get_current_line();
-	// DEPRECATED
-	// void vim_set_current_line(String line, ) 
-	MsgpackRequest* vim_set_current_line(QByteArray line);
-	// DEPRECATED
-	// void vim_del_current_line() 
-	MsgpackRequest* vim_del_current_line();
-	// DEPRECATED
-	// Object vim_get_var(String name, ) 
-	MsgpackRequest* vim_get_var(QByteArray name);
-	// DEPRECATED
-	// Object vim_get_vvar(String name, ) 
-	MsgpackRequest* vim_get_vvar(QByteArray name);
-	// DEPRECATED
-	// Object vim_get_option(String name, ) 
-	MsgpackRequest* vim_get_option(QByteArray name);
-	// DEPRECATED
-	// void vim_set_option(String name, Object value, ) 
-	MsgpackRequest* vim_set_option(QByteArray name, QVariant value);
-	// DEPRECATED
-	// void vim_out_write(String str, ) 
-	MsgpackRequest* vim_out_write(QByteArray str);
-	// DEPRECATED
-	// void vim_err_write(String str, ) 
-	MsgpackRequest* vim_err_write(QByteArray str);
-	// DEPRECATED
-	// void vim_report_error(String str, ) 
-	MsgpackRequest* vim_report_error(QByteArray str);
-	// DEPRECATED
-	// ArrayOf(Buffer) vim_get_buffers() 
-	MsgpackRequest* vim_get_buffers();
-	// DEPRECATED
-	// Buffer vim_get_current_buffer() 
-	MsgpackRequest* vim_get_current_buffer();
-	// DEPRECATED
-	// void vim_set_current_buffer(Buffer buffer, ) 
-	MsgpackRequest* vim_set_current_buffer(int64_t buffer);
-	// DEPRECATED
-	// ArrayOf(Window) vim_get_windows() 
-	MsgpackRequest* vim_get_windows();
-	// DEPRECATED
-	// Window vim_get_current_window() 
-	MsgpackRequest* vim_get_current_window();
-	// DEPRECATED
-	// void vim_set_current_window(Window window, ) 
-	MsgpackRequest* vim_set_current_window(int64_t window);
-	// DEPRECATED
-	// ArrayOf(Tabpage) vim_get_tabpages() 
-	MsgpackRequest* vim_get_tabpages();
-	// DEPRECATED
-	// Tabpage vim_get_current_tabpage() 
-	MsgpackRequest* vim_get_current_tabpage();
-	// DEPRECATED
-	// void vim_set_current_tabpage(Tabpage tabpage, ) 
-	MsgpackRequest* vim_set_current_tabpage(int64_t tabpage);
-	// DEPRECATED
-	// void vim_subscribe(String event, ) 
-	MsgpackRequest* vim_subscribe(QByteArray event);
-	// DEPRECATED
-	// void vim_unsubscribe(String event, ) 
-	MsgpackRequest* vim_unsubscribe(QByteArray event);
-	// DEPRECATED
-	// Integer vim_name_to_color(String name, ) 
-	MsgpackRequest* vim_name_to_color(QByteArray name);
-	// DEPRECATED
-	// Dictionary vim_get_color_map() 
-	MsgpackRequest* vim_get_color_map();
-	// DEPRECATED
-	// Buffer window_get_buffer(Window window, ) 
-	MsgpackRequest* window_get_buffer(int64_t window);
-	// DEPRECATED
-	// ArrayOf(Integer, 2) window_get_cursor(Window window, ) 
-	MsgpackRequest* window_get_cursor(int64_t window);
-	// DEPRECATED
-	// void window_set_cursor(Window window, ArrayOf(Integer, 2) pos, ) 
-	MsgpackRequest* window_set_cursor(int64_t window, QPoint pos);
-	// DEPRECATED
-	// Integer window_get_height(Window window, ) 
-	MsgpackRequest* window_get_height(int64_t window);
-	// DEPRECATED
-	// void window_set_height(Window window, Integer height, ) 
-	MsgpackRequest* window_set_height(int64_t window, int64_t height);
-	// DEPRECATED
-	// Integer window_get_width(Window window, ) 
-	MsgpackRequest* window_get_width(int64_t window);
-	// DEPRECATED
-	// void window_set_width(Window window, Integer width, ) 
-	MsgpackRequest* window_set_width(int64_t window, int64_t width);
-	// DEPRECATED
-	// Object window_get_var(Window window, String name, ) 
-	MsgpackRequest* window_get_var(int64_t window, QByteArray name);
-	// DEPRECATED
-	// Object window_get_option(Window window, String name, ) 
-	MsgpackRequest* window_get_option(int64_t window, QByteArray name);
-	// DEPRECATED
-	// void window_set_option(Window window, String name, Object value, ) 
-	MsgpackRequest* window_set_option(int64_t window, QByteArray name, QVariant value);
-	// DEPRECATED
-	// ArrayOf(Integer, 2) window_get_position(Window window, ) 
-	MsgpackRequest* window_get_position(int64_t window);
-	// DEPRECATED
-	// Tabpage window_get_tabpage(Window window, ) 
-	MsgpackRequest* window_get_tabpage(int64_t window);
-	// DEPRECATED
-	// Boolean window_is_valid(Window window, ) 
-	MsgpackRequest* window_is_valid(int64_t window);
+	/// Integer nvim_buf_line_count(Buffer buffer, )
+	NeovimQt::MsgpackRequest* nvim_buf_line_count(int64_t buffer);
+
+	/// DEPRECATED: String buffer_get_line(Buffer buffer, Integer index, )
+	NeovimQt::MsgpackRequest* buffer_get_line(int64_t buffer, int64_t index);
+
+	/// DEPRECATED: void buffer_set_line(Buffer buffer, Integer index, String line, )
+	NeovimQt::MsgpackRequest* buffer_set_line(int64_t buffer, int64_t index, QByteArray line);
+
+	/// DEPRECATED: void buffer_del_line(Buffer buffer, Integer index, )
+	NeovimQt::MsgpackRequest* buffer_del_line(int64_t buffer, int64_t index);
+
+	/// DEPRECATED: ArrayOf(String) buffer_get_line_slice(Buffer buffer, Integer start, Integer end, Boolean include_start, Boolean include_end, )
+	NeovimQt::MsgpackRequest* buffer_get_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end);
+
+	/// ArrayOf(String) nvim_buf_get_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, )
+	NeovimQt::MsgpackRequest* nvim_buf_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing);
+
+	/// DEPRECATED: void buffer_set_line_slice(Buffer buffer, Integer start, Integer end, Boolean include_start, Boolean include_end, ArrayOf(String) replacement, )
+	NeovimQt::MsgpackRequest* buffer_set_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end, QList<QByteArray> replacement);
+
+	/// void nvim_buf_set_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ArrayOf(String) replacement, )
+	NeovimQt::MsgpackRequest* nvim_buf_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement);
+
+	/// Object nvim_buf_get_var(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* nvim_buf_get_var(int64_t buffer, QByteArray name);
+
+	/// Integer nvim_buf_get_changedtick(Buffer buffer, )
+	NeovimQt::MsgpackRequest* nvim_buf_get_changedtick(int64_t buffer);
+
+	/// ArrayOf(Dictionary) nvim_buf_get_keymap(Buffer buffer, String mode, )
+	NeovimQt::MsgpackRequest* nvim_buf_get_keymap(int64_t buffer, QByteArray mode);
+
+	/// void nvim_buf_set_var(Buffer buffer, String name, Object value, )
+	NeovimQt::MsgpackRequest* nvim_buf_set_var(int64_t buffer, QByteArray name, QVariant value);
+
+	/// void nvim_buf_del_var(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* nvim_buf_del_var(int64_t buffer, QByteArray name);
+
+	/// DEPRECATED: Object buffer_set_var(Buffer buffer, String name, Object value, )
+	NeovimQt::MsgpackRequest* buffer_set_var(int64_t buffer, QByteArray name, QVariant value);
+
+	/// DEPRECATED: Object buffer_del_var(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* buffer_del_var(int64_t buffer, QByteArray name);
+
+	/// Object nvim_buf_get_option(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* nvim_buf_get_option(int64_t buffer, QByteArray name);
+
+	/// void nvim_buf_set_option(Buffer buffer, String name, Object value, )
+	NeovimQt::MsgpackRequest* nvim_buf_set_option(int64_t buffer, QByteArray name, QVariant value);
+
+	/// DEPRECATED: Integer nvim_buf_get_number(Buffer buffer, )
+	NeovimQt::MsgpackRequest* nvim_buf_get_number(int64_t buffer);
+
+	/// String nvim_buf_get_name(Buffer buffer, )
+	NeovimQt::MsgpackRequest* nvim_buf_get_name(int64_t buffer);
+
+	/// void nvim_buf_set_name(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* nvim_buf_set_name(int64_t buffer, QByteArray name);
+
+	/// Boolean nvim_buf_is_valid(Buffer buffer, )
+	NeovimQt::MsgpackRequest* nvim_buf_is_valid(int64_t buffer);
+
+	/// DEPRECATED: void buffer_insert(Buffer buffer, Integer lnum, ArrayOf(String) lines, )
+	NeovimQt::MsgpackRequest* buffer_insert(int64_t buffer, int64_t lnum, QList<QByteArray> lines);
+
+	/// ArrayOf(Integer, 2) nvim_buf_get_mark(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* nvim_buf_get_mark(int64_t buffer, QByteArray name);
+
+	/// Integer nvim_buf_add_highlight(Buffer buffer, Integer src_id, String hl_group, Integer line, Integer col_start, Integer col_end, )
+	NeovimQt::MsgpackRequest* nvim_buf_add_highlight(int64_t buffer, int64_t src_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end);
+
+	/// void nvim_buf_clear_highlight(Buffer buffer, Integer src_id, Integer line_start, Integer line_end, )
+	NeovimQt::MsgpackRequest* nvim_buf_clear_highlight(int64_t buffer, int64_t src_id, int64_t line_start, int64_t line_end);
+
+	/// ArrayOf(Window) nvim_tabpage_list_wins(Tabpage tabpage, )
+	NeovimQt::MsgpackRequest* nvim_tabpage_list_wins(int64_t tabpage);
+
+	/// Object nvim_tabpage_get_var(Tabpage tabpage, String name, )
+	NeovimQt::MsgpackRequest* nvim_tabpage_get_var(int64_t tabpage, QByteArray name);
+
+	/// void nvim_tabpage_set_var(Tabpage tabpage, String name, Object value, )
+	NeovimQt::MsgpackRequest* nvim_tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value);
+
+	/// void nvim_tabpage_del_var(Tabpage tabpage, String name, )
+	NeovimQt::MsgpackRequest* nvim_tabpage_del_var(int64_t tabpage, QByteArray name);
+
+	/// DEPRECATED: Object tabpage_set_var(Tabpage tabpage, String name, Object value, )
+	NeovimQt::MsgpackRequest* tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value);
+
+	/// DEPRECATED: Object tabpage_del_var(Tabpage tabpage, String name, )
+	NeovimQt::MsgpackRequest* tabpage_del_var(int64_t tabpage, QByteArray name);
+
+	/// Window nvim_tabpage_get_win(Tabpage tabpage, )
+	NeovimQt::MsgpackRequest* nvim_tabpage_get_win(int64_t tabpage);
+
+	/// Integer nvim_tabpage_get_number(Tabpage tabpage, )
+	NeovimQt::MsgpackRequest* nvim_tabpage_get_number(int64_t tabpage);
+
+	/// Boolean nvim_tabpage_is_valid(Tabpage tabpage, )
+	NeovimQt::MsgpackRequest* nvim_tabpage_is_valid(int64_t tabpage);
+
+	/// void nvim_ui_attach(Integer width, Integer height, Dictionary options, )
+	NeovimQt::MsgpackRequest* nvim_ui_attach(int64_t width, int64_t height, QVariantMap options);
+
+	/// DEPRECATED: void ui_attach(Integer width, Integer height, Boolean enable_rgb, )
+	NeovimQt::MsgpackRequest* ui_attach(int64_t width, int64_t height, bool enable_rgb);
+
+	/// void nvim_ui_detach()
+	NeovimQt::MsgpackRequest* nvim_ui_detach();
+
+	/// void nvim_ui_try_resize(Integer width, Integer height, )
+	NeovimQt::MsgpackRequest* nvim_ui_try_resize(int64_t width, int64_t height);
+
+	/// void nvim_ui_set_option(String name, Object value, )
+	NeovimQt::MsgpackRequest* nvim_ui_set_option(QByteArray name, QVariant value);
+
+	/// void nvim_command(String command, )
+	NeovimQt::MsgpackRequest* nvim_command(QByteArray command);
+
+	/// Dictionary nvim_get_hl_by_name(String name, Boolean rgb, )
+	NeovimQt::MsgpackRequest* nvim_get_hl_by_name(QByteArray name, bool rgb);
+
+	/// Dictionary nvim_get_hl_by_id(Integer hl_id, Boolean rgb, )
+	NeovimQt::MsgpackRequest* nvim_get_hl_by_id(int64_t hl_id, bool rgb);
+
+	/// void nvim_feedkeys(String keys, String mode, Boolean escape_csi, )
+	NeovimQt::MsgpackRequest* nvim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi);
+
+	/// Integer nvim_input(String keys, )
+	NeovimQt::MsgpackRequest* nvim_input(QByteArray keys);
+
+	/// String nvim_replace_termcodes(String str, Boolean from_part, Boolean do_lt, Boolean special, )
+	NeovimQt::MsgpackRequest* nvim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special);
+
+	/// String nvim_command_output(String str, )
+	NeovimQt::MsgpackRequest* nvim_command_output(QByteArray str);
+
+	/// Object nvim_eval(String expr, )
+	NeovimQt::MsgpackRequest* nvim_eval(QByteArray expr);
+
+	/// Object nvim_call_function(String fname, Array args, )
+	NeovimQt::MsgpackRequest* nvim_call_function(QByteArray fname, QVariantList args);
+
+	/// Object nvim_execute_lua(String code, Array args, )
+	NeovimQt::MsgpackRequest* nvim_execute_lua(QByteArray code, QVariantList args);
+
+	/// Integer nvim_strwidth(String text, )
+	NeovimQt::MsgpackRequest* nvim_strwidth(QByteArray text);
+
+	/// ArrayOf(String) nvim_list_runtime_paths()
+	NeovimQt::MsgpackRequest* nvim_list_runtime_paths();
+
+	/// void nvim_set_current_dir(String dir, )
+	NeovimQt::MsgpackRequest* nvim_set_current_dir(QByteArray dir);
+
+	/// String nvim_get_current_line()
+	NeovimQt::MsgpackRequest* nvim_get_current_line();
+
+	/// void nvim_set_current_line(String line, )
+	NeovimQt::MsgpackRequest* nvim_set_current_line(QByteArray line);
+
+	/// void nvim_del_current_line()
+	NeovimQt::MsgpackRequest* nvim_del_current_line();
+
+	/// Object nvim_get_var(String name, )
+	NeovimQt::MsgpackRequest* nvim_get_var(QByteArray name);
+
+	/// void nvim_set_var(String name, Object value, )
+	NeovimQt::MsgpackRequest* nvim_set_var(QByteArray name, QVariant value);
+
+	/// void nvim_del_var(String name, )
+	NeovimQt::MsgpackRequest* nvim_del_var(QByteArray name);
+
+	/// DEPRECATED: Object vim_set_var(String name, Object value, )
+	NeovimQt::MsgpackRequest* vim_set_var(QByteArray name, QVariant value);
+
+	/// DEPRECATED: Object vim_del_var(String name, )
+	NeovimQt::MsgpackRequest* vim_del_var(QByteArray name);
+
+	/// Object nvim_get_vvar(String name, )
+	NeovimQt::MsgpackRequest* nvim_get_vvar(QByteArray name);
+
+	/// Object nvim_get_option(String name, )
+	NeovimQt::MsgpackRequest* nvim_get_option(QByteArray name);
+
+	/// void nvim_set_option(String name, Object value, )
+	NeovimQt::MsgpackRequest* nvim_set_option(QByteArray name, QVariant value);
+
+	/// void nvim_out_write(String str, )
+	NeovimQt::MsgpackRequest* nvim_out_write(QByteArray str);
+
+	/// void nvim_err_write(String str, )
+	NeovimQt::MsgpackRequest* nvim_err_write(QByteArray str);
+
+	/// void nvim_err_writeln(String str, )
+	NeovimQt::MsgpackRequest* nvim_err_writeln(QByteArray str);
+
+	/// ArrayOf(Buffer) nvim_list_bufs()
+	NeovimQt::MsgpackRequest* nvim_list_bufs();
+
+	/// Buffer nvim_get_current_buf()
+	NeovimQt::MsgpackRequest* nvim_get_current_buf();
+
+	/// void nvim_set_current_buf(Buffer buffer, )
+	NeovimQt::MsgpackRequest* nvim_set_current_buf(int64_t buffer);
+
+	/// ArrayOf(Window) nvim_list_wins()
+	NeovimQt::MsgpackRequest* nvim_list_wins();
+
+	/// Window nvim_get_current_win()
+	NeovimQt::MsgpackRequest* nvim_get_current_win();
+
+	/// void nvim_set_current_win(Window window, )
+	NeovimQt::MsgpackRequest* nvim_set_current_win(int64_t window);
+
+	/// ArrayOf(Tabpage) nvim_list_tabpages()
+	NeovimQt::MsgpackRequest* nvim_list_tabpages();
+
+	/// Tabpage nvim_get_current_tabpage()
+	NeovimQt::MsgpackRequest* nvim_get_current_tabpage();
+
+	/// void nvim_set_current_tabpage(Tabpage tabpage, )
+	NeovimQt::MsgpackRequest* nvim_set_current_tabpage(int64_t tabpage);
+
+	/// void nvim_subscribe(String event, )
+	NeovimQt::MsgpackRequest* nvim_subscribe(QByteArray event);
+
+	/// void nvim_unsubscribe(String event, )
+	NeovimQt::MsgpackRequest* nvim_unsubscribe(QByteArray event);
+
+	/// Integer nvim_get_color_by_name(String name, )
+	NeovimQt::MsgpackRequest* nvim_get_color_by_name(QByteArray name);
+
+	/// Dictionary nvim_get_color_map()
+	NeovimQt::MsgpackRequest* nvim_get_color_map();
+
+	/// Dictionary nvim_get_mode()
+	NeovimQt::MsgpackRequest* nvim_get_mode();
+
+	/// ArrayOf(Dictionary) nvim_get_keymap(String mode, )
+	NeovimQt::MsgpackRequest* nvim_get_keymap(QByteArray mode);
+
+	/// Array nvim_get_api_info()
+	NeovimQt::MsgpackRequest* nvim_get_api_info();
+
+	/// Array nvim_call_atomic(Array calls, )
+	NeovimQt::MsgpackRequest* nvim_call_atomic(QVariantList calls);
+
+	/// Buffer nvim_win_get_buf(Window window, )
+	NeovimQt::MsgpackRequest* nvim_win_get_buf(int64_t window);
+
+	/// ArrayOf(Integer, 2) nvim_win_get_cursor(Window window, )
+	NeovimQt::MsgpackRequest* nvim_win_get_cursor(int64_t window);
+
+	/// void nvim_win_set_cursor(Window window, ArrayOf(Integer, 2) pos, )
+	NeovimQt::MsgpackRequest* nvim_win_set_cursor(int64_t window, QPoint pos);
+
+	/// Integer nvim_win_get_height(Window window, )
+	NeovimQt::MsgpackRequest* nvim_win_get_height(int64_t window);
+
+	/// void nvim_win_set_height(Window window, Integer height, )
+	NeovimQt::MsgpackRequest* nvim_win_set_height(int64_t window, int64_t height);
+
+	/// Integer nvim_win_get_width(Window window, )
+	NeovimQt::MsgpackRequest* nvim_win_get_width(int64_t window);
+
+	/// void nvim_win_set_width(Window window, Integer width, )
+	NeovimQt::MsgpackRequest* nvim_win_set_width(int64_t window, int64_t width);
+
+	/// Object nvim_win_get_var(Window window, String name, )
+	NeovimQt::MsgpackRequest* nvim_win_get_var(int64_t window, QByteArray name);
+
+	/// void nvim_win_set_var(Window window, String name, Object value, )
+	NeovimQt::MsgpackRequest* nvim_win_set_var(int64_t window, QByteArray name, QVariant value);
+
+	/// void nvim_win_del_var(Window window, String name, )
+	NeovimQt::MsgpackRequest* nvim_win_del_var(int64_t window, QByteArray name);
+
+	/// DEPRECATED: Object window_set_var(Window window, String name, Object value, )
+	NeovimQt::MsgpackRequest* window_set_var(int64_t window, QByteArray name, QVariant value);
+
+	/// DEPRECATED: Object window_del_var(Window window, String name, )
+	NeovimQt::MsgpackRequest* window_del_var(int64_t window, QByteArray name);
+
+	/// Object nvim_win_get_option(Window window, String name, )
+	NeovimQt::MsgpackRequest* nvim_win_get_option(int64_t window, QByteArray name);
+
+	/// void nvim_win_set_option(Window window, String name, Object value, )
+	NeovimQt::MsgpackRequest* nvim_win_set_option(int64_t window, QByteArray name, QVariant value);
+
+	/// ArrayOf(Integer, 2) nvim_win_get_position(Window window, )
+	NeovimQt::MsgpackRequest* nvim_win_get_position(int64_t window);
+
+	/// Tabpage nvim_win_get_tabpage(Window window, )
+	NeovimQt::MsgpackRequest* nvim_win_get_tabpage(int64_t window);
+
+	/// Integer nvim_win_get_number(Window window, )
+	NeovimQt::MsgpackRequest* nvim_win_get_number(int64_t window);
+
+	/// Boolean nvim_win_is_valid(Window window, )
+	NeovimQt::MsgpackRequest* nvim_win_is_valid(int64_t window);
+
+	/// DEPRECATED: Integer buffer_line_count(Buffer buffer, )
+	NeovimQt::MsgpackRequest* buffer_line_count(int64_t buffer);
+
+	/// DEPRECATED: ArrayOf(String) buffer_get_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, )
+	NeovimQt::MsgpackRequest* buffer_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing);
+
+	/// DEPRECATED: void buffer_set_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ArrayOf(String) replacement, )
+	NeovimQt::MsgpackRequest* buffer_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement);
+
+	/// DEPRECATED: Object buffer_get_var(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* buffer_get_var(int64_t buffer, QByteArray name);
+
+	/// DEPRECATED: Object buffer_get_option(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* buffer_get_option(int64_t buffer, QByteArray name);
+
+	/// DEPRECATED: void buffer_set_option(Buffer buffer, String name, Object value, )
+	NeovimQt::MsgpackRequest* buffer_set_option(int64_t buffer, QByteArray name, QVariant value);
+
+	/// DEPRECATED: Integer buffer_get_number(Buffer buffer, )
+	NeovimQt::MsgpackRequest* buffer_get_number(int64_t buffer);
+
+	/// DEPRECATED: String buffer_get_name(Buffer buffer, )
+	NeovimQt::MsgpackRequest* buffer_get_name(int64_t buffer);
+
+	/// DEPRECATED: void buffer_set_name(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* buffer_set_name(int64_t buffer, QByteArray name);
+
+	/// DEPRECATED: Boolean buffer_is_valid(Buffer buffer, )
+	NeovimQt::MsgpackRequest* buffer_is_valid(int64_t buffer);
+
+	/// DEPRECATED: ArrayOf(Integer, 2) buffer_get_mark(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* buffer_get_mark(int64_t buffer, QByteArray name);
+
+	/// DEPRECATED: Integer buffer_add_highlight(Buffer buffer, Integer src_id, String hl_group, Integer line, Integer col_start, Integer col_end, )
+	NeovimQt::MsgpackRequest* buffer_add_highlight(int64_t buffer, int64_t src_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end);
+
+	/// DEPRECATED: void buffer_clear_highlight(Buffer buffer, Integer src_id, Integer line_start, Integer line_end, )
+	NeovimQt::MsgpackRequest* buffer_clear_highlight(int64_t buffer, int64_t src_id, int64_t line_start, int64_t line_end);
+
+	/// DEPRECATED: ArrayOf(Window) tabpage_get_windows(Tabpage tabpage, )
+	NeovimQt::MsgpackRequest* tabpage_get_windows(int64_t tabpage);
+
+	/// DEPRECATED: Object tabpage_get_var(Tabpage tabpage, String name, )
+	NeovimQt::MsgpackRequest* tabpage_get_var(int64_t tabpage, QByteArray name);
+
+	/// DEPRECATED: Window tabpage_get_window(Tabpage tabpage, )
+	NeovimQt::MsgpackRequest* tabpage_get_window(int64_t tabpage);
+
+	/// DEPRECATED: Boolean tabpage_is_valid(Tabpage tabpage, )
+	NeovimQt::MsgpackRequest* tabpage_is_valid(int64_t tabpage);
+
+	/// DEPRECATED: void ui_detach()
+	NeovimQt::MsgpackRequest* ui_detach();
+
+	/// DEPRECATED: Object ui_try_resize(Integer width, Integer height, )
+	NeovimQt::MsgpackRequest* ui_try_resize(int64_t width, int64_t height);
+
+	/// DEPRECATED: void vim_command(String command, )
+	NeovimQt::MsgpackRequest* vim_command(QByteArray command);
+
+	/// DEPRECATED: void vim_feedkeys(String keys, String mode, Boolean escape_csi, )
+	NeovimQt::MsgpackRequest* vim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi);
+
+	/// DEPRECATED: Integer vim_input(String keys, )
+	NeovimQt::MsgpackRequest* vim_input(QByteArray keys);
+
+	/// DEPRECATED: String vim_replace_termcodes(String str, Boolean from_part, Boolean do_lt, Boolean special, )
+	NeovimQt::MsgpackRequest* vim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special);
+
+	/// DEPRECATED: String vim_command_output(String str, )
+	NeovimQt::MsgpackRequest* vim_command_output(QByteArray str);
+
+	/// DEPRECATED: Object vim_eval(String expr, )
+	NeovimQt::MsgpackRequest* vim_eval(QByteArray expr);
+
+	/// DEPRECATED: Object vim_call_function(String fname, Array args, )
+	NeovimQt::MsgpackRequest* vim_call_function(QByteArray fname, QVariantList args);
+
+	/// DEPRECATED: Integer vim_strwidth(String text, )
+	NeovimQt::MsgpackRequest* vim_strwidth(QByteArray text);
+
+	/// DEPRECATED: ArrayOf(String) vim_list_runtime_paths()
+	NeovimQt::MsgpackRequest* vim_list_runtime_paths();
+
+	/// DEPRECATED: void vim_change_directory(String dir, )
+	NeovimQt::MsgpackRequest* vim_change_directory(QByteArray dir);
+
+	/// DEPRECATED: String vim_get_current_line()
+	NeovimQt::MsgpackRequest* vim_get_current_line();
+
+	/// DEPRECATED: void vim_set_current_line(String line, )
+	NeovimQt::MsgpackRequest* vim_set_current_line(QByteArray line);
+
+	/// DEPRECATED: void vim_del_current_line()
+	NeovimQt::MsgpackRequest* vim_del_current_line();
+
+	/// DEPRECATED: Object vim_get_var(String name, )
+	NeovimQt::MsgpackRequest* vim_get_var(QByteArray name);
+
+	/// DEPRECATED: Object vim_get_vvar(String name, )
+	NeovimQt::MsgpackRequest* vim_get_vvar(QByteArray name);
+
+	/// DEPRECATED: Object vim_get_option(String name, )
+	NeovimQt::MsgpackRequest* vim_get_option(QByteArray name);
+
+	/// DEPRECATED: void vim_set_option(String name, Object value, )
+	NeovimQt::MsgpackRequest* vim_set_option(QByteArray name, QVariant value);
+
+	/// DEPRECATED: void vim_out_write(String str, )
+	NeovimQt::MsgpackRequest* vim_out_write(QByteArray str);
+
+	/// DEPRECATED: void vim_err_write(String str, )
+	NeovimQt::MsgpackRequest* vim_err_write(QByteArray str);
+
+	/// DEPRECATED: void vim_report_error(String str, )
+	NeovimQt::MsgpackRequest* vim_report_error(QByteArray str);
+
+	/// DEPRECATED: ArrayOf(Buffer) vim_get_buffers()
+	NeovimQt::MsgpackRequest* vim_get_buffers();
+
+	/// DEPRECATED: Buffer vim_get_current_buffer()
+	NeovimQt::MsgpackRequest* vim_get_current_buffer();
+
+	/// DEPRECATED: void vim_set_current_buffer(Buffer buffer, )
+	NeovimQt::MsgpackRequest* vim_set_current_buffer(int64_t buffer);
+
+	/// DEPRECATED: ArrayOf(Window) vim_get_windows()
+	NeovimQt::MsgpackRequest* vim_get_windows();
+
+	/// DEPRECATED: Window vim_get_current_window()
+	NeovimQt::MsgpackRequest* vim_get_current_window();
+
+	/// DEPRECATED: void vim_set_current_window(Window window, )
+	NeovimQt::MsgpackRequest* vim_set_current_window(int64_t window);
+
+	/// DEPRECATED: ArrayOf(Tabpage) vim_get_tabpages()
+	NeovimQt::MsgpackRequest* vim_get_tabpages();
+
+	/// DEPRECATED: Tabpage vim_get_current_tabpage()
+	NeovimQt::MsgpackRequest* vim_get_current_tabpage();
+
+	/// DEPRECATED: void vim_set_current_tabpage(Tabpage tabpage, )
+	NeovimQt::MsgpackRequest* vim_set_current_tabpage(int64_t tabpage);
+
+	/// DEPRECATED: void vim_subscribe(String event, )
+	NeovimQt::MsgpackRequest* vim_subscribe(QByteArray event);
+
+	/// DEPRECATED: void vim_unsubscribe(String event, )
+	NeovimQt::MsgpackRequest* vim_unsubscribe(QByteArray event);
+
+	/// DEPRECATED: Integer vim_name_to_color(String name, )
+	NeovimQt::MsgpackRequest* vim_name_to_color(QByteArray name);
+
+	/// DEPRECATED: Dictionary vim_get_color_map()
+	NeovimQt::MsgpackRequest* vim_get_color_map();
+
+	/// DEPRECATED: Buffer window_get_buffer(Window window, )
+	NeovimQt::MsgpackRequest* window_get_buffer(int64_t window);
+
+	/// DEPRECATED: ArrayOf(Integer, 2) window_get_cursor(Window window, )
+	NeovimQt::MsgpackRequest* window_get_cursor(int64_t window);
+
+	/// DEPRECATED: void window_set_cursor(Window window, ArrayOf(Integer, 2) pos, )
+	NeovimQt::MsgpackRequest* window_set_cursor(int64_t window, QPoint pos);
+
+	/// DEPRECATED: Integer window_get_height(Window window, )
+	NeovimQt::MsgpackRequest* window_get_height(int64_t window);
+
+	/// DEPRECATED: void window_set_height(Window window, Integer height, )
+	NeovimQt::MsgpackRequest* window_set_height(int64_t window, int64_t height);
+
+	/// DEPRECATED: Integer window_get_width(Window window, )
+	NeovimQt::MsgpackRequest* window_get_width(int64_t window);
+
+	/// DEPRECATED: void window_set_width(Window window, Integer width, )
+	NeovimQt::MsgpackRequest* window_set_width(int64_t window, int64_t width);
+
+	/// DEPRECATED: Object window_get_var(Window window, String name, )
+	NeovimQt::MsgpackRequest* window_get_var(int64_t window, QByteArray name);
+
+	/// DEPRECATED: Object window_get_option(Window window, String name, )
+	NeovimQt::MsgpackRequest* window_get_option(int64_t window, QByteArray name);
+
+	/// DEPRECATED: void window_set_option(Window window, String name, Object value, )
+	NeovimQt::MsgpackRequest* window_set_option(int64_t window, QByteArray name, QVariant value);
+
+	/// DEPRECATED: ArrayOf(Integer, 2) window_get_position(Window window, )
+	NeovimQt::MsgpackRequest* window_get_position(int64_t window);
+
+	/// DEPRECATED: Tabpage window_get_tabpage(Window window, )
+	NeovimQt::MsgpackRequest* window_get_tabpage(int64_t window);
+
+	/// DEPRECATED: Boolean window_is_valid(Window window, )
+	NeovimQt::MsgpackRequest* window_is_valid(int64_t window);
+
 
 signals:
 	void on_nvim_buf_line_count(int64_t);
@@ -1115,5 +1208,5 @@ signals:
 	void err_window_is_valid(const QString&, const QVariant&);
 
 };
-} // namespace
-#endif
+
+} // namespace NeovimQt

--- a/src/auto/neovimapi4.cpp
+++ b/src/auto/neovimapi4.cpp
@@ -1,15 +1,15 @@
-// Auto generated 2018-09-04 09:18:09.710960 from nvim API level:4
+// Auto generated 2020-09-09 13:30:54.235834 from nvim API level:4
 #include "auto/neovimapi4.h"
-#include "neovimconnector.h"
-#include "msgpackrequest.h"
 #include "msgpackiodevice.h"
+#include "msgpackrequest.h"
+#include "neovimconnector.h"
 #include "util.h"
 
 namespace NeovimQt {
 /* Unpack Neovim EXT types Window, Buffer Tabpage which are all
  * uint64_t see Neovim:msgpack_rpc_to_
  */
-QVariant unpackBufferApi4(MsgpackIODevice *dev, const char* in, quint32 size)
+static QVariant unpackBufferApi4(MsgpackIODevice *dev, const char* in, uint32_t size) noexcept
 {
 	msgpack_unpacked result;
 	msgpack_unpacked_init(&result);
@@ -20,10 +20,10 @@ QVariant unpackBufferApi4(MsgpackIODevice *dev, const char* in, quint32 size)
 	if (ret == MSGPACK_UNPACK_SUCCESS) {
 		switch (result.data.type) {
 			case MSGPACK_OBJECT_NEGATIVE_INTEGER:
-				variant = (qint64)result.data.via.i64;
+				variant.setValue<int64_t>(result.data.via.i64);
 				break;
 			case MSGPACK_OBJECT_POSITIVE_INTEGER:
-				variant = (quint64)result.data.via.u64;
+				variant.setValue<uint64_t>(result.data.via.u64);
 				break;
 			default:
 				// TODO it would be nice if we could call back MsgpackIoDevice method or primitive types here
@@ -34,1730 +34,1916 @@ QVariant unpackBufferApi4(MsgpackIODevice *dev, const char* in, quint32 size)
 	msgpack_unpacked_destroy(&result);
 	return variant;
 }
-#define unpackWindowApi4 unpackBufferApi4
-#define unpackTabpageApi4 unpackBufferApi4
 
-NeovimApi4::NeovimApi4(NeovimConnector *c)
-:m_c(c)
+static QVariant unpackWindowApi4(MsgpackIODevice *dev, const char* in, uint32_t size) noexcept
+{
+	return unpackBufferApi4(dev, in, size);
+}
+
+static QVariant unpackTabpageApi4(MsgpackIODevice *dev, const char* in, uint32_t size) noexcept
+{
+	return unpackBufferApi4(dev, in, size);
+}
+
+NeovimApi4::NeovimApi4(NeovimConnector *c) noexcept
+	: m_connector{ c }
 {
 	// EXT types
-		m_c->m_dev->registerExtType(0, unpackBufferApi4);
-		m_c->m_dev->registerExtType(1, unpackWindowApi4);
-		m_c->m_dev->registerExtType(2, unpackTabpageApi4);
-		connect(m_c->m_dev, &MsgpackIODevice::notification,
-			this, &NeovimApi4::neovimNotification);
+	m_connector->m_dev->registerExtType(0, unpackBufferApi4);
+	m_connector->m_dev->registerExtType(1, unpackWindowApi4);
+	m_connector->m_dev->registerExtType(2, unpackTabpageApi4);
+	connect(m_connector->m_dev, &MsgpackIODevice::notification,
+		this, &NeovimApi4::neovimNotification);
 }
 
 // Slots
 MsgpackRequest* NeovimApi4::nvim_buf_line_count(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_line_count", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_line_count", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_BUF_LINE_COUNT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::buffer_get_line(int64_t buffer, int64_t index)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_line", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_get_line", 2) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_BUFFER_GET_LINE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(index);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(index);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_buf_attach(int64_t buffer, bool send_buffer, QVariantMap opts)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_attach", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_attach", 3) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_BUF_ATTACH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(send_buffer);
-	m_c->m_dev->send(opts);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(send_buffer);
+	m_connector->m_dev->send(opts);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_buf_detach(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_detach", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_detach", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_BUF_DETACH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::buffer_set_line(int64_t buffer, int64_t index, QByteArray line)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_set_line", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_set_line", 3) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_BUFFER_SET_LINE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(index);
-	m_c->m_dev->send(line);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(index);
+	m_connector->m_dev->send(line);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::buffer_del_line(int64_t buffer, int64_t index)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_del_line", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_del_line", 2) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_BUFFER_DEL_LINE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(index);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(index);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::buffer_get_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_line_slice", 5);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_get_line_slice", 5) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_BUFFER_GET_LINE_SLICE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(start);
-	m_c->m_dev->send(end);
-	m_c->m_dev->send(include_start);
-	m_c->m_dev->send(include_end);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(start);
+	m_connector->m_dev->send(end);
+	m_connector->m_dev->send(include_start);
+	m_connector->m_dev->send(include_end);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_buf_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_get_lines", 4);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_get_lines", 4) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_BUF_GET_LINES);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(start);
-	m_c->m_dev->send(end);
-	m_c->m_dev->send(strict_indexing);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(start);
+	m_connector->m_dev->send(end);
+	m_connector->m_dev->send(strict_indexing);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::buffer_set_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end, QList<QByteArray> replacement)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_set_line_slice", 6);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_set_line_slice", 6) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_BUFFER_SET_LINE_SLICE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(start);
-	m_c->m_dev->send(end);
-	m_c->m_dev->send(include_start);
-	m_c->m_dev->send(include_end);
-	m_c->m_dev->sendArrayOf(replacement);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(start);
+	m_connector->m_dev->send(end);
+	m_connector->m_dev->send(include_start);
+	m_connector->m_dev->send(include_end);
+	m_connector->m_dev->sendArrayOf(replacement);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_buf_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_set_lines", 5);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_set_lines", 5) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_BUF_SET_LINES);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(start);
-	m_c->m_dev->send(end);
-	m_c->m_dev->send(strict_indexing);
-	m_c->m_dev->sendArrayOf(replacement);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(start);
+	m_connector->m_dev->send(end);
+	m_connector->m_dev->send(strict_indexing);
+	m_connector->m_dev->sendArrayOf(replacement);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_buf_get_var(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_get_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_get_var", 2) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_BUF_GET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_buf_get_changedtick(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_get_changedtick", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_get_changedtick", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_BUF_GET_CHANGEDTICK);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_buf_get_keymap(int64_t buffer, QByteArray mode)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_get_keymap", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_get_keymap", 2) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_BUF_GET_KEYMAP);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(mode);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(mode);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_buf_get_commands(int64_t buffer, QVariantMap opts)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_get_commands", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_get_commands", 2) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_BUF_GET_COMMANDS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(opts);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(opts);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_buf_set_var(int64_t buffer, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_set_var", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_set_var", 3) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_BUF_SET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_buf_del_var(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_del_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_del_var", 2) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_BUF_DEL_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::buffer_set_var(int64_t buffer, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_set_var", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_set_var", 3) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_BUFFER_SET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::buffer_del_var(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_del_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_del_var", 2) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_BUFFER_DEL_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_buf_get_option(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_get_option", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_get_option", 2) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_BUF_GET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_buf_set_option(int64_t buffer, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_set_option", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_set_option", 3) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_BUF_SET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_buf_get_number(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_get_number", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_get_number", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_BUF_GET_NUMBER);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_buf_get_name(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_get_name", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_get_name", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_BUF_GET_NAME);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_buf_set_name(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_set_name", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_set_name", 2) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_BUF_SET_NAME);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_buf_is_valid(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_is_valid", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_is_valid", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_BUF_IS_VALID);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::buffer_insert(int64_t buffer, int64_t lnum, QList<QByteArray> lines)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_insert", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_insert", 3) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_BUFFER_INSERT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(lnum);
-	m_c->m_dev->sendArrayOf(lines);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(lnum);
+	m_connector->m_dev->sendArrayOf(lines);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_buf_get_mark(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_get_mark", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_get_mark", 2) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_BUF_GET_MARK);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_buf_add_highlight(int64_t buffer, int64_t src_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_add_highlight", 6);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_add_highlight", 6) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_BUF_ADD_HIGHLIGHT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(src_id);
-	m_c->m_dev->send(hl_group);
-	m_c->m_dev->send(line);
-	m_c->m_dev->send(col_start);
-	m_c->m_dev->send(col_end);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(src_id);
+	m_connector->m_dev->send(hl_group);
+	m_connector->m_dev->send(line);
+	m_connector->m_dev->send(col_start);
+	m_connector->m_dev->send(col_end);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_buf_clear_highlight(int64_t buffer, int64_t src_id, int64_t line_start, int64_t line_end)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_clear_highlight", 4);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_clear_highlight", 4) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_BUF_CLEAR_HIGHLIGHT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(src_id);
-	m_c->m_dev->send(line_start);
-	m_c->m_dev->send(line_end);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(src_id);
+	m_connector->m_dev->send(line_start);
+	m_connector->m_dev->send(line_end);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_tabpage_list_wins(int64_t tabpage)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_tabpage_list_wins", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_tabpage_list_wins", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_TABPAGE_LIST_WINS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(tabpage);
+	m_connector->m_dev->send(tabpage);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_tabpage_get_var(int64_t tabpage, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_tabpage_get_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_tabpage_get_var", 2) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_TABPAGE_GET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(tabpage);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(tabpage);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_tabpage_set_var", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_tabpage_set_var", 3) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_TABPAGE_SET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(tabpage);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(tabpage);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_tabpage_del_var(int64_t tabpage, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_tabpage_del_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_tabpage_del_var", 2) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_TABPAGE_DEL_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(tabpage);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(tabpage);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("tabpage_set_var", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("tabpage_set_var", 3) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_TABPAGE_SET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(tabpage);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(tabpage);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::tabpage_del_var(int64_t tabpage, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("tabpage_del_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("tabpage_del_var", 2) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_TABPAGE_DEL_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(tabpage);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(tabpage);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_tabpage_get_win(int64_t tabpage)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_tabpage_get_win", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_tabpage_get_win", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_TABPAGE_GET_WIN);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(tabpage);
+	m_connector->m_dev->send(tabpage);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_tabpage_get_number(int64_t tabpage)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_tabpage_get_number", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_tabpage_get_number", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_TABPAGE_GET_NUMBER);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(tabpage);
+	m_connector->m_dev->send(tabpage);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_tabpage_is_valid(int64_t tabpage)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_tabpage_is_valid", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_tabpage_is_valid", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_TABPAGE_IS_VALID);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(tabpage);
+	m_connector->m_dev->send(tabpage);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_ui_attach(int64_t width, int64_t height, QVariantMap options)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_ui_attach", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_ui_attach", 3) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_UI_ATTACH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(width);
-	m_c->m_dev->send(height);
-	m_c->m_dev->send(options);
+	m_connector->m_dev->send(width);
+	m_connector->m_dev->send(height);
+	m_connector->m_dev->send(options);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::ui_attach(int64_t width, int64_t height, bool enable_rgb)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("ui_attach", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("ui_attach", 3) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_UI_ATTACH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(width);
-	m_c->m_dev->send(height);
-	m_c->m_dev->send(enable_rgb);
+	m_connector->m_dev->send(width);
+	m_connector->m_dev->send(height);
+	m_connector->m_dev->send(enable_rgb);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_ui_detach()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_ui_detach", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_ui_detach", 0) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_UI_DETACH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_ui_try_resize(int64_t width, int64_t height)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_ui_try_resize", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_ui_try_resize", 2) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_UI_TRY_RESIZE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(width);
-	m_c->m_dev->send(height);
+	m_connector->m_dev->send(width);
+	m_connector->m_dev->send(height);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_ui_set_option(QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_ui_set_option", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_ui_set_option", 2) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_UI_SET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_command(QByteArray command)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_command", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_command", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_COMMAND);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(command);
+	m_connector->m_dev->send(command);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_get_hl_by_name(QByteArray name, bool rgb)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_hl_by_name", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_hl_by_name", 2) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_GET_HL_BY_NAME);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(rgb);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(rgb);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_get_hl_by_id(int64_t hl_id, bool rgb)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_hl_by_id", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_hl_by_id", 2) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_GET_HL_BY_ID);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(hl_id);
-	m_c->m_dev->send(rgb);
+	m_connector->m_dev->send(hl_id);
+	m_connector->m_dev->send(rgb);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_feedkeys", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_feedkeys", 3) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_FEEDKEYS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(keys);
-	m_c->m_dev->send(mode);
-	m_c->m_dev->send(escape_csi);
+	m_connector->m_dev->send(keys);
+	m_connector->m_dev->send(mode);
+	m_connector->m_dev->send(escape_csi);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_input(QByteArray keys)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_input", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_input", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_INPUT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(keys);
+	m_connector->m_dev->send(keys);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_replace_termcodes", 4);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_replace_termcodes", 4) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_REPLACE_TERMCODES);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(str);
-	m_c->m_dev->send(from_part);
-	m_c->m_dev->send(do_lt);
-	m_c->m_dev->send(special);
+	m_connector->m_dev->send(str);
+	m_connector->m_dev->send(from_part);
+	m_connector->m_dev->send(do_lt);
+	m_connector->m_dev->send(special);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_command_output(QByteArray command)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_command_output", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_command_output", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_COMMAND_OUTPUT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(command);
+	m_connector->m_dev->send(command);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_eval(QByteArray expr)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_eval", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_eval", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_EVAL);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(expr);
+	m_connector->m_dev->send(expr);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_execute_lua(QByteArray code, QVariantList args)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_execute_lua", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_execute_lua", 2) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_EXECUTE_LUA);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(code);
-	m_c->m_dev->send(args);
+	m_connector->m_dev->send(code);
+	m_connector->m_dev->send(args);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_call_function(QByteArray fn, QVariantList args)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_call_function", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_call_function", 2) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_CALL_FUNCTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(fn);
-	m_c->m_dev->send(args);
+	m_connector->m_dev->send(fn);
+	m_connector->m_dev->send(args);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_call_dict_function(QVariant dict, QByteArray fn, QVariantList args)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_call_dict_function", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_call_dict_function", 3) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_CALL_DICT_FUNCTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(dict);
-	m_c->m_dev->send(fn);
-	m_c->m_dev->send(args);
+	m_connector->m_dev->send(dict);
+	m_connector->m_dev->send(fn);
+	m_connector->m_dev->send(args);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_strwidth(QByteArray text)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_strwidth", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_strwidth", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_STRWIDTH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(text);
+	m_connector->m_dev->send(text);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_list_runtime_paths()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_list_runtime_paths", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_list_runtime_paths", 0) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_LIST_RUNTIME_PATHS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_set_current_dir(QByteArray dir)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_set_current_dir", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_set_current_dir", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_SET_CURRENT_DIR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(dir);
+	m_connector->m_dev->send(dir);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_get_current_line()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_current_line", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_current_line", 0) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_GET_CURRENT_LINE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_set_current_line(QByteArray line)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_set_current_line", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_set_current_line", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_SET_CURRENT_LINE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(line);
+	m_connector->m_dev->send(line);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_del_current_line()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_del_current_line", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_del_current_line", 0) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_DEL_CURRENT_LINE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_get_var(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_var", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_var", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_GET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_set_var(QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_set_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_set_var", 2) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_SET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_del_var(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_del_var", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_del_var", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_DEL_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::vim_set_var(QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_set_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_set_var", 2) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_VIM_SET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::vim_del_var(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_del_var", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_del_var", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_VIM_DEL_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_get_vvar(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_vvar", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_vvar", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_GET_VVAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_get_option(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_option", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_option", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_GET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_set_option(QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_set_option", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_set_option", 2) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_SET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_out_write(QByteArray str)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_out_write", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_out_write", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_OUT_WRITE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(str);
+	m_connector->m_dev->send(str);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_err_write(QByteArray str)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_err_write", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_err_write", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_ERR_WRITE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(str);
+	m_connector->m_dev->send(str);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_err_writeln(QByteArray str)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_err_writeln", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_err_writeln", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_ERR_WRITELN);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(str);
+	m_connector->m_dev->send(str);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_list_bufs()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_list_bufs", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_list_bufs", 0) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_LIST_BUFS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_get_current_buf()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_current_buf", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_current_buf", 0) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_GET_CURRENT_BUF);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_set_current_buf(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_set_current_buf", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_set_current_buf", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_SET_CURRENT_BUF);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_list_wins()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_list_wins", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_list_wins", 0) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_LIST_WINS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_get_current_win()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_current_win", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_current_win", 0) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_GET_CURRENT_WIN);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_set_current_win(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_set_current_win", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_set_current_win", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_SET_CURRENT_WIN);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_list_tabpages()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_list_tabpages", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_list_tabpages", 0) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_LIST_TABPAGES);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_get_current_tabpage()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_current_tabpage", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_current_tabpage", 0) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_GET_CURRENT_TABPAGE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_set_current_tabpage(int64_t tabpage)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_set_current_tabpage", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_set_current_tabpage", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_SET_CURRENT_TABPAGE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(tabpage);
+	m_connector->m_dev->send(tabpage);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_subscribe(QByteArray event)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_subscribe", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_subscribe", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_SUBSCRIBE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(event);
+	m_connector->m_dev->send(event);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_unsubscribe(QByteArray event)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_unsubscribe", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_unsubscribe", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_UNSUBSCRIBE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(event);
+	m_connector->m_dev->send(event);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_get_color_by_name(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_color_by_name", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_color_by_name", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_GET_COLOR_BY_NAME);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_get_color_map()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_color_map", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_color_map", 0) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_GET_COLOR_MAP);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_get_mode()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_mode", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_mode", 0) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_GET_MODE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_get_keymap(QByteArray mode)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_keymap", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_keymap", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_GET_KEYMAP);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(mode);
+	m_connector->m_dev->send(mode);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_get_commands(QVariantMap opts)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_commands", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_commands", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_GET_COMMANDS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(opts);
+	m_connector->m_dev->send(opts);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_get_api_info()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_api_info", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_api_info", 0) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_GET_API_INFO);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_set_client_info(QByteArray name, QVariantMap version, QByteArray type, QVariantMap methods, QVariantMap attributes)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_set_client_info", 5);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_set_client_info", 5) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_SET_CLIENT_INFO);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(version);
-	m_c->m_dev->send(type);
-	m_c->m_dev->send(methods);
-	m_c->m_dev->send(attributes);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(version);
+	m_connector->m_dev->send(type);
+	m_connector->m_dev->send(methods);
+	m_connector->m_dev->send(attributes);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_get_chan_info(int64_t chan)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_chan_info", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_chan_info", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_GET_CHAN_INFO);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(chan);
+	m_connector->m_dev->send(chan);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_list_chans()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_list_chans", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_list_chans", 0) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_LIST_CHANS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_call_atomic(QVariantList calls)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_call_atomic", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_call_atomic", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_CALL_ATOMIC);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(calls);
+	m_connector->m_dev->send(calls);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_parse_expression(QByteArray expr, QByteArray flags, bool highlight)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_parse_expression", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_parse_expression", 3) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_PARSE_EXPRESSION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(expr);
-	m_c->m_dev->send(flags);
-	m_c->m_dev->send(highlight);
+	m_connector->m_dev->send(expr);
+	m_connector->m_dev->send(flags);
+	m_connector->m_dev->send(highlight);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_list_uis()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_list_uis", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_list_uis", 0) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_LIST_UIS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_get_proc_children(int64_t pid)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_proc_children", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_proc_children", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_GET_PROC_CHILDREN);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(pid);
+	m_connector->m_dev->send(pid);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_get_proc(int64_t pid)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_proc", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_proc", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_GET_PROC);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(pid);
+	m_connector->m_dev->send(pid);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_win_get_buf(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_buf", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_get_buf", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_WIN_GET_BUF);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_win_get_cursor(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_cursor", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_get_cursor", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_WIN_GET_CURSOR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_win_set_cursor(int64_t window, QPoint pos)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_set_cursor", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_set_cursor", 2) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_WIN_SET_CURSOR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(pos);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(pos);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_win_get_height(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_height", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_get_height", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_WIN_GET_HEIGHT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_win_set_height(int64_t window, int64_t height)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_set_height", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_set_height", 2) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_WIN_SET_HEIGHT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(height);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(height);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_win_get_width(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_width", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_get_width", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_WIN_GET_WIDTH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_win_set_width(int64_t window, int64_t width)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_set_width", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_set_width", 2) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_WIN_SET_WIDTH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(width);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(width);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_win_get_var(int64_t window, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_get_var", 2) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_WIN_GET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_win_set_var(int64_t window, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_set_var", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_set_var", 3) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_WIN_SET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_win_del_var(int64_t window, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_del_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_del_var", 2) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_WIN_DEL_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::window_set_var(int64_t window, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_set_var", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_set_var", 3) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_WINDOW_SET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::window_del_var(int64_t window, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_del_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_del_var", 2) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_WINDOW_DEL_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_win_get_option(int64_t window, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_option", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_get_option", 2) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_WIN_GET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_win_set_option(int64_t window, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_set_option", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_set_option", 3) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_WIN_SET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_win_get_position(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_position", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_get_position", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_WIN_GET_POSITION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_win_get_tabpage(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_tabpage", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_get_tabpage", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_WIN_GET_TABPAGE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_win_get_number(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_number", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_get_number", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_WIN_GET_NUMBER);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::nvim_win_is_valid(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_is_valid", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_is_valid", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_NVIM_WIN_IS_VALID);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::buffer_line_count(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_line_count", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_line_count", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_BUFFER_LINE_COUNT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::buffer_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_lines", 4);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_get_lines", 4) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_BUFFER_GET_LINES);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(start);
-	m_c->m_dev->send(end);
-	m_c->m_dev->send(strict_indexing);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(start);
+	m_connector->m_dev->send(end);
+	m_connector->m_dev->send(strict_indexing);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::buffer_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_set_lines", 5);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_set_lines", 5) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_BUFFER_SET_LINES);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(start);
-	m_c->m_dev->send(end);
-	m_c->m_dev->send(strict_indexing);
-	m_c->m_dev->sendArrayOf(replacement);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(start);
+	m_connector->m_dev->send(end);
+	m_connector->m_dev->send(strict_indexing);
+	m_connector->m_dev->sendArrayOf(replacement);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::buffer_get_var(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_get_var", 2) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_BUFFER_GET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::buffer_get_option(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_option", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_get_option", 2) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_BUFFER_GET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::buffer_set_option(int64_t buffer, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_set_option", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_set_option", 3) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_BUFFER_SET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::buffer_get_number(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_number", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_get_number", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_BUFFER_GET_NUMBER);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::buffer_get_name(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_name", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_get_name", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_BUFFER_GET_NAME);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::buffer_set_name(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_set_name", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_set_name", 2) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_BUFFER_SET_NAME);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::buffer_is_valid(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_is_valid", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_is_valid", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_BUFFER_IS_VALID);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::buffer_get_mark(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_mark", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_get_mark", 2) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_BUFFER_GET_MARK);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::buffer_add_highlight(int64_t buffer, int64_t src_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_add_highlight", 6);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_add_highlight", 6) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_BUFFER_ADD_HIGHLIGHT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(src_id);
-	m_c->m_dev->send(hl_group);
-	m_c->m_dev->send(line);
-	m_c->m_dev->send(col_start);
-	m_c->m_dev->send(col_end);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(src_id);
+	m_connector->m_dev->send(hl_group);
+	m_connector->m_dev->send(line);
+	m_connector->m_dev->send(col_start);
+	m_connector->m_dev->send(col_end);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::buffer_clear_highlight(int64_t buffer, int64_t src_id, int64_t line_start, int64_t line_end)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_clear_highlight", 4);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_clear_highlight", 4) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_BUFFER_CLEAR_HIGHLIGHT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(src_id);
-	m_c->m_dev->send(line_start);
-	m_c->m_dev->send(line_end);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(src_id);
+	m_connector->m_dev->send(line_start);
+	m_connector->m_dev->send(line_end);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::tabpage_get_windows(int64_t tabpage)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("tabpage_get_windows", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("tabpage_get_windows", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_TABPAGE_GET_WINDOWS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(tabpage);
+	m_connector->m_dev->send(tabpage);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::tabpage_get_var(int64_t tabpage, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("tabpage_get_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("tabpage_get_var", 2) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_TABPAGE_GET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(tabpage);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(tabpage);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::tabpage_get_window(int64_t tabpage)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("tabpage_get_window", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("tabpage_get_window", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_TABPAGE_GET_WINDOW);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(tabpage);
+	m_connector->m_dev->send(tabpage);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::tabpage_is_valid(int64_t tabpage)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("tabpage_is_valid", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("tabpage_is_valid", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_TABPAGE_IS_VALID);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(tabpage);
+	m_connector->m_dev->send(tabpage);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::ui_detach()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("ui_detach", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("ui_detach", 0) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_UI_DETACH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::ui_try_resize(int64_t width, int64_t height)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("ui_try_resize", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("ui_try_resize", 2) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_UI_TRY_RESIZE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(width);
-	m_c->m_dev->send(height);
+	m_connector->m_dev->send(width);
+	m_connector->m_dev->send(height);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::vim_command(QByteArray command)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_command", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_command", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_VIM_COMMAND);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(command);
+	m_connector->m_dev->send(command);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::vim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_feedkeys", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_feedkeys", 3) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_VIM_FEEDKEYS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(keys);
-	m_c->m_dev->send(mode);
-	m_c->m_dev->send(escape_csi);
+	m_connector->m_dev->send(keys);
+	m_connector->m_dev->send(mode);
+	m_connector->m_dev->send(escape_csi);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::vim_input(QByteArray keys)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_input", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_input", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_VIM_INPUT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(keys);
+	m_connector->m_dev->send(keys);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::vim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_replace_termcodes", 4);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_replace_termcodes", 4) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_VIM_REPLACE_TERMCODES);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(str);
-	m_c->m_dev->send(from_part);
-	m_c->m_dev->send(do_lt);
-	m_c->m_dev->send(special);
+	m_connector->m_dev->send(str);
+	m_connector->m_dev->send(from_part);
+	m_connector->m_dev->send(do_lt);
+	m_connector->m_dev->send(special);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::vim_command_output(QByteArray command)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_command_output", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_command_output", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_VIM_COMMAND_OUTPUT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(command);
+	m_connector->m_dev->send(command);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::vim_eval(QByteArray expr)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_eval", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_eval", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_VIM_EVAL);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(expr);
+	m_connector->m_dev->send(expr);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::vim_call_function(QByteArray fn, QVariantList args)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_call_function", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_call_function", 2) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_VIM_CALL_FUNCTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(fn);
-	m_c->m_dev->send(args);
+	m_connector->m_dev->send(fn);
+	m_connector->m_dev->send(args);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::vim_strwidth(QByteArray text)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_strwidth", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_strwidth", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_VIM_STRWIDTH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(text);
+	m_connector->m_dev->send(text);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::vim_list_runtime_paths()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_list_runtime_paths", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_list_runtime_paths", 0) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_VIM_LIST_RUNTIME_PATHS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::vim_change_directory(QByteArray dir)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_change_directory", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_change_directory", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_VIM_CHANGE_DIRECTORY);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(dir);
+	m_connector->m_dev->send(dir);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::vim_get_current_line()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_current_line", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_current_line", 0) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_VIM_GET_CURRENT_LINE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::vim_set_current_line(QByteArray line)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_set_current_line", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_set_current_line", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_VIM_SET_CURRENT_LINE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(line);
+	m_connector->m_dev->send(line);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::vim_del_current_line()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_del_current_line", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_del_current_line", 0) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_VIM_DEL_CURRENT_LINE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::vim_get_var(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_var", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_var", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_VIM_GET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::vim_get_vvar(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_vvar", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_vvar", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_VIM_GET_VVAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::vim_get_option(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_option", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_option", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_VIM_GET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::vim_set_option(QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_set_option", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_set_option", 2) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_VIM_SET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::vim_out_write(QByteArray str)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_out_write", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_out_write", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_VIM_OUT_WRITE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(str);
+	m_connector->m_dev->send(str);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::vim_err_write(QByteArray str)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_err_write", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_err_write", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_VIM_ERR_WRITE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(str);
+	m_connector->m_dev->send(str);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::vim_report_error(QByteArray str)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_report_error", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_report_error", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_VIM_REPORT_ERROR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(str);
+	m_connector->m_dev->send(str);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::vim_get_buffers()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_buffers", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_buffers", 0) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_VIM_GET_BUFFERS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::vim_get_current_buffer()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_current_buffer", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_current_buffer", 0) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_VIM_GET_CURRENT_BUFFER);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::vim_set_current_buffer(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_set_current_buffer", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_set_current_buffer", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_VIM_SET_CURRENT_BUFFER);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::vim_get_windows()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_windows", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_windows", 0) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_VIM_GET_WINDOWS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::vim_get_current_window()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_current_window", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_current_window", 0) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_VIM_GET_CURRENT_WINDOW);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::vim_set_current_window(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_set_current_window", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_set_current_window", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_VIM_SET_CURRENT_WINDOW);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::vim_get_tabpages()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_tabpages", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_tabpages", 0) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_VIM_GET_TABPAGES);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::vim_get_current_tabpage()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_current_tabpage", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_current_tabpage", 0) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_VIM_GET_CURRENT_TABPAGE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::vim_set_current_tabpage(int64_t tabpage)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_set_current_tabpage", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_set_current_tabpage", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_VIM_SET_CURRENT_TABPAGE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(tabpage);
+	m_connector->m_dev->send(tabpage);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::vim_subscribe(QByteArray event)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_subscribe", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_subscribe", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_VIM_SUBSCRIBE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(event);
+	m_connector->m_dev->send(event);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::vim_unsubscribe(QByteArray event)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_unsubscribe", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_unsubscribe", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_VIM_UNSUBSCRIBE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(event);
+	m_connector->m_dev->send(event);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::vim_name_to_color(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_name_to_color", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_name_to_color", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_VIM_NAME_TO_COLOR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::vim_get_color_map()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_color_map", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_color_map", 0) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_VIM_GET_COLOR_MAP);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::window_get_buffer(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_buffer", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_get_buffer", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_WINDOW_GET_BUFFER);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::window_get_cursor(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_cursor", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_get_cursor", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_WINDOW_GET_CURSOR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::window_set_cursor(int64_t window, QPoint pos)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_set_cursor", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_set_cursor", 2) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_WINDOW_SET_CURSOR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(pos);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(pos);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::window_get_height(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_height", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_get_height", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_WINDOW_GET_HEIGHT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::window_set_height(int64_t window, int64_t height)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_set_height", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_set_height", 2) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_WINDOW_SET_HEIGHT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(height);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(height);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::window_get_width(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_width", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_get_width", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_WINDOW_GET_WIDTH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::window_set_width(int64_t window, int64_t width)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_set_width", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_set_width", 2) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_WINDOW_SET_WIDTH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(width);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(width);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::window_get_var(int64_t window, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_get_var", 2) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_WINDOW_GET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::window_get_option(int64_t window, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_option", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_get_option", 2) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_WINDOW_GET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::window_set_option(int64_t window, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_set_option", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_set_option", 3) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_WINDOW_SET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::window_get_position(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_position", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_get_position", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_WINDOW_GET_POSITION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::window_get_tabpage(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_tabpage", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_get_tabpage", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_WINDOW_GET_TABPAGE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi4::window_is_valid(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_is_valid", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_is_valid", 1) };
 	r->setFunction(NeovimApi4::NEOVIM_FN_WINDOW_IS_VALID);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi4::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi4::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
 
+
 // Handlers
 
-void NeovimApi4::handleResponseError(quint32 msgid, quint64 fun, const QVariant& res)
+void NeovimApi4::handleResponseError(uint32_t msgid, uint64_t fun, const QVariant& res)
 {
 
 	// TODO: support Neovim error types Exception/Validation/etc
@@ -1765,7 +1951,7 @@ void NeovimApi4::handleResponseError(quint32 msgid, quint64 fun, const QVariant&
 	const QVariantList asList = res.toList();
 	if (asList.size() >= 2) {
 		if (asList.at(1).canConvert<QByteArray>()) {
-			errMsg = m_c->m_dev->decode(asList.at(1).toByteArray());
+			errMsg = m_connector->m_dev->decode(asList.at(1).toByteArray());
 		} else {
 			errMsg = tr("Received unsupported Neovim error type");
 		}
@@ -2307,1771 +2493,1771 @@ void NeovimApi4::handleResponseError(quint32 msgid, quint64 fun, const QVariant&
 		emit err_window_is_valid(errMsg, res);
 		break;
 	default:
-		m_c->setError(NeovimConnector::RuntimeMsgpackError, QString("Received error for function that should not fail: %s").arg(fun));
+		m_connector->setError(NeovimConnector::RuntimeMsgpackError, QString("Received error for function that should not fail: %s").arg(fun));
 	}
 }
 
-void NeovimApi4::handleResponse(quint32 msgid, quint64 fun, const QVariant& res)
+void NeovimApi4::handleResponse(uint32_t msgid, uint64_t fun, const QVariant& res)
 {
 	switch(fun) {
-	case NeovimApi4::NEOVIM_FN_NVIM_BUF_LINE_COUNT:
+		case NeovimApi4::NEOVIM_FN_NVIM_BUF_LINE_COUNT:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_line_count");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_line_count");
 				return;
-			} else {
-				emit on_nvim_buf_line_count(data);
 			}
 
+			emit on_nvim_buf_line_count(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_BUFFER_GET_LINE:
+
+		case NeovimApi4::NEOVIM_FN_BUFFER_GET_LINE:
 		{
 			QByteArray data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_line");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_line");
 				return;
-			} else {
-				emit on_buffer_get_line(data);
 			}
 
+			emit on_buffer_get_line(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_BUF_ATTACH:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_BUF_ATTACH:
 		{
 			bool data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_attach");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_attach");
 				return;
-			} else {
-				emit on_nvim_buf_attach(data);
 			}
 
+			emit on_nvim_buf_attach(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_BUF_DETACH:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_BUF_DETACH:
 		{
 			bool data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_detach");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_detach");
 				return;
-			} else {
-				emit on_nvim_buf_detach(data);
 			}
 
+			emit on_nvim_buf_detach(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_BUFFER_SET_LINE:
+
+		case NeovimApi4::NEOVIM_FN_BUFFER_SET_LINE:
 		{
 			emit on_buffer_set_line();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_BUFFER_DEL_LINE:
+
+		case NeovimApi4::NEOVIM_FN_BUFFER_DEL_LINE:
 		{
 			emit on_buffer_del_line();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_BUFFER_GET_LINE_SLICE:
+
+		case NeovimApi4::NEOVIM_FN_BUFFER_GET_LINE_SLICE:
 		{
 			QList<QByteArray> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_line_slice");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_line_slice");
 				return;
-			} else {
-				emit on_buffer_get_line_slice(data);
 			}
 
+			emit on_buffer_get_line_slice(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_BUF_GET_LINES:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_BUF_GET_LINES:
 		{
 			QList<QByteArray> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_lines");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_lines");
 				return;
-			} else {
-				emit on_nvim_buf_get_lines(data);
 			}
 
+			emit on_nvim_buf_get_lines(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_BUFFER_SET_LINE_SLICE:
+
+		case NeovimApi4::NEOVIM_FN_BUFFER_SET_LINE_SLICE:
 		{
 			emit on_buffer_set_line_slice();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_BUF_SET_LINES:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_BUF_SET_LINES:
 		{
 			emit on_nvim_buf_set_lines();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_BUF_GET_VAR:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_BUF_GET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_var");
 				return;
-			} else {
-				emit on_nvim_buf_get_var(data);
 			}
 
+			emit on_nvim_buf_get_var(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_BUF_GET_CHANGEDTICK:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_BUF_GET_CHANGEDTICK:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_changedtick");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_changedtick");
 				return;
-			} else {
-				emit on_nvim_buf_get_changedtick(data);
 			}
 
+			emit on_nvim_buf_get_changedtick(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_BUF_GET_KEYMAP:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_BUF_GET_KEYMAP:
 		{
 			QList<QVariantMap> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_keymap");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_keymap");
 				return;
-			} else {
-				emit on_nvim_buf_get_keymap(data);
 			}
 
+			emit on_nvim_buf_get_keymap(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_BUF_GET_COMMANDS:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_BUF_GET_COMMANDS:
 		{
 			QVariantMap data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_commands");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_commands");
 				return;
-			} else {
-				emit on_nvim_buf_get_commands(data);
 			}
 
+			emit on_nvim_buf_get_commands(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_BUF_SET_VAR:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_BUF_SET_VAR:
 		{
 			emit on_nvim_buf_set_var();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_BUF_DEL_VAR:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_BUF_DEL_VAR:
 		{
 			emit on_nvim_buf_del_var();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_BUFFER_SET_VAR:
+
+		case NeovimApi4::NEOVIM_FN_BUFFER_SET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_set_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_set_var");
 				return;
-			} else {
-				emit on_buffer_set_var(data);
 			}
 
+			emit on_buffer_set_var(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_BUFFER_DEL_VAR:
+
+		case NeovimApi4::NEOVIM_FN_BUFFER_DEL_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_del_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_del_var");
 				return;
-			} else {
-				emit on_buffer_del_var(data);
 			}
 
+			emit on_buffer_del_var(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_BUF_GET_OPTION:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_BUF_GET_OPTION:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_option");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_option");
 				return;
-			} else {
-				emit on_nvim_buf_get_option(data);
 			}
 
+			emit on_nvim_buf_get_option(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_BUF_SET_OPTION:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_BUF_SET_OPTION:
 		{
 			emit on_nvim_buf_set_option();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_BUF_GET_NUMBER:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_BUF_GET_NUMBER:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_number");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_number");
 				return;
-			} else {
-				emit on_nvim_buf_get_number(data);
 			}
 
+			emit on_nvim_buf_get_number(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_BUF_GET_NAME:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_BUF_GET_NAME:
 		{
 			QByteArray data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_name");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_name");
 				return;
-			} else {
-				emit on_nvim_buf_get_name(data);
 			}
 
+			emit on_nvim_buf_get_name(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_BUF_SET_NAME:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_BUF_SET_NAME:
 		{
 			emit on_nvim_buf_set_name();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_BUF_IS_VALID:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_BUF_IS_VALID:
 		{
 			bool data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_is_valid");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_is_valid");
 				return;
-			} else {
-				emit on_nvim_buf_is_valid(data);
 			}
 
+			emit on_nvim_buf_is_valid(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_BUFFER_INSERT:
+
+		case NeovimApi4::NEOVIM_FN_BUFFER_INSERT:
 		{
 			emit on_buffer_insert();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_BUF_GET_MARK:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_BUF_GET_MARK:
 		{
 			QPoint data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_mark");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_mark");
 				return;
-			} else {
-				emit on_nvim_buf_get_mark(data);
 			}
 
+			emit on_nvim_buf_get_mark(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_BUF_ADD_HIGHLIGHT:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_BUF_ADD_HIGHLIGHT:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_add_highlight");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_add_highlight");
 				return;
-			} else {
-				emit on_nvim_buf_add_highlight(data);
 			}
 
+			emit on_nvim_buf_add_highlight(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_BUF_CLEAR_HIGHLIGHT:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_BUF_CLEAR_HIGHLIGHT:
 		{
 			emit on_nvim_buf_clear_highlight();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_TABPAGE_LIST_WINS:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_TABPAGE_LIST_WINS:
 		{
 			QList<int64_t> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_list_wins");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_list_wins");
 				return;
-			} else {
-				emit on_nvim_tabpage_list_wins(data);
 			}
 
+			emit on_nvim_tabpage_list_wins(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_TABPAGE_GET_VAR:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_TABPAGE_GET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_get_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_get_var");
 				return;
-			} else {
-				emit on_nvim_tabpage_get_var(data);
 			}
 
+			emit on_nvim_tabpage_get_var(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_TABPAGE_SET_VAR:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_TABPAGE_SET_VAR:
 		{
 			emit on_nvim_tabpage_set_var();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_TABPAGE_DEL_VAR:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_TABPAGE_DEL_VAR:
 		{
 			emit on_nvim_tabpage_del_var();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_TABPAGE_SET_VAR:
+
+		case NeovimApi4::NEOVIM_FN_TABPAGE_SET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_set_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_set_var");
 				return;
-			} else {
-				emit on_tabpage_set_var(data);
 			}
 
+			emit on_tabpage_set_var(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_TABPAGE_DEL_VAR:
+
+		case NeovimApi4::NEOVIM_FN_TABPAGE_DEL_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_del_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_del_var");
 				return;
-			} else {
-				emit on_tabpage_del_var(data);
 			}
 
+			emit on_tabpage_del_var(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_TABPAGE_GET_WIN:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_TABPAGE_GET_WIN:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_get_win");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_get_win");
 				return;
-			} else {
-				emit on_nvim_tabpage_get_win(data);
 			}
 
+			emit on_nvim_tabpage_get_win(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_TABPAGE_GET_NUMBER:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_TABPAGE_GET_NUMBER:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_get_number");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_get_number");
 				return;
-			} else {
-				emit on_nvim_tabpage_get_number(data);
 			}
 
+			emit on_nvim_tabpage_get_number(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_TABPAGE_IS_VALID:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_TABPAGE_IS_VALID:
 		{
 			bool data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_is_valid");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_is_valid");
 				return;
-			} else {
-				emit on_nvim_tabpage_is_valid(data);
 			}
 
+			emit on_nvim_tabpage_is_valid(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_UI_ATTACH:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_UI_ATTACH:
 		{
 			emit on_nvim_ui_attach();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_UI_ATTACH:
+
+		case NeovimApi4::NEOVIM_FN_UI_ATTACH:
 		{
 			emit on_ui_attach();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_UI_DETACH:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_UI_DETACH:
 		{
 			emit on_nvim_ui_detach();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_UI_TRY_RESIZE:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_UI_TRY_RESIZE:
 		{
 			emit on_nvim_ui_try_resize();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_UI_SET_OPTION:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_UI_SET_OPTION:
 		{
 			emit on_nvim_ui_set_option();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_COMMAND:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_COMMAND:
 		{
 			emit on_nvim_command();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_GET_HL_BY_NAME:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_GET_HL_BY_NAME:
 		{
 			QVariantMap data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_hl_by_name");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_hl_by_name");
 				return;
-			} else {
-				emit on_nvim_get_hl_by_name(data);
 			}
 
+			emit on_nvim_get_hl_by_name(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_GET_HL_BY_ID:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_GET_HL_BY_ID:
 		{
 			QVariantMap data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_hl_by_id");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_hl_by_id");
 				return;
-			} else {
-				emit on_nvim_get_hl_by_id(data);
 			}
 
+			emit on_nvim_get_hl_by_id(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_FEEDKEYS:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_FEEDKEYS:
 		{
 			emit on_nvim_feedkeys();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_INPUT:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_INPUT:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_input");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_input");
 				return;
-			} else {
-				emit on_nvim_input(data);
 			}
 
+			emit on_nvim_input(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_REPLACE_TERMCODES:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_REPLACE_TERMCODES:
 		{
 			QByteArray data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_replace_termcodes");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_replace_termcodes");
 				return;
-			} else {
-				emit on_nvim_replace_termcodes(data);
 			}
 
+			emit on_nvim_replace_termcodes(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_COMMAND_OUTPUT:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_COMMAND_OUTPUT:
 		{
 			QByteArray data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_command_output");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_command_output");
 				return;
-			} else {
-				emit on_nvim_command_output(data);
 			}
 
+			emit on_nvim_command_output(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_EVAL:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_EVAL:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_eval");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_eval");
 				return;
-			} else {
-				emit on_nvim_eval(data);
 			}
 
+			emit on_nvim_eval(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_EXECUTE_LUA:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_EXECUTE_LUA:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_execute_lua");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_execute_lua");
 				return;
-			} else {
-				emit on_nvim_execute_lua(data);
 			}
 
+			emit on_nvim_execute_lua(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_CALL_FUNCTION:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_CALL_FUNCTION:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_call_function");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_call_function");
 				return;
-			} else {
-				emit on_nvim_call_function(data);
 			}
 
+			emit on_nvim_call_function(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_CALL_DICT_FUNCTION:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_CALL_DICT_FUNCTION:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_call_dict_function");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_call_dict_function");
 				return;
-			} else {
-				emit on_nvim_call_dict_function(data);
 			}
 
+			emit on_nvim_call_dict_function(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_STRWIDTH:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_STRWIDTH:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_strwidth");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_strwidth");
 				return;
-			} else {
-				emit on_nvim_strwidth(data);
 			}
 
+			emit on_nvim_strwidth(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_LIST_RUNTIME_PATHS:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_LIST_RUNTIME_PATHS:
 		{
 			QList<QByteArray> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_runtime_paths");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_runtime_paths");
 				return;
-			} else {
-				emit on_nvim_list_runtime_paths(data);
 			}
 
+			emit on_nvim_list_runtime_paths(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_SET_CURRENT_DIR:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_SET_CURRENT_DIR:
 		{
 			emit on_nvim_set_current_dir();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_GET_CURRENT_LINE:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_GET_CURRENT_LINE:
 		{
 			QByteArray data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_current_line");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_current_line");
 				return;
-			} else {
-				emit on_nvim_get_current_line(data);
 			}
 
+			emit on_nvim_get_current_line(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_SET_CURRENT_LINE:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_SET_CURRENT_LINE:
 		{
 			emit on_nvim_set_current_line();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_DEL_CURRENT_LINE:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_DEL_CURRENT_LINE:
 		{
 			emit on_nvim_del_current_line();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_GET_VAR:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_GET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_var");
 				return;
-			} else {
-				emit on_nvim_get_var(data);
 			}
 
+			emit on_nvim_get_var(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_SET_VAR:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_SET_VAR:
 		{
 			emit on_nvim_set_var();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_DEL_VAR:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_DEL_VAR:
 		{
 			emit on_nvim_del_var();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_VIM_SET_VAR:
+
+		case NeovimApi4::NEOVIM_FN_VIM_SET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_set_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_set_var");
 				return;
-			} else {
-				emit on_vim_set_var(data);
 			}
 
+			emit on_vim_set_var(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_VIM_DEL_VAR:
+
+		case NeovimApi4::NEOVIM_FN_VIM_DEL_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_del_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_del_var");
 				return;
-			} else {
-				emit on_vim_del_var(data);
 			}
 
+			emit on_vim_del_var(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_GET_VVAR:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_GET_VVAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_vvar");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_vvar");
 				return;
-			} else {
-				emit on_nvim_get_vvar(data);
 			}
 
+			emit on_nvim_get_vvar(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_GET_OPTION:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_GET_OPTION:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_option");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_option");
 				return;
-			} else {
-				emit on_nvim_get_option(data);
 			}
 
+			emit on_nvim_get_option(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_SET_OPTION:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_SET_OPTION:
 		{
 			emit on_nvim_set_option();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_OUT_WRITE:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_OUT_WRITE:
 		{
 			emit on_nvim_out_write();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_ERR_WRITE:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_ERR_WRITE:
 		{
 			emit on_nvim_err_write();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_ERR_WRITELN:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_ERR_WRITELN:
 		{
 			emit on_nvim_err_writeln();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_LIST_BUFS:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_LIST_BUFS:
 		{
 			QList<int64_t> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_bufs");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_bufs");
 				return;
-			} else {
-				emit on_nvim_list_bufs(data);
 			}
 
+			emit on_nvim_list_bufs(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_GET_CURRENT_BUF:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_GET_CURRENT_BUF:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_current_buf");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_current_buf");
 				return;
-			} else {
-				emit on_nvim_get_current_buf(data);
 			}
 
+			emit on_nvim_get_current_buf(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_SET_CURRENT_BUF:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_SET_CURRENT_BUF:
 		{
 			emit on_nvim_set_current_buf();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_LIST_WINS:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_LIST_WINS:
 		{
 			QList<int64_t> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_wins");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_wins");
 				return;
-			} else {
-				emit on_nvim_list_wins(data);
 			}
 
+			emit on_nvim_list_wins(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_GET_CURRENT_WIN:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_GET_CURRENT_WIN:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_current_win");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_current_win");
 				return;
-			} else {
-				emit on_nvim_get_current_win(data);
 			}
 
+			emit on_nvim_get_current_win(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_SET_CURRENT_WIN:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_SET_CURRENT_WIN:
 		{
 			emit on_nvim_set_current_win();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_LIST_TABPAGES:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_LIST_TABPAGES:
 		{
 			QList<int64_t> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_tabpages");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_tabpages");
 				return;
-			} else {
-				emit on_nvim_list_tabpages(data);
 			}
 
+			emit on_nvim_list_tabpages(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_GET_CURRENT_TABPAGE:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_GET_CURRENT_TABPAGE:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_current_tabpage");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_current_tabpage");
 				return;
-			} else {
-				emit on_nvim_get_current_tabpage(data);
 			}
 
+			emit on_nvim_get_current_tabpage(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_SET_CURRENT_TABPAGE:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_SET_CURRENT_TABPAGE:
 		{
 			emit on_nvim_set_current_tabpage();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_SUBSCRIBE:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_SUBSCRIBE:
 		{
 			emit on_nvim_subscribe();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_UNSUBSCRIBE:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_UNSUBSCRIBE:
 		{
 			emit on_nvim_unsubscribe();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_GET_COLOR_BY_NAME:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_GET_COLOR_BY_NAME:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_color_by_name");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_color_by_name");
 				return;
-			} else {
-				emit on_nvim_get_color_by_name(data);
 			}
 
+			emit on_nvim_get_color_by_name(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_GET_COLOR_MAP:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_GET_COLOR_MAP:
 		{
 			QVariantMap data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_color_map");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_color_map");
 				return;
-			} else {
-				emit on_nvim_get_color_map(data);
 			}
 
+			emit on_nvim_get_color_map(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_GET_MODE:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_GET_MODE:
 		{
 			QVariantMap data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_mode");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_mode");
 				return;
-			} else {
-				emit on_nvim_get_mode(data);
 			}
 
+			emit on_nvim_get_mode(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_GET_KEYMAP:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_GET_KEYMAP:
 		{
 			QList<QVariantMap> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_keymap");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_keymap");
 				return;
-			} else {
-				emit on_nvim_get_keymap(data);
 			}
 
+			emit on_nvim_get_keymap(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_GET_COMMANDS:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_GET_COMMANDS:
 		{
 			QVariantMap data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_commands");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_commands");
 				return;
-			} else {
-				emit on_nvim_get_commands(data);
 			}
 
+			emit on_nvim_get_commands(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_GET_API_INFO:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_GET_API_INFO:
 		{
 			QVariantList data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_api_info");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_api_info");
 				return;
-			} else {
-				emit on_nvim_get_api_info(data);
 			}
 
+			emit on_nvim_get_api_info(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_SET_CLIENT_INFO:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_SET_CLIENT_INFO:
 		{
 			emit on_nvim_set_client_info();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_GET_CHAN_INFO:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_GET_CHAN_INFO:
 		{
 			QVariantMap data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_chan_info");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_chan_info");
 				return;
-			} else {
-				emit on_nvim_get_chan_info(data);
 			}
 
+			emit on_nvim_get_chan_info(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_LIST_CHANS:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_LIST_CHANS:
 		{
 			QVariantList data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_chans");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_chans");
 				return;
-			} else {
-				emit on_nvim_list_chans(data);
 			}
 
+			emit on_nvim_list_chans(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_CALL_ATOMIC:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_CALL_ATOMIC:
 		{
 			QVariantList data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_call_atomic");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_call_atomic");
 				return;
-			} else {
-				emit on_nvim_call_atomic(data);
 			}
 
+			emit on_nvim_call_atomic(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_PARSE_EXPRESSION:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_PARSE_EXPRESSION:
 		{
 			QVariantMap data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_parse_expression");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_parse_expression");
 				return;
-			} else {
-				emit on_nvim_parse_expression(data);
 			}
 
+			emit on_nvim_parse_expression(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_LIST_UIS:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_LIST_UIS:
 		{
 			QVariantList data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_uis");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_uis");
 				return;
-			} else {
-				emit on_nvim_list_uis(data);
 			}
 
+			emit on_nvim_list_uis(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_GET_PROC_CHILDREN:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_GET_PROC_CHILDREN:
 		{
 			QVariantList data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_proc_children");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_proc_children");
 				return;
-			} else {
-				emit on_nvim_get_proc_children(data);
 			}
 
+			emit on_nvim_get_proc_children(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_GET_PROC:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_GET_PROC:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_proc");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_proc");
 				return;
-			} else {
-				emit on_nvim_get_proc(data);
 			}
 
+			emit on_nvim_get_proc(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_WIN_GET_BUF:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_WIN_GET_BUF:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_buf");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_buf");
 				return;
-			} else {
-				emit on_nvim_win_get_buf(data);
 			}
 
+			emit on_nvim_win_get_buf(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_WIN_GET_CURSOR:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_WIN_GET_CURSOR:
 		{
 			QPoint data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_cursor");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_cursor");
 				return;
-			} else {
-				emit on_nvim_win_get_cursor(data);
 			}
 
+			emit on_nvim_win_get_cursor(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_WIN_SET_CURSOR:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_WIN_SET_CURSOR:
 		{
 			emit on_nvim_win_set_cursor();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_WIN_GET_HEIGHT:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_WIN_GET_HEIGHT:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_height");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_height");
 				return;
-			} else {
-				emit on_nvim_win_get_height(data);
 			}
 
+			emit on_nvim_win_get_height(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_WIN_SET_HEIGHT:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_WIN_SET_HEIGHT:
 		{
 			emit on_nvim_win_set_height();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_WIN_GET_WIDTH:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_WIN_GET_WIDTH:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_width");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_width");
 				return;
-			} else {
-				emit on_nvim_win_get_width(data);
 			}
 
+			emit on_nvim_win_get_width(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_WIN_SET_WIDTH:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_WIN_SET_WIDTH:
 		{
 			emit on_nvim_win_set_width();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_WIN_GET_VAR:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_WIN_GET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_var");
 				return;
-			} else {
-				emit on_nvim_win_get_var(data);
 			}
 
+			emit on_nvim_win_get_var(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_WIN_SET_VAR:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_WIN_SET_VAR:
 		{
 			emit on_nvim_win_set_var();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_WIN_DEL_VAR:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_WIN_DEL_VAR:
 		{
 			emit on_nvim_win_del_var();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_WINDOW_SET_VAR:
+
+		case NeovimApi4::NEOVIM_FN_WINDOW_SET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_set_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_set_var");
 				return;
-			} else {
-				emit on_window_set_var(data);
 			}
 
+			emit on_window_set_var(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_WINDOW_DEL_VAR:
+
+		case NeovimApi4::NEOVIM_FN_WINDOW_DEL_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_del_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_del_var");
 				return;
-			} else {
-				emit on_window_del_var(data);
 			}
 
+			emit on_window_del_var(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_WIN_GET_OPTION:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_WIN_GET_OPTION:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_option");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_option");
 				return;
-			} else {
-				emit on_nvim_win_get_option(data);
 			}
 
+			emit on_nvim_win_get_option(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_WIN_SET_OPTION:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_WIN_SET_OPTION:
 		{
 			emit on_nvim_win_set_option();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_WIN_GET_POSITION:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_WIN_GET_POSITION:
 		{
 			QPoint data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_position");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_position");
 				return;
-			} else {
-				emit on_nvim_win_get_position(data);
 			}
 
+			emit on_nvim_win_get_position(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_WIN_GET_TABPAGE:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_WIN_GET_TABPAGE:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_tabpage");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_tabpage");
 				return;
-			} else {
-				emit on_nvim_win_get_tabpage(data);
 			}
 
+			emit on_nvim_win_get_tabpage(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_WIN_GET_NUMBER:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_WIN_GET_NUMBER:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_number");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_number");
 				return;
-			} else {
-				emit on_nvim_win_get_number(data);
 			}
 
+			emit on_nvim_win_get_number(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_NVIM_WIN_IS_VALID:
+
+		case NeovimApi4::NEOVIM_FN_NVIM_WIN_IS_VALID:
 		{
 			bool data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_is_valid");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_is_valid");
 				return;
-			} else {
-				emit on_nvim_win_is_valid(data);
 			}
 
+			emit on_nvim_win_is_valid(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_BUFFER_LINE_COUNT:
+
+		case NeovimApi4::NEOVIM_FN_BUFFER_LINE_COUNT:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_line_count");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_line_count");
 				return;
-			} else {
-				emit on_buffer_line_count(data);
 			}
 
+			emit on_buffer_line_count(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_BUFFER_GET_LINES:
+
+		case NeovimApi4::NEOVIM_FN_BUFFER_GET_LINES:
 		{
 			QList<QByteArray> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_lines");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_lines");
 				return;
-			} else {
-				emit on_buffer_get_lines(data);
 			}
 
+			emit on_buffer_get_lines(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_BUFFER_SET_LINES:
+
+		case NeovimApi4::NEOVIM_FN_BUFFER_SET_LINES:
 		{
 			emit on_buffer_set_lines();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_BUFFER_GET_VAR:
+
+		case NeovimApi4::NEOVIM_FN_BUFFER_GET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_var");
 				return;
-			} else {
-				emit on_buffer_get_var(data);
 			}
 
+			emit on_buffer_get_var(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_BUFFER_GET_OPTION:
+
+		case NeovimApi4::NEOVIM_FN_BUFFER_GET_OPTION:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_option");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_option");
 				return;
-			} else {
-				emit on_buffer_get_option(data);
 			}
 
+			emit on_buffer_get_option(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_BUFFER_SET_OPTION:
+
+		case NeovimApi4::NEOVIM_FN_BUFFER_SET_OPTION:
 		{
 			emit on_buffer_set_option();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_BUFFER_GET_NUMBER:
+
+		case NeovimApi4::NEOVIM_FN_BUFFER_GET_NUMBER:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_number");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_number");
 				return;
-			} else {
-				emit on_buffer_get_number(data);
 			}
 
+			emit on_buffer_get_number(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_BUFFER_GET_NAME:
+
+		case NeovimApi4::NEOVIM_FN_BUFFER_GET_NAME:
 		{
 			QByteArray data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_name");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_name");
 				return;
-			} else {
-				emit on_buffer_get_name(data);
 			}
 
+			emit on_buffer_get_name(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_BUFFER_SET_NAME:
+
+		case NeovimApi4::NEOVIM_FN_BUFFER_SET_NAME:
 		{
 			emit on_buffer_set_name();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_BUFFER_IS_VALID:
+
+		case NeovimApi4::NEOVIM_FN_BUFFER_IS_VALID:
 		{
 			bool data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_is_valid");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_is_valid");
 				return;
-			} else {
-				emit on_buffer_is_valid(data);
 			}
 
+			emit on_buffer_is_valid(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_BUFFER_GET_MARK:
+
+		case NeovimApi4::NEOVIM_FN_BUFFER_GET_MARK:
 		{
 			QPoint data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_mark");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_mark");
 				return;
-			} else {
-				emit on_buffer_get_mark(data);
 			}
 
+			emit on_buffer_get_mark(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_BUFFER_ADD_HIGHLIGHT:
+
+		case NeovimApi4::NEOVIM_FN_BUFFER_ADD_HIGHLIGHT:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_add_highlight");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_add_highlight");
 				return;
-			} else {
-				emit on_buffer_add_highlight(data);
 			}
 
+			emit on_buffer_add_highlight(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_BUFFER_CLEAR_HIGHLIGHT:
+
+		case NeovimApi4::NEOVIM_FN_BUFFER_CLEAR_HIGHLIGHT:
 		{
 			emit on_buffer_clear_highlight();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_TABPAGE_GET_WINDOWS:
+
+		case NeovimApi4::NEOVIM_FN_TABPAGE_GET_WINDOWS:
 		{
 			QList<int64_t> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_get_windows");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_get_windows");
 				return;
-			} else {
-				emit on_tabpage_get_windows(data);
 			}
 
+			emit on_tabpage_get_windows(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_TABPAGE_GET_VAR:
+
+		case NeovimApi4::NEOVIM_FN_TABPAGE_GET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_get_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_get_var");
 				return;
-			} else {
-				emit on_tabpage_get_var(data);
 			}
 
+			emit on_tabpage_get_var(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_TABPAGE_GET_WINDOW:
+
+		case NeovimApi4::NEOVIM_FN_TABPAGE_GET_WINDOW:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_get_window");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_get_window");
 				return;
-			} else {
-				emit on_tabpage_get_window(data);
 			}
 
+			emit on_tabpage_get_window(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_TABPAGE_IS_VALID:
+
+		case NeovimApi4::NEOVIM_FN_TABPAGE_IS_VALID:
 		{
 			bool data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_is_valid");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_is_valid");
 				return;
-			} else {
-				emit on_tabpage_is_valid(data);
 			}
 
+			emit on_tabpage_is_valid(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_UI_DETACH:
+
+		case NeovimApi4::NEOVIM_FN_UI_DETACH:
 		{
 			emit on_ui_detach();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_UI_TRY_RESIZE:
+
+		case NeovimApi4::NEOVIM_FN_UI_TRY_RESIZE:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for ui_try_resize");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for ui_try_resize");
 				return;
-			} else {
-				emit on_ui_try_resize(data);
 			}
 
+			emit on_ui_try_resize(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_VIM_COMMAND:
+
+		case NeovimApi4::NEOVIM_FN_VIM_COMMAND:
 		{
 			emit on_vim_command();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_VIM_FEEDKEYS:
+
+		case NeovimApi4::NEOVIM_FN_VIM_FEEDKEYS:
 		{
 			emit on_vim_feedkeys();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_VIM_INPUT:
+
+		case NeovimApi4::NEOVIM_FN_VIM_INPUT:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_input");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_input");
 				return;
-			} else {
-				emit on_vim_input(data);
 			}
 
+			emit on_vim_input(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_VIM_REPLACE_TERMCODES:
+
+		case NeovimApi4::NEOVIM_FN_VIM_REPLACE_TERMCODES:
 		{
 			QByteArray data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_replace_termcodes");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_replace_termcodes");
 				return;
-			} else {
-				emit on_vim_replace_termcodes(data);
 			}
 
+			emit on_vim_replace_termcodes(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_VIM_COMMAND_OUTPUT:
+
+		case NeovimApi4::NEOVIM_FN_VIM_COMMAND_OUTPUT:
 		{
 			QByteArray data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_command_output");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_command_output");
 				return;
-			} else {
-				emit on_vim_command_output(data);
 			}
 
+			emit on_vim_command_output(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_VIM_EVAL:
+
+		case NeovimApi4::NEOVIM_FN_VIM_EVAL:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_eval");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_eval");
 				return;
-			} else {
-				emit on_vim_eval(data);
 			}
 
+			emit on_vim_eval(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_VIM_CALL_FUNCTION:
+
+		case NeovimApi4::NEOVIM_FN_VIM_CALL_FUNCTION:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_call_function");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_call_function");
 				return;
-			} else {
-				emit on_vim_call_function(data);
 			}
 
+			emit on_vim_call_function(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_VIM_STRWIDTH:
+
+		case NeovimApi4::NEOVIM_FN_VIM_STRWIDTH:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_strwidth");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_strwidth");
 				return;
-			} else {
-				emit on_vim_strwidth(data);
 			}
 
+			emit on_vim_strwidth(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_VIM_LIST_RUNTIME_PATHS:
+
+		case NeovimApi4::NEOVIM_FN_VIM_LIST_RUNTIME_PATHS:
 		{
 			QList<QByteArray> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_list_runtime_paths");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_list_runtime_paths");
 				return;
-			} else {
-				emit on_vim_list_runtime_paths(data);
 			}
 
+			emit on_vim_list_runtime_paths(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_VIM_CHANGE_DIRECTORY:
+
+		case NeovimApi4::NEOVIM_FN_VIM_CHANGE_DIRECTORY:
 		{
 			emit on_vim_change_directory();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_VIM_GET_CURRENT_LINE:
+
+		case NeovimApi4::NEOVIM_FN_VIM_GET_CURRENT_LINE:
 		{
 			QByteArray data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_current_line");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_current_line");
 				return;
-			} else {
-				emit on_vim_get_current_line(data);
 			}
 
+			emit on_vim_get_current_line(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_VIM_SET_CURRENT_LINE:
+
+		case NeovimApi4::NEOVIM_FN_VIM_SET_CURRENT_LINE:
 		{
 			emit on_vim_set_current_line();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_VIM_DEL_CURRENT_LINE:
+
+		case NeovimApi4::NEOVIM_FN_VIM_DEL_CURRENT_LINE:
 		{
 			emit on_vim_del_current_line();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_VIM_GET_VAR:
+
+		case NeovimApi4::NEOVIM_FN_VIM_GET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_var");
 				return;
-			} else {
-				emit on_vim_get_var(data);
 			}
 
+			emit on_vim_get_var(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_VIM_GET_VVAR:
+
+		case NeovimApi4::NEOVIM_FN_VIM_GET_VVAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_vvar");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_vvar");
 				return;
-			} else {
-				emit on_vim_get_vvar(data);
 			}
 
+			emit on_vim_get_vvar(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_VIM_GET_OPTION:
+
+		case NeovimApi4::NEOVIM_FN_VIM_GET_OPTION:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_option");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_option");
 				return;
-			} else {
-				emit on_vim_get_option(data);
 			}
 
+			emit on_vim_get_option(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_VIM_SET_OPTION:
+
+		case NeovimApi4::NEOVIM_FN_VIM_SET_OPTION:
 		{
 			emit on_vim_set_option();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_VIM_OUT_WRITE:
+
+		case NeovimApi4::NEOVIM_FN_VIM_OUT_WRITE:
 		{
 			emit on_vim_out_write();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_VIM_ERR_WRITE:
+
+		case NeovimApi4::NEOVIM_FN_VIM_ERR_WRITE:
 		{
 			emit on_vim_err_write();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_VIM_REPORT_ERROR:
+
+		case NeovimApi4::NEOVIM_FN_VIM_REPORT_ERROR:
 		{
 			emit on_vim_report_error();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_VIM_GET_BUFFERS:
+
+		case NeovimApi4::NEOVIM_FN_VIM_GET_BUFFERS:
 		{
 			QList<int64_t> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_buffers");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_buffers");
 				return;
-			} else {
-				emit on_vim_get_buffers(data);
 			}
 
+			emit on_vim_get_buffers(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_VIM_GET_CURRENT_BUFFER:
+
+		case NeovimApi4::NEOVIM_FN_VIM_GET_CURRENT_BUFFER:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_current_buffer");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_current_buffer");
 				return;
-			} else {
-				emit on_vim_get_current_buffer(data);
 			}
 
+			emit on_vim_get_current_buffer(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_VIM_SET_CURRENT_BUFFER:
+
+		case NeovimApi4::NEOVIM_FN_VIM_SET_CURRENT_BUFFER:
 		{
 			emit on_vim_set_current_buffer();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_VIM_GET_WINDOWS:
+
+		case NeovimApi4::NEOVIM_FN_VIM_GET_WINDOWS:
 		{
 			QList<int64_t> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_windows");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_windows");
 				return;
-			} else {
-				emit on_vim_get_windows(data);
 			}
 
+			emit on_vim_get_windows(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_VIM_GET_CURRENT_WINDOW:
+
+		case NeovimApi4::NEOVIM_FN_VIM_GET_CURRENT_WINDOW:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_current_window");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_current_window");
 				return;
-			} else {
-				emit on_vim_get_current_window(data);
 			}
 
+			emit on_vim_get_current_window(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_VIM_SET_CURRENT_WINDOW:
+
+		case NeovimApi4::NEOVIM_FN_VIM_SET_CURRENT_WINDOW:
 		{
 			emit on_vim_set_current_window();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_VIM_GET_TABPAGES:
+
+		case NeovimApi4::NEOVIM_FN_VIM_GET_TABPAGES:
 		{
 			QList<int64_t> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_tabpages");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_tabpages");
 				return;
-			} else {
-				emit on_vim_get_tabpages(data);
 			}
 
+			emit on_vim_get_tabpages(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_VIM_GET_CURRENT_TABPAGE:
+
+		case NeovimApi4::NEOVIM_FN_VIM_GET_CURRENT_TABPAGE:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_current_tabpage");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_current_tabpage");
 				return;
-			} else {
-				emit on_vim_get_current_tabpage(data);
 			}
 
+			emit on_vim_get_current_tabpage(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_VIM_SET_CURRENT_TABPAGE:
+
+		case NeovimApi4::NEOVIM_FN_VIM_SET_CURRENT_TABPAGE:
 		{
 			emit on_vim_set_current_tabpage();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_VIM_SUBSCRIBE:
+
+		case NeovimApi4::NEOVIM_FN_VIM_SUBSCRIBE:
 		{
 			emit on_vim_subscribe();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_VIM_UNSUBSCRIBE:
+
+		case NeovimApi4::NEOVIM_FN_VIM_UNSUBSCRIBE:
 		{
 			emit on_vim_unsubscribe();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_VIM_NAME_TO_COLOR:
+
+		case NeovimApi4::NEOVIM_FN_VIM_NAME_TO_COLOR:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_name_to_color");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_name_to_color");
 				return;
-			} else {
-				emit on_vim_name_to_color(data);
 			}
 
+			emit on_vim_name_to_color(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_VIM_GET_COLOR_MAP:
+
+		case NeovimApi4::NEOVIM_FN_VIM_GET_COLOR_MAP:
 		{
 			QVariantMap data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_color_map");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_color_map");
 				return;
-			} else {
-				emit on_vim_get_color_map(data);
 			}
 
+			emit on_vim_get_color_map(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_WINDOW_GET_BUFFER:
+
+		case NeovimApi4::NEOVIM_FN_WINDOW_GET_BUFFER:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_buffer");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_buffer");
 				return;
-			} else {
-				emit on_window_get_buffer(data);
 			}
 
+			emit on_window_get_buffer(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_WINDOW_GET_CURSOR:
+
+		case NeovimApi4::NEOVIM_FN_WINDOW_GET_CURSOR:
 		{
 			QPoint data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_cursor");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_cursor");
 				return;
-			} else {
-				emit on_window_get_cursor(data);
 			}
 
+			emit on_window_get_cursor(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_WINDOW_SET_CURSOR:
+
+		case NeovimApi4::NEOVIM_FN_WINDOW_SET_CURSOR:
 		{
 			emit on_window_set_cursor();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_WINDOW_GET_HEIGHT:
+
+		case NeovimApi4::NEOVIM_FN_WINDOW_GET_HEIGHT:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_height");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_height");
 				return;
-			} else {
-				emit on_window_get_height(data);
 			}
 
+			emit on_window_get_height(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_WINDOW_SET_HEIGHT:
+
+		case NeovimApi4::NEOVIM_FN_WINDOW_SET_HEIGHT:
 		{
 			emit on_window_set_height();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_WINDOW_GET_WIDTH:
+
+		case NeovimApi4::NEOVIM_FN_WINDOW_GET_WIDTH:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_width");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_width");
 				return;
-			} else {
-				emit on_window_get_width(data);
 			}
 
+			emit on_window_get_width(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_WINDOW_SET_WIDTH:
+
+		case NeovimApi4::NEOVIM_FN_WINDOW_SET_WIDTH:
 		{
 			emit on_window_set_width();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_WINDOW_GET_VAR:
+
+		case NeovimApi4::NEOVIM_FN_WINDOW_GET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_var");
 				return;
-			} else {
-				emit on_window_get_var(data);
 			}
 
+			emit on_window_get_var(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_WINDOW_GET_OPTION:
+
+		case NeovimApi4::NEOVIM_FN_WINDOW_GET_OPTION:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_option");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_option");
 				return;
-			} else {
-				emit on_window_get_option(data);
 			}
 
+			emit on_window_get_option(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_WINDOW_SET_OPTION:
+
+		case NeovimApi4::NEOVIM_FN_WINDOW_SET_OPTION:
 		{
 			emit on_window_set_option();
-
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_WINDOW_GET_POSITION:
+
+		case NeovimApi4::NEOVIM_FN_WINDOW_GET_POSITION:
 		{
 			QPoint data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_position");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_position");
 				return;
-			} else {
-				emit on_window_get_position(data);
 			}
 
+			emit on_window_get_position(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_WINDOW_GET_TABPAGE:
+
+		case NeovimApi4::NEOVIM_FN_WINDOW_GET_TABPAGE:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_tabpage");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_tabpage");
 				return;
-			} else {
-				emit on_window_get_tabpage(data);
 			}
 
+			emit on_window_get_tabpage(data);
 		}
 		break;
-	case NeovimApi4::NEOVIM_FN_WINDOW_IS_VALID:
+
+		case NeovimApi4::NEOVIM_FN_WINDOW_IS_VALID:
 		{
 			bool data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_is_valid");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_is_valid");
 				return;
-			} else {
-				emit on_window_is_valid(data);
 			}
 
+			emit on_window_is_valid(data);
 		}
 		break;
+
 	default:
 		qWarning() << "Received unexpected response";
 	}
@@ -4085,831 +4271,1363 @@ void NeovimApi4::handleResponse(quint32 msgid, quint64 fun, const QVariant& res)
  *
  * Returns false if there is an API mismatch
  */
-bool NeovimApi4::checkFunctions(const QVariantList& ftable)
+/*static*/ bool NeovimApi4::checkFunctions(const QVariantList& ftable) noexcept
 {
-
-	QList<Function> required;
-	required
-		<< Function("Integer", "nvim_buf_line_count",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("String", "buffer_get_line",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						, false)
-		<< Function("Boolean", "nvim_buf_attach",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Boolean")
-						<< QString("Dictionary")
-						, false)
-		<< Function("Boolean", "nvim_buf_detach",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("void", "buffer_set_line",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("String")
-						, false)
-		<< Function("void", "buffer_del_line",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						, false)
-		<< Function("ArrayOf(String)", "buffer_get_line_slice",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Boolean")
-						<< QString("Boolean")
-						, false)
-		<< Function("ArrayOf(String)", "nvim_buf_get_lines",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Boolean")
-						, false)
-		<< Function("void", "buffer_set_line_slice",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Boolean")
-						<< QString("Boolean")
-						<< QString("ArrayOf(String)")
-						, false)
-		<< Function("void", "nvim_buf_set_lines",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Boolean")
-						<< QString("ArrayOf(String)")
-						, false)
-		<< Function("Object", "nvim_buf_get_var",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("Integer", "nvim_buf_get_changedtick",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("ArrayOf(Dictionary)", "nvim_buf_get_keymap",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("Dictionary", "nvim_buf_get_commands",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Dictionary")
-						, false)
-		<< Function("void", "nvim_buf_set_var",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("void", "nvim_buf_del_var",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("Object", "buffer_set_var",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("Object", "buffer_del_var",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("Object", "nvim_buf_get_option",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_buf_set_option",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("Integer", "nvim_buf_get_number",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("String", "nvim_buf_get_name",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("void", "nvim_buf_set_name",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("Boolean", "nvim_buf_is_valid",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("void", "buffer_insert",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("ArrayOf(String)")
-						, false)
-		<< Function("ArrayOf(Integer, 2)", "nvim_buf_get_mark",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("Integer", "nvim_buf_add_highlight",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("String")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Integer")
-						, false)
-		<< Function("void", "nvim_buf_clear_highlight",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Integer")
-						, false)
-		<< Function("ArrayOf(Window)", "nvim_tabpage_list_wins",
-			QList<QString>()
-						<< QString("Tabpage")
-						, false)
-		<< Function("Object", "nvim_tabpage_get_var",
-			QList<QString>()
-						<< QString("Tabpage")
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_tabpage_set_var",
-			QList<QString>()
-						<< QString("Tabpage")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("void", "nvim_tabpage_del_var",
-			QList<QString>()
-						<< QString("Tabpage")
-						<< QString("String")
-						, false)
-		<< Function("Object", "tabpage_set_var",
-			QList<QString>()
-						<< QString("Tabpage")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("Object", "tabpage_del_var",
-			QList<QString>()
-						<< QString("Tabpage")
-						<< QString("String")
-						, false)
-		<< Function("Window", "nvim_tabpage_get_win",
-			QList<QString>()
-						<< QString("Tabpage")
-						, false)
-		<< Function("Integer", "nvim_tabpage_get_number",
-			QList<QString>()
-						<< QString("Tabpage")
-						, false)
-		<< Function("Boolean", "nvim_tabpage_is_valid",
-			QList<QString>()
-						<< QString("Tabpage")
-						, false)
-		<< Function("void", "nvim_ui_attach",
-			QList<QString>()
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Dictionary")
-						, false)
-		<< Function("void", "ui_attach",
-			QList<QString>()
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Boolean")
-						, false)
-		<< Function("void", "nvim_ui_detach",
-			QList<QString>()
-						, false)
-		<< Function("void", "nvim_ui_try_resize",
-			QList<QString>()
-						<< QString("Integer")
-						<< QString("Integer")
-						, false)
-		<< Function("void", "nvim_ui_set_option",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("void", "nvim_command",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Dictionary", "nvim_get_hl_by_name",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Boolean")
-						, false)
-		<< Function("Dictionary", "nvim_get_hl_by_id",
-			QList<QString>()
-						<< QString("Integer")
-						<< QString("Boolean")
-						, false)
-		<< Function("void", "nvim_feedkeys",
-			QList<QString>()
-						<< QString("String")
-						<< QString("String")
-						<< QString("Boolean")
-						, false)
-		<< Function("Integer", "nvim_input",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("String", "nvim_replace_termcodes",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Boolean")
-						<< QString("Boolean")
-						<< QString("Boolean")
-						, false)
-		<< Function("String", "nvim_command_output",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Object", "nvim_eval",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Object", "nvim_execute_lua",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Array")
-						, false)
-		<< Function("Object", "nvim_call_function",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Array")
-						, false)
-		<< Function("Object", "nvim_call_dict_function",
-			QList<QString>()
-						<< QString("Object")
-						<< QString("String")
-						<< QString("Array")
-						, false)
-		<< Function("Integer", "nvim_strwidth",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("ArrayOf(String)", "nvim_list_runtime_paths",
-			QList<QString>()
-						, false)
-		<< Function("void", "nvim_set_current_dir",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("String", "nvim_get_current_line",
-			QList<QString>()
-						, false)
-		<< Function("void", "nvim_set_current_line",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_del_current_line",
-			QList<QString>()
-						, false)
-		<< Function("Object", "nvim_get_var",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_set_var",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("void", "nvim_del_var",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Object", "vim_set_var",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("Object", "vim_del_var",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Object", "nvim_get_vvar",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Object", "nvim_get_option",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_set_option",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("void", "nvim_out_write",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_err_write",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_err_writeln",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("ArrayOf(Buffer)", "nvim_list_bufs",
-			QList<QString>()
-						, false)
-		<< Function("Buffer", "nvim_get_current_buf",
-			QList<QString>()
-						, false)
-		<< Function("void", "nvim_set_current_buf",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("ArrayOf(Window)", "nvim_list_wins",
-			QList<QString>()
-						, false)
-		<< Function("Window", "nvim_get_current_win",
-			QList<QString>()
-						, false)
-		<< Function("void", "nvim_set_current_win",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("ArrayOf(Tabpage)", "nvim_list_tabpages",
-			QList<QString>()
-						, false)
-		<< Function("Tabpage", "nvim_get_current_tabpage",
-			QList<QString>()
-						, false)
-		<< Function("void", "nvim_set_current_tabpage",
-			QList<QString>()
-						<< QString("Tabpage")
-						, false)
-		<< Function("void", "nvim_subscribe",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_unsubscribe",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Integer", "nvim_get_color_by_name",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Dictionary", "nvim_get_color_map",
-			QList<QString>()
-						, false)
-		<< Function("Dictionary", "nvim_get_mode",
-			QList<QString>()
-						, false)
-		<< Function("ArrayOf(Dictionary)", "nvim_get_keymap",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Dictionary", "nvim_get_commands",
-			QList<QString>()
-						<< QString("Dictionary")
-						, false)
-		<< Function("Array", "nvim_get_api_info",
-			QList<QString>()
-						, false)
-		<< Function("void", "nvim_set_client_info",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Dictionary")
-						<< QString("String")
-						<< QString("Dictionary")
-						<< QString("Dictionary")
-						, false)
-		<< Function("Dictionary", "nvim_get_chan_info",
-			QList<QString>()
-						<< QString("Integer")
-						, false)
-		<< Function("Array", "nvim_list_chans",
-			QList<QString>()
-						, false)
-		<< Function("Array", "nvim_call_atomic",
-			QList<QString>()
-						<< QString("Array")
-						, false)
-		<< Function("Dictionary", "nvim_parse_expression",
-			QList<QString>()
-						<< QString("String")
-						<< QString("String")
-						<< QString("Boolean")
-						, false)
-		<< Function("Array", "nvim_list_uis",
-			QList<QString>()
-						, false)
-		<< Function("Array", "nvim_get_proc_children",
-			QList<QString>()
-						<< QString("Integer")
-						, false)
-		<< Function("Object", "nvim_get_proc",
-			QList<QString>()
-						<< QString("Integer")
-						, false)
-		<< Function("Buffer", "nvim_win_get_buf",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("ArrayOf(Integer, 2)", "nvim_win_get_cursor",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("void", "nvim_win_set_cursor",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("ArrayOf(Integer, 2)")
-						, false)
-		<< Function("Integer", "nvim_win_get_height",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("void", "nvim_win_set_height",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("Integer")
-						, false)
-		<< Function("Integer", "nvim_win_get_width",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("void", "nvim_win_set_width",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("Integer")
-						, false)
-		<< Function("Object", "nvim_win_get_var",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_win_set_var",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("void", "nvim_win_del_var",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						, false)
-		<< Function("Object", "window_set_var",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("Object", "window_del_var",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						, false)
-		<< Function("Object", "nvim_win_get_option",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_win_set_option",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("ArrayOf(Integer, 2)", "nvim_win_get_position",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("Tabpage", "nvim_win_get_tabpage",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("Integer", "nvim_win_get_number",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("Boolean", "nvim_win_is_valid",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("Integer", "buffer_line_count",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("ArrayOf(String)", "buffer_get_lines",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Boolean")
-						, false)
-		<< Function("void", "buffer_set_lines",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Boolean")
-						<< QString("ArrayOf(String)")
-						, false)
-		<< Function("Object", "buffer_get_var",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("Object", "buffer_get_option",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("void", "buffer_set_option",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("Integer", "buffer_get_number",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("String", "buffer_get_name",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("void", "buffer_set_name",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("Boolean", "buffer_is_valid",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("ArrayOf(Integer, 2)", "buffer_get_mark",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("Integer", "buffer_add_highlight",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("String")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Integer")
-						, false)
-		<< Function("void", "buffer_clear_highlight",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Integer")
-						, false)
-		<< Function("ArrayOf(Window)", "tabpage_get_windows",
-			QList<QString>()
-						<< QString("Tabpage")
-						, false)
-		<< Function("Object", "tabpage_get_var",
-			QList<QString>()
-						<< QString("Tabpage")
-						<< QString("String")
-						, false)
-		<< Function("Window", "tabpage_get_window",
-			QList<QString>()
-						<< QString("Tabpage")
-						, false)
-		<< Function("Boolean", "tabpage_is_valid",
-			QList<QString>()
-						<< QString("Tabpage")
-						, false)
-		<< Function("void", "ui_detach",
-			QList<QString>()
-						, false)
-		<< Function("Object", "ui_try_resize",
-			QList<QString>()
-						<< QString("Integer")
-						<< QString("Integer")
-						, false)
-		<< Function("void", "vim_command",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "vim_feedkeys",
-			QList<QString>()
-						<< QString("String")
-						<< QString("String")
-						<< QString("Boolean")
-						, false)
-		<< Function("Integer", "vim_input",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("String", "vim_replace_termcodes",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Boolean")
-						<< QString("Boolean")
-						<< QString("Boolean")
-						, false)
-		<< Function("String", "vim_command_output",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Object", "vim_eval",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Object", "vim_call_function",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Array")
-						, false)
-		<< Function("Integer", "vim_strwidth",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("ArrayOf(String)", "vim_list_runtime_paths",
-			QList<QString>()
-						, false)
-		<< Function("void", "vim_change_directory",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("String", "vim_get_current_line",
-			QList<QString>()
-						, false)
-		<< Function("void", "vim_set_current_line",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "vim_del_current_line",
-			QList<QString>()
-						, false)
-		<< Function("Object", "vim_get_var",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Object", "vim_get_vvar",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Object", "vim_get_option",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "vim_set_option",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("void", "vim_out_write",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "vim_err_write",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "vim_report_error",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("ArrayOf(Buffer)", "vim_get_buffers",
-			QList<QString>()
-						, false)
-		<< Function("Buffer", "vim_get_current_buffer",
-			QList<QString>()
-						, false)
-		<< Function("void", "vim_set_current_buffer",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("ArrayOf(Window)", "vim_get_windows",
-			QList<QString>()
-						, false)
-		<< Function("Window", "vim_get_current_window",
-			QList<QString>()
-						, false)
-		<< Function("void", "vim_set_current_window",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("ArrayOf(Tabpage)", "vim_get_tabpages",
-			QList<QString>()
-						, false)
-		<< Function("Tabpage", "vim_get_current_tabpage",
-			QList<QString>()
-						, false)
-		<< Function("void", "vim_set_current_tabpage",
-			QList<QString>()
-						<< QString("Tabpage")
-						, false)
-		<< Function("void", "vim_subscribe",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "vim_unsubscribe",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Integer", "vim_name_to_color",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Dictionary", "vim_get_color_map",
-			QList<QString>()
-						, false)
-		<< Function("Buffer", "window_get_buffer",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("ArrayOf(Integer, 2)", "window_get_cursor",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("void", "window_set_cursor",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("ArrayOf(Integer, 2)")
-						, false)
-		<< Function("Integer", "window_get_height",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("void", "window_set_height",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("Integer")
-						, false)
-		<< Function("Integer", "window_get_width",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("void", "window_set_width",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("Integer")
-						, false)
-		<< Function("Object", "window_get_var",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						, false)
-		<< Function("Object", "window_get_option",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						, false)
-		<< Function("void", "window_set_option",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("ArrayOf(Integer, 2)", "window_get_position",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("Tabpage", "window_get_tabpage",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("Boolean", "window_is_valid",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		;
-
+	static const QList<Function> required{
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_buf_line_count"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("String"),
+				QStringLiteral("buffer_get_line"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Boolean"),
+				QStringLiteral("nvim_buf_attach"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("Dictionary"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Boolean"),
+				QStringLiteral("nvim_buf_detach"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("buffer_set_line"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("buffer_del_line"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(String)"),
+				QStringLiteral("buffer_get_line_slice"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(String)"),
+				QStringLiteral("nvim_buf_get_lines"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("buffer_set_line_slice"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("ArrayOf(String)"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_buf_set_lines"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("ArrayOf(String)"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_buf_get_var"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_buf_get_changedtick"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Dictionary)"),
+				QStringLiteral("nvim_buf_get_keymap"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Dictionary"),
+				QStringLiteral("nvim_buf_get_commands"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Dictionary"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_buf_set_var"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_buf_del_var"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("buffer_set_var"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("buffer_del_var"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_buf_get_option"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_buf_set_option"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_buf_get_number"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("String"),
+				QStringLiteral("nvim_buf_get_name"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_buf_set_name"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Boolean"),
+				QStringLiteral("nvim_buf_is_valid"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("buffer_insert"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("ArrayOf(String)"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Integer, 2)"),
+				QStringLiteral("nvim_buf_get_mark"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_buf_add_highlight"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("String"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_buf_clear_highlight"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Window)"),
+				QStringLiteral("nvim_tabpage_list_wins"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_tabpage_get_var"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_tabpage_set_var"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_tabpage_del_var"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("tabpage_set_var"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("tabpage_del_var"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Window"),
+				QStringLiteral("nvim_tabpage_get_win"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_tabpage_get_number"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Boolean"),
+				QStringLiteral("nvim_tabpage_is_valid"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_ui_attach"),
+				QStringList{
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Dictionary"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("ui_attach"),
+				QStringList{
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_ui_detach"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_ui_try_resize"),
+				QStringList{
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_ui_set_option"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_command"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Dictionary"),
+				QStringLiteral("nvim_get_hl_by_name"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Dictionary"),
+				QStringLiteral("nvim_get_hl_by_id"),
+				QStringList{
+					QStringLiteral("Integer"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_feedkeys"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("String"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_input"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("String"),
+				QStringLiteral("nvim_replace_termcodes"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("String"),
+				QStringLiteral("nvim_command_output"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_eval"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_execute_lua"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Array"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_call_function"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Array"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_call_dict_function"),
+				QStringList{
+					QStringLiteral("Object"),
+					QStringLiteral("String"),
+					QStringLiteral("Array"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_strwidth"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(String)"),
+				QStringLiteral("nvim_list_runtime_paths"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_set_current_dir"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("String"),
+				QStringLiteral("nvim_get_current_line"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_set_current_line"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_del_current_line"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_get_var"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_set_var"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_del_var"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("vim_set_var"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("vim_del_var"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_get_vvar"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_get_option"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_set_option"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_out_write"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_err_write"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_err_writeln"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Buffer)"),
+				QStringLiteral("nvim_list_bufs"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Buffer"),
+				QStringLiteral("nvim_get_current_buf"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_set_current_buf"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Window)"),
+				QStringLiteral("nvim_list_wins"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Window"),
+				QStringLiteral("nvim_get_current_win"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_set_current_win"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Tabpage)"),
+				QStringLiteral("nvim_list_tabpages"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Tabpage"),
+				QStringLiteral("nvim_get_current_tabpage"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_set_current_tabpage"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_subscribe"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_unsubscribe"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_get_color_by_name"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Dictionary"),
+				QStringLiteral("nvim_get_color_map"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Dictionary"),
+				QStringLiteral("nvim_get_mode"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Dictionary)"),
+				QStringLiteral("nvim_get_keymap"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Dictionary"),
+				QStringLiteral("nvim_get_commands"),
+				QStringList{
+					QStringLiteral("Dictionary"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Array"),
+				QStringLiteral("nvim_get_api_info"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_set_client_info"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Dictionary"),
+					QStringLiteral("String"),
+					QStringLiteral("Dictionary"),
+					QStringLiteral("Dictionary"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Dictionary"),
+				QStringLiteral("nvim_get_chan_info"),
+				QStringList{
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Array"),
+				QStringLiteral("nvim_list_chans"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Array"),
+				QStringLiteral("nvim_call_atomic"),
+				QStringList{
+					QStringLiteral("Array"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Dictionary"),
+				QStringLiteral("nvim_parse_expression"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("String"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Array"),
+				QStringLiteral("nvim_list_uis"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Array"),
+				QStringLiteral("nvim_get_proc_children"),
+				QStringList{
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_get_proc"),
+				QStringList{
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Buffer"),
+				QStringLiteral("nvim_win_get_buf"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Integer, 2)"),
+				QStringLiteral("nvim_win_get_cursor"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_win_set_cursor"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("ArrayOf(Integer, 2)"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_win_get_height"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_win_set_height"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_win_get_width"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_win_set_width"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_win_get_var"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_win_set_var"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_win_del_var"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("window_set_var"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("window_del_var"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_win_get_option"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_win_set_option"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Integer, 2)"),
+				QStringLiteral("nvim_win_get_position"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Tabpage"),
+				QStringLiteral("nvim_win_get_tabpage"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_win_get_number"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Boolean"),
+				QStringLiteral("nvim_win_is_valid"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("buffer_line_count"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(String)"),
+				QStringLiteral("buffer_get_lines"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("buffer_set_lines"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("ArrayOf(String)"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("buffer_get_var"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("buffer_get_option"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("buffer_set_option"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("buffer_get_number"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("String"),
+				QStringLiteral("buffer_get_name"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("buffer_set_name"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Boolean"),
+				QStringLiteral("buffer_is_valid"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Integer, 2)"),
+				QStringLiteral("buffer_get_mark"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("buffer_add_highlight"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("String"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("buffer_clear_highlight"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Window)"),
+				QStringLiteral("tabpage_get_windows"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("tabpage_get_var"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Window"),
+				QStringLiteral("tabpage_get_window"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Boolean"),
+				QStringLiteral("tabpage_is_valid"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("ui_detach"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("ui_try_resize"),
+				QStringList{
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_command"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_feedkeys"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("String"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("vim_input"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("String"),
+				QStringLiteral("vim_replace_termcodes"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("String"),
+				QStringLiteral("vim_command_output"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("vim_eval"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("vim_call_function"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Array"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("vim_strwidth"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(String)"),
+				QStringLiteral("vim_list_runtime_paths"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_change_directory"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("String"),
+				QStringLiteral("vim_get_current_line"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_set_current_line"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_del_current_line"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("vim_get_var"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("vim_get_vvar"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("vim_get_option"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_set_option"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_out_write"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_err_write"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_report_error"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Buffer)"),
+				QStringLiteral("vim_get_buffers"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Buffer"),
+				QStringLiteral("vim_get_current_buffer"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_set_current_buffer"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Window)"),
+				QStringLiteral("vim_get_windows"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Window"),
+				QStringLiteral("vim_get_current_window"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_set_current_window"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Tabpage)"),
+				QStringLiteral("vim_get_tabpages"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Tabpage"),
+				QStringLiteral("vim_get_current_tabpage"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_set_current_tabpage"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_subscribe"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_unsubscribe"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("vim_name_to_color"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Dictionary"),
+				QStringLiteral("vim_get_color_map"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Buffer"),
+				QStringLiteral("window_get_buffer"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Integer, 2)"),
+				QStringLiteral("window_get_cursor"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("window_set_cursor"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("ArrayOf(Integer, 2)"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("window_get_height"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("window_set_height"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("window_get_width"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("window_set_width"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("window_get_var"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("window_get_option"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("window_set_option"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Integer, 2)"),
+				QStringLiteral("window_get_position"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Tabpage"),
+				QStringLiteral("window_get_tabpage"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Boolean"),
+				QStringLiteral("window_is_valid"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+		};
 
 	QList<Function> supported;
-	foreach(const QVariant& val, ftable) {
+	supported.reserve(ftable.size());
+	for(const auto& val : ftable) {
 		auto f = Function::fromVariant(val);
 		if (!f.isValid()) {
 			qDebug() << "Invalid function in metadata" << f;
@@ -4923,7 +5641,7 @@ bool NeovimApi4::checkFunctions(const QVariantList& ftable)
 	}
 
 	bool ok = true;
-	foreach(const Function& f, required) {
+	for(const auto& f : required) {
 		if (!supported.contains(f)) {
 			qDebug() << "- instance DOES NOT support API4:" << f;
 			ok = false;

--- a/src/auto/neovimapi4.cpp
+++ b/src/auto/neovimapi4.cpp
@@ -1,4 +1,4 @@
-// Auto generated 2020-09-09 13:30:54.235834 from nvim API level:4
+// Auto generated 2020-09-09 15:16:42.888567 from nvim API level:4
 #include "auto/neovimapi4.h"
 #include "msgpackiodevice.h"
 #include "msgpackrequest.h"
@@ -5625,7 +5625,7 @@ void NeovimApi4::handleResponse(uint32_t msgid, uint64_t fun, const QVariant& re
 				, false },
 		};
 
-	QList<Function> supported;
+	QVector<Function> supported;
 	supported.reserve(ftable.size());
 	for(const auto& val : ftable) {
 		auto f = Function::fromVariant(val);

--- a/src/auto/neovimapi4.h
+++ b/src/auto/neovimapi4.h
@@ -1,4 +1,4 @@
-// Auto generated 2020-09-09 13:30:54.254121 from nvim API level:4
+// Auto generated 2020-09-09 15:16:42.907450 from nvim API level:4
 #pragma once
 
 #include <QObject>

--- a/src/auto/neovimapi4.h
+++ b/src/auto/neovimapi4.h
@@ -1,655 +1,760 @@
-// Auto generated 2018-09-04 09:18:09.666239 from nvim API level:4
-#ifndef NEOVIM_QT_NEOVIMAPI4
-#define NEOVIM_QT_NEOVIMAPI4
-#include "msgpack.h"
+// Auto generated 2020-09-09 13:30:54.254121 from nvim API level:4
+#pragma once
+
 #include <QObject>
-#include <QVariant>
 #include <QPoint>
+#include <QVariant>
+
 #include "function.h"
+#include "msgpack.h"
 
 namespace NeovimQt {
+
 class NeovimConnector;
 class MsgpackRequest;
 
-class NeovimApi4: public QObject
+class NeovimApi4 : public QObject
 {
 	Q_OBJECT
-	Q_ENUMS(FunctionId)
 
 public:
-
 	enum FunctionId {
-		NEOVIM_FN_NULL=0,
-				NEOVIM_FN_NVIM_BUF_LINE_COUNT,
-				NEOVIM_FN_BUFFER_GET_LINE,
-				NEOVIM_FN_NVIM_BUF_ATTACH,
-				NEOVIM_FN_NVIM_BUF_DETACH,
-				NEOVIM_FN_BUFFER_SET_LINE,
-				NEOVIM_FN_BUFFER_DEL_LINE,
-				NEOVIM_FN_BUFFER_GET_LINE_SLICE,
-				NEOVIM_FN_NVIM_BUF_GET_LINES,
-				NEOVIM_FN_BUFFER_SET_LINE_SLICE,
-				NEOVIM_FN_NVIM_BUF_SET_LINES,
-				NEOVIM_FN_NVIM_BUF_GET_VAR,
-				NEOVIM_FN_NVIM_BUF_GET_CHANGEDTICK,
-				NEOVIM_FN_NVIM_BUF_GET_KEYMAP,
-				NEOVIM_FN_NVIM_BUF_GET_COMMANDS,
-				NEOVIM_FN_NVIM_BUF_SET_VAR,
-				NEOVIM_FN_NVIM_BUF_DEL_VAR,
-				NEOVIM_FN_BUFFER_SET_VAR,
-				NEOVIM_FN_BUFFER_DEL_VAR,
-				NEOVIM_FN_NVIM_BUF_GET_OPTION,
-				NEOVIM_FN_NVIM_BUF_SET_OPTION,
-				NEOVIM_FN_NVIM_BUF_GET_NUMBER,
-				NEOVIM_FN_NVIM_BUF_GET_NAME,
-				NEOVIM_FN_NVIM_BUF_SET_NAME,
-				NEOVIM_FN_NVIM_BUF_IS_VALID,
-				NEOVIM_FN_BUFFER_INSERT,
-				NEOVIM_FN_NVIM_BUF_GET_MARK,
-				NEOVIM_FN_NVIM_BUF_ADD_HIGHLIGHT,
-				NEOVIM_FN_NVIM_BUF_CLEAR_HIGHLIGHT,
-				NEOVIM_FN_NVIM_TABPAGE_LIST_WINS,
-				NEOVIM_FN_NVIM_TABPAGE_GET_VAR,
-				NEOVIM_FN_NVIM_TABPAGE_SET_VAR,
-				NEOVIM_FN_NVIM_TABPAGE_DEL_VAR,
-				NEOVIM_FN_TABPAGE_SET_VAR,
-				NEOVIM_FN_TABPAGE_DEL_VAR,
-				NEOVIM_FN_NVIM_TABPAGE_GET_WIN,
-				NEOVIM_FN_NVIM_TABPAGE_GET_NUMBER,
-				NEOVIM_FN_NVIM_TABPAGE_IS_VALID,
-				NEOVIM_FN_NVIM_UI_ATTACH,
-				NEOVIM_FN_UI_ATTACH,
-				NEOVIM_FN_NVIM_UI_DETACH,
-				NEOVIM_FN_NVIM_UI_TRY_RESIZE,
-				NEOVIM_FN_NVIM_UI_SET_OPTION,
-				NEOVIM_FN_NVIM_COMMAND,
-				NEOVIM_FN_NVIM_GET_HL_BY_NAME,
-				NEOVIM_FN_NVIM_GET_HL_BY_ID,
-				NEOVIM_FN_NVIM_FEEDKEYS,
-				NEOVIM_FN_NVIM_INPUT,
-				NEOVIM_FN_NVIM_REPLACE_TERMCODES,
-				NEOVIM_FN_NVIM_COMMAND_OUTPUT,
-				NEOVIM_FN_NVIM_EVAL,
-				NEOVIM_FN_NVIM_EXECUTE_LUA,
-				NEOVIM_FN_NVIM_CALL_FUNCTION,
-				NEOVIM_FN_NVIM_CALL_DICT_FUNCTION,
-				NEOVIM_FN_NVIM_STRWIDTH,
-				NEOVIM_FN_NVIM_LIST_RUNTIME_PATHS,
-				NEOVIM_FN_NVIM_SET_CURRENT_DIR,
-				NEOVIM_FN_NVIM_GET_CURRENT_LINE,
-				NEOVIM_FN_NVIM_SET_CURRENT_LINE,
-				NEOVIM_FN_NVIM_DEL_CURRENT_LINE,
-				NEOVIM_FN_NVIM_GET_VAR,
-				NEOVIM_FN_NVIM_SET_VAR,
-				NEOVIM_FN_NVIM_DEL_VAR,
-				NEOVIM_FN_VIM_SET_VAR,
-				NEOVIM_FN_VIM_DEL_VAR,
-				NEOVIM_FN_NVIM_GET_VVAR,
-				NEOVIM_FN_NVIM_GET_OPTION,
-				NEOVIM_FN_NVIM_SET_OPTION,
-				NEOVIM_FN_NVIM_OUT_WRITE,
-				NEOVIM_FN_NVIM_ERR_WRITE,
-				NEOVIM_FN_NVIM_ERR_WRITELN,
-				NEOVIM_FN_NVIM_LIST_BUFS,
-				NEOVIM_FN_NVIM_GET_CURRENT_BUF,
-				NEOVIM_FN_NVIM_SET_CURRENT_BUF,
-				NEOVIM_FN_NVIM_LIST_WINS,
-				NEOVIM_FN_NVIM_GET_CURRENT_WIN,
-				NEOVIM_FN_NVIM_SET_CURRENT_WIN,
-				NEOVIM_FN_NVIM_LIST_TABPAGES,
-				NEOVIM_FN_NVIM_GET_CURRENT_TABPAGE,
-				NEOVIM_FN_NVIM_SET_CURRENT_TABPAGE,
-				NEOVIM_FN_NVIM_SUBSCRIBE,
-				NEOVIM_FN_NVIM_UNSUBSCRIBE,
-				NEOVIM_FN_NVIM_GET_COLOR_BY_NAME,
-				NEOVIM_FN_NVIM_GET_COLOR_MAP,
-				NEOVIM_FN_NVIM_GET_MODE,
-				NEOVIM_FN_NVIM_GET_KEYMAP,
-				NEOVIM_FN_NVIM_GET_COMMANDS,
-				NEOVIM_FN_NVIM_GET_API_INFO,
-				NEOVIM_FN_NVIM_SET_CLIENT_INFO,
-				NEOVIM_FN_NVIM_GET_CHAN_INFO,
-				NEOVIM_FN_NVIM_LIST_CHANS,
-				NEOVIM_FN_NVIM_CALL_ATOMIC,
-				NEOVIM_FN_NVIM_PARSE_EXPRESSION,
-				NEOVIM_FN_NVIM_LIST_UIS,
-				NEOVIM_FN_NVIM_GET_PROC_CHILDREN,
-				NEOVIM_FN_NVIM_GET_PROC,
-				NEOVIM_FN_NVIM_WIN_GET_BUF,
-				NEOVIM_FN_NVIM_WIN_GET_CURSOR,
-				NEOVIM_FN_NVIM_WIN_SET_CURSOR,
-				NEOVIM_FN_NVIM_WIN_GET_HEIGHT,
-				NEOVIM_FN_NVIM_WIN_SET_HEIGHT,
-				NEOVIM_FN_NVIM_WIN_GET_WIDTH,
-				NEOVIM_FN_NVIM_WIN_SET_WIDTH,
-				NEOVIM_FN_NVIM_WIN_GET_VAR,
-				NEOVIM_FN_NVIM_WIN_SET_VAR,
-				NEOVIM_FN_NVIM_WIN_DEL_VAR,
-				NEOVIM_FN_WINDOW_SET_VAR,
-				NEOVIM_FN_WINDOW_DEL_VAR,
-				NEOVIM_FN_NVIM_WIN_GET_OPTION,
-				NEOVIM_FN_NVIM_WIN_SET_OPTION,
-				NEOVIM_FN_NVIM_WIN_GET_POSITION,
-				NEOVIM_FN_NVIM_WIN_GET_TABPAGE,
-				NEOVIM_FN_NVIM_WIN_GET_NUMBER,
-				NEOVIM_FN_NVIM_WIN_IS_VALID,
-				NEOVIM_FN_BUFFER_LINE_COUNT,
-				NEOVIM_FN_BUFFER_GET_LINES,
-				NEOVIM_FN_BUFFER_SET_LINES,
-				NEOVIM_FN_BUFFER_GET_VAR,
-				NEOVIM_FN_BUFFER_GET_OPTION,
-				NEOVIM_FN_BUFFER_SET_OPTION,
-				NEOVIM_FN_BUFFER_GET_NUMBER,
-				NEOVIM_FN_BUFFER_GET_NAME,
-				NEOVIM_FN_BUFFER_SET_NAME,
-				NEOVIM_FN_BUFFER_IS_VALID,
-				NEOVIM_FN_BUFFER_GET_MARK,
-				NEOVIM_FN_BUFFER_ADD_HIGHLIGHT,
-				NEOVIM_FN_BUFFER_CLEAR_HIGHLIGHT,
-				NEOVIM_FN_TABPAGE_GET_WINDOWS,
-				NEOVIM_FN_TABPAGE_GET_VAR,
-				NEOVIM_FN_TABPAGE_GET_WINDOW,
-				NEOVIM_FN_TABPAGE_IS_VALID,
-				NEOVIM_FN_UI_DETACH,
-				NEOVIM_FN_UI_TRY_RESIZE,
-				NEOVIM_FN_VIM_COMMAND,
-				NEOVIM_FN_VIM_FEEDKEYS,
-				NEOVIM_FN_VIM_INPUT,
-				NEOVIM_FN_VIM_REPLACE_TERMCODES,
-				NEOVIM_FN_VIM_COMMAND_OUTPUT,
-				NEOVIM_FN_VIM_EVAL,
-				NEOVIM_FN_VIM_CALL_FUNCTION,
-				NEOVIM_FN_VIM_STRWIDTH,
-				NEOVIM_FN_VIM_LIST_RUNTIME_PATHS,
-				NEOVIM_FN_VIM_CHANGE_DIRECTORY,
-				NEOVIM_FN_VIM_GET_CURRENT_LINE,
-				NEOVIM_FN_VIM_SET_CURRENT_LINE,
-				NEOVIM_FN_VIM_DEL_CURRENT_LINE,
-				NEOVIM_FN_VIM_GET_VAR,
-				NEOVIM_FN_VIM_GET_VVAR,
-				NEOVIM_FN_VIM_GET_OPTION,
-				NEOVIM_FN_VIM_SET_OPTION,
-				NEOVIM_FN_VIM_OUT_WRITE,
-				NEOVIM_FN_VIM_ERR_WRITE,
-				NEOVIM_FN_VIM_REPORT_ERROR,
-				NEOVIM_FN_VIM_GET_BUFFERS,
-				NEOVIM_FN_VIM_GET_CURRENT_BUFFER,
-				NEOVIM_FN_VIM_SET_CURRENT_BUFFER,
-				NEOVIM_FN_VIM_GET_WINDOWS,
-				NEOVIM_FN_VIM_GET_CURRENT_WINDOW,
-				NEOVIM_FN_VIM_SET_CURRENT_WINDOW,
-				NEOVIM_FN_VIM_GET_TABPAGES,
-				NEOVIM_FN_VIM_GET_CURRENT_TABPAGE,
-				NEOVIM_FN_VIM_SET_CURRENT_TABPAGE,
-				NEOVIM_FN_VIM_SUBSCRIBE,
-				NEOVIM_FN_VIM_UNSUBSCRIBE,
-				NEOVIM_FN_VIM_NAME_TO_COLOR,
-				NEOVIM_FN_VIM_GET_COLOR_MAP,
-				NEOVIM_FN_WINDOW_GET_BUFFER,
-				NEOVIM_FN_WINDOW_GET_CURSOR,
-				NEOVIM_FN_WINDOW_SET_CURSOR,
-				NEOVIM_FN_WINDOW_GET_HEIGHT,
-				NEOVIM_FN_WINDOW_SET_HEIGHT,
-				NEOVIM_FN_WINDOW_GET_WIDTH,
-				NEOVIM_FN_WINDOW_SET_WIDTH,
-				NEOVIM_FN_WINDOW_GET_VAR,
-				NEOVIM_FN_WINDOW_GET_OPTION,
-				NEOVIM_FN_WINDOW_SET_OPTION,
-				NEOVIM_FN_WINDOW_GET_POSITION,
-				NEOVIM_FN_WINDOW_GET_TABPAGE,
-				NEOVIM_FN_WINDOW_IS_VALID,
+		NEOVIM_FN_NULL,
+		NEOVIM_FN_NVIM_BUF_LINE_COUNT,
+		NEOVIM_FN_BUFFER_GET_LINE,
+		NEOVIM_FN_NVIM_BUF_ATTACH,
+		NEOVIM_FN_NVIM_BUF_DETACH,
+		NEOVIM_FN_BUFFER_SET_LINE,
+		NEOVIM_FN_BUFFER_DEL_LINE,
+		NEOVIM_FN_BUFFER_GET_LINE_SLICE,
+		NEOVIM_FN_NVIM_BUF_GET_LINES,
+		NEOVIM_FN_BUFFER_SET_LINE_SLICE,
+		NEOVIM_FN_NVIM_BUF_SET_LINES,
+		NEOVIM_FN_NVIM_BUF_GET_VAR,
+		NEOVIM_FN_NVIM_BUF_GET_CHANGEDTICK,
+		NEOVIM_FN_NVIM_BUF_GET_KEYMAP,
+		NEOVIM_FN_NVIM_BUF_GET_COMMANDS,
+		NEOVIM_FN_NVIM_BUF_SET_VAR,
+		NEOVIM_FN_NVIM_BUF_DEL_VAR,
+		NEOVIM_FN_BUFFER_SET_VAR,
+		NEOVIM_FN_BUFFER_DEL_VAR,
+		NEOVIM_FN_NVIM_BUF_GET_OPTION,
+		NEOVIM_FN_NVIM_BUF_SET_OPTION,
+		NEOVIM_FN_NVIM_BUF_GET_NUMBER,
+		NEOVIM_FN_NVIM_BUF_GET_NAME,
+		NEOVIM_FN_NVIM_BUF_SET_NAME,
+		NEOVIM_FN_NVIM_BUF_IS_VALID,
+		NEOVIM_FN_BUFFER_INSERT,
+		NEOVIM_FN_NVIM_BUF_GET_MARK,
+		NEOVIM_FN_NVIM_BUF_ADD_HIGHLIGHT,
+		NEOVIM_FN_NVIM_BUF_CLEAR_HIGHLIGHT,
+		NEOVIM_FN_NVIM_TABPAGE_LIST_WINS,
+		NEOVIM_FN_NVIM_TABPAGE_GET_VAR,
+		NEOVIM_FN_NVIM_TABPAGE_SET_VAR,
+		NEOVIM_FN_NVIM_TABPAGE_DEL_VAR,
+		NEOVIM_FN_TABPAGE_SET_VAR,
+		NEOVIM_FN_TABPAGE_DEL_VAR,
+		NEOVIM_FN_NVIM_TABPAGE_GET_WIN,
+		NEOVIM_FN_NVIM_TABPAGE_GET_NUMBER,
+		NEOVIM_FN_NVIM_TABPAGE_IS_VALID,
+		NEOVIM_FN_NVIM_UI_ATTACH,
+		NEOVIM_FN_UI_ATTACH,
+		NEOVIM_FN_NVIM_UI_DETACH,
+		NEOVIM_FN_NVIM_UI_TRY_RESIZE,
+		NEOVIM_FN_NVIM_UI_SET_OPTION,
+		NEOVIM_FN_NVIM_COMMAND,
+		NEOVIM_FN_NVIM_GET_HL_BY_NAME,
+		NEOVIM_FN_NVIM_GET_HL_BY_ID,
+		NEOVIM_FN_NVIM_FEEDKEYS,
+		NEOVIM_FN_NVIM_INPUT,
+		NEOVIM_FN_NVIM_REPLACE_TERMCODES,
+		NEOVIM_FN_NVIM_COMMAND_OUTPUT,
+		NEOVIM_FN_NVIM_EVAL,
+		NEOVIM_FN_NVIM_EXECUTE_LUA,
+		NEOVIM_FN_NVIM_CALL_FUNCTION,
+		NEOVIM_FN_NVIM_CALL_DICT_FUNCTION,
+		NEOVIM_FN_NVIM_STRWIDTH,
+		NEOVIM_FN_NVIM_LIST_RUNTIME_PATHS,
+		NEOVIM_FN_NVIM_SET_CURRENT_DIR,
+		NEOVIM_FN_NVIM_GET_CURRENT_LINE,
+		NEOVIM_FN_NVIM_SET_CURRENT_LINE,
+		NEOVIM_FN_NVIM_DEL_CURRENT_LINE,
+		NEOVIM_FN_NVIM_GET_VAR,
+		NEOVIM_FN_NVIM_SET_VAR,
+		NEOVIM_FN_NVIM_DEL_VAR,
+		NEOVIM_FN_VIM_SET_VAR,
+		NEOVIM_FN_VIM_DEL_VAR,
+		NEOVIM_FN_NVIM_GET_VVAR,
+		NEOVIM_FN_NVIM_GET_OPTION,
+		NEOVIM_FN_NVIM_SET_OPTION,
+		NEOVIM_FN_NVIM_OUT_WRITE,
+		NEOVIM_FN_NVIM_ERR_WRITE,
+		NEOVIM_FN_NVIM_ERR_WRITELN,
+		NEOVIM_FN_NVIM_LIST_BUFS,
+		NEOVIM_FN_NVIM_GET_CURRENT_BUF,
+		NEOVIM_FN_NVIM_SET_CURRENT_BUF,
+		NEOVIM_FN_NVIM_LIST_WINS,
+		NEOVIM_FN_NVIM_GET_CURRENT_WIN,
+		NEOVIM_FN_NVIM_SET_CURRENT_WIN,
+		NEOVIM_FN_NVIM_LIST_TABPAGES,
+		NEOVIM_FN_NVIM_GET_CURRENT_TABPAGE,
+		NEOVIM_FN_NVIM_SET_CURRENT_TABPAGE,
+		NEOVIM_FN_NVIM_SUBSCRIBE,
+		NEOVIM_FN_NVIM_UNSUBSCRIBE,
+		NEOVIM_FN_NVIM_GET_COLOR_BY_NAME,
+		NEOVIM_FN_NVIM_GET_COLOR_MAP,
+		NEOVIM_FN_NVIM_GET_MODE,
+		NEOVIM_FN_NVIM_GET_KEYMAP,
+		NEOVIM_FN_NVIM_GET_COMMANDS,
+		NEOVIM_FN_NVIM_GET_API_INFO,
+		NEOVIM_FN_NVIM_SET_CLIENT_INFO,
+		NEOVIM_FN_NVIM_GET_CHAN_INFO,
+		NEOVIM_FN_NVIM_LIST_CHANS,
+		NEOVIM_FN_NVIM_CALL_ATOMIC,
+		NEOVIM_FN_NVIM_PARSE_EXPRESSION,
+		NEOVIM_FN_NVIM_LIST_UIS,
+		NEOVIM_FN_NVIM_GET_PROC_CHILDREN,
+		NEOVIM_FN_NVIM_GET_PROC,
+		NEOVIM_FN_NVIM_WIN_GET_BUF,
+		NEOVIM_FN_NVIM_WIN_GET_CURSOR,
+		NEOVIM_FN_NVIM_WIN_SET_CURSOR,
+		NEOVIM_FN_NVIM_WIN_GET_HEIGHT,
+		NEOVIM_FN_NVIM_WIN_SET_HEIGHT,
+		NEOVIM_FN_NVIM_WIN_GET_WIDTH,
+		NEOVIM_FN_NVIM_WIN_SET_WIDTH,
+		NEOVIM_FN_NVIM_WIN_GET_VAR,
+		NEOVIM_FN_NVIM_WIN_SET_VAR,
+		NEOVIM_FN_NVIM_WIN_DEL_VAR,
+		NEOVIM_FN_WINDOW_SET_VAR,
+		NEOVIM_FN_WINDOW_DEL_VAR,
+		NEOVIM_FN_NVIM_WIN_GET_OPTION,
+		NEOVIM_FN_NVIM_WIN_SET_OPTION,
+		NEOVIM_FN_NVIM_WIN_GET_POSITION,
+		NEOVIM_FN_NVIM_WIN_GET_TABPAGE,
+		NEOVIM_FN_NVIM_WIN_GET_NUMBER,
+		NEOVIM_FN_NVIM_WIN_IS_VALID,
+		NEOVIM_FN_BUFFER_LINE_COUNT,
+		NEOVIM_FN_BUFFER_GET_LINES,
+		NEOVIM_FN_BUFFER_SET_LINES,
+		NEOVIM_FN_BUFFER_GET_VAR,
+		NEOVIM_FN_BUFFER_GET_OPTION,
+		NEOVIM_FN_BUFFER_SET_OPTION,
+		NEOVIM_FN_BUFFER_GET_NUMBER,
+		NEOVIM_FN_BUFFER_GET_NAME,
+		NEOVIM_FN_BUFFER_SET_NAME,
+		NEOVIM_FN_BUFFER_IS_VALID,
+		NEOVIM_FN_BUFFER_GET_MARK,
+		NEOVIM_FN_BUFFER_ADD_HIGHLIGHT,
+		NEOVIM_FN_BUFFER_CLEAR_HIGHLIGHT,
+		NEOVIM_FN_TABPAGE_GET_WINDOWS,
+		NEOVIM_FN_TABPAGE_GET_VAR,
+		NEOVIM_FN_TABPAGE_GET_WINDOW,
+		NEOVIM_FN_TABPAGE_IS_VALID,
+		NEOVIM_FN_UI_DETACH,
+		NEOVIM_FN_UI_TRY_RESIZE,
+		NEOVIM_FN_VIM_COMMAND,
+		NEOVIM_FN_VIM_FEEDKEYS,
+		NEOVIM_FN_VIM_INPUT,
+		NEOVIM_FN_VIM_REPLACE_TERMCODES,
+		NEOVIM_FN_VIM_COMMAND_OUTPUT,
+		NEOVIM_FN_VIM_EVAL,
+		NEOVIM_FN_VIM_CALL_FUNCTION,
+		NEOVIM_FN_VIM_STRWIDTH,
+		NEOVIM_FN_VIM_LIST_RUNTIME_PATHS,
+		NEOVIM_FN_VIM_CHANGE_DIRECTORY,
+		NEOVIM_FN_VIM_GET_CURRENT_LINE,
+		NEOVIM_FN_VIM_SET_CURRENT_LINE,
+		NEOVIM_FN_VIM_DEL_CURRENT_LINE,
+		NEOVIM_FN_VIM_GET_VAR,
+		NEOVIM_FN_VIM_GET_VVAR,
+		NEOVIM_FN_VIM_GET_OPTION,
+		NEOVIM_FN_VIM_SET_OPTION,
+		NEOVIM_FN_VIM_OUT_WRITE,
+		NEOVIM_FN_VIM_ERR_WRITE,
+		NEOVIM_FN_VIM_REPORT_ERROR,
+		NEOVIM_FN_VIM_GET_BUFFERS,
+		NEOVIM_FN_VIM_GET_CURRENT_BUFFER,
+		NEOVIM_FN_VIM_SET_CURRENT_BUFFER,
+		NEOVIM_FN_VIM_GET_WINDOWS,
+		NEOVIM_FN_VIM_GET_CURRENT_WINDOW,
+		NEOVIM_FN_VIM_SET_CURRENT_WINDOW,
+		NEOVIM_FN_VIM_GET_TABPAGES,
+		NEOVIM_FN_VIM_GET_CURRENT_TABPAGE,
+		NEOVIM_FN_VIM_SET_CURRENT_TABPAGE,
+		NEOVIM_FN_VIM_SUBSCRIBE,
+		NEOVIM_FN_VIM_UNSUBSCRIBE,
+		NEOVIM_FN_VIM_NAME_TO_COLOR,
+		NEOVIM_FN_VIM_GET_COLOR_MAP,
+		NEOVIM_FN_WINDOW_GET_BUFFER,
+		NEOVIM_FN_WINDOW_GET_CURSOR,
+		NEOVIM_FN_WINDOW_SET_CURSOR,
+		NEOVIM_FN_WINDOW_GET_HEIGHT,
+		NEOVIM_FN_WINDOW_SET_HEIGHT,
+		NEOVIM_FN_WINDOW_GET_WIDTH,
+		NEOVIM_FN_WINDOW_SET_WIDTH,
+		NEOVIM_FN_WINDOW_GET_VAR,
+		NEOVIM_FN_WINDOW_GET_OPTION,
+		NEOVIM_FN_WINDOW_SET_OPTION,
+		NEOVIM_FN_WINDOW_GET_POSITION,
+		NEOVIM_FN_WINDOW_GET_TABPAGE,
+		NEOVIM_FN_WINDOW_IS_VALID,
 			};
+	Q_ENUM(FunctionId)
 
-	static bool checkFunctions(const QVariantList& ftable);
-	static FunctionId functionId(const Function& f);
+	static bool checkFunctions(const QVariantList& ftable) noexcept;
 
-	NeovimApi4(NeovimConnector *);
+	static FunctionId functionId(const Function& f) noexcept;
+
+	NeovimApi4(NeovimConnector* c) noexcept;
+
 protected slots:
-	void handleResponse(quint32 id, quint64 fun, const QVariant&);
-	void handleResponseError(quint32 id, quint64 fun, const QVariant&);
+	void handleResponse(uint32_t id, uint64_t fun, const QVariant&);
+
+	void handleResponseError(uint32_t id, uint64_t fun, const QVariant&);
+
 signals:
 	void error(const QString& errmsg, const QVariant& errObj);
+
 	void neovimNotification(const QByteArray &name, const QVariantList& args);
+
 private:
-	NeovimConnector *m_c;
+	NeovimConnector* m_connector;
+
 public slots:
-	// Integer nvim_buf_line_count(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_line_count(int64_t buffer);
-	// DEPRECATED
-	// String buffer_get_line(Buffer buffer, Integer index, ) 
-	MsgpackRequest* buffer_get_line(int64_t buffer, int64_t index);
-	// Boolean nvim_buf_attach(Buffer buffer, Boolean send_buffer, Dictionary opts, ) 
-	MsgpackRequest* nvim_buf_attach(int64_t buffer, bool send_buffer, QVariantMap opts);
-	// Boolean nvim_buf_detach(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_detach(int64_t buffer);
-	// DEPRECATED
-	// void buffer_set_line(Buffer buffer, Integer index, String line, ) 
-	MsgpackRequest* buffer_set_line(int64_t buffer, int64_t index, QByteArray line);
-	// DEPRECATED
-	// void buffer_del_line(Buffer buffer, Integer index, ) 
-	MsgpackRequest* buffer_del_line(int64_t buffer, int64_t index);
-	// DEPRECATED
-	// ArrayOf(String) buffer_get_line_slice(Buffer buffer, Integer start, Integer end, Boolean include_start, Boolean include_end, ) 
-	MsgpackRequest* buffer_get_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end);
-	// ArrayOf(String) nvim_buf_get_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ) 
-	MsgpackRequest* nvim_buf_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing);
-	// DEPRECATED
-	// void buffer_set_line_slice(Buffer buffer, Integer start, Integer end, Boolean include_start, Boolean include_end, ArrayOf(String) replacement, ) 
-	MsgpackRequest* buffer_set_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end, QList<QByteArray> replacement);
-	// void nvim_buf_set_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ArrayOf(String) replacement, ) 
-	MsgpackRequest* nvim_buf_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement);
-	// Object nvim_buf_get_var(Buffer buffer, String name, ) 
-	MsgpackRequest* nvim_buf_get_var(int64_t buffer, QByteArray name);
-	// Integer nvim_buf_get_changedtick(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_get_changedtick(int64_t buffer);
-	// ArrayOf(Dictionary) nvim_buf_get_keymap(Buffer buffer, String mode, ) 
-	MsgpackRequest* nvim_buf_get_keymap(int64_t buffer, QByteArray mode);
-	// Dictionary nvim_buf_get_commands(Buffer buffer, Dictionary opts, ) 
-	MsgpackRequest* nvim_buf_get_commands(int64_t buffer, QVariantMap opts);
-	// void nvim_buf_set_var(Buffer buffer, String name, Object value, ) 
-	MsgpackRequest* nvim_buf_set_var(int64_t buffer, QByteArray name, QVariant value);
-	// void nvim_buf_del_var(Buffer buffer, String name, ) 
-	MsgpackRequest* nvim_buf_del_var(int64_t buffer, QByteArray name);
-	// DEPRECATED
-	// Object buffer_set_var(Buffer buffer, String name, Object value, ) 
-	MsgpackRequest* buffer_set_var(int64_t buffer, QByteArray name, QVariant value);
-	// DEPRECATED
-	// Object buffer_del_var(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_del_var(int64_t buffer, QByteArray name);
-	// Object nvim_buf_get_option(Buffer buffer, String name, ) 
-	MsgpackRequest* nvim_buf_get_option(int64_t buffer, QByteArray name);
-	// void nvim_buf_set_option(Buffer buffer, String name, Object value, ) 
-	MsgpackRequest* nvim_buf_set_option(int64_t buffer, QByteArray name, QVariant value);
-	// DEPRECATED
-	// Integer nvim_buf_get_number(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_get_number(int64_t buffer);
-	// String nvim_buf_get_name(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_get_name(int64_t buffer);
-	// void nvim_buf_set_name(Buffer buffer, String name, ) 
-	MsgpackRequest* nvim_buf_set_name(int64_t buffer, QByteArray name);
-	// Boolean nvim_buf_is_valid(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_is_valid(int64_t buffer);
-	// DEPRECATED
-	// void buffer_insert(Buffer buffer, Integer lnum, ArrayOf(String) lines, ) 
-	MsgpackRequest* buffer_insert(int64_t buffer, int64_t lnum, QList<QByteArray> lines);
-	// ArrayOf(Integer, 2) nvim_buf_get_mark(Buffer buffer, String name, ) 
-	MsgpackRequest* nvim_buf_get_mark(int64_t buffer, QByteArray name);
-	// Integer nvim_buf_add_highlight(Buffer buffer, Integer src_id, String hl_group, Integer line, Integer col_start, Integer col_end, ) 
-	MsgpackRequest* nvim_buf_add_highlight(int64_t buffer, int64_t src_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end);
-	// void nvim_buf_clear_highlight(Buffer buffer, Integer src_id, Integer line_start, Integer line_end, ) 
-	MsgpackRequest* nvim_buf_clear_highlight(int64_t buffer, int64_t src_id, int64_t line_start, int64_t line_end);
-	// ArrayOf(Window) nvim_tabpage_list_wins(Tabpage tabpage, ) 
-	MsgpackRequest* nvim_tabpage_list_wins(int64_t tabpage);
-	// Object nvim_tabpage_get_var(Tabpage tabpage, String name, ) 
-	MsgpackRequest* nvim_tabpage_get_var(int64_t tabpage, QByteArray name);
-	// void nvim_tabpage_set_var(Tabpage tabpage, String name, Object value, ) 
-	MsgpackRequest* nvim_tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value);
-	// void nvim_tabpage_del_var(Tabpage tabpage, String name, ) 
-	MsgpackRequest* nvim_tabpage_del_var(int64_t tabpage, QByteArray name);
-	// DEPRECATED
-	// Object tabpage_set_var(Tabpage tabpage, String name, Object value, ) 
-	MsgpackRequest* tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value);
-	// DEPRECATED
-	// Object tabpage_del_var(Tabpage tabpage, String name, ) 
-	MsgpackRequest* tabpage_del_var(int64_t tabpage, QByteArray name);
-	// Window nvim_tabpage_get_win(Tabpage tabpage, ) 
-	MsgpackRequest* nvim_tabpage_get_win(int64_t tabpage);
-	// Integer nvim_tabpage_get_number(Tabpage tabpage, ) 
-	MsgpackRequest* nvim_tabpage_get_number(int64_t tabpage);
-	// Boolean nvim_tabpage_is_valid(Tabpage tabpage, ) 
-	MsgpackRequest* nvim_tabpage_is_valid(int64_t tabpage);
-	// void nvim_ui_attach(Integer width, Integer height, Dictionary options, ) 
-	MsgpackRequest* nvim_ui_attach(int64_t width, int64_t height, QVariantMap options);
-	// DEPRECATED
-	// void ui_attach(Integer width, Integer height, Boolean enable_rgb, ) 
-	MsgpackRequest* ui_attach(int64_t width, int64_t height, bool enable_rgb);
-	// void nvim_ui_detach() 
-	MsgpackRequest* nvim_ui_detach();
-	// void nvim_ui_try_resize(Integer width, Integer height, ) 
-	MsgpackRequest* nvim_ui_try_resize(int64_t width, int64_t height);
-	// void nvim_ui_set_option(String name, Object value, ) 
-	MsgpackRequest* nvim_ui_set_option(QByteArray name, QVariant value);
-	// void nvim_command(String command, ) 
-	MsgpackRequest* nvim_command(QByteArray command);
-	// Dictionary nvim_get_hl_by_name(String name, Boolean rgb, ) 
-	MsgpackRequest* nvim_get_hl_by_name(QByteArray name, bool rgb);
-	// Dictionary nvim_get_hl_by_id(Integer hl_id, Boolean rgb, ) 
-	MsgpackRequest* nvim_get_hl_by_id(int64_t hl_id, bool rgb);
-	// void nvim_feedkeys(String keys, String mode, Boolean escape_csi, ) 
-	MsgpackRequest* nvim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi);
-	// Integer nvim_input(String keys, ) 
-	MsgpackRequest* nvim_input(QByteArray keys);
-	// String nvim_replace_termcodes(String str, Boolean from_part, Boolean do_lt, Boolean special, ) 
-	MsgpackRequest* nvim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special);
-	// String nvim_command_output(String command, ) 
-	MsgpackRequest* nvim_command_output(QByteArray command);
-	// Object nvim_eval(String expr, ) 
-	MsgpackRequest* nvim_eval(QByteArray expr);
-	// Object nvim_execute_lua(String code, Array args, ) 
-	MsgpackRequest* nvim_execute_lua(QByteArray code, QVariantList args);
-	// Object nvim_call_function(String fn, Array args, ) 
-	MsgpackRequest* nvim_call_function(QByteArray fn, QVariantList args);
-	// Object nvim_call_dict_function(Object dict, String fn, Array args, ) 
-	MsgpackRequest* nvim_call_dict_function(QVariant dict, QByteArray fn, QVariantList args);
-	// Integer nvim_strwidth(String text, ) 
-	MsgpackRequest* nvim_strwidth(QByteArray text);
-	// ArrayOf(String) nvim_list_runtime_paths() 
-	MsgpackRequest* nvim_list_runtime_paths();
-	// void nvim_set_current_dir(String dir, ) 
-	MsgpackRequest* nvim_set_current_dir(QByteArray dir);
-	// String nvim_get_current_line() 
-	MsgpackRequest* nvim_get_current_line();
-	// void nvim_set_current_line(String line, ) 
-	MsgpackRequest* nvim_set_current_line(QByteArray line);
-	// void nvim_del_current_line() 
-	MsgpackRequest* nvim_del_current_line();
-	// Object nvim_get_var(String name, ) 
-	MsgpackRequest* nvim_get_var(QByteArray name);
-	// void nvim_set_var(String name, Object value, ) 
-	MsgpackRequest* nvim_set_var(QByteArray name, QVariant value);
-	// void nvim_del_var(String name, ) 
-	MsgpackRequest* nvim_del_var(QByteArray name);
-	// DEPRECATED
-	// Object vim_set_var(String name, Object value, ) 
-	MsgpackRequest* vim_set_var(QByteArray name, QVariant value);
-	// DEPRECATED
-	// Object vim_del_var(String name, ) 
-	MsgpackRequest* vim_del_var(QByteArray name);
-	// Object nvim_get_vvar(String name, ) 
-	MsgpackRequest* nvim_get_vvar(QByteArray name);
-	// Object nvim_get_option(String name, ) 
-	MsgpackRequest* nvim_get_option(QByteArray name);
-	// void nvim_set_option(String name, Object value, ) 
-	MsgpackRequest* nvim_set_option(QByteArray name, QVariant value);
-	// void nvim_out_write(String str, ) 
-	MsgpackRequest* nvim_out_write(QByteArray str);
-	// void nvim_err_write(String str, ) 
-	MsgpackRequest* nvim_err_write(QByteArray str);
-	// void nvim_err_writeln(String str, ) 
-	MsgpackRequest* nvim_err_writeln(QByteArray str);
-	// ArrayOf(Buffer) nvim_list_bufs() 
-	MsgpackRequest* nvim_list_bufs();
-	// Buffer nvim_get_current_buf() 
-	MsgpackRequest* nvim_get_current_buf();
-	// void nvim_set_current_buf(Buffer buffer, ) 
-	MsgpackRequest* nvim_set_current_buf(int64_t buffer);
-	// ArrayOf(Window) nvim_list_wins() 
-	MsgpackRequest* nvim_list_wins();
-	// Window nvim_get_current_win() 
-	MsgpackRequest* nvim_get_current_win();
-	// void nvim_set_current_win(Window window, ) 
-	MsgpackRequest* nvim_set_current_win(int64_t window);
-	// ArrayOf(Tabpage) nvim_list_tabpages() 
-	MsgpackRequest* nvim_list_tabpages();
-	// Tabpage nvim_get_current_tabpage() 
-	MsgpackRequest* nvim_get_current_tabpage();
-	// void nvim_set_current_tabpage(Tabpage tabpage, ) 
-	MsgpackRequest* nvim_set_current_tabpage(int64_t tabpage);
-	// void nvim_subscribe(String event, ) 
-	MsgpackRequest* nvim_subscribe(QByteArray event);
-	// void nvim_unsubscribe(String event, ) 
-	MsgpackRequest* nvim_unsubscribe(QByteArray event);
-	// Integer nvim_get_color_by_name(String name, ) 
-	MsgpackRequest* nvim_get_color_by_name(QByteArray name);
-	// Dictionary nvim_get_color_map() 
-	MsgpackRequest* nvim_get_color_map();
-	// Dictionary nvim_get_mode() 
-	MsgpackRequest* nvim_get_mode();
-	// ArrayOf(Dictionary) nvim_get_keymap(String mode, ) 
-	MsgpackRequest* nvim_get_keymap(QByteArray mode);
-	// Dictionary nvim_get_commands(Dictionary opts, ) 
-	MsgpackRequest* nvim_get_commands(QVariantMap opts);
-	// Array nvim_get_api_info() 
-	MsgpackRequest* nvim_get_api_info();
-	// void nvim_set_client_info(String name, Dictionary version, String type, Dictionary methods, Dictionary attributes, ) 
-	MsgpackRequest* nvim_set_client_info(QByteArray name, QVariantMap version, QByteArray type, QVariantMap methods, QVariantMap attributes);
-	// Dictionary nvim_get_chan_info(Integer chan, ) 
-	MsgpackRequest* nvim_get_chan_info(int64_t chan);
-	// Array nvim_list_chans() 
-	MsgpackRequest* nvim_list_chans();
-	// Array nvim_call_atomic(Array calls, ) 
-	MsgpackRequest* nvim_call_atomic(QVariantList calls);
-	// Dictionary nvim_parse_expression(String expr, String flags, Boolean highlight, ) 
-	MsgpackRequest* nvim_parse_expression(QByteArray expr, QByteArray flags, bool highlight);
-	// Array nvim_list_uis() 
-	MsgpackRequest* nvim_list_uis();
-	// Array nvim_get_proc_children(Integer pid, ) 
-	MsgpackRequest* nvim_get_proc_children(int64_t pid);
-	// Object nvim_get_proc(Integer pid, ) 
-	MsgpackRequest* nvim_get_proc(int64_t pid);
-	// Buffer nvim_win_get_buf(Window window, ) 
-	MsgpackRequest* nvim_win_get_buf(int64_t window);
-	// ArrayOf(Integer, 2) nvim_win_get_cursor(Window window, ) 
-	MsgpackRequest* nvim_win_get_cursor(int64_t window);
-	// void nvim_win_set_cursor(Window window, ArrayOf(Integer, 2) pos, ) 
-	MsgpackRequest* nvim_win_set_cursor(int64_t window, QPoint pos);
-	// Integer nvim_win_get_height(Window window, ) 
-	MsgpackRequest* nvim_win_get_height(int64_t window);
-	// void nvim_win_set_height(Window window, Integer height, ) 
-	MsgpackRequest* nvim_win_set_height(int64_t window, int64_t height);
-	// Integer nvim_win_get_width(Window window, ) 
-	MsgpackRequest* nvim_win_get_width(int64_t window);
-	// void nvim_win_set_width(Window window, Integer width, ) 
-	MsgpackRequest* nvim_win_set_width(int64_t window, int64_t width);
-	// Object nvim_win_get_var(Window window, String name, ) 
-	MsgpackRequest* nvim_win_get_var(int64_t window, QByteArray name);
-	// void nvim_win_set_var(Window window, String name, Object value, ) 
-	MsgpackRequest* nvim_win_set_var(int64_t window, QByteArray name, QVariant value);
-	// void nvim_win_del_var(Window window, String name, ) 
-	MsgpackRequest* nvim_win_del_var(int64_t window, QByteArray name);
-	// DEPRECATED
-	// Object window_set_var(Window window, String name, Object value, ) 
-	MsgpackRequest* window_set_var(int64_t window, QByteArray name, QVariant value);
-	// DEPRECATED
-	// Object window_del_var(Window window, String name, ) 
-	MsgpackRequest* window_del_var(int64_t window, QByteArray name);
-	// Object nvim_win_get_option(Window window, String name, ) 
-	MsgpackRequest* nvim_win_get_option(int64_t window, QByteArray name);
-	// void nvim_win_set_option(Window window, String name, Object value, ) 
-	MsgpackRequest* nvim_win_set_option(int64_t window, QByteArray name, QVariant value);
-	// ArrayOf(Integer, 2) nvim_win_get_position(Window window, ) 
-	MsgpackRequest* nvim_win_get_position(int64_t window);
-	// Tabpage nvim_win_get_tabpage(Window window, ) 
-	MsgpackRequest* nvim_win_get_tabpage(int64_t window);
-	// Integer nvim_win_get_number(Window window, ) 
-	MsgpackRequest* nvim_win_get_number(int64_t window);
-	// Boolean nvim_win_is_valid(Window window, ) 
-	MsgpackRequest* nvim_win_is_valid(int64_t window);
-	// DEPRECATED
-	// Integer buffer_line_count(Buffer buffer, ) 
-	MsgpackRequest* buffer_line_count(int64_t buffer);
-	// DEPRECATED
-	// ArrayOf(String) buffer_get_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ) 
-	MsgpackRequest* buffer_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing);
-	// DEPRECATED
-	// void buffer_set_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ArrayOf(String) replacement, ) 
-	MsgpackRequest* buffer_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement);
-	// DEPRECATED
-	// Object buffer_get_var(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_get_var(int64_t buffer, QByteArray name);
-	// DEPRECATED
-	// Object buffer_get_option(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_get_option(int64_t buffer, QByteArray name);
-	// DEPRECATED
-	// void buffer_set_option(Buffer buffer, String name, Object value, ) 
-	MsgpackRequest* buffer_set_option(int64_t buffer, QByteArray name, QVariant value);
-	// DEPRECATED
-	// Integer buffer_get_number(Buffer buffer, ) 
-	MsgpackRequest* buffer_get_number(int64_t buffer);
-	// DEPRECATED
-	// String buffer_get_name(Buffer buffer, ) 
-	MsgpackRequest* buffer_get_name(int64_t buffer);
-	// DEPRECATED
-	// void buffer_set_name(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_set_name(int64_t buffer, QByteArray name);
-	// DEPRECATED
-	// Boolean buffer_is_valid(Buffer buffer, ) 
-	MsgpackRequest* buffer_is_valid(int64_t buffer);
-	// DEPRECATED
-	// ArrayOf(Integer, 2) buffer_get_mark(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_get_mark(int64_t buffer, QByteArray name);
-	// DEPRECATED
-	// Integer buffer_add_highlight(Buffer buffer, Integer src_id, String hl_group, Integer line, Integer col_start, Integer col_end, ) 
-	MsgpackRequest* buffer_add_highlight(int64_t buffer, int64_t src_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end);
-	// DEPRECATED
-	// void buffer_clear_highlight(Buffer buffer, Integer src_id, Integer line_start, Integer line_end, ) 
-	MsgpackRequest* buffer_clear_highlight(int64_t buffer, int64_t src_id, int64_t line_start, int64_t line_end);
-	// DEPRECATED
-	// ArrayOf(Window) tabpage_get_windows(Tabpage tabpage, ) 
-	MsgpackRequest* tabpage_get_windows(int64_t tabpage);
-	// DEPRECATED
-	// Object tabpage_get_var(Tabpage tabpage, String name, ) 
-	MsgpackRequest* tabpage_get_var(int64_t tabpage, QByteArray name);
-	// DEPRECATED
-	// Window tabpage_get_window(Tabpage tabpage, ) 
-	MsgpackRequest* tabpage_get_window(int64_t tabpage);
-	// DEPRECATED
-	// Boolean tabpage_is_valid(Tabpage tabpage, ) 
-	MsgpackRequest* tabpage_is_valid(int64_t tabpage);
-	// DEPRECATED
-	// void ui_detach() 
-	MsgpackRequest* ui_detach();
-	// DEPRECATED
-	// Object ui_try_resize(Integer width, Integer height, ) 
-	MsgpackRequest* ui_try_resize(int64_t width, int64_t height);
-	// DEPRECATED
-	// void vim_command(String command, ) 
-	MsgpackRequest* vim_command(QByteArray command);
-	// DEPRECATED
-	// void vim_feedkeys(String keys, String mode, Boolean escape_csi, ) 
-	MsgpackRequest* vim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi);
-	// DEPRECATED
-	// Integer vim_input(String keys, ) 
-	MsgpackRequest* vim_input(QByteArray keys);
-	// DEPRECATED
-	// String vim_replace_termcodes(String str, Boolean from_part, Boolean do_lt, Boolean special, ) 
-	MsgpackRequest* vim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special);
-	// DEPRECATED
-	// String vim_command_output(String command, ) 
-	MsgpackRequest* vim_command_output(QByteArray command);
-	// DEPRECATED
-	// Object vim_eval(String expr, ) 
-	MsgpackRequest* vim_eval(QByteArray expr);
-	// DEPRECATED
-	// Object vim_call_function(String fn, Array args, ) 
-	MsgpackRequest* vim_call_function(QByteArray fn, QVariantList args);
-	// DEPRECATED
-	// Integer vim_strwidth(String text, ) 
-	MsgpackRequest* vim_strwidth(QByteArray text);
-	// DEPRECATED
-	// ArrayOf(String) vim_list_runtime_paths() 
-	MsgpackRequest* vim_list_runtime_paths();
-	// DEPRECATED
-	// void vim_change_directory(String dir, ) 
-	MsgpackRequest* vim_change_directory(QByteArray dir);
-	// DEPRECATED
-	// String vim_get_current_line() 
-	MsgpackRequest* vim_get_current_line();
-	// DEPRECATED
-	// void vim_set_current_line(String line, ) 
-	MsgpackRequest* vim_set_current_line(QByteArray line);
-	// DEPRECATED
-	// void vim_del_current_line() 
-	MsgpackRequest* vim_del_current_line();
-	// DEPRECATED
-	// Object vim_get_var(String name, ) 
-	MsgpackRequest* vim_get_var(QByteArray name);
-	// DEPRECATED
-	// Object vim_get_vvar(String name, ) 
-	MsgpackRequest* vim_get_vvar(QByteArray name);
-	// DEPRECATED
-	// Object vim_get_option(String name, ) 
-	MsgpackRequest* vim_get_option(QByteArray name);
-	// DEPRECATED
-	// void vim_set_option(String name, Object value, ) 
-	MsgpackRequest* vim_set_option(QByteArray name, QVariant value);
-	// DEPRECATED
-	// void vim_out_write(String str, ) 
-	MsgpackRequest* vim_out_write(QByteArray str);
-	// DEPRECATED
-	// void vim_err_write(String str, ) 
-	MsgpackRequest* vim_err_write(QByteArray str);
-	// DEPRECATED
-	// void vim_report_error(String str, ) 
-	MsgpackRequest* vim_report_error(QByteArray str);
-	// DEPRECATED
-	// ArrayOf(Buffer) vim_get_buffers() 
-	MsgpackRequest* vim_get_buffers();
-	// DEPRECATED
-	// Buffer vim_get_current_buffer() 
-	MsgpackRequest* vim_get_current_buffer();
-	// DEPRECATED
-	// void vim_set_current_buffer(Buffer buffer, ) 
-	MsgpackRequest* vim_set_current_buffer(int64_t buffer);
-	// DEPRECATED
-	// ArrayOf(Window) vim_get_windows() 
-	MsgpackRequest* vim_get_windows();
-	// DEPRECATED
-	// Window vim_get_current_window() 
-	MsgpackRequest* vim_get_current_window();
-	// DEPRECATED
-	// void vim_set_current_window(Window window, ) 
-	MsgpackRequest* vim_set_current_window(int64_t window);
-	// DEPRECATED
-	// ArrayOf(Tabpage) vim_get_tabpages() 
-	MsgpackRequest* vim_get_tabpages();
-	// DEPRECATED
-	// Tabpage vim_get_current_tabpage() 
-	MsgpackRequest* vim_get_current_tabpage();
-	// DEPRECATED
-	// void vim_set_current_tabpage(Tabpage tabpage, ) 
-	MsgpackRequest* vim_set_current_tabpage(int64_t tabpage);
-	// DEPRECATED
-	// void vim_subscribe(String event, ) 
-	MsgpackRequest* vim_subscribe(QByteArray event);
-	// DEPRECATED
-	// void vim_unsubscribe(String event, ) 
-	MsgpackRequest* vim_unsubscribe(QByteArray event);
-	// DEPRECATED
-	// Integer vim_name_to_color(String name, ) 
-	MsgpackRequest* vim_name_to_color(QByteArray name);
-	// DEPRECATED
-	// Dictionary vim_get_color_map() 
-	MsgpackRequest* vim_get_color_map();
-	// DEPRECATED
-	// Buffer window_get_buffer(Window window, ) 
-	MsgpackRequest* window_get_buffer(int64_t window);
-	// DEPRECATED
-	// ArrayOf(Integer, 2) window_get_cursor(Window window, ) 
-	MsgpackRequest* window_get_cursor(int64_t window);
-	// DEPRECATED
-	// void window_set_cursor(Window window, ArrayOf(Integer, 2) pos, ) 
-	MsgpackRequest* window_set_cursor(int64_t window, QPoint pos);
-	// DEPRECATED
-	// Integer window_get_height(Window window, ) 
-	MsgpackRequest* window_get_height(int64_t window);
-	// DEPRECATED
-	// void window_set_height(Window window, Integer height, ) 
-	MsgpackRequest* window_set_height(int64_t window, int64_t height);
-	// DEPRECATED
-	// Integer window_get_width(Window window, ) 
-	MsgpackRequest* window_get_width(int64_t window);
-	// DEPRECATED
-	// void window_set_width(Window window, Integer width, ) 
-	MsgpackRequest* window_set_width(int64_t window, int64_t width);
-	// DEPRECATED
-	// Object window_get_var(Window window, String name, ) 
-	MsgpackRequest* window_get_var(int64_t window, QByteArray name);
-	// DEPRECATED
-	// Object window_get_option(Window window, String name, ) 
-	MsgpackRequest* window_get_option(int64_t window, QByteArray name);
-	// DEPRECATED
-	// void window_set_option(Window window, String name, Object value, ) 
-	MsgpackRequest* window_set_option(int64_t window, QByteArray name, QVariant value);
-	// DEPRECATED
-	// ArrayOf(Integer, 2) window_get_position(Window window, ) 
-	MsgpackRequest* window_get_position(int64_t window);
-	// DEPRECATED
-	// Tabpage window_get_tabpage(Window window, ) 
-	MsgpackRequest* window_get_tabpage(int64_t window);
-	// DEPRECATED
-	// Boolean window_is_valid(Window window, ) 
-	MsgpackRequest* window_is_valid(int64_t window);
+	/// Integer nvim_buf_line_count(Buffer buffer, )
+	NeovimQt::MsgpackRequest* nvim_buf_line_count(int64_t buffer);
+
+	/// DEPRECATED: String buffer_get_line(Buffer buffer, Integer index, )
+	NeovimQt::MsgpackRequest* buffer_get_line(int64_t buffer, int64_t index);
+
+	/// Boolean nvim_buf_attach(Buffer buffer, Boolean send_buffer, Dictionary opts, )
+	NeovimQt::MsgpackRequest* nvim_buf_attach(int64_t buffer, bool send_buffer, QVariantMap opts);
+
+	/// Boolean nvim_buf_detach(Buffer buffer, )
+	NeovimQt::MsgpackRequest* nvim_buf_detach(int64_t buffer);
+
+	/// DEPRECATED: void buffer_set_line(Buffer buffer, Integer index, String line, )
+	NeovimQt::MsgpackRequest* buffer_set_line(int64_t buffer, int64_t index, QByteArray line);
+
+	/// DEPRECATED: void buffer_del_line(Buffer buffer, Integer index, )
+	NeovimQt::MsgpackRequest* buffer_del_line(int64_t buffer, int64_t index);
+
+	/// DEPRECATED: ArrayOf(String) buffer_get_line_slice(Buffer buffer, Integer start, Integer end, Boolean include_start, Boolean include_end, )
+	NeovimQt::MsgpackRequest* buffer_get_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end);
+
+	/// ArrayOf(String) nvim_buf_get_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, )
+	NeovimQt::MsgpackRequest* nvim_buf_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing);
+
+	/// DEPRECATED: void buffer_set_line_slice(Buffer buffer, Integer start, Integer end, Boolean include_start, Boolean include_end, ArrayOf(String) replacement, )
+	NeovimQt::MsgpackRequest* buffer_set_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end, QList<QByteArray> replacement);
+
+	/// void nvim_buf_set_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ArrayOf(String) replacement, )
+	NeovimQt::MsgpackRequest* nvim_buf_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement);
+
+	/// Object nvim_buf_get_var(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* nvim_buf_get_var(int64_t buffer, QByteArray name);
+
+	/// Integer nvim_buf_get_changedtick(Buffer buffer, )
+	NeovimQt::MsgpackRequest* nvim_buf_get_changedtick(int64_t buffer);
+
+	/// ArrayOf(Dictionary) nvim_buf_get_keymap(Buffer buffer, String mode, )
+	NeovimQt::MsgpackRequest* nvim_buf_get_keymap(int64_t buffer, QByteArray mode);
+
+	/// Dictionary nvim_buf_get_commands(Buffer buffer, Dictionary opts, )
+	NeovimQt::MsgpackRequest* nvim_buf_get_commands(int64_t buffer, QVariantMap opts);
+
+	/// void nvim_buf_set_var(Buffer buffer, String name, Object value, )
+	NeovimQt::MsgpackRequest* nvim_buf_set_var(int64_t buffer, QByteArray name, QVariant value);
+
+	/// void nvim_buf_del_var(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* nvim_buf_del_var(int64_t buffer, QByteArray name);
+
+	/// DEPRECATED: Object buffer_set_var(Buffer buffer, String name, Object value, )
+	NeovimQt::MsgpackRequest* buffer_set_var(int64_t buffer, QByteArray name, QVariant value);
+
+	/// DEPRECATED: Object buffer_del_var(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* buffer_del_var(int64_t buffer, QByteArray name);
+
+	/// Object nvim_buf_get_option(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* nvim_buf_get_option(int64_t buffer, QByteArray name);
+
+	/// void nvim_buf_set_option(Buffer buffer, String name, Object value, )
+	NeovimQt::MsgpackRequest* nvim_buf_set_option(int64_t buffer, QByteArray name, QVariant value);
+
+	/// DEPRECATED: Integer nvim_buf_get_number(Buffer buffer, )
+	NeovimQt::MsgpackRequest* nvim_buf_get_number(int64_t buffer);
+
+	/// String nvim_buf_get_name(Buffer buffer, )
+	NeovimQt::MsgpackRequest* nvim_buf_get_name(int64_t buffer);
+
+	/// void nvim_buf_set_name(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* nvim_buf_set_name(int64_t buffer, QByteArray name);
+
+	/// Boolean nvim_buf_is_valid(Buffer buffer, )
+	NeovimQt::MsgpackRequest* nvim_buf_is_valid(int64_t buffer);
+
+	/// DEPRECATED: void buffer_insert(Buffer buffer, Integer lnum, ArrayOf(String) lines, )
+	NeovimQt::MsgpackRequest* buffer_insert(int64_t buffer, int64_t lnum, QList<QByteArray> lines);
+
+	/// ArrayOf(Integer, 2) nvim_buf_get_mark(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* nvim_buf_get_mark(int64_t buffer, QByteArray name);
+
+	/// Integer nvim_buf_add_highlight(Buffer buffer, Integer src_id, String hl_group, Integer line, Integer col_start, Integer col_end, )
+	NeovimQt::MsgpackRequest* nvim_buf_add_highlight(int64_t buffer, int64_t src_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end);
+
+	/// void nvim_buf_clear_highlight(Buffer buffer, Integer src_id, Integer line_start, Integer line_end, )
+	NeovimQt::MsgpackRequest* nvim_buf_clear_highlight(int64_t buffer, int64_t src_id, int64_t line_start, int64_t line_end);
+
+	/// ArrayOf(Window) nvim_tabpage_list_wins(Tabpage tabpage, )
+	NeovimQt::MsgpackRequest* nvim_tabpage_list_wins(int64_t tabpage);
+
+	/// Object nvim_tabpage_get_var(Tabpage tabpage, String name, )
+	NeovimQt::MsgpackRequest* nvim_tabpage_get_var(int64_t tabpage, QByteArray name);
+
+	/// void nvim_tabpage_set_var(Tabpage tabpage, String name, Object value, )
+	NeovimQt::MsgpackRequest* nvim_tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value);
+
+	/// void nvim_tabpage_del_var(Tabpage tabpage, String name, )
+	NeovimQt::MsgpackRequest* nvim_tabpage_del_var(int64_t tabpage, QByteArray name);
+
+	/// DEPRECATED: Object tabpage_set_var(Tabpage tabpage, String name, Object value, )
+	NeovimQt::MsgpackRequest* tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value);
+
+	/// DEPRECATED: Object tabpage_del_var(Tabpage tabpage, String name, )
+	NeovimQt::MsgpackRequest* tabpage_del_var(int64_t tabpage, QByteArray name);
+
+	/// Window nvim_tabpage_get_win(Tabpage tabpage, )
+	NeovimQt::MsgpackRequest* nvim_tabpage_get_win(int64_t tabpage);
+
+	/// Integer nvim_tabpage_get_number(Tabpage tabpage, )
+	NeovimQt::MsgpackRequest* nvim_tabpage_get_number(int64_t tabpage);
+
+	/// Boolean nvim_tabpage_is_valid(Tabpage tabpage, )
+	NeovimQt::MsgpackRequest* nvim_tabpage_is_valid(int64_t tabpage);
+
+	/// void nvim_ui_attach(Integer width, Integer height, Dictionary options, )
+	NeovimQt::MsgpackRequest* nvim_ui_attach(int64_t width, int64_t height, QVariantMap options);
+
+	/// DEPRECATED: void ui_attach(Integer width, Integer height, Boolean enable_rgb, )
+	NeovimQt::MsgpackRequest* ui_attach(int64_t width, int64_t height, bool enable_rgb);
+
+	/// void nvim_ui_detach()
+	NeovimQt::MsgpackRequest* nvim_ui_detach();
+
+	/// void nvim_ui_try_resize(Integer width, Integer height, )
+	NeovimQt::MsgpackRequest* nvim_ui_try_resize(int64_t width, int64_t height);
+
+	/// void nvim_ui_set_option(String name, Object value, )
+	NeovimQt::MsgpackRequest* nvim_ui_set_option(QByteArray name, QVariant value);
+
+	/// void nvim_command(String command, )
+	NeovimQt::MsgpackRequest* nvim_command(QByteArray command);
+
+	/// Dictionary nvim_get_hl_by_name(String name, Boolean rgb, )
+	NeovimQt::MsgpackRequest* nvim_get_hl_by_name(QByteArray name, bool rgb);
+
+	/// Dictionary nvim_get_hl_by_id(Integer hl_id, Boolean rgb, )
+	NeovimQt::MsgpackRequest* nvim_get_hl_by_id(int64_t hl_id, bool rgb);
+
+	/// void nvim_feedkeys(String keys, String mode, Boolean escape_csi, )
+	NeovimQt::MsgpackRequest* nvim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi);
+
+	/// Integer nvim_input(String keys, )
+	NeovimQt::MsgpackRequest* nvim_input(QByteArray keys);
+
+	/// String nvim_replace_termcodes(String str, Boolean from_part, Boolean do_lt, Boolean special, )
+	NeovimQt::MsgpackRequest* nvim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special);
+
+	/// String nvim_command_output(String command, )
+	NeovimQt::MsgpackRequest* nvim_command_output(QByteArray command);
+
+	/// Object nvim_eval(String expr, )
+	NeovimQt::MsgpackRequest* nvim_eval(QByteArray expr);
+
+	/// Object nvim_execute_lua(String code, Array args, )
+	NeovimQt::MsgpackRequest* nvim_execute_lua(QByteArray code, QVariantList args);
+
+	/// Object nvim_call_function(String fn, Array args, )
+	NeovimQt::MsgpackRequest* nvim_call_function(QByteArray fn, QVariantList args);
+
+	/// Object nvim_call_dict_function(Object dict, String fn, Array args, )
+	NeovimQt::MsgpackRequest* nvim_call_dict_function(QVariant dict, QByteArray fn, QVariantList args);
+
+	/// Integer nvim_strwidth(String text, )
+	NeovimQt::MsgpackRequest* nvim_strwidth(QByteArray text);
+
+	/// ArrayOf(String) nvim_list_runtime_paths()
+	NeovimQt::MsgpackRequest* nvim_list_runtime_paths();
+
+	/// void nvim_set_current_dir(String dir, )
+	NeovimQt::MsgpackRequest* nvim_set_current_dir(QByteArray dir);
+
+	/// String nvim_get_current_line()
+	NeovimQt::MsgpackRequest* nvim_get_current_line();
+
+	/// void nvim_set_current_line(String line, )
+	NeovimQt::MsgpackRequest* nvim_set_current_line(QByteArray line);
+
+	/// void nvim_del_current_line()
+	NeovimQt::MsgpackRequest* nvim_del_current_line();
+
+	/// Object nvim_get_var(String name, )
+	NeovimQt::MsgpackRequest* nvim_get_var(QByteArray name);
+
+	/// void nvim_set_var(String name, Object value, )
+	NeovimQt::MsgpackRequest* nvim_set_var(QByteArray name, QVariant value);
+
+	/// void nvim_del_var(String name, )
+	NeovimQt::MsgpackRequest* nvim_del_var(QByteArray name);
+
+	/// DEPRECATED: Object vim_set_var(String name, Object value, )
+	NeovimQt::MsgpackRequest* vim_set_var(QByteArray name, QVariant value);
+
+	/// DEPRECATED: Object vim_del_var(String name, )
+	NeovimQt::MsgpackRequest* vim_del_var(QByteArray name);
+
+	/// Object nvim_get_vvar(String name, )
+	NeovimQt::MsgpackRequest* nvim_get_vvar(QByteArray name);
+
+	/// Object nvim_get_option(String name, )
+	NeovimQt::MsgpackRequest* nvim_get_option(QByteArray name);
+
+	/// void nvim_set_option(String name, Object value, )
+	NeovimQt::MsgpackRequest* nvim_set_option(QByteArray name, QVariant value);
+
+	/// void nvim_out_write(String str, )
+	NeovimQt::MsgpackRequest* nvim_out_write(QByteArray str);
+
+	/// void nvim_err_write(String str, )
+	NeovimQt::MsgpackRequest* nvim_err_write(QByteArray str);
+
+	/// void nvim_err_writeln(String str, )
+	NeovimQt::MsgpackRequest* nvim_err_writeln(QByteArray str);
+
+	/// ArrayOf(Buffer) nvim_list_bufs()
+	NeovimQt::MsgpackRequest* nvim_list_bufs();
+
+	/// Buffer nvim_get_current_buf()
+	NeovimQt::MsgpackRequest* nvim_get_current_buf();
+
+	/// void nvim_set_current_buf(Buffer buffer, )
+	NeovimQt::MsgpackRequest* nvim_set_current_buf(int64_t buffer);
+
+	/// ArrayOf(Window) nvim_list_wins()
+	NeovimQt::MsgpackRequest* nvim_list_wins();
+
+	/// Window nvim_get_current_win()
+	NeovimQt::MsgpackRequest* nvim_get_current_win();
+
+	/// void nvim_set_current_win(Window window, )
+	NeovimQt::MsgpackRequest* nvim_set_current_win(int64_t window);
+
+	/// ArrayOf(Tabpage) nvim_list_tabpages()
+	NeovimQt::MsgpackRequest* nvim_list_tabpages();
+
+	/// Tabpage nvim_get_current_tabpage()
+	NeovimQt::MsgpackRequest* nvim_get_current_tabpage();
+
+	/// void nvim_set_current_tabpage(Tabpage tabpage, )
+	NeovimQt::MsgpackRequest* nvim_set_current_tabpage(int64_t tabpage);
+
+	/// void nvim_subscribe(String event, )
+	NeovimQt::MsgpackRequest* nvim_subscribe(QByteArray event);
+
+	/// void nvim_unsubscribe(String event, )
+	NeovimQt::MsgpackRequest* nvim_unsubscribe(QByteArray event);
+
+	/// Integer nvim_get_color_by_name(String name, )
+	NeovimQt::MsgpackRequest* nvim_get_color_by_name(QByteArray name);
+
+	/// Dictionary nvim_get_color_map()
+	NeovimQt::MsgpackRequest* nvim_get_color_map();
+
+	/// Dictionary nvim_get_mode()
+	NeovimQt::MsgpackRequest* nvim_get_mode();
+
+	/// ArrayOf(Dictionary) nvim_get_keymap(String mode, )
+	NeovimQt::MsgpackRequest* nvim_get_keymap(QByteArray mode);
+
+	/// Dictionary nvim_get_commands(Dictionary opts, )
+	NeovimQt::MsgpackRequest* nvim_get_commands(QVariantMap opts);
+
+	/// Array nvim_get_api_info()
+	NeovimQt::MsgpackRequest* nvim_get_api_info();
+
+	/// void nvim_set_client_info(String name, Dictionary version, String type, Dictionary methods, Dictionary attributes, )
+	NeovimQt::MsgpackRequest* nvim_set_client_info(QByteArray name, QVariantMap version, QByteArray type, QVariantMap methods, QVariantMap attributes);
+
+	/// Dictionary nvim_get_chan_info(Integer chan, )
+	NeovimQt::MsgpackRequest* nvim_get_chan_info(int64_t chan);
+
+	/// Array nvim_list_chans()
+	NeovimQt::MsgpackRequest* nvim_list_chans();
+
+	/// Array nvim_call_atomic(Array calls, )
+	NeovimQt::MsgpackRequest* nvim_call_atomic(QVariantList calls);
+
+	/// Dictionary nvim_parse_expression(String expr, String flags, Boolean highlight, )
+	NeovimQt::MsgpackRequest* nvim_parse_expression(QByteArray expr, QByteArray flags, bool highlight);
+
+	/// Array nvim_list_uis()
+	NeovimQt::MsgpackRequest* nvim_list_uis();
+
+	/// Array nvim_get_proc_children(Integer pid, )
+	NeovimQt::MsgpackRequest* nvim_get_proc_children(int64_t pid);
+
+	/// Object nvim_get_proc(Integer pid, )
+	NeovimQt::MsgpackRequest* nvim_get_proc(int64_t pid);
+
+	/// Buffer nvim_win_get_buf(Window window, )
+	NeovimQt::MsgpackRequest* nvim_win_get_buf(int64_t window);
+
+	/// ArrayOf(Integer, 2) nvim_win_get_cursor(Window window, )
+	NeovimQt::MsgpackRequest* nvim_win_get_cursor(int64_t window);
+
+	/// void nvim_win_set_cursor(Window window, ArrayOf(Integer, 2) pos, )
+	NeovimQt::MsgpackRequest* nvim_win_set_cursor(int64_t window, QPoint pos);
+
+	/// Integer nvim_win_get_height(Window window, )
+	NeovimQt::MsgpackRequest* nvim_win_get_height(int64_t window);
+
+	/// void nvim_win_set_height(Window window, Integer height, )
+	NeovimQt::MsgpackRequest* nvim_win_set_height(int64_t window, int64_t height);
+
+	/// Integer nvim_win_get_width(Window window, )
+	NeovimQt::MsgpackRequest* nvim_win_get_width(int64_t window);
+
+	/// void nvim_win_set_width(Window window, Integer width, )
+	NeovimQt::MsgpackRequest* nvim_win_set_width(int64_t window, int64_t width);
+
+	/// Object nvim_win_get_var(Window window, String name, )
+	NeovimQt::MsgpackRequest* nvim_win_get_var(int64_t window, QByteArray name);
+
+	/// void nvim_win_set_var(Window window, String name, Object value, )
+	NeovimQt::MsgpackRequest* nvim_win_set_var(int64_t window, QByteArray name, QVariant value);
+
+	/// void nvim_win_del_var(Window window, String name, )
+	NeovimQt::MsgpackRequest* nvim_win_del_var(int64_t window, QByteArray name);
+
+	/// DEPRECATED: Object window_set_var(Window window, String name, Object value, )
+	NeovimQt::MsgpackRequest* window_set_var(int64_t window, QByteArray name, QVariant value);
+
+	/// DEPRECATED: Object window_del_var(Window window, String name, )
+	NeovimQt::MsgpackRequest* window_del_var(int64_t window, QByteArray name);
+
+	/// Object nvim_win_get_option(Window window, String name, )
+	NeovimQt::MsgpackRequest* nvim_win_get_option(int64_t window, QByteArray name);
+
+	/// void nvim_win_set_option(Window window, String name, Object value, )
+	NeovimQt::MsgpackRequest* nvim_win_set_option(int64_t window, QByteArray name, QVariant value);
+
+	/// ArrayOf(Integer, 2) nvim_win_get_position(Window window, )
+	NeovimQt::MsgpackRequest* nvim_win_get_position(int64_t window);
+
+	/// Tabpage nvim_win_get_tabpage(Window window, )
+	NeovimQt::MsgpackRequest* nvim_win_get_tabpage(int64_t window);
+
+	/// Integer nvim_win_get_number(Window window, )
+	NeovimQt::MsgpackRequest* nvim_win_get_number(int64_t window);
+
+	/// Boolean nvim_win_is_valid(Window window, )
+	NeovimQt::MsgpackRequest* nvim_win_is_valid(int64_t window);
+
+	/// DEPRECATED: Integer buffer_line_count(Buffer buffer, )
+	NeovimQt::MsgpackRequest* buffer_line_count(int64_t buffer);
+
+	/// DEPRECATED: ArrayOf(String) buffer_get_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, )
+	NeovimQt::MsgpackRequest* buffer_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing);
+
+	/// DEPRECATED: void buffer_set_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ArrayOf(String) replacement, )
+	NeovimQt::MsgpackRequest* buffer_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement);
+
+	/// DEPRECATED: Object buffer_get_var(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* buffer_get_var(int64_t buffer, QByteArray name);
+
+	/// DEPRECATED: Object buffer_get_option(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* buffer_get_option(int64_t buffer, QByteArray name);
+
+	/// DEPRECATED: void buffer_set_option(Buffer buffer, String name, Object value, )
+	NeovimQt::MsgpackRequest* buffer_set_option(int64_t buffer, QByteArray name, QVariant value);
+
+	/// DEPRECATED: Integer buffer_get_number(Buffer buffer, )
+	NeovimQt::MsgpackRequest* buffer_get_number(int64_t buffer);
+
+	/// DEPRECATED: String buffer_get_name(Buffer buffer, )
+	NeovimQt::MsgpackRequest* buffer_get_name(int64_t buffer);
+
+	/// DEPRECATED: void buffer_set_name(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* buffer_set_name(int64_t buffer, QByteArray name);
+
+	/// DEPRECATED: Boolean buffer_is_valid(Buffer buffer, )
+	NeovimQt::MsgpackRequest* buffer_is_valid(int64_t buffer);
+
+	/// DEPRECATED: ArrayOf(Integer, 2) buffer_get_mark(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* buffer_get_mark(int64_t buffer, QByteArray name);
+
+	/// DEPRECATED: Integer buffer_add_highlight(Buffer buffer, Integer src_id, String hl_group, Integer line, Integer col_start, Integer col_end, )
+	NeovimQt::MsgpackRequest* buffer_add_highlight(int64_t buffer, int64_t src_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end);
+
+	/// DEPRECATED: void buffer_clear_highlight(Buffer buffer, Integer src_id, Integer line_start, Integer line_end, )
+	NeovimQt::MsgpackRequest* buffer_clear_highlight(int64_t buffer, int64_t src_id, int64_t line_start, int64_t line_end);
+
+	/// DEPRECATED: ArrayOf(Window) tabpage_get_windows(Tabpage tabpage, )
+	NeovimQt::MsgpackRequest* tabpage_get_windows(int64_t tabpage);
+
+	/// DEPRECATED: Object tabpage_get_var(Tabpage tabpage, String name, )
+	NeovimQt::MsgpackRequest* tabpage_get_var(int64_t tabpage, QByteArray name);
+
+	/// DEPRECATED: Window tabpage_get_window(Tabpage tabpage, )
+	NeovimQt::MsgpackRequest* tabpage_get_window(int64_t tabpage);
+
+	/// DEPRECATED: Boolean tabpage_is_valid(Tabpage tabpage, )
+	NeovimQt::MsgpackRequest* tabpage_is_valid(int64_t tabpage);
+
+	/// DEPRECATED: void ui_detach()
+	NeovimQt::MsgpackRequest* ui_detach();
+
+	/// DEPRECATED: Object ui_try_resize(Integer width, Integer height, )
+	NeovimQt::MsgpackRequest* ui_try_resize(int64_t width, int64_t height);
+
+	/// DEPRECATED: void vim_command(String command, )
+	NeovimQt::MsgpackRequest* vim_command(QByteArray command);
+
+	/// DEPRECATED: void vim_feedkeys(String keys, String mode, Boolean escape_csi, )
+	NeovimQt::MsgpackRequest* vim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi);
+
+	/// DEPRECATED: Integer vim_input(String keys, )
+	NeovimQt::MsgpackRequest* vim_input(QByteArray keys);
+
+	/// DEPRECATED: String vim_replace_termcodes(String str, Boolean from_part, Boolean do_lt, Boolean special, )
+	NeovimQt::MsgpackRequest* vim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special);
+
+	/// DEPRECATED: String vim_command_output(String command, )
+	NeovimQt::MsgpackRequest* vim_command_output(QByteArray command);
+
+	/// DEPRECATED: Object vim_eval(String expr, )
+	NeovimQt::MsgpackRequest* vim_eval(QByteArray expr);
+
+	/// DEPRECATED: Object vim_call_function(String fn, Array args, )
+	NeovimQt::MsgpackRequest* vim_call_function(QByteArray fn, QVariantList args);
+
+	/// DEPRECATED: Integer vim_strwidth(String text, )
+	NeovimQt::MsgpackRequest* vim_strwidth(QByteArray text);
+
+	/// DEPRECATED: ArrayOf(String) vim_list_runtime_paths()
+	NeovimQt::MsgpackRequest* vim_list_runtime_paths();
+
+	/// DEPRECATED: void vim_change_directory(String dir, )
+	NeovimQt::MsgpackRequest* vim_change_directory(QByteArray dir);
+
+	/// DEPRECATED: String vim_get_current_line()
+	NeovimQt::MsgpackRequest* vim_get_current_line();
+
+	/// DEPRECATED: void vim_set_current_line(String line, )
+	NeovimQt::MsgpackRequest* vim_set_current_line(QByteArray line);
+
+	/// DEPRECATED: void vim_del_current_line()
+	NeovimQt::MsgpackRequest* vim_del_current_line();
+
+	/// DEPRECATED: Object vim_get_var(String name, )
+	NeovimQt::MsgpackRequest* vim_get_var(QByteArray name);
+
+	/// DEPRECATED: Object vim_get_vvar(String name, )
+	NeovimQt::MsgpackRequest* vim_get_vvar(QByteArray name);
+
+	/// DEPRECATED: Object vim_get_option(String name, )
+	NeovimQt::MsgpackRequest* vim_get_option(QByteArray name);
+
+	/// DEPRECATED: void vim_set_option(String name, Object value, )
+	NeovimQt::MsgpackRequest* vim_set_option(QByteArray name, QVariant value);
+
+	/// DEPRECATED: void vim_out_write(String str, )
+	NeovimQt::MsgpackRequest* vim_out_write(QByteArray str);
+
+	/// DEPRECATED: void vim_err_write(String str, )
+	NeovimQt::MsgpackRequest* vim_err_write(QByteArray str);
+
+	/// DEPRECATED: void vim_report_error(String str, )
+	NeovimQt::MsgpackRequest* vim_report_error(QByteArray str);
+
+	/// DEPRECATED: ArrayOf(Buffer) vim_get_buffers()
+	NeovimQt::MsgpackRequest* vim_get_buffers();
+
+	/// DEPRECATED: Buffer vim_get_current_buffer()
+	NeovimQt::MsgpackRequest* vim_get_current_buffer();
+
+	/// DEPRECATED: void vim_set_current_buffer(Buffer buffer, )
+	NeovimQt::MsgpackRequest* vim_set_current_buffer(int64_t buffer);
+
+	/// DEPRECATED: ArrayOf(Window) vim_get_windows()
+	NeovimQt::MsgpackRequest* vim_get_windows();
+
+	/// DEPRECATED: Window vim_get_current_window()
+	NeovimQt::MsgpackRequest* vim_get_current_window();
+
+	/// DEPRECATED: void vim_set_current_window(Window window, )
+	NeovimQt::MsgpackRequest* vim_set_current_window(int64_t window);
+
+	/// DEPRECATED: ArrayOf(Tabpage) vim_get_tabpages()
+	NeovimQt::MsgpackRequest* vim_get_tabpages();
+
+	/// DEPRECATED: Tabpage vim_get_current_tabpage()
+	NeovimQt::MsgpackRequest* vim_get_current_tabpage();
+
+	/// DEPRECATED: void vim_set_current_tabpage(Tabpage tabpage, )
+	NeovimQt::MsgpackRequest* vim_set_current_tabpage(int64_t tabpage);
+
+	/// DEPRECATED: void vim_subscribe(String event, )
+	NeovimQt::MsgpackRequest* vim_subscribe(QByteArray event);
+
+	/// DEPRECATED: void vim_unsubscribe(String event, )
+	NeovimQt::MsgpackRequest* vim_unsubscribe(QByteArray event);
+
+	/// DEPRECATED: Integer vim_name_to_color(String name, )
+	NeovimQt::MsgpackRequest* vim_name_to_color(QByteArray name);
+
+	/// DEPRECATED: Dictionary vim_get_color_map()
+	NeovimQt::MsgpackRequest* vim_get_color_map();
+
+	/// DEPRECATED: Buffer window_get_buffer(Window window, )
+	NeovimQt::MsgpackRequest* window_get_buffer(int64_t window);
+
+	/// DEPRECATED: ArrayOf(Integer, 2) window_get_cursor(Window window, )
+	NeovimQt::MsgpackRequest* window_get_cursor(int64_t window);
+
+	/// DEPRECATED: void window_set_cursor(Window window, ArrayOf(Integer, 2) pos, )
+	NeovimQt::MsgpackRequest* window_set_cursor(int64_t window, QPoint pos);
+
+	/// DEPRECATED: Integer window_get_height(Window window, )
+	NeovimQt::MsgpackRequest* window_get_height(int64_t window);
+
+	/// DEPRECATED: void window_set_height(Window window, Integer height, )
+	NeovimQt::MsgpackRequest* window_set_height(int64_t window, int64_t height);
+
+	/// DEPRECATED: Integer window_get_width(Window window, )
+	NeovimQt::MsgpackRequest* window_get_width(int64_t window);
+
+	/// DEPRECATED: void window_set_width(Window window, Integer width, )
+	NeovimQt::MsgpackRequest* window_set_width(int64_t window, int64_t width);
+
+	/// DEPRECATED: Object window_get_var(Window window, String name, )
+	NeovimQt::MsgpackRequest* window_get_var(int64_t window, QByteArray name);
+
+	/// DEPRECATED: Object window_get_option(Window window, String name, )
+	NeovimQt::MsgpackRequest* window_get_option(int64_t window, QByteArray name);
+
+	/// DEPRECATED: void window_set_option(Window window, String name, Object value, )
+	NeovimQt::MsgpackRequest* window_set_option(int64_t window, QByteArray name, QVariant value);
+
+	/// DEPRECATED: ArrayOf(Integer, 2) window_get_position(Window window, )
+	NeovimQt::MsgpackRequest* window_get_position(int64_t window);
+
+	/// DEPRECATED: Tabpage window_get_tabpage(Window window, )
+	NeovimQt::MsgpackRequest* window_get_tabpage(int64_t window);
+
+	/// DEPRECATED: Boolean window_is_valid(Window window, )
+	NeovimQt::MsgpackRequest* window_is_valid(int64_t window);
+
 
 signals:
 	void on_nvim_buf_line_count(int64_t);
@@ -1187,5 +1292,5 @@ signals:
 	void err_window_is_valid(const QString&, const QVariant&);
 
 };
-} // namespace
-#endif
+
+} // namespace NeovimQt

--- a/src/auto/neovimapi5.cpp
+++ b/src/auto/neovimapi5.cpp
@@ -1,4 +1,4 @@
-// Auto generated 2020-09-09 13:30:54.327694 from nvim API level:5
+// Auto generated 2020-09-09 15:16:42.980744 from nvim API level:5
 #include "auto/neovimapi5.h"
 #include "msgpackiodevice.h"
 #include "msgpackrequest.h"
@@ -5853,7 +5853,7 @@ void NeovimApi5::handleResponse(uint32_t msgid, uint64_t fun, const QVariant& re
 				, false },
 		};
 
-	QList<Function> supported;
+	QVector<Function> supported;
 	supported.reserve(ftable.size());
 	for(const auto& val : ftable) {
 		auto f = Function::fromVariant(val);

--- a/src/auto/neovimapi5.cpp
+++ b/src/auto/neovimapi5.cpp
@@ -1,15 +1,15 @@
-// Auto generated 2019-06-08 16:53:42.502897 from nvim API level:5
+// Auto generated 2020-09-09 13:30:54.327694 from nvim API level:5
 #include "auto/neovimapi5.h"
-#include "neovimconnector.h"
-#include "msgpackrequest.h"
 #include "msgpackiodevice.h"
+#include "msgpackrequest.h"
+#include "neovimconnector.h"
 #include "util.h"
 
 namespace NeovimQt {
 /* Unpack Neovim EXT types Window, Buffer Tabpage which are all
  * uint64_t see Neovim:msgpack_rpc_to_
  */
-QVariant unpackBufferApi5(MsgpackIODevice *dev, const char* in, quint32 size)
+static QVariant unpackBufferApi5(MsgpackIODevice *dev, const char* in, uint32_t size) noexcept
 {
 	msgpack_unpacked result;
 	msgpack_unpacked_init(&result);
@@ -20,10 +20,10 @@ QVariant unpackBufferApi5(MsgpackIODevice *dev, const char* in, quint32 size)
 	if (ret == MSGPACK_UNPACK_SUCCESS) {
 		switch (result.data.type) {
 			case MSGPACK_OBJECT_NEGATIVE_INTEGER:
-				variant = (qint64)result.data.via.i64;
+				variant.setValue<int64_t>(result.data.via.i64);
 				break;
 			case MSGPACK_OBJECT_POSITIVE_INTEGER:
-				variant = (quint64)result.data.via.u64;
+				variant.setValue<uint64_t>(result.data.via.u64);
 				break;
 			default:
 				// TODO it would be nice if we could call back MsgpackIoDevice method or primitive types here
@@ -34,1801 +34,1994 @@ QVariant unpackBufferApi5(MsgpackIODevice *dev, const char* in, quint32 size)
 	msgpack_unpacked_destroy(&result);
 	return variant;
 }
-#define unpackWindowApi5 unpackBufferApi5
-#define unpackTabpageApi5 unpackBufferApi5
 
-NeovimApi5::NeovimApi5(NeovimConnector *c)
-:m_c(c)
+static QVariant unpackWindowApi5(MsgpackIODevice *dev, const char* in, uint32_t size) noexcept
+{
+	return unpackBufferApi5(dev, in, size);
+}
+
+static QVariant unpackTabpageApi5(MsgpackIODevice *dev, const char* in, uint32_t size) noexcept
+{
+	return unpackBufferApi5(dev, in, size);
+}
+
+NeovimApi5::NeovimApi5(NeovimConnector *c) noexcept
+	: m_connector{ c }
 {
 	// EXT types
-		m_c->m_dev->registerExtType(0, unpackBufferApi5);
-		m_c->m_dev->registerExtType(1, unpackWindowApi5);
-		m_c->m_dev->registerExtType(2, unpackTabpageApi5);
-		connect(m_c->m_dev, &MsgpackIODevice::notification,
-			this, &NeovimApi5::neovimNotification);
+	m_connector->m_dev->registerExtType(0, unpackBufferApi5);
+	m_connector->m_dev->registerExtType(1, unpackWindowApi5);
+	m_connector->m_dev->registerExtType(2, unpackTabpageApi5);
+	connect(m_connector->m_dev, &MsgpackIODevice::notification,
+		this, &NeovimApi5::neovimNotification);
 }
 
 // Slots
 MsgpackRequest* NeovimApi5::nvim_buf_line_count(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_line_count", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_line_count", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_BUF_LINE_COUNT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::buffer_get_line(int64_t buffer, int64_t index)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_line", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_get_line", 2) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_BUFFER_GET_LINE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(index);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(index);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_buf_attach(int64_t buffer, bool send_buffer, QVariantMap opts)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_attach", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_attach", 3) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_BUF_ATTACH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(send_buffer);
-	m_c->m_dev->send(opts);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(send_buffer);
+	m_connector->m_dev->send(opts);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_buf_detach(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_detach", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_detach", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_BUF_DETACH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::buffer_set_line(int64_t buffer, int64_t index, QByteArray line)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_set_line", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_set_line", 3) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_BUFFER_SET_LINE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(index);
-	m_c->m_dev->send(line);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(index);
+	m_connector->m_dev->send(line);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::buffer_del_line(int64_t buffer, int64_t index)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_del_line", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_del_line", 2) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_BUFFER_DEL_LINE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(index);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(index);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::buffer_get_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_line_slice", 5);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_get_line_slice", 5) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_BUFFER_GET_LINE_SLICE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(start);
-	m_c->m_dev->send(end);
-	m_c->m_dev->send(include_start);
-	m_c->m_dev->send(include_end);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(start);
+	m_connector->m_dev->send(end);
+	m_connector->m_dev->send(include_start);
+	m_connector->m_dev->send(include_end);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_buf_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_get_lines", 4);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_get_lines", 4) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_BUF_GET_LINES);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(start);
-	m_c->m_dev->send(end);
-	m_c->m_dev->send(strict_indexing);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(start);
+	m_connector->m_dev->send(end);
+	m_connector->m_dev->send(strict_indexing);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::buffer_set_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end, QList<QByteArray> replacement)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_set_line_slice", 6);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_set_line_slice", 6) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_BUFFER_SET_LINE_SLICE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(start);
-	m_c->m_dev->send(end);
-	m_c->m_dev->send(include_start);
-	m_c->m_dev->send(include_end);
-	m_c->m_dev->sendArrayOf(replacement);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(start);
+	m_connector->m_dev->send(end);
+	m_connector->m_dev->send(include_start);
+	m_connector->m_dev->send(include_end);
+	m_connector->m_dev->sendArrayOf(replacement);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_buf_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_set_lines", 5);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_set_lines", 5) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_BUF_SET_LINES);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(start);
-	m_c->m_dev->send(end);
-	m_c->m_dev->send(strict_indexing);
-	m_c->m_dev->sendArrayOf(replacement);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(start);
+	m_connector->m_dev->send(end);
+	m_connector->m_dev->send(strict_indexing);
+	m_connector->m_dev->sendArrayOf(replacement);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_buf_get_offset(int64_t buffer, int64_t index)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_get_offset", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_get_offset", 2) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_BUF_GET_OFFSET);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(index);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(index);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_buf_get_var(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_get_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_get_var", 2) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_BUF_GET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_buf_get_changedtick(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_get_changedtick", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_get_changedtick", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_BUF_GET_CHANGEDTICK);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_buf_get_keymap(int64_t buffer, QByteArray mode)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_get_keymap", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_get_keymap", 2) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_BUF_GET_KEYMAP);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(mode);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(mode);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_buf_get_commands(int64_t buffer, QVariantMap opts)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_get_commands", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_get_commands", 2) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_BUF_GET_COMMANDS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(opts);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(opts);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_buf_set_var(int64_t buffer, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_set_var", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_set_var", 3) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_BUF_SET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_buf_del_var(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_del_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_del_var", 2) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_BUF_DEL_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::buffer_set_var(int64_t buffer, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_set_var", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_set_var", 3) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_BUFFER_SET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::buffer_del_var(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_del_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_del_var", 2) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_BUFFER_DEL_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_buf_get_option(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_get_option", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_get_option", 2) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_BUF_GET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_buf_set_option(int64_t buffer, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_set_option", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_set_option", 3) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_BUF_SET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_buf_get_number(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_get_number", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_get_number", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_BUF_GET_NUMBER);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_buf_get_name(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_get_name", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_get_name", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_BUF_GET_NAME);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_buf_set_name(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_set_name", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_set_name", 2) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_BUF_SET_NAME);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_buf_is_loaded(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_is_loaded", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_is_loaded", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_BUF_IS_LOADED);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_buf_is_valid(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_is_valid", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_is_valid", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_BUF_IS_VALID);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::buffer_insert(int64_t buffer, int64_t lnum, QList<QByteArray> lines)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_insert", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_insert", 3) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_BUFFER_INSERT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(lnum);
-	m_c->m_dev->sendArrayOf(lines);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(lnum);
+	m_connector->m_dev->sendArrayOf(lines);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_buf_get_mark(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_get_mark", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_get_mark", 2) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_BUF_GET_MARK);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_buf_add_highlight(int64_t buffer, int64_t ns_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_add_highlight", 6);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_add_highlight", 6) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_BUF_ADD_HIGHLIGHT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(ns_id);
-	m_c->m_dev->send(hl_group);
-	m_c->m_dev->send(line);
-	m_c->m_dev->send(col_start);
-	m_c->m_dev->send(col_end);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(ns_id);
+	m_connector->m_dev->send(hl_group);
+	m_connector->m_dev->send(line);
+	m_connector->m_dev->send(col_start);
+	m_connector->m_dev->send(col_end);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_buf_clear_namespace(int64_t buffer, int64_t ns_id, int64_t line_start, int64_t line_end)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_clear_namespace", 4);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_clear_namespace", 4) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_BUF_CLEAR_NAMESPACE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(ns_id);
-	m_c->m_dev->send(line_start);
-	m_c->m_dev->send(line_end);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(ns_id);
+	m_connector->m_dev->send(line_start);
+	m_connector->m_dev->send(line_end);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_buf_clear_highlight(int64_t buffer, int64_t ns_id, int64_t line_start, int64_t line_end)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_clear_highlight", 4);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_clear_highlight", 4) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_BUF_CLEAR_HIGHLIGHT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(ns_id);
-	m_c->m_dev->send(line_start);
-	m_c->m_dev->send(line_end);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(ns_id);
+	m_connector->m_dev->send(line_start);
+	m_connector->m_dev->send(line_end);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_buf_set_virtual_text(int64_t buffer, int64_t ns_id, int64_t line, QVariantList chunks, QVariantMap opts)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_set_virtual_text", 5);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_set_virtual_text", 5) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_BUF_SET_VIRTUAL_TEXT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(ns_id);
-	m_c->m_dev->send(line);
-	m_c->m_dev->send(chunks);
-	m_c->m_dev->send(opts);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(ns_id);
+	m_connector->m_dev->send(line);
+	m_connector->m_dev->send(chunks);
+	m_connector->m_dev->send(opts);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_tabpage_list_wins(int64_t tabpage)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_tabpage_list_wins", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_tabpage_list_wins", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_TABPAGE_LIST_WINS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(tabpage);
+	m_connector->m_dev->send(tabpage);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_tabpage_get_var(int64_t tabpage, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_tabpage_get_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_tabpage_get_var", 2) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_TABPAGE_GET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(tabpage);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(tabpage);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_tabpage_set_var", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_tabpage_set_var", 3) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_TABPAGE_SET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(tabpage);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(tabpage);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_tabpage_del_var(int64_t tabpage, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_tabpage_del_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_tabpage_del_var", 2) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_TABPAGE_DEL_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(tabpage);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(tabpage);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("tabpage_set_var", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("tabpage_set_var", 3) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_TABPAGE_SET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(tabpage);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(tabpage);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::tabpage_del_var(int64_t tabpage, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("tabpage_del_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("tabpage_del_var", 2) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_TABPAGE_DEL_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(tabpage);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(tabpage);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_tabpage_get_win(int64_t tabpage)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_tabpage_get_win", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_tabpage_get_win", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_TABPAGE_GET_WIN);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(tabpage);
+	m_connector->m_dev->send(tabpage);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_tabpage_get_number(int64_t tabpage)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_tabpage_get_number", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_tabpage_get_number", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_TABPAGE_GET_NUMBER);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(tabpage);
+	m_connector->m_dev->send(tabpage);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_tabpage_is_valid(int64_t tabpage)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_tabpage_is_valid", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_tabpage_is_valid", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_TABPAGE_IS_VALID);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(tabpage);
+	m_connector->m_dev->send(tabpage);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_ui_attach(int64_t width, int64_t height, QVariantMap options)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_ui_attach", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_ui_attach", 3) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_UI_ATTACH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(width);
-	m_c->m_dev->send(height);
-	m_c->m_dev->send(options);
+	m_connector->m_dev->send(width);
+	m_connector->m_dev->send(height);
+	m_connector->m_dev->send(options);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::ui_attach(int64_t width, int64_t height, bool enable_rgb)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("ui_attach", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("ui_attach", 3) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_UI_ATTACH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(width);
-	m_c->m_dev->send(height);
-	m_c->m_dev->send(enable_rgb);
+	m_connector->m_dev->send(width);
+	m_connector->m_dev->send(height);
+	m_connector->m_dev->send(enable_rgb);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_ui_detach()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_ui_detach", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_ui_detach", 0) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_UI_DETACH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_ui_try_resize(int64_t width, int64_t height)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_ui_try_resize", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_ui_try_resize", 2) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_UI_TRY_RESIZE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(width);
-	m_c->m_dev->send(height);
+	m_connector->m_dev->send(width);
+	m_connector->m_dev->send(height);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_ui_set_option(QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_ui_set_option", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_ui_set_option", 2) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_UI_SET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_command(QByteArray command)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_command", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_command", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_COMMAND);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(command);
+	m_connector->m_dev->send(command);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_get_hl_by_name(QByteArray name, bool rgb)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_hl_by_name", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_hl_by_name", 2) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_GET_HL_BY_NAME);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(rgb);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(rgb);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_get_hl_by_id(int64_t hl_id, bool rgb)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_hl_by_id", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_hl_by_id", 2) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_GET_HL_BY_ID);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(hl_id);
-	m_c->m_dev->send(rgb);
+	m_connector->m_dev->send(hl_id);
+	m_connector->m_dev->send(rgb);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_feedkeys", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_feedkeys", 3) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_FEEDKEYS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(keys);
-	m_c->m_dev->send(mode);
-	m_c->m_dev->send(escape_csi);
+	m_connector->m_dev->send(keys);
+	m_connector->m_dev->send(mode);
+	m_connector->m_dev->send(escape_csi);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_input(QByteArray keys)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_input", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_input", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_INPUT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(keys);
+	m_connector->m_dev->send(keys);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_replace_termcodes", 4);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_replace_termcodes", 4) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_REPLACE_TERMCODES);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(str);
-	m_c->m_dev->send(from_part);
-	m_c->m_dev->send(do_lt);
-	m_c->m_dev->send(special);
+	m_connector->m_dev->send(str);
+	m_connector->m_dev->send(from_part);
+	m_connector->m_dev->send(do_lt);
+	m_connector->m_dev->send(special);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_command_output(QByteArray command)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_command_output", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_command_output", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_COMMAND_OUTPUT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(command);
+	m_connector->m_dev->send(command);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_eval(QByteArray expr)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_eval", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_eval", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_EVAL);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(expr);
+	m_connector->m_dev->send(expr);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_execute_lua(QByteArray code, QVariantList args)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_execute_lua", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_execute_lua", 2) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_EXECUTE_LUA);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(code);
-	m_c->m_dev->send(args);
+	m_connector->m_dev->send(code);
+	m_connector->m_dev->send(args);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_call_function(QByteArray fn, QVariantList args)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_call_function", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_call_function", 2) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_CALL_FUNCTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(fn);
-	m_c->m_dev->send(args);
+	m_connector->m_dev->send(fn);
+	m_connector->m_dev->send(args);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_call_dict_function(QVariant dict, QByteArray fn, QVariantList args)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_call_dict_function", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_call_dict_function", 3) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_CALL_DICT_FUNCTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(dict);
-	m_c->m_dev->send(fn);
-	m_c->m_dev->send(args);
+	m_connector->m_dev->send(dict);
+	m_connector->m_dev->send(fn);
+	m_connector->m_dev->send(args);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_strwidth(QByteArray text)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_strwidth", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_strwidth", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_STRWIDTH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(text);
+	m_connector->m_dev->send(text);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_list_runtime_paths()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_list_runtime_paths", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_list_runtime_paths", 0) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_LIST_RUNTIME_PATHS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_set_current_dir(QByteArray dir)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_set_current_dir", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_set_current_dir", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_SET_CURRENT_DIR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(dir);
+	m_connector->m_dev->send(dir);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_get_current_line()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_current_line", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_current_line", 0) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_GET_CURRENT_LINE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_set_current_line(QByteArray line)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_set_current_line", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_set_current_line", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_SET_CURRENT_LINE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(line);
+	m_connector->m_dev->send(line);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_del_current_line()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_del_current_line", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_del_current_line", 0) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_DEL_CURRENT_LINE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_get_var(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_var", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_var", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_GET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_set_var(QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_set_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_set_var", 2) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_SET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_del_var(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_del_var", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_del_var", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_DEL_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::vim_set_var(QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_set_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_set_var", 2) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_SET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::vim_del_var(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_del_var", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_del_var", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_DEL_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_get_vvar(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_vvar", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_vvar", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_GET_VVAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_get_option(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_option", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_option", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_GET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_set_option(QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_set_option", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_set_option", 2) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_SET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_out_write(QByteArray str)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_out_write", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_out_write", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_OUT_WRITE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(str);
+	m_connector->m_dev->send(str);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_err_write(QByteArray str)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_err_write", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_err_write", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_ERR_WRITE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(str);
+	m_connector->m_dev->send(str);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_err_writeln(QByteArray str)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_err_writeln", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_err_writeln", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_ERR_WRITELN);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(str);
+	m_connector->m_dev->send(str);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_list_bufs()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_list_bufs", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_list_bufs", 0) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_LIST_BUFS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_get_current_buf()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_current_buf", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_current_buf", 0) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_GET_CURRENT_BUF);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_set_current_buf(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_set_current_buf", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_set_current_buf", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_SET_CURRENT_BUF);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_list_wins()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_list_wins", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_list_wins", 0) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_LIST_WINS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_get_current_win()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_current_win", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_current_win", 0) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_GET_CURRENT_WIN);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_set_current_win(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_set_current_win", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_set_current_win", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_SET_CURRENT_WIN);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_list_tabpages()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_list_tabpages", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_list_tabpages", 0) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_LIST_TABPAGES);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_get_current_tabpage()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_current_tabpage", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_current_tabpage", 0) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_GET_CURRENT_TABPAGE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_set_current_tabpage(int64_t tabpage)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_set_current_tabpage", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_set_current_tabpage", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_SET_CURRENT_TABPAGE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(tabpage);
+	m_connector->m_dev->send(tabpage);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_create_namespace(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_create_namespace", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_create_namespace", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_CREATE_NAMESPACE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_get_namespaces()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_namespaces", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_namespaces", 0) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_GET_NAMESPACES);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_subscribe(QByteArray event)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_subscribe", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_subscribe", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_SUBSCRIBE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(event);
+	m_connector->m_dev->send(event);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_unsubscribe(QByteArray event)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_unsubscribe", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_unsubscribe", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_UNSUBSCRIBE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(event);
+	m_connector->m_dev->send(event);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_get_color_by_name(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_color_by_name", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_color_by_name", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_GET_COLOR_BY_NAME);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_get_color_map()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_color_map", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_color_map", 0) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_GET_COLOR_MAP);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_get_mode()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_mode", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_mode", 0) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_GET_MODE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_get_keymap(QByteArray mode)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_keymap", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_keymap", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_GET_KEYMAP);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(mode);
+	m_connector->m_dev->send(mode);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_get_commands(QVariantMap opts)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_commands", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_commands", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_GET_COMMANDS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(opts);
+	m_connector->m_dev->send(opts);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_get_api_info()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_api_info", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_api_info", 0) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_GET_API_INFO);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_set_client_info(QByteArray name, QVariantMap version, QByteArray type, QVariantMap methods, QVariantMap attributes)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_set_client_info", 5);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_set_client_info", 5) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_SET_CLIENT_INFO);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(version);
-	m_c->m_dev->send(type);
-	m_c->m_dev->send(methods);
-	m_c->m_dev->send(attributes);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(version);
+	m_connector->m_dev->send(type);
+	m_connector->m_dev->send(methods);
+	m_connector->m_dev->send(attributes);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_get_chan_info(int64_t chan)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_chan_info", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_chan_info", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_GET_CHAN_INFO);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(chan);
+	m_connector->m_dev->send(chan);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_list_chans()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_list_chans", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_list_chans", 0) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_LIST_CHANS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_call_atomic(QVariantList calls)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_call_atomic", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_call_atomic", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_CALL_ATOMIC);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(calls);
+	m_connector->m_dev->send(calls);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_parse_expression(QByteArray expr, QByteArray flags, bool highlight)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_parse_expression", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_parse_expression", 3) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_PARSE_EXPRESSION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(expr);
-	m_c->m_dev->send(flags);
-	m_c->m_dev->send(highlight);
+	m_connector->m_dev->send(expr);
+	m_connector->m_dev->send(flags);
+	m_connector->m_dev->send(highlight);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_list_uis()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_list_uis", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_list_uis", 0) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_LIST_UIS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_get_proc_children(int64_t pid)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_proc_children", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_proc_children", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_GET_PROC_CHILDREN);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(pid);
+	m_connector->m_dev->send(pid);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_get_proc(int64_t pid)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_proc", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_proc", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_GET_PROC);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(pid);
+	m_connector->m_dev->send(pid);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_win_get_buf(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_buf", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_get_buf", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_WIN_GET_BUF);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_win_set_buf(int64_t window, int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_set_buf", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_set_buf", 2) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_WIN_SET_BUF);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_win_get_cursor(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_cursor", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_get_cursor", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_WIN_GET_CURSOR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_win_set_cursor(int64_t window, QPoint pos)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_set_cursor", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_set_cursor", 2) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_WIN_SET_CURSOR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(pos);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(pos);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_win_get_height(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_height", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_get_height", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_WIN_GET_HEIGHT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_win_set_height(int64_t window, int64_t height)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_set_height", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_set_height", 2) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_WIN_SET_HEIGHT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(height);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(height);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_win_get_width(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_width", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_get_width", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_WIN_GET_WIDTH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_win_set_width(int64_t window, int64_t width)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_set_width", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_set_width", 2) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_WIN_SET_WIDTH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(width);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(width);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_win_get_var(int64_t window, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_get_var", 2) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_WIN_GET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_win_set_var(int64_t window, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_set_var", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_set_var", 3) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_WIN_SET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_win_del_var(int64_t window, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_del_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_del_var", 2) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_WIN_DEL_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::window_set_var(int64_t window, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_set_var", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_set_var", 3) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_WINDOW_SET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::window_del_var(int64_t window, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_del_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_del_var", 2) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_WINDOW_DEL_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_win_get_option(int64_t window, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_option", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_get_option", 2) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_WIN_GET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_win_set_option(int64_t window, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_set_option", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_set_option", 3) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_WIN_SET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_win_get_position(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_position", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_get_position", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_WIN_GET_POSITION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_win_get_tabpage(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_tabpage", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_get_tabpage", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_WIN_GET_TABPAGE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_win_get_number(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_number", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_get_number", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_WIN_GET_NUMBER);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::nvim_win_is_valid(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_is_valid", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_is_valid", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_NVIM_WIN_IS_VALID);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::buffer_line_count(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_line_count", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_line_count", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_BUFFER_LINE_COUNT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::buffer_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_lines", 4);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_get_lines", 4) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_BUFFER_GET_LINES);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(start);
-	m_c->m_dev->send(end);
-	m_c->m_dev->send(strict_indexing);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(start);
+	m_connector->m_dev->send(end);
+	m_connector->m_dev->send(strict_indexing);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::buffer_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_set_lines", 5);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_set_lines", 5) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_BUFFER_SET_LINES);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(start);
-	m_c->m_dev->send(end);
-	m_c->m_dev->send(strict_indexing);
-	m_c->m_dev->sendArrayOf(replacement);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(start);
+	m_connector->m_dev->send(end);
+	m_connector->m_dev->send(strict_indexing);
+	m_connector->m_dev->sendArrayOf(replacement);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::buffer_get_var(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_get_var", 2) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_BUFFER_GET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::buffer_get_option(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_option", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_get_option", 2) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_BUFFER_GET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::buffer_set_option(int64_t buffer, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_set_option", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_set_option", 3) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_BUFFER_SET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::buffer_get_number(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_number", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_get_number", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_BUFFER_GET_NUMBER);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::buffer_get_name(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_name", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_get_name", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_BUFFER_GET_NAME);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::buffer_set_name(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_set_name", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_set_name", 2) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_BUFFER_SET_NAME);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::buffer_is_valid(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_is_valid", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_is_valid", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_BUFFER_IS_VALID);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::buffer_get_mark(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_mark", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_get_mark", 2) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_BUFFER_GET_MARK);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::buffer_add_highlight(int64_t buffer, int64_t ns_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_add_highlight", 6);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_add_highlight", 6) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_BUFFER_ADD_HIGHLIGHT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(ns_id);
-	m_c->m_dev->send(hl_group);
-	m_c->m_dev->send(line);
-	m_c->m_dev->send(col_start);
-	m_c->m_dev->send(col_end);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(ns_id);
+	m_connector->m_dev->send(hl_group);
+	m_connector->m_dev->send(line);
+	m_connector->m_dev->send(col_start);
+	m_connector->m_dev->send(col_end);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::buffer_clear_highlight(int64_t buffer, int64_t ns_id, int64_t line_start, int64_t line_end)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_clear_highlight", 4);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_clear_highlight", 4) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_BUFFER_CLEAR_HIGHLIGHT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(ns_id);
-	m_c->m_dev->send(line_start);
-	m_c->m_dev->send(line_end);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(ns_id);
+	m_connector->m_dev->send(line_start);
+	m_connector->m_dev->send(line_end);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::tabpage_get_windows(int64_t tabpage)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("tabpage_get_windows", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("tabpage_get_windows", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_TABPAGE_GET_WINDOWS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(tabpage);
+	m_connector->m_dev->send(tabpage);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::tabpage_get_var(int64_t tabpage, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("tabpage_get_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("tabpage_get_var", 2) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_TABPAGE_GET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(tabpage);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(tabpage);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::tabpage_get_window(int64_t tabpage)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("tabpage_get_window", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("tabpage_get_window", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_TABPAGE_GET_WINDOW);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(tabpage);
+	m_connector->m_dev->send(tabpage);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::tabpage_is_valid(int64_t tabpage)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("tabpage_is_valid", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("tabpage_is_valid", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_TABPAGE_IS_VALID);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(tabpage);
+	m_connector->m_dev->send(tabpage);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::ui_detach()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("ui_detach", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("ui_detach", 0) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_UI_DETACH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::ui_try_resize(int64_t width, int64_t height)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("ui_try_resize", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("ui_try_resize", 2) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_UI_TRY_RESIZE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(width);
-	m_c->m_dev->send(height);
+	m_connector->m_dev->send(width);
+	m_connector->m_dev->send(height);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::vim_command(QByteArray command)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_command", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_command", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_COMMAND);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(command);
+	m_connector->m_dev->send(command);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::vim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_feedkeys", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_feedkeys", 3) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_FEEDKEYS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(keys);
-	m_c->m_dev->send(mode);
-	m_c->m_dev->send(escape_csi);
+	m_connector->m_dev->send(keys);
+	m_connector->m_dev->send(mode);
+	m_connector->m_dev->send(escape_csi);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::vim_input(QByteArray keys)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_input", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_input", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_INPUT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(keys);
+	m_connector->m_dev->send(keys);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::vim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_replace_termcodes", 4);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_replace_termcodes", 4) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_REPLACE_TERMCODES);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(str);
-	m_c->m_dev->send(from_part);
-	m_c->m_dev->send(do_lt);
-	m_c->m_dev->send(special);
+	m_connector->m_dev->send(str);
+	m_connector->m_dev->send(from_part);
+	m_connector->m_dev->send(do_lt);
+	m_connector->m_dev->send(special);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::vim_command_output(QByteArray command)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_command_output", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_command_output", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_COMMAND_OUTPUT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(command);
+	m_connector->m_dev->send(command);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::vim_eval(QByteArray expr)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_eval", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_eval", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_EVAL);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(expr);
+	m_connector->m_dev->send(expr);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::vim_call_function(QByteArray fn, QVariantList args)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_call_function", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_call_function", 2) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_CALL_FUNCTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(fn);
-	m_c->m_dev->send(args);
+	m_connector->m_dev->send(fn);
+	m_connector->m_dev->send(args);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::vim_strwidth(QByteArray text)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_strwidth", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_strwidth", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_STRWIDTH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(text);
+	m_connector->m_dev->send(text);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::vim_list_runtime_paths()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_list_runtime_paths", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_list_runtime_paths", 0) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_LIST_RUNTIME_PATHS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::vim_change_directory(QByteArray dir)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_change_directory", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_change_directory", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_CHANGE_DIRECTORY);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(dir);
+	m_connector->m_dev->send(dir);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::vim_get_current_line()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_current_line", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_current_line", 0) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_GET_CURRENT_LINE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::vim_set_current_line(QByteArray line)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_set_current_line", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_set_current_line", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_SET_CURRENT_LINE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(line);
+	m_connector->m_dev->send(line);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::vim_del_current_line()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_del_current_line", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_del_current_line", 0) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_DEL_CURRENT_LINE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::vim_get_var(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_var", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_var", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_GET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::vim_get_vvar(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_vvar", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_vvar", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_GET_VVAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::vim_get_option(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_option", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_option", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_GET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::vim_set_option(QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_set_option", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_set_option", 2) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_SET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::vim_out_write(QByteArray str)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_out_write", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_out_write", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_OUT_WRITE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(str);
+	m_connector->m_dev->send(str);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::vim_err_write(QByteArray str)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_err_write", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_err_write", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_ERR_WRITE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(str);
+	m_connector->m_dev->send(str);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::vim_report_error(QByteArray str)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_report_error", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_report_error", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_REPORT_ERROR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(str);
+	m_connector->m_dev->send(str);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::vim_get_buffers()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_buffers", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_buffers", 0) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_GET_BUFFERS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::vim_get_current_buffer()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_current_buffer", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_current_buffer", 0) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_GET_CURRENT_BUFFER);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::vim_set_current_buffer(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_set_current_buffer", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_set_current_buffer", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_SET_CURRENT_BUFFER);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::vim_get_windows()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_windows", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_windows", 0) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_GET_WINDOWS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::vim_get_current_window()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_current_window", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_current_window", 0) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_GET_CURRENT_WINDOW);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::vim_set_current_window(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_set_current_window", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_set_current_window", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_SET_CURRENT_WINDOW);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::vim_get_tabpages()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_tabpages", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_tabpages", 0) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_GET_TABPAGES);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::vim_get_current_tabpage()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_current_tabpage", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_current_tabpage", 0) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_GET_CURRENT_TABPAGE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::vim_set_current_tabpage(int64_t tabpage)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_set_current_tabpage", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_set_current_tabpage", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_SET_CURRENT_TABPAGE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(tabpage);
+	m_connector->m_dev->send(tabpage);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::vim_subscribe(QByteArray event)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_subscribe", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_subscribe", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_SUBSCRIBE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(event);
+	m_connector->m_dev->send(event);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::vim_unsubscribe(QByteArray event)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_unsubscribe", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_unsubscribe", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_UNSUBSCRIBE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(event);
+	m_connector->m_dev->send(event);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::vim_name_to_color(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_name_to_color", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_name_to_color", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_NAME_TO_COLOR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::vim_get_color_map()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_color_map", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_color_map", 0) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_VIM_GET_COLOR_MAP);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::window_get_buffer(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_buffer", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_get_buffer", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_WINDOW_GET_BUFFER);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::window_get_cursor(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_cursor", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_get_cursor", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_WINDOW_GET_CURSOR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::window_set_cursor(int64_t window, QPoint pos)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_set_cursor", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_set_cursor", 2) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_WINDOW_SET_CURSOR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(pos);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(pos);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::window_get_height(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_height", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_get_height", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_WINDOW_GET_HEIGHT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::window_set_height(int64_t window, int64_t height)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_set_height", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_set_height", 2) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_WINDOW_SET_HEIGHT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(height);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(height);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::window_get_width(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_width", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_get_width", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_WINDOW_GET_WIDTH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::window_set_width(int64_t window, int64_t width)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_set_width", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_set_width", 2) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_WINDOW_SET_WIDTH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(width);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(width);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::window_get_var(int64_t window, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_get_var", 2) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_WINDOW_GET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::window_get_option(int64_t window, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_option", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_get_option", 2) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_WINDOW_GET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::window_set_option(int64_t window, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_set_option", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_set_option", 3) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_WINDOW_SET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::window_get_position(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_position", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_get_position", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_WINDOW_GET_POSITION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::window_get_tabpage(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_tabpage", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_get_tabpage", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_WINDOW_GET_TABPAGE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi5::window_is_valid(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_is_valid", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_is_valid", 1) };
 	r->setFunction(NeovimApi5::NEOVIM_FN_WINDOW_IS_VALID);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi5::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi5::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
 
+
 // Handlers
 
-void NeovimApi5::handleResponseError(quint32 msgid, quint64 fun, const QVariant& res)
+void NeovimApi5::handleResponseError(uint32_t msgid, uint64_t fun, const QVariant& res)
 {
 
 	// TODO: support Neovim error types Exception/Validation/etc
@@ -1836,7 +2029,7 @@ void NeovimApi5::handleResponseError(quint32 msgid, quint64 fun, const QVariant&
 	const QVariantList asList = res.toList();
 	if (asList.size() >= 2) {
 		if (asList.at(1).canConvert<QByteArray>()) {
-			errMsg = m_c->m_dev->decode(asList.at(1).toByteArray());
+			errMsg = m_connector->m_dev->decode(asList.at(1).toByteArray());
 		} else {
 			errMsg = tr("Received unsupported Neovim error type");
 		}
@@ -2399,1843 +2592,1843 @@ void NeovimApi5::handleResponseError(quint32 msgid, quint64 fun, const QVariant&
 		emit err_window_is_valid(errMsg, res);
 		break;
 	default:
-		m_c->setError(NeovimConnector::RuntimeMsgpackError, QString("Received error for function that should not fail: %s").arg(fun));
+		m_connector->setError(NeovimConnector::RuntimeMsgpackError, QString("Received error for function that should not fail: %s").arg(fun));
 	}
 }
 
-void NeovimApi5::handleResponse(quint32 msgid, quint64 fun, const QVariant& res)
+void NeovimApi5::handleResponse(uint32_t msgid, uint64_t fun, const QVariant& res)
 {
 	switch(fun) {
-	case NeovimApi5::NEOVIM_FN_NVIM_BUF_LINE_COUNT:
+		case NeovimApi5::NEOVIM_FN_NVIM_BUF_LINE_COUNT:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_line_count");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_line_count");
 				return;
-			} else {
-				emit on_nvim_buf_line_count(data);
 			}
 
+			emit on_nvim_buf_line_count(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_BUFFER_GET_LINE:
+
+		case NeovimApi5::NEOVIM_FN_BUFFER_GET_LINE:
 		{
 			QByteArray data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_line");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_line");
 				return;
-			} else {
-				emit on_buffer_get_line(data);
 			}
 
+			emit on_buffer_get_line(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_BUF_ATTACH:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_BUF_ATTACH:
 		{
 			bool data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_attach");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_attach");
 				return;
-			} else {
-				emit on_nvim_buf_attach(data);
 			}
 
+			emit on_nvim_buf_attach(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_BUF_DETACH:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_BUF_DETACH:
 		{
 			bool data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_detach");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_detach");
 				return;
-			} else {
-				emit on_nvim_buf_detach(data);
 			}
 
+			emit on_nvim_buf_detach(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_BUFFER_SET_LINE:
+
+		case NeovimApi5::NEOVIM_FN_BUFFER_SET_LINE:
 		{
 			emit on_buffer_set_line();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_BUFFER_DEL_LINE:
+
+		case NeovimApi5::NEOVIM_FN_BUFFER_DEL_LINE:
 		{
 			emit on_buffer_del_line();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_BUFFER_GET_LINE_SLICE:
+
+		case NeovimApi5::NEOVIM_FN_BUFFER_GET_LINE_SLICE:
 		{
 			QList<QByteArray> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_line_slice");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_line_slice");
 				return;
-			} else {
-				emit on_buffer_get_line_slice(data);
 			}
 
+			emit on_buffer_get_line_slice(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_BUF_GET_LINES:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_BUF_GET_LINES:
 		{
 			QList<QByteArray> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_lines");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_lines");
 				return;
-			} else {
-				emit on_nvim_buf_get_lines(data);
 			}
 
+			emit on_nvim_buf_get_lines(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_BUFFER_SET_LINE_SLICE:
+
+		case NeovimApi5::NEOVIM_FN_BUFFER_SET_LINE_SLICE:
 		{
 			emit on_buffer_set_line_slice();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_BUF_SET_LINES:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_BUF_SET_LINES:
 		{
 			emit on_nvim_buf_set_lines();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_BUF_GET_OFFSET:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_BUF_GET_OFFSET:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_offset");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_offset");
 				return;
-			} else {
-				emit on_nvim_buf_get_offset(data);
 			}
 
+			emit on_nvim_buf_get_offset(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_BUF_GET_VAR:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_BUF_GET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_var");
 				return;
-			} else {
-				emit on_nvim_buf_get_var(data);
 			}
 
+			emit on_nvim_buf_get_var(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_BUF_GET_CHANGEDTICK:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_BUF_GET_CHANGEDTICK:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_changedtick");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_changedtick");
 				return;
-			} else {
-				emit on_nvim_buf_get_changedtick(data);
 			}
 
+			emit on_nvim_buf_get_changedtick(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_BUF_GET_KEYMAP:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_BUF_GET_KEYMAP:
 		{
 			QList<QVariantMap> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_keymap");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_keymap");
 				return;
-			} else {
-				emit on_nvim_buf_get_keymap(data);
 			}
 
+			emit on_nvim_buf_get_keymap(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_BUF_GET_COMMANDS:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_BUF_GET_COMMANDS:
 		{
 			QVariantMap data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_commands");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_commands");
 				return;
-			} else {
-				emit on_nvim_buf_get_commands(data);
 			}
 
+			emit on_nvim_buf_get_commands(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_BUF_SET_VAR:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_BUF_SET_VAR:
 		{
 			emit on_nvim_buf_set_var();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_BUF_DEL_VAR:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_BUF_DEL_VAR:
 		{
 			emit on_nvim_buf_del_var();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_BUFFER_SET_VAR:
+
+		case NeovimApi5::NEOVIM_FN_BUFFER_SET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_set_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_set_var");
 				return;
-			} else {
-				emit on_buffer_set_var(data);
 			}
 
+			emit on_buffer_set_var(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_BUFFER_DEL_VAR:
+
+		case NeovimApi5::NEOVIM_FN_BUFFER_DEL_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_del_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_del_var");
 				return;
-			} else {
-				emit on_buffer_del_var(data);
 			}
 
+			emit on_buffer_del_var(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_BUF_GET_OPTION:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_BUF_GET_OPTION:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_option");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_option");
 				return;
-			} else {
-				emit on_nvim_buf_get_option(data);
 			}
 
+			emit on_nvim_buf_get_option(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_BUF_SET_OPTION:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_BUF_SET_OPTION:
 		{
 			emit on_nvim_buf_set_option();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_BUF_GET_NUMBER:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_BUF_GET_NUMBER:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_number");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_number");
 				return;
-			} else {
-				emit on_nvim_buf_get_number(data);
 			}
 
+			emit on_nvim_buf_get_number(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_BUF_GET_NAME:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_BUF_GET_NAME:
 		{
 			QByteArray data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_name");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_name");
 				return;
-			} else {
-				emit on_nvim_buf_get_name(data);
 			}
 
+			emit on_nvim_buf_get_name(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_BUF_SET_NAME:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_BUF_SET_NAME:
 		{
 			emit on_nvim_buf_set_name();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_BUF_IS_LOADED:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_BUF_IS_LOADED:
 		{
 			bool data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_is_loaded");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_is_loaded");
 				return;
-			} else {
-				emit on_nvim_buf_is_loaded(data);
 			}
 
+			emit on_nvim_buf_is_loaded(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_BUF_IS_VALID:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_BUF_IS_VALID:
 		{
 			bool data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_is_valid");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_is_valid");
 				return;
-			} else {
-				emit on_nvim_buf_is_valid(data);
 			}
 
+			emit on_nvim_buf_is_valid(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_BUFFER_INSERT:
+
+		case NeovimApi5::NEOVIM_FN_BUFFER_INSERT:
 		{
 			emit on_buffer_insert();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_BUF_GET_MARK:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_BUF_GET_MARK:
 		{
 			QPoint data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_mark");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_mark");
 				return;
-			} else {
-				emit on_nvim_buf_get_mark(data);
 			}
 
+			emit on_nvim_buf_get_mark(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_BUF_ADD_HIGHLIGHT:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_BUF_ADD_HIGHLIGHT:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_add_highlight");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_add_highlight");
 				return;
-			} else {
-				emit on_nvim_buf_add_highlight(data);
 			}
 
+			emit on_nvim_buf_add_highlight(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_BUF_CLEAR_NAMESPACE:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_BUF_CLEAR_NAMESPACE:
 		{
 			emit on_nvim_buf_clear_namespace();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_BUF_CLEAR_HIGHLIGHT:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_BUF_CLEAR_HIGHLIGHT:
 		{
 			emit on_nvim_buf_clear_highlight();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_BUF_SET_VIRTUAL_TEXT:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_BUF_SET_VIRTUAL_TEXT:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_set_virtual_text");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_set_virtual_text");
 				return;
-			} else {
-				emit on_nvim_buf_set_virtual_text(data);
 			}
 
+			emit on_nvim_buf_set_virtual_text(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_TABPAGE_LIST_WINS:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_TABPAGE_LIST_WINS:
 		{
 			QList<int64_t> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_list_wins");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_list_wins");
 				return;
-			} else {
-				emit on_nvim_tabpage_list_wins(data);
 			}
 
+			emit on_nvim_tabpage_list_wins(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_TABPAGE_GET_VAR:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_TABPAGE_GET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_get_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_get_var");
 				return;
-			} else {
-				emit on_nvim_tabpage_get_var(data);
 			}
 
+			emit on_nvim_tabpage_get_var(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_TABPAGE_SET_VAR:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_TABPAGE_SET_VAR:
 		{
 			emit on_nvim_tabpage_set_var();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_TABPAGE_DEL_VAR:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_TABPAGE_DEL_VAR:
 		{
 			emit on_nvim_tabpage_del_var();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_TABPAGE_SET_VAR:
+
+		case NeovimApi5::NEOVIM_FN_TABPAGE_SET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_set_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_set_var");
 				return;
-			} else {
-				emit on_tabpage_set_var(data);
 			}
 
+			emit on_tabpage_set_var(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_TABPAGE_DEL_VAR:
+
+		case NeovimApi5::NEOVIM_FN_TABPAGE_DEL_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_del_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_del_var");
 				return;
-			} else {
-				emit on_tabpage_del_var(data);
 			}
 
+			emit on_tabpage_del_var(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_TABPAGE_GET_WIN:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_TABPAGE_GET_WIN:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_get_win");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_get_win");
 				return;
-			} else {
-				emit on_nvim_tabpage_get_win(data);
 			}
 
+			emit on_nvim_tabpage_get_win(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_TABPAGE_GET_NUMBER:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_TABPAGE_GET_NUMBER:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_get_number");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_get_number");
 				return;
-			} else {
-				emit on_nvim_tabpage_get_number(data);
 			}
 
+			emit on_nvim_tabpage_get_number(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_TABPAGE_IS_VALID:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_TABPAGE_IS_VALID:
 		{
 			bool data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_is_valid");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_is_valid");
 				return;
-			} else {
-				emit on_nvim_tabpage_is_valid(data);
 			}
 
+			emit on_nvim_tabpage_is_valid(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_UI_ATTACH:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_UI_ATTACH:
 		{
 			emit on_nvim_ui_attach();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_UI_ATTACH:
+
+		case NeovimApi5::NEOVIM_FN_UI_ATTACH:
 		{
 			emit on_ui_attach();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_UI_DETACH:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_UI_DETACH:
 		{
 			emit on_nvim_ui_detach();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_UI_TRY_RESIZE:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_UI_TRY_RESIZE:
 		{
 			emit on_nvim_ui_try_resize();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_UI_SET_OPTION:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_UI_SET_OPTION:
 		{
 			emit on_nvim_ui_set_option();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_COMMAND:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_COMMAND:
 		{
 			emit on_nvim_command();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_GET_HL_BY_NAME:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_GET_HL_BY_NAME:
 		{
 			QVariantMap data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_hl_by_name");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_hl_by_name");
 				return;
-			} else {
-				emit on_nvim_get_hl_by_name(data);
 			}
 
+			emit on_nvim_get_hl_by_name(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_GET_HL_BY_ID:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_GET_HL_BY_ID:
 		{
 			QVariantMap data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_hl_by_id");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_hl_by_id");
 				return;
-			} else {
-				emit on_nvim_get_hl_by_id(data);
 			}
 
+			emit on_nvim_get_hl_by_id(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_FEEDKEYS:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_FEEDKEYS:
 		{
 			emit on_nvim_feedkeys();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_INPUT:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_INPUT:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_input");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_input");
 				return;
-			} else {
-				emit on_nvim_input(data);
 			}
 
+			emit on_nvim_input(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_REPLACE_TERMCODES:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_REPLACE_TERMCODES:
 		{
 			QByteArray data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_replace_termcodes");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_replace_termcodes");
 				return;
-			} else {
-				emit on_nvim_replace_termcodes(data);
 			}
 
+			emit on_nvim_replace_termcodes(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_COMMAND_OUTPUT:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_COMMAND_OUTPUT:
 		{
 			QByteArray data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_command_output");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_command_output");
 				return;
-			} else {
-				emit on_nvim_command_output(data);
 			}
 
+			emit on_nvim_command_output(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_EVAL:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_EVAL:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_eval");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_eval");
 				return;
-			} else {
-				emit on_nvim_eval(data);
 			}
 
+			emit on_nvim_eval(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_EXECUTE_LUA:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_EXECUTE_LUA:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_execute_lua");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_execute_lua");
 				return;
-			} else {
-				emit on_nvim_execute_lua(data);
 			}
 
+			emit on_nvim_execute_lua(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_CALL_FUNCTION:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_CALL_FUNCTION:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_call_function");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_call_function");
 				return;
-			} else {
-				emit on_nvim_call_function(data);
 			}
 
+			emit on_nvim_call_function(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_CALL_DICT_FUNCTION:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_CALL_DICT_FUNCTION:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_call_dict_function");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_call_dict_function");
 				return;
-			} else {
-				emit on_nvim_call_dict_function(data);
 			}
 
+			emit on_nvim_call_dict_function(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_STRWIDTH:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_STRWIDTH:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_strwidth");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_strwidth");
 				return;
-			} else {
-				emit on_nvim_strwidth(data);
 			}
 
+			emit on_nvim_strwidth(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_LIST_RUNTIME_PATHS:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_LIST_RUNTIME_PATHS:
 		{
 			QList<QByteArray> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_runtime_paths");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_runtime_paths");
 				return;
-			} else {
-				emit on_nvim_list_runtime_paths(data);
 			}
 
+			emit on_nvim_list_runtime_paths(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_SET_CURRENT_DIR:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_SET_CURRENT_DIR:
 		{
 			emit on_nvim_set_current_dir();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_GET_CURRENT_LINE:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_GET_CURRENT_LINE:
 		{
 			QByteArray data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_current_line");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_current_line");
 				return;
-			} else {
-				emit on_nvim_get_current_line(data);
 			}
 
+			emit on_nvim_get_current_line(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_SET_CURRENT_LINE:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_SET_CURRENT_LINE:
 		{
 			emit on_nvim_set_current_line();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_DEL_CURRENT_LINE:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_DEL_CURRENT_LINE:
 		{
 			emit on_nvim_del_current_line();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_GET_VAR:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_GET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_var");
 				return;
-			} else {
-				emit on_nvim_get_var(data);
 			}
 
+			emit on_nvim_get_var(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_SET_VAR:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_SET_VAR:
 		{
 			emit on_nvim_set_var();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_DEL_VAR:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_DEL_VAR:
 		{
 			emit on_nvim_del_var();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_VIM_SET_VAR:
+
+		case NeovimApi5::NEOVIM_FN_VIM_SET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_set_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_set_var");
 				return;
-			} else {
-				emit on_vim_set_var(data);
 			}
 
+			emit on_vim_set_var(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_VIM_DEL_VAR:
+
+		case NeovimApi5::NEOVIM_FN_VIM_DEL_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_del_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_del_var");
 				return;
-			} else {
-				emit on_vim_del_var(data);
 			}
 
+			emit on_vim_del_var(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_GET_VVAR:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_GET_VVAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_vvar");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_vvar");
 				return;
-			} else {
-				emit on_nvim_get_vvar(data);
 			}
 
+			emit on_nvim_get_vvar(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_GET_OPTION:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_GET_OPTION:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_option");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_option");
 				return;
-			} else {
-				emit on_nvim_get_option(data);
 			}
 
+			emit on_nvim_get_option(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_SET_OPTION:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_SET_OPTION:
 		{
 			emit on_nvim_set_option();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_OUT_WRITE:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_OUT_WRITE:
 		{
 			emit on_nvim_out_write();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_ERR_WRITE:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_ERR_WRITE:
 		{
 			emit on_nvim_err_write();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_ERR_WRITELN:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_ERR_WRITELN:
 		{
 			emit on_nvim_err_writeln();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_LIST_BUFS:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_LIST_BUFS:
 		{
 			QList<int64_t> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_bufs");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_bufs");
 				return;
-			} else {
-				emit on_nvim_list_bufs(data);
 			}
 
+			emit on_nvim_list_bufs(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_GET_CURRENT_BUF:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_GET_CURRENT_BUF:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_current_buf");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_current_buf");
 				return;
-			} else {
-				emit on_nvim_get_current_buf(data);
 			}
 
+			emit on_nvim_get_current_buf(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_SET_CURRENT_BUF:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_SET_CURRENT_BUF:
 		{
 			emit on_nvim_set_current_buf();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_LIST_WINS:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_LIST_WINS:
 		{
 			QList<int64_t> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_wins");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_wins");
 				return;
-			} else {
-				emit on_nvim_list_wins(data);
 			}
 
+			emit on_nvim_list_wins(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_GET_CURRENT_WIN:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_GET_CURRENT_WIN:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_current_win");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_current_win");
 				return;
-			} else {
-				emit on_nvim_get_current_win(data);
 			}
 
+			emit on_nvim_get_current_win(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_SET_CURRENT_WIN:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_SET_CURRENT_WIN:
 		{
 			emit on_nvim_set_current_win();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_LIST_TABPAGES:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_LIST_TABPAGES:
 		{
 			QList<int64_t> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_tabpages");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_tabpages");
 				return;
-			} else {
-				emit on_nvim_list_tabpages(data);
 			}
 
+			emit on_nvim_list_tabpages(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_GET_CURRENT_TABPAGE:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_GET_CURRENT_TABPAGE:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_current_tabpage");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_current_tabpage");
 				return;
-			} else {
-				emit on_nvim_get_current_tabpage(data);
 			}
 
+			emit on_nvim_get_current_tabpage(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_SET_CURRENT_TABPAGE:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_SET_CURRENT_TABPAGE:
 		{
 			emit on_nvim_set_current_tabpage();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_CREATE_NAMESPACE:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_CREATE_NAMESPACE:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_create_namespace");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_create_namespace");
 				return;
-			} else {
-				emit on_nvim_create_namespace(data);
 			}
 
+			emit on_nvim_create_namespace(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_GET_NAMESPACES:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_GET_NAMESPACES:
 		{
 			QVariantMap data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_namespaces");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_namespaces");
 				return;
-			} else {
-				emit on_nvim_get_namespaces(data);
 			}
 
+			emit on_nvim_get_namespaces(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_SUBSCRIBE:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_SUBSCRIBE:
 		{
 			emit on_nvim_subscribe();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_UNSUBSCRIBE:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_UNSUBSCRIBE:
 		{
 			emit on_nvim_unsubscribe();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_GET_COLOR_BY_NAME:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_GET_COLOR_BY_NAME:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_color_by_name");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_color_by_name");
 				return;
-			} else {
-				emit on_nvim_get_color_by_name(data);
 			}
 
+			emit on_nvim_get_color_by_name(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_GET_COLOR_MAP:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_GET_COLOR_MAP:
 		{
 			QVariantMap data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_color_map");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_color_map");
 				return;
-			} else {
-				emit on_nvim_get_color_map(data);
 			}
 
+			emit on_nvim_get_color_map(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_GET_MODE:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_GET_MODE:
 		{
 			QVariantMap data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_mode");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_mode");
 				return;
-			} else {
-				emit on_nvim_get_mode(data);
 			}
 
+			emit on_nvim_get_mode(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_GET_KEYMAP:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_GET_KEYMAP:
 		{
 			QList<QVariantMap> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_keymap");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_keymap");
 				return;
-			} else {
-				emit on_nvim_get_keymap(data);
 			}
 
+			emit on_nvim_get_keymap(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_GET_COMMANDS:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_GET_COMMANDS:
 		{
 			QVariantMap data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_commands");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_commands");
 				return;
-			} else {
-				emit on_nvim_get_commands(data);
 			}
 
+			emit on_nvim_get_commands(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_GET_API_INFO:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_GET_API_INFO:
 		{
 			QVariantList data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_api_info");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_api_info");
 				return;
-			} else {
-				emit on_nvim_get_api_info(data);
 			}
 
+			emit on_nvim_get_api_info(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_SET_CLIENT_INFO:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_SET_CLIENT_INFO:
 		{
 			emit on_nvim_set_client_info();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_GET_CHAN_INFO:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_GET_CHAN_INFO:
 		{
 			QVariantMap data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_chan_info");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_chan_info");
 				return;
-			} else {
-				emit on_nvim_get_chan_info(data);
 			}
 
+			emit on_nvim_get_chan_info(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_LIST_CHANS:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_LIST_CHANS:
 		{
 			QVariantList data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_chans");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_chans");
 				return;
-			} else {
-				emit on_nvim_list_chans(data);
 			}
 
+			emit on_nvim_list_chans(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_CALL_ATOMIC:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_CALL_ATOMIC:
 		{
 			QVariantList data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_call_atomic");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_call_atomic");
 				return;
-			} else {
-				emit on_nvim_call_atomic(data);
 			}
 
+			emit on_nvim_call_atomic(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_PARSE_EXPRESSION:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_PARSE_EXPRESSION:
 		{
 			QVariantMap data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_parse_expression");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_parse_expression");
 				return;
-			} else {
-				emit on_nvim_parse_expression(data);
 			}
 
+			emit on_nvim_parse_expression(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_LIST_UIS:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_LIST_UIS:
 		{
 			QVariantList data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_uis");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_uis");
 				return;
-			} else {
-				emit on_nvim_list_uis(data);
 			}
 
+			emit on_nvim_list_uis(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_GET_PROC_CHILDREN:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_GET_PROC_CHILDREN:
 		{
 			QVariantList data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_proc_children");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_proc_children");
 				return;
-			} else {
-				emit on_nvim_get_proc_children(data);
 			}
 
+			emit on_nvim_get_proc_children(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_GET_PROC:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_GET_PROC:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_proc");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_proc");
 				return;
-			} else {
-				emit on_nvim_get_proc(data);
 			}
 
+			emit on_nvim_get_proc(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_WIN_GET_BUF:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_WIN_GET_BUF:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_buf");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_buf");
 				return;
-			} else {
-				emit on_nvim_win_get_buf(data);
 			}
 
+			emit on_nvim_win_get_buf(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_WIN_SET_BUF:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_WIN_SET_BUF:
 		{
 			emit on_nvim_win_set_buf();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_WIN_GET_CURSOR:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_WIN_GET_CURSOR:
 		{
 			QPoint data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_cursor");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_cursor");
 				return;
-			} else {
-				emit on_nvim_win_get_cursor(data);
 			}
 
+			emit on_nvim_win_get_cursor(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_WIN_SET_CURSOR:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_WIN_SET_CURSOR:
 		{
 			emit on_nvim_win_set_cursor();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_WIN_GET_HEIGHT:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_WIN_GET_HEIGHT:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_height");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_height");
 				return;
-			} else {
-				emit on_nvim_win_get_height(data);
 			}
 
+			emit on_nvim_win_get_height(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_WIN_SET_HEIGHT:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_WIN_SET_HEIGHT:
 		{
 			emit on_nvim_win_set_height();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_WIN_GET_WIDTH:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_WIN_GET_WIDTH:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_width");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_width");
 				return;
-			} else {
-				emit on_nvim_win_get_width(data);
 			}
 
+			emit on_nvim_win_get_width(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_WIN_SET_WIDTH:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_WIN_SET_WIDTH:
 		{
 			emit on_nvim_win_set_width();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_WIN_GET_VAR:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_WIN_GET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_var");
 				return;
-			} else {
-				emit on_nvim_win_get_var(data);
 			}
 
+			emit on_nvim_win_get_var(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_WIN_SET_VAR:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_WIN_SET_VAR:
 		{
 			emit on_nvim_win_set_var();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_WIN_DEL_VAR:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_WIN_DEL_VAR:
 		{
 			emit on_nvim_win_del_var();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_WINDOW_SET_VAR:
+
+		case NeovimApi5::NEOVIM_FN_WINDOW_SET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_set_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_set_var");
 				return;
-			} else {
-				emit on_window_set_var(data);
 			}
 
+			emit on_window_set_var(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_WINDOW_DEL_VAR:
+
+		case NeovimApi5::NEOVIM_FN_WINDOW_DEL_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_del_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_del_var");
 				return;
-			} else {
-				emit on_window_del_var(data);
 			}
 
+			emit on_window_del_var(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_WIN_GET_OPTION:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_WIN_GET_OPTION:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_option");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_option");
 				return;
-			} else {
-				emit on_nvim_win_get_option(data);
 			}
 
+			emit on_nvim_win_get_option(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_WIN_SET_OPTION:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_WIN_SET_OPTION:
 		{
 			emit on_nvim_win_set_option();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_WIN_GET_POSITION:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_WIN_GET_POSITION:
 		{
 			QPoint data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_position");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_position");
 				return;
-			} else {
-				emit on_nvim_win_get_position(data);
 			}
 
+			emit on_nvim_win_get_position(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_WIN_GET_TABPAGE:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_WIN_GET_TABPAGE:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_tabpage");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_tabpage");
 				return;
-			} else {
-				emit on_nvim_win_get_tabpage(data);
 			}
 
+			emit on_nvim_win_get_tabpage(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_WIN_GET_NUMBER:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_WIN_GET_NUMBER:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_number");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_number");
 				return;
-			} else {
-				emit on_nvim_win_get_number(data);
 			}
 
+			emit on_nvim_win_get_number(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_NVIM_WIN_IS_VALID:
+
+		case NeovimApi5::NEOVIM_FN_NVIM_WIN_IS_VALID:
 		{
 			bool data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_is_valid");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_is_valid");
 				return;
-			} else {
-				emit on_nvim_win_is_valid(data);
 			}
 
+			emit on_nvim_win_is_valid(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_BUFFER_LINE_COUNT:
+
+		case NeovimApi5::NEOVIM_FN_BUFFER_LINE_COUNT:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_line_count");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_line_count");
 				return;
-			} else {
-				emit on_buffer_line_count(data);
 			}
 
+			emit on_buffer_line_count(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_BUFFER_GET_LINES:
+
+		case NeovimApi5::NEOVIM_FN_BUFFER_GET_LINES:
 		{
 			QList<QByteArray> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_lines");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_lines");
 				return;
-			} else {
-				emit on_buffer_get_lines(data);
 			}
 
+			emit on_buffer_get_lines(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_BUFFER_SET_LINES:
+
+		case NeovimApi5::NEOVIM_FN_BUFFER_SET_LINES:
 		{
 			emit on_buffer_set_lines();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_BUFFER_GET_VAR:
+
+		case NeovimApi5::NEOVIM_FN_BUFFER_GET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_var");
 				return;
-			} else {
-				emit on_buffer_get_var(data);
 			}
 
+			emit on_buffer_get_var(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_BUFFER_GET_OPTION:
+
+		case NeovimApi5::NEOVIM_FN_BUFFER_GET_OPTION:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_option");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_option");
 				return;
-			} else {
-				emit on_buffer_get_option(data);
 			}
 
+			emit on_buffer_get_option(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_BUFFER_SET_OPTION:
+
+		case NeovimApi5::NEOVIM_FN_BUFFER_SET_OPTION:
 		{
 			emit on_buffer_set_option();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_BUFFER_GET_NUMBER:
+
+		case NeovimApi5::NEOVIM_FN_BUFFER_GET_NUMBER:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_number");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_number");
 				return;
-			} else {
-				emit on_buffer_get_number(data);
 			}
 
+			emit on_buffer_get_number(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_BUFFER_GET_NAME:
+
+		case NeovimApi5::NEOVIM_FN_BUFFER_GET_NAME:
 		{
 			QByteArray data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_name");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_name");
 				return;
-			} else {
-				emit on_buffer_get_name(data);
 			}
 
+			emit on_buffer_get_name(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_BUFFER_SET_NAME:
+
+		case NeovimApi5::NEOVIM_FN_BUFFER_SET_NAME:
 		{
 			emit on_buffer_set_name();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_BUFFER_IS_VALID:
+
+		case NeovimApi5::NEOVIM_FN_BUFFER_IS_VALID:
 		{
 			bool data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_is_valid");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_is_valid");
 				return;
-			} else {
-				emit on_buffer_is_valid(data);
 			}
 
+			emit on_buffer_is_valid(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_BUFFER_GET_MARK:
+
+		case NeovimApi5::NEOVIM_FN_BUFFER_GET_MARK:
 		{
 			QPoint data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_mark");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_mark");
 				return;
-			} else {
-				emit on_buffer_get_mark(data);
 			}
 
+			emit on_buffer_get_mark(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_BUFFER_ADD_HIGHLIGHT:
+
+		case NeovimApi5::NEOVIM_FN_BUFFER_ADD_HIGHLIGHT:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_add_highlight");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_add_highlight");
 				return;
-			} else {
-				emit on_buffer_add_highlight(data);
 			}
 
+			emit on_buffer_add_highlight(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_BUFFER_CLEAR_HIGHLIGHT:
+
+		case NeovimApi5::NEOVIM_FN_BUFFER_CLEAR_HIGHLIGHT:
 		{
 			emit on_buffer_clear_highlight();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_TABPAGE_GET_WINDOWS:
+
+		case NeovimApi5::NEOVIM_FN_TABPAGE_GET_WINDOWS:
 		{
 			QList<int64_t> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_get_windows");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_get_windows");
 				return;
-			} else {
-				emit on_tabpage_get_windows(data);
 			}
 
+			emit on_tabpage_get_windows(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_TABPAGE_GET_VAR:
+
+		case NeovimApi5::NEOVIM_FN_TABPAGE_GET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_get_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_get_var");
 				return;
-			} else {
-				emit on_tabpage_get_var(data);
 			}
 
+			emit on_tabpage_get_var(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_TABPAGE_GET_WINDOW:
+
+		case NeovimApi5::NEOVIM_FN_TABPAGE_GET_WINDOW:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_get_window");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_get_window");
 				return;
-			} else {
-				emit on_tabpage_get_window(data);
 			}
 
+			emit on_tabpage_get_window(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_TABPAGE_IS_VALID:
+
+		case NeovimApi5::NEOVIM_FN_TABPAGE_IS_VALID:
 		{
 			bool data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_is_valid");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_is_valid");
 				return;
-			} else {
-				emit on_tabpage_is_valid(data);
 			}
 
+			emit on_tabpage_is_valid(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_UI_DETACH:
+
+		case NeovimApi5::NEOVIM_FN_UI_DETACH:
 		{
 			emit on_ui_detach();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_UI_TRY_RESIZE:
+
+		case NeovimApi5::NEOVIM_FN_UI_TRY_RESIZE:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for ui_try_resize");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for ui_try_resize");
 				return;
-			} else {
-				emit on_ui_try_resize(data);
 			}
 
+			emit on_ui_try_resize(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_VIM_COMMAND:
+
+		case NeovimApi5::NEOVIM_FN_VIM_COMMAND:
 		{
 			emit on_vim_command();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_VIM_FEEDKEYS:
+
+		case NeovimApi5::NEOVIM_FN_VIM_FEEDKEYS:
 		{
 			emit on_vim_feedkeys();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_VIM_INPUT:
+
+		case NeovimApi5::NEOVIM_FN_VIM_INPUT:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_input");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_input");
 				return;
-			} else {
-				emit on_vim_input(data);
 			}
 
+			emit on_vim_input(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_VIM_REPLACE_TERMCODES:
+
+		case NeovimApi5::NEOVIM_FN_VIM_REPLACE_TERMCODES:
 		{
 			QByteArray data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_replace_termcodes");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_replace_termcodes");
 				return;
-			} else {
-				emit on_vim_replace_termcodes(data);
 			}
 
+			emit on_vim_replace_termcodes(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_VIM_COMMAND_OUTPUT:
+
+		case NeovimApi5::NEOVIM_FN_VIM_COMMAND_OUTPUT:
 		{
 			QByteArray data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_command_output");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_command_output");
 				return;
-			} else {
-				emit on_vim_command_output(data);
 			}
 
+			emit on_vim_command_output(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_VIM_EVAL:
+
+		case NeovimApi5::NEOVIM_FN_VIM_EVAL:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_eval");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_eval");
 				return;
-			} else {
-				emit on_vim_eval(data);
 			}
 
+			emit on_vim_eval(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_VIM_CALL_FUNCTION:
+
+		case NeovimApi5::NEOVIM_FN_VIM_CALL_FUNCTION:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_call_function");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_call_function");
 				return;
-			} else {
-				emit on_vim_call_function(data);
 			}
 
+			emit on_vim_call_function(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_VIM_STRWIDTH:
+
+		case NeovimApi5::NEOVIM_FN_VIM_STRWIDTH:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_strwidth");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_strwidth");
 				return;
-			} else {
-				emit on_vim_strwidth(data);
 			}
 
+			emit on_vim_strwidth(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_VIM_LIST_RUNTIME_PATHS:
+
+		case NeovimApi5::NEOVIM_FN_VIM_LIST_RUNTIME_PATHS:
 		{
 			QList<QByteArray> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_list_runtime_paths");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_list_runtime_paths");
 				return;
-			} else {
-				emit on_vim_list_runtime_paths(data);
 			}
 
+			emit on_vim_list_runtime_paths(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_VIM_CHANGE_DIRECTORY:
+
+		case NeovimApi5::NEOVIM_FN_VIM_CHANGE_DIRECTORY:
 		{
 			emit on_vim_change_directory();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_VIM_GET_CURRENT_LINE:
+
+		case NeovimApi5::NEOVIM_FN_VIM_GET_CURRENT_LINE:
 		{
 			QByteArray data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_current_line");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_current_line");
 				return;
-			} else {
-				emit on_vim_get_current_line(data);
 			}
 
+			emit on_vim_get_current_line(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_VIM_SET_CURRENT_LINE:
+
+		case NeovimApi5::NEOVIM_FN_VIM_SET_CURRENT_LINE:
 		{
 			emit on_vim_set_current_line();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_VIM_DEL_CURRENT_LINE:
+
+		case NeovimApi5::NEOVIM_FN_VIM_DEL_CURRENT_LINE:
 		{
 			emit on_vim_del_current_line();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_VIM_GET_VAR:
+
+		case NeovimApi5::NEOVIM_FN_VIM_GET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_var");
 				return;
-			} else {
-				emit on_vim_get_var(data);
 			}
 
+			emit on_vim_get_var(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_VIM_GET_VVAR:
+
+		case NeovimApi5::NEOVIM_FN_VIM_GET_VVAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_vvar");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_vvar");
 				return;
-			} else {
-				emit on_vim_get_vvar(data);
 			}
 
+			emit on_vim_get_vvar(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_VIM_GET_OPTION:
+
+		case NeovimApi5::NEOVIM_FN_VIM_GET_OPTION:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_option");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_option");
 				return;
-			} else {
-				emit on_vim_get_option(data);
 			}
 
+			emit on_vim_get_option(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_VIM_SET_OPTION:
+
+		case NeovimApi5::NEOVIM_FN_VIM_SET_OPTION:
 		{
 			emit on_vim_set_option();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_VIM_OUT_WRITE:
+
+		case NeovimApi5::NEOVIM_FN_VIM_OUT_WRITE:
 		{
 			emit on_vim_out_write();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_VIM_ERR_WRITE:
+
+		case NeovimApi5::NEOVIM_FN_VIM_ERR_WRITE:
 		{
 			emit on_vim_err_write();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_VIM_REPORT_ERROR:
+
+		case NeovimApi5::NEOVIM_FN_VIM_REPORT_ERROR:
 		{
 			emit on_vim_report_error();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_VIM_GET_BUFFERS:
+
+		case NeovimApi5::NEOVIM_FN_VIM_GET_BUFFERS:
 		{
 			QList<int64_t> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_buffers");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_buffers");
 				return;
-			} else {
-				emit on_vim_get_buffers(data);
 			}
 
+			emit on_vim_get_buffers(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_VIM_GET_CURRENT_BUFFER:
+
+		case NeovimApi5::NEOVIM_FN_VIM_GET_CURRENT_BUFFER:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_current_buffer");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_current_buffer");
 				return;
-			} else {
-				emit on_vim_get_current_buffer(data);
 			}
 
+			emit on_vim_get_current_buffer(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_VIM_SET_CURRENT_BUFFER:
+
+		case NeovimApi5::NEOVIM_FN_VIM_SET_CURRENT_BUFFER:
 		{
 			emit on_vim_set_current_buffer();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_VIM_GET_WINDOWS:
+
+		case NeovimApi5::NEOVIM_FN_VIM_GET_WINDOWS:
 		{
 			QList<int64_t> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_windows");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_windows");
 				return;
-			} else {
-				emit on_vim_get_windows(data);
 			}
 
+			emit on_vim_get_windows(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_VIM_GET_CURRENT_WINDOW:
+
+		case NeovimApi5::NEOVIM_FN_VIM_GET_CURRENT_WINDOW:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_current_window");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_current_window");
 				return;
-			} else {
-				emit on_vim_get_current_window(data);
 			}
 
+			emit on_vim_get_current_window(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_VIM_SET_CURRENT_WINDOW:
+
+		case NeovimApi5::NEOVIM_FN_VIM_SET_CURRENT_WINDOW:
 		{
 			emit on_vim_set_current_window();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_VIM_GET_TABPAGES:
+
+		case NeovimApi5::NEOVIM_FN_VIM_GET_TABPAGES:
 		{
 			QList<int64_t> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_tabpages");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_tabpages");
 				return;
-			} else {
-				emit on_vim_get_tabpages(data);
 			}
 
+			emit on_vim_get_tabpages(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_VIM_GET_CURRENT_TABPAGE:
+
+		case NeovimApi5::NEOVIM_FN_VIM_GET_CURRENT_TABPAGE:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_current_tabpage");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_current_tabpage");
 				return;
-			} else {
-				emit on_vim_get_current_tabpage(data);
 			}
 
+			emit on_vim_get_current_tabpage(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_VIM_SET_CURRENT_TABPAGE:
+
+		case NeovimApi5::NEOVIM_FN_VIM_SET_CURRENT_TABPAGE:
 		{
 			emit on_vim_set_current_tabpage();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_VIM_SUBSCRIBE:
+
+		case NeovimApi5::NEOVIM_FN_VIM_SUBSCRIBE:
 		{
 			emit on_vim_subscribe();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_VIM_UNSUBSCRIBE:
+
+		case NeovimApi5::NEOVIM_FN_VIM_UNSUBSCRIBE:
 		{
 			emit on_vim_unsubscribe();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_VIM_NAME_TO_COLOR:
+
+		case NeovimApi5::NEOVIM_FN_VIM_NAME_TO_COLOR:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_name_to_color");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_name_to_color");
 				return;
-			} else {
-				emit on_vim_name_to_color(data);
 			}
 
+			emit on_vim_name_to_color(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_VIM_GET_COLOR_MAP:
+
+		case NeovimApi5::NEOVIM_FN_VIM_GET_COLOR_MAP:
 		{
 			QVariantMap data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_color_map");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_color_map");
 				return;
-			} else {
-				emit on_vim_get_color_map(data);
 			}
 
+			emit on_vim_get_color_map(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_WINDOW_GET_BUFFER:
+
+		case NeovimApi5::NEOVIM_FN_WINDOW_GET_BUFFER:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_buffer");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_buffer");
 				return;
-			} else {
-				emit on_window_get_buffer(data);
 			}
 
+			emit on_window_get_buffer(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_WINDOW_GET_CURSOR:
+
+		case NeovimApi5::NEOVIM_FN_WINDOW_GET_CURSOR:
 		{
 			QPoint data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_cursor");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_cursor");
 				return;
-			} else {
-				emit on_window_get_cursor(data);
 			}
 
+			emit on_window_get_cursor(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_WINDOW_SET_CURSOR:
+
+		case NeovimApi5::NEOVIM_FN_WINDOW_SET_CURSOR:
 		{
 			emit on_window_set_cursor();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_WINDOW_GET_HEIGHT:
+
+		case NeovimApi5::NEOVIM_FN_WINDOW_GET_HEIGHT:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_height");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_height");
 				return;
-			} else {
-				emit on_window_get_height(data);
 			}
 
+			emit on_window_get_height(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_WINDOW_SET_HEIGHT:
+
+		case NeovimApi5::NEOVIM_FN_WINDOW_SET_HEIGHT:
 		{
 			emit on_window_set_height();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_WINDOW_GET_WIDTH:
+
+		case NeovimApi5::NEOVIM_FN_WINDOW_GET_WIDTH:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_width");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_width");
 				return;
-			} else {
-				emit on_window_get_width(data);
 			}
 
+			emit on_window_get_width(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_WINDOW_SET_WIDTH:
+
+		case NeovimApi5::NEOVIM_FN_WINDOW_SET_WIDTH:
 		{
 			emit on_window_set_width();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_WINDOW_GET_VAR:
+
+		case NeovimApi5::NEOVIM_FN_WINDOW_GET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_var");
 				return;
-			} else {
-				emit on_window_get_var(data);
 			}
 
+			emit on_window_get_var(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_WINDOW_GET_OPTION:
+
+		case NeovimApi5::NEOVIM_FN_WINDOW_GET_OPTION:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_option");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_option");
 				return;
-			} else {
-				emit on_window_get_option(data);
 			}
 
+			emit on_window_get_option(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_WINDOW_SET_OPTION:
+
+		case NeovimApi5::NEOVIM_FN_WINDOW_SET_OPTION:
 		{
 			emit on_window_set_option();
-
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_WINDOW_GET_POSITION:
+
+		case NeovimApi5::NEOVIM_FN_WINDOW_GET_POSITION:
 		{
 			QPoint data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_position");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_position");
 				return;
-			} else {
-				emit on_window_get_position(data);
 			}
 
+			emit on_window_get_position(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_WINDOW_GET_TABPAGE:
+
+		case NeovimApi5::NEOVIM_FN_WINDOW_GET_TABPAGE:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_tabpage");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_tabpage");
 				return;
-			} else {
-				emit on_window_get_tabpage(data);
 			}
 
+			emit on_window_get_tabpage(data);
 		}
 		break;
-	case NeovimApi5::NEOVIM_FN_WINDOW_IS_VALID:
+
+		case NeovimApi5::NEOVIM_FN_WINDOW_IS_VALID:
 		{
 			bool data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_is_valid");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_is_valid");
 				return;
-			} else {
-				emit on_window_is_valid(data);
 			}
 
+			emit on_window_is_valid(data);
 		}
 		break;
+
 	default:
 		qWarning() << "Received unexpected response";
 	}
@@ -4249,867 +4442,1420 @@ void NeovimApi5::handleResponse(quint32 msgid, quint64 fun, const QVariant& res)
  *
  * Returns false if there is an API mismatch
  */
-bool NeovimApi5::checkFunctions(const QVariantList& ftable)
+/*static*/ bool NeovimApi5::checkFunctions(const QVariantList& ftable) noexcept
 {
-
-	QList<Function> required;
-	required
-		<< Function("Integer", "nvim_buf_line_count",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("String", "buffer_get_line",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						, false)
-		<< Function("Boolean", "nvim_buf_attach",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Boolean")
-						<< QString("Dictionary")
-						, false)
-		<< Function("Boolean", "nvim_buf_detach",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("void", "buffer_set_line",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("String")
-						, false)
-		<< Function("void", "buffer_del_line",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						, false)
-		<< Function("ArrayOf(String)", "buffer_get_line_slice",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Boolean")
-						<< QString("Boolean")
-						, false)
-		<< Function("ArrayOf(String)", "nvim_buf_get_lines",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Boolean")
-						, false)
-		<< Function("void", "buffer_set_line_slice",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Boolean")
-						<< QString("Boolean")
-						<< QString("ArrayOf(String)")
-						, false)
-		<< Function("void", "nvim_buf_set_lines",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Boolean")
-						<< QString("ArrayOf(String)")
-						, false)
-		<< Function("Integer", "nvim_buf_get_offset",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						, false)
-		<< Function("Object", "nvim_buf_get_var",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("Integer", "nvim_buf_get_changedtick",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("ArrayOf(Dictionary)", "nvim_buf_get_keymap",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("Dictionary", "nvim_buf_get_commands",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Dictionary")
-						, false)
-		<< Function("void", "nvim_buf_set_var",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("void", "nvim_buf_del_var",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("Object", "buffer_set_var",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("Object", "buffer_del_var",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("Object", "nvim_buf_get_option",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_buf_set_option",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("Integer", "nvim_buf_get_number",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("String", "nvim_buf_get_name",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("void", "nvim_buf_set_name",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("Boolean", "nvim_buf_is_loaded",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("Boolean", "nvim_buf_is_valid",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("void", "buffer_insert",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("ArrayOf(String)")
-						, false)
-		<< Function("ArrayOf(Integer, 2)", "nvim_buf_get_mark",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("Integer", "nvim_buf_add_highlight",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("String")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Integer")
-						, false)
-		<< Function("void", "nvim_buf_clear_namespace",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Integer")
-						, false)
-		<< Function("void", "nvim_buf_clear_highlight",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Integer")
-						, false)
-		<< Function("Integer", "nvim_buf_set_virtual_text",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Array")
-						<< QString("Dictionary")
-						, false)
-		<< Function("ArrayOf(Window)", "nvim_tabpage_list_wins",
-			QList<QString>()
-						<< QString("Tabpage")
-						, false)
-		<< Function("Object", "nvim_tabpage_get_var",
-			QList<QString>()
-						<< QString("Tabpage")
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_tabpage_set_var",
-			QList<QString>()
-						<< QString("Tabpage")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("void", "nvim_tabpage_del_var",
-			QList<QString>()
-						<< QString("Tabpage")
-						<< QString("String")
-						, false)
-		<< Function("Object", "tabpage_set_var",
-			QList<QString>()
-						<< QString("Tabpage")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("Object", "tabpage_del_var",
-			QList<QString>()
-						<< QString("Tabpage")
-						<< QString("String")
-						, false)
-		<< Function("Window", "nvim_tabpage_get_win",
-			QList<QString>()
-						<< QString("Tabpage")
-						, false)
-		<< Function("Integer", "nvim_tabpage_get_number",
-			QList<QString>()
-						<< QString("Tabpage")
-						, false)
-		<< Function("Boolean", "nvim_tabpage_is_valid",
-			QList<QString>()
-						<< QString("Tabpage")
-						, false)
-		<< Function("void", "nvim_ui_attach",
-			QList<QString>()
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Dictionary")
-						, false)
-		<< Function("void", "ui_attach",
-			QList<QString>()
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Boolean")
-						, false)
-		<< Function("void", "nvim_ui_detach",
-			QList<QString>()
-						, false)
-		<< Function("void", "nvim_ui_try_resize",
-			QList<QString>()
-						<< QString("Integer")
-						<< QString("Integer")
-						, false)
-		<< Function("void", "nvim_ui_set_option",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("void", "nvim_command",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Dictionary", "nvim_get_hl_by_name",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Boolean")
-						, false)
-		<< Function("Dictionary", "nvim_get_hl_by_id",
-			QList<QString>()
-						<< QString("Integer")
-						<< QString("Boolean")
-						, false)
-		<< Function("void", "nvim_feedkeys",
-			QList<QString>()
-						<< QString("String")
-						<< QString("String")
-						<< QString("Boolean")
-						, false)
-		<< Function("Integer", "nvim_input",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("String", "nvim_replace_termcodes",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Boolean")
-						<< QString("Boolean")
-						<< QString("Boolean")
-						, false)
-		<< Function("String", "nvim_command_output",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Object", "nvim_eval",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Object", "nvim_execute_lua",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Array")
-						, false)
-		<< Function("Object", "nvim_call_function",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Array")
-						, false)
-		<< Function("Object", "nvim_call_dict_function",
-			QList<QString>()
-						<< QString("Object")
-						<< QString("String")
-						<< QString("Array")
-						, false)
-		<< Function("Integer", "nvim_strwidth",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("ArrayOf(String)", "nvim_list_runtime_paths",
-			QList<QString>()
-						, false)
-		<< Function("void", "nvim_set_current_dir",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("String", "nvim_get_current_line",
-			QList<QString>()
-						, false)
-		<< Function("void", "nvim_set_current_line",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_del_current_line",
-			QList<QString>()
-						, false)
-		<< Function("Object", "nvim_get_var",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_set_var",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("void", "nvim_del_var",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Object", "vim_set_var",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("Object", "vim_del_var",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Object", "nvim_get_vvar",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Object", "nvim_get_option",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_set_option",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("void", "nvim_out_write",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_err_write",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_err_writeln",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("ArrayOf(Buffer)", "nvim_list_bufs",
-			QList<QString>()
-						, false)
-		<< Function("Buffer", "nvim_get_current_buf",
-			QList<QString>()
-						, false)
-		<< Function("void", "nvim_set_current_buf",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("ArrayOf(Window)", "nvim_list_wins",
-			QList<QString>()
-						, false)
-		<< Function("Window", "nvim_get_current_win",
-			QList<QString>()
-						, false)
-		<< Function("void", "nvim_set_current_win",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("ArrayOf(Tabpage)", "nvim_list_tabpages",
-			QList<QString>()
-						, false)
-		<< Function("Tabpage", "nvim_get_current_tabpage",
-			QList<QString>()
-						, false)
-		<< Function("void", "nvim_set_current_tabpage",
-			QList<QString>()
-						<< QString("Tabpage")
-						, false)
-		<< Function("Integer", "nvim_create_namespace",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Dictionary", "nvim_get_namespaces",
-			QList<QString>()
-						, false)
-		<< Function("void", "nvim_subscribe",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_unsubscribe",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Integer", "nvim_get_color_by_name",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Dictionary", "nvim_get_color_map",
-			QList<QString>()
-						, false)
-		<< Function("Dictionary", "nvim_get_mode",
-			QList<QString>()
-						, false)
-		<< Function("ArrayOf(Dictionary)", "nvim_get_keymap",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Dictionary", "nvim_get_commands",
-			QList<QString>()
-						<< QString("Dictionary")
-						, false)
-		<< Function("Array", "nvim_get_api_info",
-			QList<QString>()
-						, false)
-		<< Function("void", "nvim_set_client_info",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Dictionary")
-						<< QString("String")
-						<< QString("Dictionary")
-						<< QString("Dictionary")
-						, false)
-		<< Function("Dictionary", "nvim_get_chan_info",
-			QList<QString>()
-						<< QString("Integer")
-						, false)
-		<< Function("Array", "nvim_list_chans",
-			QList<QString>()
-						, false)
-		<< Function("Array", "nvim_call_atomic",
-			QList<QString>()
-						<< QString("Array")
-						, false)
-		<< Function("Dictionary", "nvim_parse_expression",
-			QList<QString>()
-						<< QString("String")
-						<< QString("String")
-						<< QString("Boolean")
-						, false)
-		<< Function("Array", "nvim_list_uis",
-			QList<QString>()
-						, false)
-		<< Function("Array", "nvim_get_proc_children",
-			QList<QString>()
-						<< QString("Integer")
-						, false)
-		<< Function("Object", "nvim_get_proc",
-			QList<QString>()
-						<< QString("Integer")
-						, false)
-		<< Function("Buffer", "nvim_win_get_buf",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("void", "nvim_win_set_buf",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("Buffer")
-						, false)
-		<< Function("ArrayOf(Integer, 2)", "nvim_win_get_cursor",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("void", "nvim_win_set_cursor",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("ArrayOf(Integer, 2)")
-						, false)
-		<< Function("Integer", "nvim_win_get_height",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("void", "nvim_win_set_height",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("Integer")
-						, false)
-		<< Function("Integer", "nvim_win_get_width",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("void", "nvim_win_set_width",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("Integer")
-						, false)
-		<< Function("Object", "nvim_win_get_var",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_win_set_var",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("void", "nvim_win_del_var",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						, false)
-		<< Function("Object", "window_set_var",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("Object", "window_del_var",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						, false)
-		<< Function("Object", "nvim_win_get_option",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_win_set_option",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("ArrayOf(Integer, 2)", "nvim_win_get_position",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("Tabpage", "nvim_win_get_tabpage",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("Integer", "nvim_win_get_number",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("Boolean", "nvim_win_is_valid",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("Integer", "buffer_line_count",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("ArrayOf(String)", "buffer_get_lines",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Boolean")
-						, false)
-		<< Function("void", "buffer_set_lines",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Boolean")
-						<< QString("ArrayOf(String)")
-						, false)
-		<< Function("Object", "buffer_get_var",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("Object", "buffer_get_option",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("void", "buffer_set_option",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("Integer", "buffer_get_number",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("String", "buffer_get_name",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("void", "buffer_set_name",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("Boolean", "buffer_is_valid",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("ArrayOf(Integer, 2)", "buffer_get_mark",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("Integer", "buffer_add_highlight",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("String")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Integer")
-						, false)
-		<< Function("void", "buffer_clear_highlight",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Integer")
-						, false)
-		<< Function("ArrayOf(Window)", "tabpage_get_windows",
-			QList<QString>()
-						<< QString("Tabpage")
-						, false)
-		<< Function("Object", "tabpage_get_var",
-			QList<QString>()
-						<< QString("Tabpage")
-						<< QString("String")
-						, false)
-		<< Function("Window", "tabpage_get_window",
-			QList<QString>()
-						<< QString("Tabpage")
-						, false)
-		<< Function("Boolean", "tabpage_is_valid",
-			QList<QString>()
-						<< QString("Tabpage")
-						, false)
-		<< Function("void", "ui_detach",
-			QList<QString>()
-						, false)
-		<< Function("Object", "ui_try_resize",
-			QList<QString>()
-						<< QString("Integer")
-						<< QString("Integer")
-						, false)
-		<< Function("void", "vim_command",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "vim_feedkeys",
-			QList<QString>()
-						<< QString("String")
-						<< QString("String")
-						<< QString("Boolean")
-						, false)
-		<< Function("Integer", "vim_input",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("String", "vim_replace_termcodes",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Boolean")
-						<< QString("Boolean")
-						<< QString("Boolean")
-						, false)
-		<< Function("String", "vim_command_output",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Object", "vim_eval",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Object", "vim_call_function",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Array")
-						, false)
-		<< Function("Integer", "vim_strwidth",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("ArrayOf(String)", "vim_list_runtime_paths",
-			QList<QString>()
-						, false)
-		<< Function("void", "vim_change_directory",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("String", "vim_get_current_line",
-			QList<QString>()
-						, false)
-		<< Function("void", "vim_set_current_line",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "vim_del_current_line",
-			QList<QString>()
-						, false)
-		<< Function("Object", "vim_get_var",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Object", "vim_get_vvar",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Object", "vim_get_option",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "vim_set_option",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("void", "vim_out_write",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "vim_err_write",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "vim_report_error",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("ArrayOf(Buffer)", "vim_get_buffers",
-			QList<QString>()
-						, false)
-		<< Function("Buffer", "vim_get_current_buffer",
-			QList<QString>()
-						, false)
-		<< Function("void", "vim_set_current_buffer",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("ArrayOf(Window)", "vim_get_windows",
-			QList<QString>()
-						, false)
-		<< Function("Window", "vim_get_current_window",
-			QList<QString>()
-						, false)
-		<< Function("void", "vim_set_current_window",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("ArrayOf(Tabpage)", "vim_get_tabpages",
-			QList<QString>()
-						, false)
-		<< Function("Tabpage", "vim_get_current_tabpage",
-			QList<QString>()
-						, false)
-		<< Function("void", "vim_set_current_tabpage",
-			QList<QString>()
-						<< QString("Tabpage")
-						, false)
-		<< Function("void", "vim_subscribe",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "vim_unsubscribe",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Integer", "vim_name_to_color",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Dictionary", "vim_get_color_map",
-			QList<QString>()
-						, false)
-		<< Function("Buffer", "window_get_buffer",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("ArrayOf(Integer, 2)", "window_get_cursor",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("void", "window_set_cursor",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("ArrayOf(Integer, 2)")
-						, false)
-		<< Function("Integer", "window_get_height",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("void", "window_set_height",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("Integer")
-						, false)
-		<< Function("Integer", "window_get_width",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("void", "window_set_width",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("Integer")
-						, false)
-		<< Function("Object", "window_get_var",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						, false)
-		<< Function("Object", "window_get_option",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						, false)
-		<< Function("void", "window_set_option",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("ArrayOf(Integer, 2)", "window_get_position",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("Tabpage", "window_get_tabpage",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("Boolean", "window_is_valid",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		;
-
+	static const QList<Function> required{
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_buf_line_count"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("String"),
+				QStringLiteral("buffer_get_line"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Boolean"),
+				QStringLiteral("nvim_buf_attach"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("Dictionary"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Boolean"),
+				QStringLiteral("nvim_buf_detach"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("buffer_set_line"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("buffer_del_line"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(String)"),
+				QStringLiteral("buffer_get_line_slice"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(String)"),
+				QStringLiteral("nvim_buf_get_lines"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("buffer_set_line_slice"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("ArrayOf(String)"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_buf_set_lines"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("ArrayOf(String)"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_buf_get_offset"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_buf_get_var"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_buf_get_changedtick"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Dictionary)"),
+				QStringLiteral("nvim_buf_get_keymap"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Dictionary"),
+				QStringLiteral("nvim_buf_get_commands"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Dictionary"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_buf_set_var"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_buf_del_var"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("buffer_set_var"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("buffer_del_var"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_buf_get_option"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_buf_set_option"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_buf_get_number"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("String"),
+				QStringLiteral("nvim_buf_get_name"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_buf_set_name"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Boolean"),
+				QStringLiteral("nvim_buf_is_loaded"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Boolean"),
+				QStringLiteral("nvim_buf_is_valid"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("buffer_insert"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("ArrayOf(String)"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Integer, 2)"),
+				QStringLiteral("nvim_buf_get_mark"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_buf_add_highlight"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("String"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_buf_clear_namespace"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_buf_clear_highlight"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_buf_set_virtual_text"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Array"),
+					QStringLiteral("Dictionary"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Window)"),
+				QStringLiteral("nvim_tabpage_list_wins"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_tabpage_get_var"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_tabpage_set_var"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_tabpage_del_var"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("tabpage_set_var"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("tabpage_del_var"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Window"),
+				QStringLiteral("nvim_tabpage_get_win"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_tabpage_get_number"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Boolean"),
+				QStringLiteral("nvim_tabpage_is_valid"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_ui_attach"),
+				QStringList{
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Dictionary"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("ui_attach"),
+				QStringList{
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_ui_detach"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_ui_try_resize"),
+				QStringList{
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_ui_set_option"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_command"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Dictionary"),
+				QStringLiteral("nvim_get_hl_by_name"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Dictionary"),
+				QStringLiteral("nvim_get_hl_by_id"),
+				QStringList{
+					QStringLiteral("Integer"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_feedkeys"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("String"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_input"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("String"),
+				QStringLiteral("nvim_replace_termcodes"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("String"),
+				QStringLiteral("nvim_command_output"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_eval"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_execute_lua"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Array"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_call_function"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Array"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_call_dict_function"),
+				QStringList{
+					QStringLiteral("Object"),
+					QStringLiteral("String"),
+					QStringLiteral("Array"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_strwidth"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(String)"),
+				QStringLiteral("nvim_list_runtime_paths"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_set_current_dir"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("String"),
+				QStringLiteral("nvim_get_current_line"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_set_current_line"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_del_current_line"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_get_var"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_set_var"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_del_var"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("vim_set_var"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("vim_del_var"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_get_vvar"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_get_option"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_set_option"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_out_write"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_err_write"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_err_writeln"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Buffer)"),
+				QStringLiteral("nvim_list_bufs"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Buffer"),
+				QStringLiteral("nvim_get_current_buf"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_set_current_buf"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Window)"),
+				QStringLiteral("nvim_list_wins"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Window"),
+				QStringLiteral("nvim_get_current_win"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_set_current_win"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Tabpage)"),
+				QStringLiteral("nvim_list_tabpages"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Tabpage"),
+				QStringLiteral("nvim_get_current_tabpage"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_set_current_tabpage"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_create_namespace"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Dictionary"),
+				QStringLiteral("nvim_get_namespaces"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_subscribe"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_unsubscribe"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_get_color_by_name"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Dictionary"),
+				QStringLiteral("nvim_get_color_map"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Dictionary"),
+				QStringLiteral("nvim_get_mode"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Dictionary)"),
+				QStringLiteral("nvim_get_keymap"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Dictionary"),
+				QStringLiteral("nvim_get_commands"),
+				QStringList{
+					QStringLiteral("Dictionary"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Array"),
+				QStringLiteral("nvim_get_api_info"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_set_client_info"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Dictionary"),
+					QStringLiteral("String"),
+					QStringLiteral("Dictionary"),
+					QStringLiteral("Dictionary"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Dictionary"),
+				QStringLiteral("nvim_get_chan_info"),
+				QStringList{
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Array"),
+				QStringLiteral("nvim_list_chans"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Array"),
+				QStringLiteral("nvim_call_atomic"),
+				QStringList{
+					QStringLiteral("Array"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Dictionary"),
+				QStringLiteral("nvim_parse_expression"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("String"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Array"),
+				QStringLiteral("nvim_list_uis"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Array"),
+				QStringLiteral("nvim_get_proc_children"),
+				QStringList{
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_get_proc"),
+				QStringList{
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Buffer"),
+				QStringLiteral("nvim_win_get_buf"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_win_set_buf"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Integer, 2)"),
+				QStringLiteral("nvim_win_get_cursor"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_win_set_cursor"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("ArrayOf(Integer, 2)"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_win_get_height"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_win_set_height"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_win_get_width"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_win_set_width"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_win_get_var"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_win_set_var"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_win_del_var"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("window_set_var"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("window_del_var"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_win_get_option"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_win_set_option"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Integer, 2)"),
+				QStringLiteral("nvim_win_get_position"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Tabpage"),
+				QStringLiteral("nvim_win_get_tabpage"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_win_get_number"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Boolean"),
+				QStringLiteral("nvim_win_is_valid"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("buffer_line_count"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(String)"),
+				QStringLiteral("buffer_get_lines"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("buffer_set_lines"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("ArrayOf(String)"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("buffer_get_var"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("buffer_get_option"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("buffer_set_option"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("buffer_get_number"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("String"),
+				QStringLiteral("buffer_get_name"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("buffer_set_name"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Boolean"),
+				QStringLiteral("buffer_is_valid"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Integer, 2)"),
+				QStringLiteral("buffer_get_mark"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("buffer_add_highlight"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("String"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("buffer_clear_highlight"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Window)"),
+				QStringLiteral("tabpage_get_windows"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("tabpage_get_var"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Window"),
+				QStringLiteral("tabpage_get_window"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Boolean"),
+				QStringLiteral("tabpage_is_valid"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("ui_detach"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("ui_try_resize"),
+				QStringList{
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_command"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_feedkeys"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("String"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("vim_input"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("String"),
+				QStringLiteral("vim_replace_termcodes"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("String"),
+				QStringLiteral("vim_command_output"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("vim_eval"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("vim_call_function"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Array"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("vim_strwidth"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(String)"),
+				QStringLiteral("vim_list_runtime_paths"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_change_directory"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("String"),
+				QStringLiteral("vim_get_current_line"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_set_current_line"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_del_current_line"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("vim_get_var"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("vim_get_vvar"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("vim_get_option"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_set_option"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_out_write"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_err_write"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_report_error"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Buffer)"),
+				QStringLiteral("vim_get_buffers"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Buffer"),
+				QStringLiteral("vim_get_current_buffer"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_set_current_buffer"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Window)"),
+				QStringLiteral("vim_get_windows"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Window"),
+				QStringLiteral("vim_get_current_window"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_set_current_window"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Tabpage)"),
+				QStringLiteral("vim_get_tabpages"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Tabpage"),
+				QStringLiteral("vim_get_current_tabpage"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_set_current_tabpage"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_subscribe"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_unsubscribe"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("vim_name_to_color"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Dictionary"),
+				QStringLiteral("vim_get_color_map"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Buffer"),
+				QStringLiteral("window_get_buffer"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Integer, 2)"),
+				QStringLiteral("window_get_cursor"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("window_set_cursor"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("ArrayOf(Integer, 2)"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("window_get_height"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("window_set_height"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("window_get_width"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("window_set_width"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("window_get_var"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("window_get_option"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("window_set_option"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Integer, 2)"),
+				QStringLiteral("window_get_position"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Tabpage"),
+				QStringLiteral("window_get_tabpage"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Boolean"),
+				QStringLiteral("window_is_valid"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+		};
 
 	QList<Function> supported;
-	foreach(const QVariant& val, ftable) {
+	supported.reserve(ftable.size());
+	for(const auto& val : ftable) {
 		auto f = Function::fromVariant(val);
 		if (!f.isValid()) {
 			qDebug() << "Invalid function in metadata" << f;
@@ -5123,7 +5869,7 @@ bool NeovimApi5::checkFunctions(const QVariantList& ftable)
 	}
 
 	bool ok = true;
-	foreach(const Function& f, required) {
+	for(const auto& f : required) {
 		if (!supported.contains(f)) {
 			qDebug() << "- instance DOES NOT support API5:" << f;
 			ok = false;

--- a/src/auto/neovimapi5.h
+++ b/src/auto/neovimapi5.h
@@ -1,4 +1,4 @@
-// Auto generated 2020-09-09 13:30:54.346353 from nvim API level:5
+// Auto generated 2020-09-09 15:16:43.000090 from nvim API level:5
 #pragma once
 
 #include <QObject>

--- a/src/auto/neovimapi5.h
+++ b/src/auto/neovimapi5.h
@@ -1,676 +1,788 @@
-// Auto generated 2019-06-08 16:53:42.519531 from nvim API level:5
-#ifndef NEOVIM_QT_NEOVIMAPI5
-#define NEOVIM_QT_NEOVIMAPI5
-#include "msgpack.h"
+// Auto generated 2020-09-09 13:30:54.346353 from nvim API level:5
+#pragma once
+
 #include <QObject>
-#include <QVariant>
 #include <QPoint>
+#include <QVariant>
+
 #include "function.h"
+#include "msgpack.h"
 
 namespace NeovimQt {
+
 class NeovimConnector;
 class MsgpackRequest;
 
-class NeovimApi5: public QObject
+class NeovimApi5 : public QObject
 {
 	Q_OBJECT
-	Q_ENUMS(FunctionId)
 
 public:
-
 	enum FunctionId {
-		NEOVIM_FN_NULL=0,
-				NEOVIM_FN_NVIM_BUF_LINE_COUNT,
-				NEOVIM_FN_BUFFER_GET_LINE,
-				NEOVIM_FN_NVIM_BUF_ATTACH,
-				NEOVIM_FN_NVIM_BUF_DETACH,
-				NEOVIM_FN_BUFFER_SET_LINE,
-				NEOVIM_FN_BUFFER_DEL_LINE,
-				NEOVIM_FN_BUFFER_GET_LINE_SLICE,
-				NEOVIM_FN_NVIM_BUF_GET_LINES,
-				NEOVIM_FN_BUFFER_SET_LINE_SLICE,
-				NEOVIM_FN_NVIM_BUF_SET_LINES,
-				NEOVIM_FN_NVIM_BUF_GET_OFFSET,
-				NEOVIM_FN_NVIM_BUF_GET_VAR,
-				NEOVIM_FN_NVIM_BUF_GET_CHANGEDTICK,
-				NEOVIM_FN_NVIM_BUF_GET_KEYMAP,
-				NEOVIM_FN_NVIM_BUF_GET_COMMANDS,
-				NEOVIM_FN_NVIM_BUF_SET_VAR,
-				NEOVIM_FN_NVIM_BUF_DEL_VAR,
-				NEOVIM_FN_BUFFER_SET_VAR,
-				NEOVIM_FN_BUFFER_DEL_VAR,
-				NEOVIM_FN_NVIM_BUF_GET_OPTION,
-				NEOVIM_FN_NVIM_BUF_SET_OPTION,
-				NEOVIM_FN_NVIM_BUF_GET_NUMBER,
-				NEOVIM_FN_NVIM_BUF_GET_NAME,
-				NEOVIM_FN_NVIM_BUF_SET_NAME,
-				NEOVIM_FN_NVIM_BUF_IS_LOADED,
-				NEOVIM_FN_NVIM_BUF_IS_VALID,
-				NEOVIM_FN_BUFFER_INSERT,
-				NEOVIM_FN_NVIM_BUF_GET_MARK,
-				NEOVIM_FN_NVIM_BUF_ADD_HIGHLIGHT,
-				NEOVIM_FN_NVIM_BUF_CLEAR_NAMESPACE,
-				NEOVIM_FN_NVIM_BUF_CLEAR_HIGHLIGHT,
-				NEOVIM_FN_NVIM_BUF_SET_VIRTUAL_TEXT,
-				NEOVIM_FN_NVIM_TABPAGE_LIST_WINS,
-				NEOVIM_FN_NVIM_TABPAGE_GET_VAR,
-				NEOVIM_FN_NVIM_TABPAGE_SET_VAR,
-				NEOVIM_FN_NVIM_TABPAGE_DEL_VAR,
-				NEOVIM_FN_TABPAGE_SET_VAR,
-				NEOVIM_FN_TABPAGE_DEL_VAR,
-				NEOVIM_FN_NVIM_TABPAGE_GET_WIN,
-				NEOVIM_FN_NVIM_TABPAGE_GET_NUMBER,
-				NEOVIM_FN_NVIM_TABPAGE_IS_VALID,
-				NEOVIM_FN_NVIM_UI_ATTACH,
-				NEOVIM_FN_UI_ATTACH,
-				NEOVIM_FN_NVIM_UI_DETACH,
-				NEOVIM_FN_NVIM_UI_TRY_RESIZE,
-				NEOVIM_FN_NVIM_UI_SET_OPTION,
-				NEOVIM_FN_NVIM_COMMAND,
-				NEOVIM_FN_NVIM_GET_HL_BY_NAME,
-				NEOVIM_FN_NVIM_GET_HL_BY_ID,
-				NEOVIM_FN_NVIM_FEEDKEYS,
-				NEOVIM_FN_NVIM_INPUT,
-				NEOVIM_FN_NVIM_REPLACE_TERMCODES,
-				NEOVIM_FN_NVIM_COMMAND_OUTPUT,
-				NEOVIM_FN_NVIM_EVAL,
-				NEOVIM_FN_NVIM_EXECUTE_LUA,
-				NEOVIM_FN_NVIM_CALL_FUNCTION,
-				NEOVIM_FN_NVIM_CALL_DICT_FUNCTION,
-				NEOVIM_FN_NVIM_STRWIDTH,
-				NEOVIM_FN_NVIM_LIST_RUNTIME_PATHS,
-				NEOVIM_FN_NVIM_SET_CURRENT_DIR,
-				NEOVIM_FN_NVIM_GET_CURRENT_LINE,
-				NEOVIM_FN_NVIM_SET_CURRENT_LINE,
-				NEOVIM_FN_NVIM_DEL_CURRENT_LINE,
-				NEOVIM_FN_NVIM_GET_VAR,
-				NEOVIM_FN_NVIM_SET_VAR,
-				NEOVIM_FN_NVIM_DEL_VAR,
-				NEOVIM_FN_VIM_SET_VAR,
-				NEOVIM_FN_VIM_DEL_VAR,
-				NEOVIM_FN_NVIM_GET_VVAR,
-				NEOVIM_FN_NVIM_GET_OPTION,
-				NEOVIM_FN_NVIM_SET_OPTION,
-				NEOVIM_FN_NVIM_OUT_WRITE,
-				NEOVIM_FN_NVIM_ERR_WRITE,
-				NEOVIM_FN_NVIM_ERR_WRITELN,
-				NEOVIM_FN_NVIM_LIST_BUFS,
-				NEOVIM_FN_NVIM_GET_CURRENT_BUF,
-				NEOVIM_FN_NVIM_SET_CURRENT_BUF,
-				NEOVIM_FN_NVIM_LIST_WINS,
-				NEOVIM_FN_NVIM_GET_CURRENT_WIN,
-				NEOVIM_FN_NVIM_SET_CURRENT_WIN,
-				NEOVIM_FN_NVIM_LIST_TABPAGES,
-				NEOVIM_FN_NVIM_GET_CURRENT_TABPAGE,
-				NEOVIM_FN_NVIM_SET_CURRENT_TABPAGE,
-				NEOVIM_FN_NVIM_CREATE_NAMESPACE,
-				NEOVIM_FN_NVIM_GET_NAMESPACES,
-				NEOVIM_FN_NVIM_SUBSCRIBE,
-				NEOVIM_FN_NVIM_UNSUBSCRIBE,
-				NEOVIM_FN_NVIM_GET_COLOR_BY_NAME,
-				NEOVIM_FN_NVIM_GET_COLOR_MAP,
-				NEOVIM_FN_NVIM_GET_MODE,
-				NEOVIM_FN_NVIM_GET_KEYMAP,
-				NEOVIM_FN_NVIM_GET_COMMANDS,
-				NEOVIM_FN_NVIM_GET_API_INFO,
-				NEOVIM_FN_NVIM_SET_CLIENT_INFO,
-				NEOVIM_FN_NVIM_GET_CHAN_INFO,
-				NEOVIM_FN_NVIM_LIST_CHANS,
-				NEOVIM_FN_NVIM_CALL_ATOMIC,
-				NEOVIM_FN_NVIM_PARSE_EXPRESSION,
-				NEOVIM_FN_NVIM_LIST_UIS,
-				NEOVIM_FN_NVIM_GET_PROC_CHILDREN,
-				NEOVIM_FN_NVIM_GET_PROC,
-				NEOVIM_FN_NVIM_WIN_GET_BUF,
-				NEOVIM_FN_NVIM_WIN_SET_BUF,
-				NEOVIM_FN_NVIM_WIN_GET_CURSOR,
-				NEOVIM_FN_NVIM_WIN_SET_CURSOR,
-				NEOVIM_FN_NVIM_WIN_GET_HEIGHT,
-				NEOVIM_FN_NVIM_WIN_SET_HEIGHT,
-				NEOVIM_FN_NVIM_WIN_GET_WIDTH,
-				NEOVIM_FN_NVIM_WIN_SET_WIDTH,
-				NEOVIM_FN_NVIM_WIN_GET_VAR,
-				NEOVIM_FN_NVIM_WIN_SET_VAR,
-				NEOVIM_FN_NVIM_WIN_DEL_VAR,
-				NEOVIM_FN_WINDOW_SET_VAR,
-				NEOVIM_FN_WINDOW_DEL_VAR,
-				NEOVIM_FN_NVIM_WIN_GET_OPTION,
-				NEOVIM_FN_NVIM_WIN_SET_OPTION,
-				NEOVIM_FN_NVIM_WIN_GET_POSITION,
-				NEOVIM_FN_NVIM_WIN_GET_TABPAGE,
-				NEOVIM_FN_NVIM_WIN_GET_NUMBER,
-				NEOVIM_FN_NVIM_WIN_IS_VALID,
-				NEOVIM_FN_BUFFER_LINE_COUNT,
-				NEOVIM_FN_BUFFER_GET_LINES,
-				NEOVIM_FN_BUFFER_SET_LINES,
-				NEOVIM_FN_BUFFER_GET_VAR,
-				NEOVIM_FN_BUFFER_GET_OPTION,
-				NEOVIM_FN_BUFFER_SET_OPTION,
-				NEOVIM_FN_BUFFER_GET_NUMBER,
-				NEOVIM_FN_BUFFER_GET_NAME,
-				NEOVIM_FN_BUFFER_SET_NAME,
-				NEOVIM_FN_BUFFER_IS_VALID,
-				NEOVIM_FN_BUFFER_GET_MARK,
-				NEOVIM_FN_BUFFER_ADD_HIGHLIGHT,
-				NEOVIM_FN_BUFFER_CLEAR_HIGHLIGHT,
-				NEOVIM_FN_TABPAGE_GET_WINDOWS,
-				NEOVIM_FN_TABPAGE_GET_VAR,
-				NEOVIM_FN_TABPAGE_GET_WINDOW,
-				NEOVIM_FN_TABPAGE_IS_VALID,
-				NEOVIM_FN_UI_DETACH,
-				NEOVIM_FN_UI_TRY_RESIZE,
-				NEOVIM_FN_VIM_COMMAND,
-				NEOVIM_FN_VIM_FEEDKEYS,
-				NEOVIM_FN_VIM_INPUT,
-				NEOVIM_FN_VIM_REPLACE_TERMCODES,
-				NEOVIM_FN_VIM_COMMAND_OUTPUT,
-				NEOVIM_FN_VIM_EVAL,
-				NEOVIM_FN_VIM_CALL_FUNCTION,
-				NEOVIM_FN_VIM_STRWIDTH,
-				NEOVIM_FN_VIM_LIST_RUNTIME_PATHS,
-				NEOVIM_FN_VIM_CHANGE_DIRECTORY,
-				NEOVIM_FN_VIM_GET_CURRENT_LINE,
-				NEOVIM_FN_VIM_SET_CURRENT_LINE,
-				NEOVIM_FN_VIM_DEL_CURRENT_LINE,
-				NEOVIM_FN_VIM_GET_VAR,
-				NEOVIM_FN_VIM_GET_VVAR,
-				NEOVIM_FN_VIM_GET_OPTION,
-				NEOVIM_FN_VIM_SET_OPTION,
-				NEOVIM_FN_VIM_OUT_WRITE,
-				NEOVIM_FN_VIM_ERR_WRITE,
-				NEOVIM_FN_VIM_REPORT_ERROR,
-				NEOVIM_FN_VIM_GET_BUFFERS,
-				NEOVIM_FN_VIM_GET_CURRENT_BUFFER,
-				NEOVIM_FN_VIM_SET_CURRENT_BUFFER,
-				NEOVIM_FN_VIM_GET_WINDOWS,
-				NEOVIM_FN_VIM_GET_CURRENT_WINDOW,
-				NEOVIM_FN_VIM_SET_CURRENT_WINDOW,
-				NEOVIM_FN_VIM_GET_TABPAGES,
-				NEOVIM_FN_VIM_GET_CURRENT_TABPAGE,
-				NEOVIM_FN_VIM_SET_CURRENT_TABPAGE,
-				NEOVIM_FN_VIM_SUBSCRIBE,
-				NEOVIM_FN_VIM_UNSUBSCRIBE,
-				NEOVIM_FN_VIM_NAME_TO_COLOR,
-				NEOVIM_FN_VIM_GET_COLOR_MAP,
-				NEOVIM_FN_WINDOW_GET_BUFFER,
-				NEOVIM_FN_WINDOW_GET_CURSOR,
-				NEOVIM_FN_WINDOW_SET_CURSOR,
-				NEOVIM_FN_WINDOW_GET_HEIGHT,
-				NEOVIM_FN_WINDOW_SET_HEIGHT,
-				NEOVIM_FN_WINDOW_GET_WIDTH,
-				NEOVIM_FN_WINDOW_SET_WIDTH,
-				NEOVIM_FN_WINDOW_GET_VAR,
-				NEOVIM_FN_WINDOW_GET_OPTION,
-				NEOVIM_FN_WINDOW_SET_OPTION,
-				NEOVIM_FN_WINDOW_GET_POSITION,
-				NEOVIM_FN_WINDOW_GET_TABPAGE,
-				NEOVIM_FN_WINDOW_IS_VALID,
+		NEOVIM_FN_NULL,
+		NEOVIM_FN_NVIM_BUF_LINE_COUNT,
+		NEOVIM_FN_BUFFER_GET_LINE,
+		NEOVIM_FN_NVIM_BUF_ATTACH,
+		NEOVIM_FN_NVIM_BUF_DETACH,
+		NEOVIM_FN_BUFFER_SET_LINE,
+		NEOVIM_FN_BUFFER_DEL_LINE,
+		NEOVIM_FN_BUFFER_GET_LINE_SLICE,
+		NEOVIM_FN_NVIM_BUF_GET_LINES,
+		NEOVIM_FN_BUFFER_SET_LINE_SLICE,
+		NEOVIM_FN_NVIM_BUF_SET_LINES,
+		NEOVIM_FN_NVIM_BUF_GET_OFFSET,
+		NEOVIM_FN_NVIM_BUF_GET_VAR,
+		NEOVIM_FN_NVIM_BUF_GET_CHANGEDTICK,
+		NEOVIM_FN_NVIM_BUF_GET_KEYMAP,
+		NEOVIM_FN_NVIM_BUF_GET_COMMANDS,
+		NEOVIM_FN_NVIM_BUF_SET_VAR,
+		NEOVIM_FN_NVIM_BUF_DEL_VAR,
+		NEOVIM_FN_BUFFER_SET_VAR,
+		NEOVIM_FN_BUFFER_DEL_VAR,
+		NEOVIM_FN_NVIM_BUF_GET_OPTION,
+		NEOVIM_FN_NVIM_BUF_SET_OPTION,
+		NEOVIM_FN_NVIM_BUF_GET_NUMBER,
+		NEOVIM_FN_NVIM_BUF_GET_NAME,
+		NEOVIM_FN_NVIM_BUF_SET_NAME,
+		NEOVIM_FN_NVIM_BUF_IS_LOADED,
+		NEOVIM_FN_NVIM_BUF_IS_VALID,
+		NEOVIM_FN_BUFFER_INSERT,
+		NEOVIM_FN_NVIM_BUF_GET_MARK,
+		NEOVIM_FN_NVIM_BUF_ADD_HIGHLIGHT,
+		NEOVIM_FN_NVIM_BUF_CLEAR_NAMESPACE,
+		NEOVIM_FN_NVIM_BUF_CLEAR_HIGHLIGHT,
+		NEOVIM_FN_NVIM_BUF_SET_VIRTUAL_TEXT,
+		NEOVIM_FN_NVIM_TABPAGE_LIST_WINS,
+		NEOVIM_FN_NVIM_TABPAGE_GET_VAR,
+		NEOVIM_FN_NVIM_TABPAGE_SET_VAR,
+		NEOVIM_FN_NVIM_TABPAGE_DEL_VAR,
+		NEOVIM_FN_TABPAGE_SET_VAR,
+		NEOVIM_FN_TABPAGE_DEL_VAR,
+		NEOVIM_FN_NVIM_TABPAGE_GET_WIN,
+		NEOVIM_FN_NVIM_TABPAGE_GET_NUMBER,
+		NEOVIM_FN_NVIM_TABPAGE_IS_VALID,
+		NEOVIM_FN_NVIM_UI_ATTACH,
+		NEOVIM_FN_UI_ATTACH,
+		NEOVIM_FN_NVIM_UI_DETACH,
+		NEOVIM_FN_NVIM_UI_TRY_RESIZE,
+		NEOVIM_FN_NVIM_UI_SET_OPTION,
+		NEOVIM_FN_NVIM_COMMAND,
+		NEOVIM_FN_NVIM_GET_HL_BY_NAME,
+		NEOVIM_FN_NVIM_GET_HL_BY_ID,
+		NEOVIM_FN_NVIM_FEEDKEYS,
+		NEOVIM_FN_NVIM_INPUT,
+		NEOVIM_FN_NVIM_REPLACE_TERMCODES,
+		NEOVIM_FN_NVIM_COMMAND_OUTPUT,
+		NEOVIM_FN_NVIM_EVAL,
+		NEOVIM_FN_NVIM_EXECUTE_LUA,
+		NEOVIM_FN_NVIM_CALL_FUNCTION,
+		NEOVIM_FN_NVIM_CALL_DICT_FUNCTION,
+		NEOVIM_FN_NVIM_STRWIDTH,
+		NEOVIM_FN_NVIM_LIST_RUNTIME_PATHS,
+		NEOVIM_FN_NVIM_SET_CURRENT_DIR,
+		NEOVIM_FN_NVIM_GET_CURRENT_LINE,
+		NEOVIM_FN_NVIM_SET_CURRENT_LINE,
+		NEOVIM_FN_NVIM_DEL_CURRENT_LINE,
+		NEOVIM_FN_NVIM_GET_VAR,
+		NEOVIM_FN_NVIM_SET_VAR,
+		NEOVIM_FN_NVIM_DEL_VAR,
+		NEOVIM_FN_VIM_SET_VAR,
+		NEOVIM_FN_VIM_DEL_VAR,
+		NEOVIM_FN_NVIM_GET_VVAR,
+		NEOVIM_FN_NVIM_GET_OPTION,
+		NEOVIM_FN_NVIM_SET_OPTION,
+		NEOVIM_FN_NVIM_OUT_WRITE,
+		NEOVIM_FN_NVIM_ERR_WRITE,
+		NEOVIM_FN_NVIM_ERR_WRITELN,
+		NEOVIM_FN_NVIM_LIST_BUFS,
+		NEOVIM_FN_NVIM_GET_CURRENT_BUF,
+		NEOVIM_FN_NVIM_SET_CURRENT_BUF,
+		NEOVIM_FN_NVIM_LIST_WINS,
+		NEOVIM_FN_NVIM_GET_CURRENT_WIN,
+		NEOVIM_FN_NVIM_SET_CURRENT_WIN,
+		NEOVIM_FN_NVIM_LIST_TABPAGES,
+		NEOVIM_FN_NVIM_GET_CURRENT_TABPAGE,
+		NEOVIM_FN_NVIM_SET_CURRENT_TABPAGE,
+		NEOVIM_FN_NVIM_CREATE_NAMESPACE,
+		NEOVIM_FN_NVIM_GET_NAMESPACES,
+		NEOVIM_FN_NVIM_SUBSCRIBE,
+		NEOVIM_FN_NVIM_UNSUBSCRIBE,
+		NEOVIM_FN_NVIM_GET_COLOR_BY_NAME,
+		NEOVIM_FN_NVIM_GET_COLOR_MAP,
+		NEOVIM_FN_NVIM_GET_MODE,
+		NEOVIM_FN_NVIM_GET_KEYMAP,
+		NEOVIM_FN_NVIM_GET_COMMANDS,
+		NEOVIM_FN_NVIM_GET_API_INFO,
+		NEOVIM_FN_NVIM_SET_CLIENT_INFO,
+		NEOVIM_FN_NVIM_GET_CHAN_INFO,
+		NEOVIM_FN_NVIM_LIST_CHANS,
+		NEOVIM_FN_NVIM_CALL_ATOMIC,
+		NEOVIM_FN_NVIM_PARSE_EXPRESSION,
+		NEOVIM_FN_NVIM_LIST_UIS,
+		NEOVIM_FN_NVIM_GET_PROC_CHILDREN,
+		NEOVIM_FN_NVIM_GET_PROC,
+		NEOVIM_FN_NVIM_WIN_GET_BUF,
+		NEOVIM_FN_NVIM_WIN_SET_BUF,
+		NEOVIM_FN_NVIM_WIN_GET_CURSOR,
+		NEOVIM_FN_NVIM_WIN_SET_CURSOR,
+		NEOVIM_FN_NVIM_WIN_GET_HEIGHT,
+		NEOVIM_FN_NVIM_WIN_SET_HEIGHT,
+		NEOVIM_FN_NVIM_WIN_GET_WIDTH,
+		NEOVIM_FN_NVIM_WIN_SET_WIDTH,
+		NEOVIM_FN_NVIM_WIN_GET_VAR,
+		NEOVIM_FN_NVIM_WIN_SET_VAR,
+		NEOVIM_FN_NVIM_WIN_DEL_VAR,
+		NEOVIM_FN_WINDOW_SET_VAR,
+		NEOVIM_FN_WINDOW_DEL_VAR,
+		NEOVIM_FN_NVIM_WIN_GET_OPTION,
+		NEOVIM_FN_NVIM_WIN_SET_OPTION,
+		NEOVIM_FN_NVIM_WIN_GET_POSITION,
+		NEOVIM_FN_NVIM_WIN_GET_TABPAGE,
+		NEOVIM_FN_NVIM_WIN_GET_NUMBER,
+		NEOVIM_FN_NVIM_WIN_IS_VALID,
+		NEOVIM_FN_BUFFER_LINE_COUNT,
+		NEOVIM_FN_BUFFER_GET_LINES,
+		NEOVIM_FN_BUFFER_SET_LINES,
+		NEOVIM_FN_BUFFER_GET_VAR,
+		NEOVIM_FN_BUFFER_GET_OPTION,
+		NEOVIM_FN_BUFFER_SET_OPTION,
+		NEOVIM_FN_BUFFER_GET_NUMBER,
+		NEOVIM_FN_BUFFER_GET_NAME,
+		NEOVIM_FN_BUFFER_SET_NAME,
+		NEOVIM_FN_BUFFER_IS_VALID,
+		NEOVIM_FN_BUFFER_GET_MARK,
+		NEOVIM_FN_BUFFER_ADD_HIGHLIGHT,
+		NEOVIM_FN_BUFFER_CLEAR_HIGHLIGHT,
+		NEOVIM_FN_TABPAGE_GET_WINDOWS,
+		NEOVIM_FN_TABPAGE_GET_VAR,
+		NEOVIM_FN_TABPAGE_GET_WINDOW,
+		NEOVIM_FN_TABPAGE_IS_VALID,
+		NEOVIM_FN_UI_DETACH,
+		NEOVIM_FN_UI_TRY_RESIZE,
+		NEOVIM_FN_VIM_COMMAND,
+		NEOVIM_FN_VIM_FEEDKEYS,
+		NEOVIM_FN_VIM_INPUT,
+		NEOVIM_FN_VIM_REPLACE_TERMCODES,
+		NEOVIM_FN_VIM_COMMAND_OUTPUT,
+		NEOVIM_FN_VIM_EVAL,
+		NEOVIM_FN_VIM_CALL_FUNCTION,
+		NEOVIM_FN_VIM_STRWIDTH,
+		NEOVIM_FN_VIM_LIST_RUNTIME_PATHS,
+		NEOVIM_FN_VIM_CHANGE_DIRECTORY,
+		NEOVIM_FN_VIM_GET_CURRENT_LINE,
+		NEOVIM_FN_VIM_SET_CURRENT_LINE,
+		NEOVIM_FN_VIM_DEL_CURRENT_LINE,
+		NEOVIM_FN_VIM_GET_VAR,
+		NEOVIM_FN_VIM_GET_VVAR,
+		NEOVIM_FN_VIM_GET_OPTION,
+		NEOVIM_FN_VIM_SET_OPTION,
+		NEOVIM_FN_VIM_OUT_WRITE,
+		NEOVIM_FN_VIM_ERR_WRITE,
+		NEOVIM_FN_VIM_REPORT_ERROR,
+		NEOVIM_FN_VIM_GET_BUFFERS,
+		NEOVIM_FN_VIM_GET_CURRENT_BUFFER,
+		NEOVIM_FN_VIM_SET_CURRENT_BUFFER,
+		NEOVIM_FN_VIM_GET_WINDOWS,
+		NEOVIM_FN_VIM_GET_CURRENT_WINDOW,
+		NEOVIM_FN_VIM_SET_CURRENT_WINDOW,
+		NEOVIM_FN_VIM_GET_TABPAGES,
+		NEOVIM_FN_VIM_GET_CURRENT_TABPAGE,
+		NEOVIM_FN_VIM_SET_CURRENT_TABPAGE,
+		NEOVIM_FN_VIM_SUBSCRIBE,
+		NEOVIM_FN_VIM_UNSUBSCRIBE,
+		NEOVIM_FN_VIM_NAME_TO_COLOR,
+		NEOVIM_FN_VIM_GET_COLOR_MAP,
+		NEOVIM_FN_WINDOW_GET_BUFFER,
+		NEOVIM_FN_WINDOW_GET_CURSOR,
+		NEOVIM_FN_WINDOW_SET_CURSOR,
+		NEOVIM_FN_WINDOW_GET_HEIGHT,
+		NEOVIM_FN_WINDOW_SET_HEIGHT,
+		NEOVIM_FN_WINDOW_GET_WIDTH,
+		NEOVIM_FN_WINDOW_SET_WIDTH,
+		NEOVIM_FN_WINDOW_GET_VAR,
+		NEOVIM_FN_WINDOW_GET_OPTION,
+		NEOVIM_FN_WINDOW_SET_OPTION,
+		NEOVIM_FN_WINDOW_GET_POSITION,
+		NEOVIM_FN_WINDOW_GET_TABPAGE,
+		NEOVIM_FN_WINDOW_IS_VALID,
 			};
+	Q_ENUM(FunctionId)
 
-	static bool checkFunctions(const QVariantList& ftable);
-	static FunctionId functionId(const Function& f);
+	static bool checkFunctions(const QVariantList& ftable) noexcept;
 
-	NeovimApi5(NeovimConnector *);
+	static FunctionId functionId(const Function& f) noexcept;
+
+	NeovimApi5(NeovimConnector* c) noexcept;
+
 protected slots:
-	void handleResponse(quint32 id, quint64 fun, const QVariant&);
-	void handleResponseError(quint32 id, quint64 fun, const QVariant&);
+	void handleResponse(uint32_t id, uint64_t fun, const QVariant&);
+
+	void handleResponseError(uint32_t id, uint64_t fun, const QVariant&);
+
 signals:
 	void error(const QString& errmsg, const QVariant& errObj);
+
 	void neovimNotification(const QByteArray &name, const QVariantList& args);
+
 private:
-	NeovimConnector *m_c;
+	NeovimConnector* m_connector;
+
 public slots:
-	// Integer nvim_buf_line_count(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_line_count(int64_t buffer);
-	// DEPRECATED
-	// String buffer_get_line(Buffer buffer, Integer index, ) 
-	MsgpackRequest* buffer_get_line(int64_t buffer, int64_t index);
-	// Boolean nvim_buf_attach(Buffer buffer, Boolean send_buffer, Dictionary opts, ) 
-	MsgpackRequest* nvim_buf_attach(int64_t buffer, bool send_buffer, QVariantMap opts);
-	// Boolean nvim_buf_detach(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_detach(int64_t buffer);
-	// DEPRECATED
-	// void buffer_set_line(Buffer buffer, Integer index, String line, ) 
-	MsgpackRequest* buffer_set_line(int64_t buffer, int64_t index, QByteArray line);
-	// DEPRECATED
-	// void buffer_del_line(Buffer buffer, Integer index, ) 
-	MsgpackRequest* buffer_del_line(int64_t buffer, int64_t index);
-	// DEPRECATED
-	// ArrayOf(String) buffer_get_line_slice(Buffer buffer, Integer start, Integer end, Boolean include_start, Boolean include_end, ) 
-	MsgpackRequest* buffer_get_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end);
-	// ArrayOf(String) nvim_buf_get_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ) 
-	MsgpackRequest* nvim_buf_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing);
-	// DEPRECATED
-	// void buffer_set_line_slice(Buffer buffer, Integer start, Integer end, Boolean include_start, Boolean include_end, ArrayOf(String) replacement, ) 
-	MsgpackRequest* buffer_set_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end, QList<QByteArray> replacement);
-	// void nvim_buf_set_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ArrayOf(String) replacement, ) 
-	MsgpackRequest* nvim_buf_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement);
-	// Integer nvim_buf_get_offset(Buffer buffer, Integer index, ) 
-	MsgpackRequest* nvim_buf_get_offset(int64_t buffer, int64_t index);
-	// Object nvim_buf_get_var(Buffer buffer, String name, ) 
-	MsgpackRequest* nvim_buf_get_var(int64_t buffer, QByteArray name);
-	// Integer nvim_buf_get_changedtick(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_get_changedtick(int64_t buffer);
-	// ArrayOf(Dictionary) nvim_buf_get_keymap(Buffer buffer, String mode, ) 
-	MsgpackRequest* nvim_buf_get_keymap(int64_t buffer, QByteArray mode);
-	// Dictionary nvim_buf_get_commands(Buffer buffer, Dictionary opts, ) 
-	MsgpackRequest* nvim_buf_get_commands(int64_t buffer, QVariantMap opts);
-	// void nvim_buf_set_var(Buffer buffer, String name, Object value, ) 
-	MsgpackRequest* nvim_buf_set_var(int64_t buffer, QByteArray name, QVariant value);
-	// void nvim_buf_del_var(Buffer buffer, String name, ) 
-	MsgpackRequest* nvim_buf_del_var(int64_t buffer, QByteArray name);
-	// DEPRECATED
-	// Object buffer_set_var(Buffer buffer, String name, Object value, ) 
-	MsgpackRequest* buffer_set_var(int64_t buffer, QByteArray name, QVariant value);
-	// DEPRECATED
-	// Object buffer_del_var(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_del_var(int64_t buffer, QByteArray name);
-	// Object nvim_buf_get_option(Buffer buffer, String name, ) 
-	MsgpackRequest* nvim_buf_get_option(int64_t buffer, QByteArray name);
-	// void nvim_buf_set_option(Buffer buffer, String name, Object value, ) 
-	MsgpackRequest* nvim_buf_set_option(int64_t buffer, QByteArray name, QVariant value);
-	// DEPRECATED
-	// Integer nvim_buf_get_number(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_get_number(int64_t buffer);
-	// String nvim_buf_get_name(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_get_name(int64_t buffer);
-	// void nvim_buf_set_name(Buffer buffer, String name, ) 
-	MsgpackRequest* nvim_buf_set_name(int64_t buffer, QByteArray name);
-	// Boolean nvim_buf_is_loaded(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_is_loaded(int64_t buffer);
-	// Boolean nvim_buf_is_valid(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_is_valid(int64_t buffer);
-	// DEPRECATED
-	// void buffer_insert(Buffer buffer, Integer lnum, ArrayOf(String) lines, ) 
-	MsgpackRequest* buffer_insert(int64_t buffer, int64_t lnum, QList<QByteArray> lines);
-	// ArrayOf(Integer, 2) nvim_buf_get_mark(Buffer buffer, String name, ) 
-	MsgpackRequest* nvim_buf_get_mark(int64_t buffer, QByteArray name);
-	// Integer nvim_buf_add_highlight(Buffer buffer, Integer ns_id, String hl_group, Integer line, Integer col_start, Integer col_end, ) 
-	MsgpackRequest* nvim_buf_add_highlight(int64_t buffer, int64_t ns_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end);
-	// void nvim_buf_clear_namespace(Buffer buffer, Integer ns_id, Integer line_start, Integer line_end, ) 
-	MsgpackRequest* nvim_buf_clear_namespace(int64_t buffer, int64_t ns_id, int64_t line_start, int64_t line_end);
-	// void nvim_buf_clear_highlight(Buffer buffer, Integer ns_id, Integer line_start, Integer line_end, ) 
-	MsgpackRequest* nvim_buf_clear_highlight(int64_t buffer, int64_t ns_id, int64_t line_start, int64_t line_end);
-	// Integer nvim_buf_set_virtual_text(Buffer buffer, Integer ns_id, Integer line, Array chunks, Dictionary opts, ) 
-	MsgpackRequest* nvim_buf_set_virtual_text(int64_t buffer, int64_t ns_id, int64_t line, QVariantList chunks, QVariantMap opts);
-	// ArrayOf(Window) nvim_tabpage_list_wins(Tabpage tabpage, ) 
-	MsgpackRequest* nvim_tabpage_list_wins(int64_t tabpage);
-	// Object nvim_tabpage_get_var(Tabpage tabpage, String name, ) 
-	MsgpackRequest* nvim_tabpage_get_var(int64_t tabpage, QByteArray name);
-	// void nvim_tabpage_set_var(Tabpage tabpage, String name, Object value, ) 
-	MsgpackRequest* nvim_tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value);
-	// void nvim_tabpage_del_var(Tabpage tabpage, String name, ) 
-	MsgpackRequest* nvim_tabpage_del_var(int64_t tabpage, QByteArray name);
-	// DEPRECATED
-	// Object tabpage_set_var(Tabpage tabpage, String name, Object value, ) 
-	MsgpackRequest* tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value);
-	// DEPRECATED
-	// Object tabpage_del_var(Tabpage tabpage, String name, ) 
-	MsgpackRequest* tabpage_del_var(int64_t tabpage, QByteArray name);
-	// Window nvim_tabpage_get_win(Tabpage tabpage, ) 
-	MsgpackRequest* nvim_tabpage_get_win(int64_t tabpage);
-	// Integer nvim_tabpage_get_number(Tabpage tabpage, ) 
-	MsgpackRequest* nvim_tabpage_get_number(int64_t tabpage);
-	// Boolean nvim_tabpage_is_valid(Tabpage tabpage, ) 
-	MsgpackRequest* nvim_tabpage_is_valid(int64_t tabpage);
-	// void nvim_ui_attach(Integer width, Integer height, Dictionary options, ) 
-	MsgpackRequest* nvim_ui_attach(int64_t width, int64_t height, QVariantMap options);
-	// DEPRECATED
-	// void ui_attach(Integer width, Integer height, Boolean enable_rgb, ) 
-	MsgpackRequest* ui_attach(int64_t width, int64_t height, bool enable_rgb);
-	// void nvim_ui_detach() 
-	MsgpackRequest* nvim_ui_detach();
-	// void nvim_ui_try_resize(Integer width, Integer height, ) 
-	MsgpackRequest* nvim_ui_try_resize(int64_t width, int64_t height);
-	// void nvim_ui_set_option(String name, Object value, ) 
-	MsgpackRequest* nvim_ui_set_option(QByteArray name, QVariant value);
-	// void nvim_command(String command, ) 
-	MsgpackRequest* nvim_command(QByteArray command);
-	// Dictionary nvim_get_hl_by_name(String name, Boolean rgb, ) 
-	MsgpackRequest* nvim_get_hl_by_name(QByteArray name, bool rgb);
-	// Dictionary nvim_get_hl_by_id(Integer hl_id, Boolean rgb, ) 
-	MsgpackRequest* nvim_get_hl_by_id(int64_t hl_id, bool rgb);
-	// void nvim_feedkeys(String keys, String mode, Boolean escape_csi, ) 
-	MsgpackRequest* nvim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi);
-	// Integer nvim_input(String keys, ) 
-	MsgpackRequest* nvim_input(QByteArray keys);
-	// String nvim_replace_termcodes(String str, Boolean from_part, Boolean do_lt, Boolean special, ) 
-	MsgpackRequest* nvim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special);
-	// String nvim_command_output(String command, ) 
-	MsgpackRequest* nvim_command_output(QByteArray command);
-	// Object nvim_eval(String expr, ) 
-	MsgpackRequest* nvim_eval(QByteArray expr);
-	// Object nvim_execute_lua(String code, Array args, ) 
-	MsgpackRequest* nvim_execute_lua(QByteArray code, QVariantList args);
-	// Object nvim_call_function(String fn, Array args, ) 
-	MsgpackRequest* nvim_call_function(QByteArray fn, QVariantList args);
-	// Object nvim_call_dict_function(Object dict, String fn, Array args, ) 
-	MsgpackRequest* nvim_call_dict_function(QVariant dict, QByteArray fn, QVariantList args);
-	// Integer nvim_strwidth(String text, ) 
-	MsgpackRequest* nvim_strwidth(QByteArray text);
-	// ArrayOf(String) nvim_list_runtime_paths() 
-	MsgpackRequest* nvim_list_runtime_paths();
-	// void nvim_set_current_dir(String dir, ) 
-	MsgpackRequest* nvim_set_current_dir(QByteArray dir);
-	// String nvim_get_current_line() 
-	MsgpackRequest* nvim_get_current_line();
-	// void nvim_set_current_line(String line, ) 
-	MsgpackRequest* nvim_set_current_line(QByteArray line);
-	// void nvim_del_current_line() 
-	MsgpackRequest* nvim_del_current_line();
-	// Object nvim_get_var(String name, ) 
-	MsgpackRequest* nvim_get_var(QByteArray name);
-	// void nvim_set_var(String name, Object value, ) 
-	MsgpackRequest* nvim_set_var(QByteArray name, QVariant value);
-	// void nvim_del_var(String name, ) 
-	MsgpackRequest* nvim_del_var(QByteArray name);
-	// DEPRECATED
-	// Object vim_set_var(String name, Object value, ) 
-	MsgpackRequest* vim_set_var(QByteArray name, QVariant value);
-	// DEPRECATED
-	// Object vim_del_var(String name, ) 
-	MsgpackRequest* vim_del_var(QByteArray name);
-	// Object nvim_get_vvar(String name, ) 
-	MsgpackRequest* nvim_get_vvar(QByteArray name);
-	// Object nvim_get_option(String name, ) 
-	MsgpackRequest* nvim_get_option(QByteArray name);
-	// void nvim_set_option(String name, Object value, ) 
-	MsgpackRequest* nvim_set_option(QByteArray name, QVariant value);
-	// void nvim_out_write(String str, ) 
-	MsgpackRequest* nvim_out_write(QByteArray str);
-	// void nvim_err_write(String str, ) 
-	MsgpackRequest* nvim_err_write(QByteArray str);
-	// void nvim_err_writeln(String str, ) 
-	MsgpackRequest* nvim_err_writeln(QByteArray str);
-	// ArrayOf(Buffer) nvim_list_bufs() 
-	MsgpackRequest* nvim_list_bufs();
-	// Buffer nvim_get_current_buf() 
-	MsgpackRequest* nvim_get_current_buf();
-	// void nvim_set_current_buf(Buffer buffer, ) 
-	MsgpackRequest* nvim_set_current_buf(int64_t buffer);
-	// ArrayOf(Window) nvim_list_wins() 
-	MsgpackRequest* nvim_list_wins();
-	// Window nvim_get_current_win() 
-	MsgpackRequest* nvim_get_current_win();
-	// void nvim_set_current_win(Window window, ) 
-	MsgpackRequest* nvim_set_current_win(int64_t window);
-	// ArrayOf(Tabpage) nvim_list_tabpages() 
-	MsgpackRequest* nvim_list_tabpages();
-	// Tabpage nvim_get_current_tabpage() 
-	MsgpackRequest* nvim_get_current_tabpage();
-	// void nvim_set_current_tabpage(Tabpage tabpage, ) 
-	MsgpackRequest* nvim_set_current_tabpage(int64_t tabpage);
-	// Integer nvim_create_namespace(String name, ) 
-	MsgpackRequest* nvim_create_namespace(QByteArray name);
-	// Dictionary nvim_get_namespaces() 
-	MsgpackRequest* nvim_get_namespaces();
-	// void nvim_subscribe(String event, ) 
-	MsgpackRequest* nvim_subscribe(QByteArray event);
-	// void nvim_unsubscribe(String event, ) 
-	MsgpackRequest* nvim_unsubscribe(QByteArray event);
-	// Integer nvim_get_color_by_name(String name, ) 
-	MsgpackRequest* nvim_get_color_by_name(QByteArray name);
-	// Dictionary nvim_get_color_map() 
-	MsgpackRequest* nvim_get_color_map();
-	// Dictionary nvim_get_mode() 
-	MsgpackRequest* nvim_get_mode();
-	// ArrayOf(Dictionary) nvim_get_keymap(String mode, ) 
-	MsgpackRequest* nvim_get_keymap(QByteArray mode);
-	// Dictionary nvim_get_commands(Dictionary opts, ) 
-	MsgpackRequest* nvim_get_commands(QVariantMap opts);
-	// Array nvim_get_api_info() 
-	MsgpackRequest* nvim_get_api_info();
-	// void nvim_set_client_info(String name, Dictionary version, String type, Dictionary methods, Dictionary attributes, ) 
-	MsgpackRequest* nvim_set_client_info(QByteArray name, QVariantMap version, QByteArray type, QVariantMap methods, QVariantMap attributes);
-	// Dictionary nvim_get_chan_info(Integer chan, ) 
-	MsgpackRequest* nvim_get_chan_info(int64_t chan);
-	// Array nvim_list_chans() 
-	MsgpackRequest* nvim_list_chans();
-	// Array nvim_call_atomic(Array calls, ) 
-	MsgpackRequest* nvim_call_atomic(QVariantList calls);
-	// Dictionary nvim_parse_expression(String expr, String flags, Boolean highlight, ) 
-	MsgpackRequest* nvim_parse_expression(QByteArray expr, QByteArray flags, bool highlight);
-	// Array nvim_list_uis() 
-	MsgpackRequest* nvim_list_uis();
-	// Array nvim_get_proc_children(Integer pid, ) 
-	MsgpackRequest* nvim_get_proc_children(int64_t pid);
-	// Object nvim_get_proc(Integer pid, ) 
-	MsgpackRequest* nvim_get_proc(int64_t pid);
-	// Buffer nvim_win_get_buf(Window window, ) 
-	MsgpackRequest* nvim_win_get_buf(int64_t window);
-	// void nvim_win_set_buf(Window window, Buffer buffer, ) 
-	MsgpackRequest* nvim_win_set_buf(int64_t window, int64_t buffer);
-	// ArrayOf(Integer, 2) nvim_win_get_cursor(Window window, ) 
-	MsgpackRequest* nvim_win_get_cursor(int64_t window);
-	// void nvim_win_set_cursor(Window window, ArrayOf(Integer, 2) pos, ) 
-	MsgpackRequest* nvim_win_set_cursor(int64_t window, QPoint pos);
-	// Integer nvim_win_get_height(Window window, ) 
-	MsgpackRequest* nvim_win_get_height(int64_t window);
-	// void nvim_win_set_height(Window window, Integer height, ) 
-	MsgpackRequest* nvim_win_set_height(int64_t window, int64_t height);
-	// Integer nvim_win_get_width(Window window, ) 
-	MsgpackRequest* nvim_win_get_width(int64_t window);
-	// void nvim_win_set_width(Window window, Integer width, ) 
-	MsgpackRequest* nvim_win_set_width(int64_t window, int64_t width);
-	// Object nvim_win_get_var(Window window, String name, ) 
-	MsgpackRequest* nvim_win_get_var(int64_t window, QByteArray name);
-	// void nvim_win_set_var(Window window, String name, Object value, ) 
-	MsgpackRequest* nvim_win_set_var(int64_t window, QByteArray name, QVariant value);
-	// void nvim_win_del_var(Window window, String name, ) 
-	MsgpackRequest* nvim_win_del_var(int64_t window, QByteArray name);
-	// DEPRECATED
-	// Object window_set_var(Window window, String name, Object value, ) 
-	MsgpackRequest* window_set_var(int64_t window, QByteArray name, QVariant value);
-	// DEPRECATED
-	// Object window_del_var(Window window, String name, ) 
-	MsgpackRequest* window_del_var(int64_t window, QByteArray name);
-	// Object nvim_win_get_option(Window window, String name, ) 
-	MsgpackRequest* nvim_win_get_option(int64_t window, QByteArray name);
-	// void nvim_win_set_option(Window window, String name, Object value, ) 
-	MsgpackRequest* nvim_win_set_option(int64_t window, QByteArray name, QVariant value);
-	// ArrayOf(Integer, 2) nvim_win_get_position(Window window, ) 
-	MsgpackRequest* nvim_win_get_position(int64_t window);
-	// Tabpage nvim_win_get_tabpage(Window window, ) 
-	MsgpackRequest* nvim_win_get_tabpage(int64_t window);
-	// Integer nvim_win_get_number(Window window, ) 
-	MsgpackRequest* nvim_win_get_number(int64_t window);
-	// Boolean nvim_win_is_valid(Window window, ) 
-	MsgpackRequest* nvim_win_is_valid(int64_t window);
-	// DEPRECATED
-	// Integer buffer_line_count(Buffer buffer, ) 
-	MsgpackRequest* buffer_line_count(int64_t buffer);
-	// DEPRECATED
-	// ArrayOf(String) buffer_get_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ) 
-	MsgpackRequest* buffer_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing);
-	// DEPRECATED
-	// void buffer_set_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ArrayOf(String) replacement, ) 
-	MsgpackRequest* buffer_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement);
-	// DEPRECATED
-	// Object buffer_get_var(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_get_var(int64_t buffer, QByteArray name);
-	// DEPRECATED
-	// Object buffer_get_option(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_get_option(int64_t buffer, QByteArray name);
-	// DEPRECATED
-	// void buffer_set_option(Buffer buffer, String name, Object value, ) 
-	MsgpackRequest* buffer_set_option(int64_t buffer, QByteArray name, QVariant value);
-	// DEPRECATED
-	// Integer buffer_get_number(Buffer buffer, ) 
-	MsgpackRequest* buffer_get_number(int64_t buffer);
-	// DEPRECATED
-	// String buffer_get_name(Buffer buffer, ) 
-	MsgpackRequest* buffer_get_name(int64_t buffer);
-	// DEPRECATED
-	// void buffer_set_name(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_set_name(int64_t buffer, QByteArray name);
-	// DEPRECATED
-	// Boolean buffer_is_valid(Buffer buffer, ) 
-	MsgpackRequest* buffer_is_valid(int64_t buffer);
-	// DEPRECATED
-	// ArrayOf(Integer, 2) buffer_get_mark(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_get_mark(int64_t buffer, QByteArray name);
-	// DEPRECATED
-	// Integer buffer_add_highlight(Buffer buffer, Integer ns_id, String hl_group, Integer line, Integer col_start, Integer col_end, ) 
-	MsgpackRequest* buffer_add_highlight(int64_t buffer, int64_t ns_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end);
-	// DEPRECATED
-	// void buffer_clear_highlight(Buffer buffer, Integer ns_id, Integer line_start, Integer line_end, ) 
-	MsgpackRequest* buffer_clear_highlight(int64_t buffer, int64_t ns_id, int64_t line_start, int64_t line_end);
-	// DEPRECATED
-	// ArrayOf(Window) tabpage_get_windows(Tabpage tabpage, ) 
-	MsgpackRequest* tabpage_get_windows(int64_t tabpage);
-	// DEPRECATED
-	// Object tabpage_get_var(Tabpage tabpage, String name, ) 
-	MsgpackRequest* tabpage_get_var(int64_t tabpage, QByteArray name);
-	// DEPRECATED
-	// Window tabpage_get_window(Tabpage tabpage, ) 
-	MsgpackRequest* tabpage_get_window(int64_t tabpage);
-	// DEPRECATED
-	// Boolean tabpage_is_valid(Tabpage tabpage, ) 
-	MsgpackRequest* tabpage_is_valid(int64_t tabpage);
-	// DEPRECATED
-	// void ui_detach() 
-	MsgpackRequest* ui_detach();
-	// DEPRECATED
-	// Object ui_try_resize(Integer width, Integer height, ) 
-	MsgpackRequest* ui_try_resize(int64_t width, int64_t height);
-	// DEPRECATED
-	// void vim_command(String command, ) 
-	MsgpackRequest* vim_command(QByteArray command);
-	// DEPRECATED
-	// void vim_feedkeys(String keys, String mode, Boolean escape_csi, ) 
-	MsgpackRequest* vim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi);
-	// DEPRECATED
-	// Integer vim_input(String keys, ) 
-	MsgpackRequest* vim_input(QByteArray keys);
-	// DEPRECATED
-	// String vim_replace_termcodes(String str, Boolean from_part, Boolean do_lt, Boolean special, ) 
-	MsgpackRequest* vim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special);
-	// DEPRECATED
-	// String vim_command_output(String command, ) 
-	MsgpackRequest* vim_command_output(QByteArray command);
-	// DEPRECATED
-	// Object vim_eval(String expr, ) 
-	MsgpackRequest* vim_eval(QByteArray expr);
-	// DEPRECATED
-	// Object vim_call_function(String fn, Array args, ) 
-	MsgpackRequest* vim_call_function(QByteArray fn, QVariantList args);
-	// DEPRECATED
-	// Integer vim_strwidth(String text, ) 
-	MsgpackRequest* vim_strwidth(QByteArray text);
-	// DEPRECATED
-	// ArrayOf(String) vim_list_runtime_paths() 
-	MsgpackRequest* vim_list_runtime_paths();
-	// DEPRECATED
-	// void vim_change_directory(String dir, ) 
-	MsgpackRequest* vim_change_directory(QByteArray dir);
-	// DEPRECATED
-	// String vim_get_current_line() 
-	MsgpackRequest* vim_get_current_line();
-	// DEPRECATED
-	// void vim_set_current_line(String line, ) 
-	MsgpackRequest* vim_set_current_line(QByteArray line);
-	// DEPRECATED
-	// void vim_del_current_line() 
-	MsgpackRequest* vim_del_current_line();
-	// DEPRECATED
-	// Object vim_get_var(String name, ) 
-	MsgpackRequest* vim_get_var(QByteArray name);
-	// DEPRECATED
-	// Object vim_get_vvar(String name, ) 
-	MsgpackRequest* vim_get_vvar(QByteArray name);
-	// DEPRECATED
-	// Object vim_get_option(String name, ) 
-	MsgpackRequest* vim_get_option(QByteArray name);
-	// DEPRECATED
-	// void vim_set_option(String name, Object value, ) 
-	MsgpackRequest* vim_set_option(QByteArray name, QVariant value);
-	// DEPRECATED
-	// void vim_out_write(String str, ) 
-	MsgpackRequest* vim_out_write(QByteArray str);
-	// DEPRECATED
-	// void vim_err_write(String str, ) 
-	MsgpackRequest* vim_err_write(QByteArray str);
-	// DEPRECATED
-	// void vim_report_error(String str, ) 
-	MsgpackRequest* vim_report_error(QByteArray str);
-	// DEPRECATED
-	// ArrayOf(Buffer) vim_get_buffers() 
-	MsgpackRequest* vim_get_buffers();
-	// DEPRECATED
-	// Buffer vim_get_current_buffer() 
-	MsgpackRequest* vim_get_current_buffer();
-	// DEPRECATED
-	// void vim_set_current_buffer(Buffer buffer, ) 
-	MsgpackRequest* vim_set_current_buffer(int64_t buffer);
-	// DEPRECATED
-	// ArrayOf(Window) vim_get_windows() 
-	MsgpackRequest* vim_get_windows();
-	// DEPRECATED
-	// Window vim_get_current_window() 
-	MsgpackRequest* vim_get_current_window();
-	// DEPRECATED
-	// void vim_set_current_window(Window window, ) 
-	MsgpackRequest* vim_set_current_window(int64_t window);
-	// DEPRECATED
-	// ArrayOf(Tabpage) vim_get_tabpages() 
-	MsgpackRequest* vim_get_tabpages();
-	// DEPRECATED
-	// Tabpage vim_get_current_tabpage() 
-	MsgpackRequest* vim_get_current_tabpage();
-	// DEPRECATED
-	// void vim_set_current_tabpage(Tabpage tabpage, ) 
-	MsgpackRequest* vim_set_current_tabpage(int64_t tabpage);
-	// DEPRECATED
-	// void vim_subscribe(String event, ) 
-	MsgpackRequest* vim_subscribe(QByteArray event);
-	// DEPRECATED
-	// void vim_unsubscribe(String event, ) 
-	MsgpackRequest* vim_unsubscribe(QByteArray event);
-	// DEPRECATED
-	// Integer vim_name_to_color(String name, ) 
-	MsgpackRequest* vim_name_to_color(QByteArray name);
-	// DEPRECATED
-	// Dictionary vim_get_color_map() 
-	MsgpackRequest* vim_get_color_map();
-	// DEPRECATED
-	// Buffer window_get_buffer(Window window, ) 
-	MsgpackRequest* window_get_buffer(int64_t window);
-	// DEPRECATED
-	// ArrayOf(Integer, 2) window_get_cursor(Window window, ) 
-	MsgpackRequest* window_get_cursor(int64_t window);
-	// DEPRECATED
-	// void window_set_cursor(Window window, ArrayOf(Integer, 2) pos, ) 
-	MsgpackRequest* window_set_cursor(int64_t window, QPoint pos);
-	// DEPRECATED
-	// Integer window_get_height(Window window, ) 
-	MsgpackRequest* window_get_height(int64_t window);
-	// DEPRECATED
-	// void window_set_height(Window window, Integer height, ) 
-	MsgpackRequest* window_set_height(int64_t window, int64_t height);
-	// DEPRECATED
-	// Integer window_get_width(Window window, ) 
-	MsgpackRequest* window_get_width(int64_t window);
-	// DEPRECATED
-	// void window_set_width(Window window, Integer width, ) 
-	MsgpackRequest* window_set_width(int64_t window, int64_t width);
-	// DEPRECATED
-	// Object window_get_var(Window window, String name, ) 
-	MsgpackRequest* window_get_var(int64_t window, QByteArray name);
-	// DEPRECATED
-	// Object window_get_option(Window window, String name, ) 
-	MsgpackRequest* window_get_option(int64_t window, QByteArray name);
-	// DEPRECATED
-	// void window_set_option(Window window, String name, Object value, ) 
-	MsgpackRequest* window_set_option(int64_t window, QByteArray name, QVariant value);
-	// DEPRECATED
-	// ArrayOf(Integer, 2) window_get_position(Window window, ) 
-	MsgpackRequest* window_get_position(int64_t window);
-	// DEPRECATED
-	// Tabpage window_get_tabpage(Window window, ) 
-	MsgpackRequest* window_get_tabpage(int64_t window);
-	// DEPRECATED
-	// Boolean window_is_valid(Window window, ) 
-	MsgpackRequest* window_is_valid(int64_t window);
+	/// Integer nvim_buf_line_count(Buffer buffer, )
+	NeovimQt::MsgpackRequest* nvim_buf_line_count(int64_t buffer);
+
+	/// DEPRECATED: String buffer_get_line(Buffer buffer, Integer index, )
+	NeovimQt::MsgpackRequest* buffer_get_line(int64_t buffer, int64_t index);
+
+	/// Boolean nvim_buf_attach(Buffer buffer, Boolean send_buffer, Dictionary opts, )
+	NeovimQt::MsgpackRequest* nvim_buf_attach(int64_t buffer, bool send_buffer, QVariantMap opts);
+
+	/// Boolean nvim_buf_detach(Buffer buffer, )
+	NeovimQt::MsgpackRequest* nvim_buf_detach(int64_t buffer);
+
+	/// DEPRECATED: void buffer_set_line(Buffer buffer, Integer index, String line, )
+	NeovimQt::MsgpackRequest* buffer_set_line(int64_t buffer, int64_t index, QByteArray line);
+
+	/// DEPRECATED: void buffer_del_line(Buffer buffer, Integer index, )
+	NeovimQt::MsgpackRequest* buffer_del_line(int64_t buffer, int64_t index);
+
+	/// DEPRECATED: ArrayOf(String) buffer_get_line_slice(Buffer buffer, Integer start, Integer end, Boolean include_start, Boolean include_end, )
+	NeovimQt::MsgpackRequest* buffer_get_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end);
+
+	/// ArrayOf(String) nvim_buf_get_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, )
+	NeovimQt::MsgpackRequest* nvim_buf_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing);
+
+	/// DEPRECATED: void buffer_set_line_slice(Buffer buffer, Integer start, Integer end, Boolean include_start, Boolean include_end, ArrayOf(String) replacement, )
+	NeovimQt::MsgpackRequest* buffer_set_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end, QList<QByteArray> replacement);
+
+	/// void nvim_buf_set_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ArrayOf(String) replacement, )
+	NeovimQt::MsgpackRequest* nvim_buf_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement);
+
+	/// Integer nvim_buf_get_offset(Buffer buffer, Integer index, )
+	NeovimQt::MsgpackRequest* nvim_buf_get_offset(int64_t buffer, int64_t index);
+
+	/// Object nvim_buf_get_var(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* nvim_buf_get_var(int64_t buffer, QByteArray name);
+
+	/// Integer nvim_buf_get_changedtick(Buffer buffer, )
+	NeovimQt::MsgpackRequest* nvim_buf_get_changedtick(int64_t buffer);
+
+	/// ArrayOf(Dictionary) nvim_buf_get_keymap(Buffer buffer, String mode, )
+	NeovimQt::MsgpackRequest* nvim_buf_get_keymap(int64_t buffer, QByteArray mode);
+
+	/// Dictionary nvim_buf_get_commands(Buffer buffer, Dictionary opts, )
+	NeovimQt::MsgpackRequest* nvim_buf_get_commands(int64_t buffer, QVariantMap opts);
+
+	/// void nvim_buf_set_var(Buffer buffer, String name, Object value, )
+	NeovimQt::MsgpackRequest* nvim_buf_set_var(int64_t buffer, QByteArray name, QVariant value);
+
+	/// void nvim_buf_del_var(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* nvim_buf_del_var(int64_t buffer, QByteArray name);
+
+	/// DEPRECATED: Object buffer_set_var(Buffer buffer, String name, Object value, )
+	NeovimQt::MsgpackRequest* buffer_set_var(int64_t buffer, QByteArray name, QVariant value);
+
+	/// DEPRECATED: Object buffer_del_var(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* buffer_del_var(int64_t buffer, QByteArray name);
+
+	/// Object nvim_buf_get_option(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* nvim_buf_get_option(int64_t buffer, QByteArray name);
+
+	/// void nvim_buf_set_option(Buffer buffer, String name, Object value, )
+	NeovimQt::MsgpackRequest* nvim_buf_set_option(int64_t buffer, QByteArray name, QVariant value);
+
+	/// DEPRECATED: Integer nvim_buf_get_number(Buffer buffer, )
+	NeovimQt::MsgpackRequest* nvim_buf_get_number(int64_t buffer);
+
+	/// String nvim_buf_get_name(Buffer buffer, )
+	NeovimQt::MsgpackRequest* nvim_buf_get_name(int64_t buffer);
+
+	/// void nvim_buf_set_name(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* nvim_buf_set_name(int64_t buffer, QByteArray name);
+
+	/// Boolean nvim_buf_is_loaded(Buffer buffer, )
+	NeovimQt::MsgpackRequest* nvim_buf_is_loaded(int64_t buffer);
+
+	/// Boolean nvim_buf_is_valid(Buffer buffer, )
+	NeovimQt::MsgpackRequest* nvim_buf_is_valid(int64_t buffer);
+
+	/// DEPRECATED: void buffer_insert(Buffer buffer, Integer lnum, ArrayOf(String) lines, )
+	NeovimQt::MsgpackRequest* buffer_insert(int64_t buffer, int64_t lnum, QList<QByteArray> lines);
+
+	/// ArrayOf(Integer, 2) nvim_buf_get_mark(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* nvim_buf_get_mark(int64_t buffer, QByteArray name);
+
+	/// Integer nvim_buf_add_highlight(Buffer buffer, Integer ns_id, String hl_group, Integer line, Integer col_start, Integer col_end, )
+	NeovimQt::MsgpackRequest* nvim_buf_add_highlight(int64_t buffer, int64_t ns_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end);
+
+	/// void nvim_buf_clear_namespace(Buffer buffer, Integer ns_id, Integer line_start, Integer line_end, )
+	NeovimQt::MsgpackRequest* nvim_buf_clear_namespace(int64_t buffer, int64_t ns_id, int64_t line_start, int64_t line_end);
+
+	/// void nvim_buf_clear_highlight(Buffer buffer, Integer ns_id, Integer line_start, Integer line_end, )
+	NeovimQt::MsgpackRequest* nvim_buf_clear_highlight(int64_t buffer, int64_t ns_id, int64_t line_start, int64_t line_end);
+
+	/// Integer nvim_buf_set_virtual_text(Buffer buffer, Integer ns_id, Integer line, Array chunks, Dictionary opts, )
+	NeovimQt::MsgpackRequest* nvim_buf_set_virtual_text(int64_t buffer, int64_t ns_id, int64_t line, QVariantList chunks, QVariantMap opts);
+
+	/// ArrayOf(Window) nvim_tabpage_list_wins(Tabpage tabpage, )
+	NeovimQt::MsgpackRequest* nvim_tabpage_list_wins(int64_t tabpage);
+
+	/// Object nvim_tabpage_get_var(Tabpage tabpage, String name, )
+	NeovimQt::MsgpackRequest* nvim_tabpage_get_var(int64_t tabpage, QByteArray name);
+
+	/// void nvim_tabpage_set_var(Tabpage tabpage, String name, Object value, )
+	NeovimQt::MsgpackRequest* nvim_tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value);
+
+	/// void nvim_tabpage_del_var(Tabpage tabpage, String name, )
+	NeovimQt::MsgpackRequest* nvim_tabpage_del_var(int64_t tabpage, QByteArray name);
+
+	/// DEPRECATED: Object tabpage_set_var(Tabpage tabpage, String name, Object value, )
+	NeovimQt::MsgpackRequest* tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value);
+
+	/// DEPRECATED: Object tabpage_del_var(Tabpage tabpage, String name, )
+	NeovimQt::MsgpackRequest* tabpage_del_var(int64_t tabpage, QByteArray name);
+
+	/// Window nvim_tabpage_get_win(Tabpage tabpage, )
+	NeovimQt::MsgpackRequest* nvim_tabpage_get_win(int64_t tabpage);
+
+	/// Integer nvim_tabpage_get_number(Tabpage tabpage, )
+	NeovimQt::MsgpackRequest* nvim_tabpage_get_number(int64_t tabpage);
+
+	/// Boolean nvim_tabpage_is_valid(Tabpage tabpage, )
+	NeovimQt::MsgpackRequest* nvim_tabpage_is_valid(int64_t tabpage);
+
+	/// void nvim_ui_attach(Integer width, Integer height, Dictionary options, )
+	NeovimQt::MsgpackRequest* nvim_ui_attach(int64_t width, int64_t height, QVariantMap options);
+
+	/// DEPRECATED: void ui_attach(Integer width, Integer height, Boolean enable_rgb, )
+	NeovimQt::MsgpackRequest* ui_attach(int64_t width, int64_t height, bool enable_rgb);
+
+	/// void nvim_ui_detach()
+	NeovimQt::MsgpackRequest* nvim_ui_detach();
+
+	/// void nvim_ui_try_resize(Integer width, Integer height, )
+	NeovimQt::MsgpackRequest* nvim_ui_try_resize(int64_t width, int64_t height);
+
+	/// void nvim_ui_set_option(String name, Object value, )
+	NeovimQt::MsgpackRequest* nvim_ui_set_option(QByteArray name, QVariant value);
+
+	/// void nvim_command(String command, )
+	NeovimQt::MsgpackRequest* nvim_command(QByteArray command);
+
+	/// Dictionary nvim_get_hl_by_name(String name, Boolean rgb, )
+	NeovimQt::MsgpackRequest* nvim_get_hl_by_name(QByteArray name, bool rgb);
+
+	/// Dictionary nvim_get_hl_by_id(Integer hl_id, Boolean rgb, )
+	NeovimQt::MsgpackRequest* nvim_get_hl_by_id(int64_t hl_id, bool rgb);
+
+	/// void nvim_feedkeys(String keys, String mode, Boolean escape_csi, )
+	NeovimQt::MsgpackRequest* nvim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi);
+
+	/// Integer nvim_input(String keys, )
+	NeovimQt::MsgpackRequest* nvim_input(QByteArray keys);
+
+	/// String nvim_replace_termcodes(String str, Boolean from_part, Boolean do_lt, Boolean special, )
+	NeovimQt::MsgpackRequest* nvim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special);
+
+	/// String nvim_command_output(String command, )
+	NeovimQt::MsgpackRequest* nvim_command_output(QByteArray command);
+
+	/// Object nvim_eval(String expr, )
+	NeovimQt::MsgpackRequest* nvim_eval(QByteArray expr);
+
+	/// Object nvim_execute_lua(String code, Array args, )
+	NeovimQt::MsgpackRequest* nvim_execute_lua(QByteArray code, QVariantList args);
+
+	/// Object nvim_call_function(String fn, Array args, )
+	NeovimQt::MsgpackRequest* nvim_call_function(QByteArray fn, QVariantList args);
+
+	/// Object nvim_call_dict_function(Object dict, String fn, Array args, )
+	NeovimQt::MsgpackRequest* nvim_call_dict_function(QVariant dict, QByteArray fn, QVariantList args);
+
+	/// Integer nvim_strwidth(String text, )
+	NeovimQt::MsgpackRequest* nvim_strwidth(QByteArray text);
+
+	/// ArrayOf(String) nvim_list_runtime_paths()
+	NeovimQt::MsgpackRequest* nvim_list_runtime_paths();
+
+	/// void nvim_set_current_dir(String dir, )
+	NeovimQt::MsgpackRequest* nvim_set_current_dir(QByteArray dir);
+
+	/// String nvim_get_current_line()
+	NeovimQt::MsgpackRequest* nvim_get_current_line();
+
+	/// void nvim_set_current_line(String line, )
+	NeovimQt::MsgpackRequest* nvim_set_current_line(QByteArray line);
+
+	/// void nvim_del_current_line()
+	NeovimQt::MsgpackRequest* nvim_del_current_line();
+
+	/// Object nvim_get_var(String name, )
+	NeovimQt::MsgpackRequest* nvim_get_var(QByteArray name);
+
+	/// void nvim_set_var(String name, Object value, )
+	NeovimQt::MsgpackRequest* nvim_set_var(QByteArray name, QVariant value);
+
+	/// void nvim_del_var(String name, )
+	NeovimQt::MsgpackRequest* nvim_del_var(QByteArray name);
+
+	/// DEPRECATED: Object vim_set_var(String name, Object value, )
+	NeovimQt::MsgpackRequest* vim_set_var(QByteArray name, QVariant value);
+
+	/// DEPRECATED: Object vim_del_var(String name, )
+	NeovimQt::MsgpackRequest* vim_del_var(QByteArray name);
+
+	/// Object nvim_get_vvar(String name, )
+	NeovimQt::MsgpackRequest* nvim_get_vvar(QByteArray name);
+
+	/// Object nvim_get_option(String name, )
+	NeovimQt::MsgpackRequest* nvim_get_option(QByteArray name);
+
+	/// void nvim_set_option(String name, Object value, )
+	NeovimQt::MsgpackRequest* nvim_set_option(QByteArray name, QVariant value);
+
+	/// void nvim_out_write(String str, )
+	NeovimQt::MsgpackRequest* nvim_out_write(QByteArray str);
+
+	/// void nvim_err_write(String str, )
+	NeovimQt::MsgpackRequest* nvim_err_write(QByteArray str);
+
+	/// void nvim_err_writeln(String str, )
+	NeovimQt::MsgpackRequest* nvim_err_writeln(QByteArray str);
+
+	/// ArrayOf(Buffer) nvim_list_bufs()
+	NeovimQt::MsgpackRequest* nvim_list_bufs();
+
+	/// Buffer nvim_get_current_buf()
+	NeovimQt::MsgpackRequest* nvim_get_current_buf();
+
+	/// void nvim_set_current_buf(Buffer buffer, )
+	NeovimQt::MsgpackRequest* nvim_set_current_buf(int64_t buffer);
+
+	/// ArrayOf(Window) nvim_list_wins()
+	NeovimQt::MsgpackRequest* nvim_list_wins();
+
+	/// Window nvim_get_current_win()
+	NeovimQt::MsgpackRequest* nvim_get_current_win();
+
+	/// void nvim_set_current_win(Window window, )
+	NeovimQt::MsgpackRequest* nvim_set_current_win(int64_t window);
+
+	/// ArrayOf(Tabpage) nvim_list_tabpages()
+	NeovimQt::MsgpackRequest* nvim_list_tabpages();
+
+	/// Tabpage nvim_get_current_tabpage()
+	NeovimQt::MsgpackRequest* nvim_get_current_tabpage();
+
+	/// void nvim_set_current_tabpage(Tabpage tabpage, )
+	NeovimQt::MsgpackRequest* nvim_set_current_tabpage(int64_t tabpage);
+
+	/// Integer nvim_create_namespace(String name, )
+	NeovimQt::MsgpackRequest* nvim_create_namespace(QByteArray name);
+
+	/// Dictionary nvim_get_namespaces()
+	NeovimQt::MsgpackRequest* nvim_get_namespaces();
+
+	/// void nvim_subscribe(String event, )
+	NeovimQt::MsgpackRequest* nvim_subscribe(QByteArray event);
+
+	/// void nvim_unsubscribe(String event, )
+	NeovimQt::MsgpackRequest* nvim_unsubscribe(QByteArray event);
+
+	/// Integer nvim_get_color_by_name(String name, )
+	NeovimQt::MsgpackRequest* nvim_get_color_by_name(QByteArray name);
+
+	/// Dictionary nvim_get_color_map()
+	NeovimQt::MsgpackRequest* nvim_get_color_map();
+
+	/// Dictionary nvim_get_mode()
+	NeovimQt::MsgpackRequest* nvim_get_mode();
+
+	/// ArrayOf(Dictionary) nvim_get_keymap(String mode, )
+	NeovimQt::MsgpackRequest* nvim_get_keymap(QByteArray mode);
+
+	/// Dictionary nvim_get_commands(Dictionary opts, )
+	NeovimQt::MsgpackRequest* nvim_get_commands(QVariantMap opts);
+
+	/// Array nvim_get_api_info()
+	NeovimQt::MsgpackRequest* nvim_get_api_info();
+
+	/// void nvim_set_client_info(String name, Dictionary version, String type, Dictionary methods, Dictionary attributes, )
+	NeovimQt::MsgpackRequest* nvim_set_client_info(QByteArray name, QVariantMap version, QByteArray type, QVariantMap methods, QVariantMap attributes);
+
+	/// Dictionary nvim_get_chan_info(Integer chan, )
+	NeovimQt::MsgpackRequest* nvim_get_chan_info(int64_t chan);
+
+	/// Array nvim_list_chans()
+	NeovimQt::MsgpackRequest* nvim_list_chans();
+
+	/// Array nvim_call_atomic(Array calls, )
+	NeovimQt::MsgpackRequest* nvim_call_atomic(QVariantList calls);
+
+	/// Dictionary nvim_parse_expression(String expr, String flags, Boolean highlight, )
+	NeovimQt::MsgpackRequest* nvim_parse_expression(QByteArray expr, QByteArray flags, bool highlight);
+
+	/// Array nvim_list_uis()
+	NeovimQt::MsgpackRequest* nvim_list_uis();
+
+	/// Array nvim_get_proc_children(Integer pid, )
+	NeovimQt::MsgpackRequest* nvim_get_proc_children(int64_t pid);
+
+	/// Object nvim_get_proc(Integer pid, )
+	NeovimQt::MsgpackRequest* nvim_get_proc(int64_t pid);
+
+	/// Buffer nvim_win_get_buf(Window window, )
+	NeovimQt::MsgpackRequest* nvim_win_get_buf(int64_t window);
+
+	/// void nvim_win_set_buf(Window window, Buffer buffer, )
+	NeovimQt::MsgpackRequest* nvim_win_set_buf(int64_t window, int64_t buffer);
+
+	/// ArrayOf(Integer, 2) nvim_win_get_cursor(Window window, )
+	NeovimQt::MsgpackRequest* nvim_win_get_cursor(int64_t window);
+
+	/// void nvim_win_set_cursor(Window window, ArrayOf(Integer, 2) pos, )
+	NeovimQt::MsgpackRequest* nvim_win_set_cursor(int64_t window, QPoint pos);
+
+	/// Integer nvim_win_get_height(Window window, )
+	NeovimQt::MsgpackRequest* nvim_win_get_height(int64_t window);
+
+	/// void nvim_win_set_height(Window window, Integer height, )
+	NeovimQt::MsgpackRequest* nvim_win_set_height(int64_t window, int64_t height);
+
+	/// Integer nvim_win_get_width(Window window, )
+	NeovimQt::MsgpackRequest* nvim_win_get_width(int64_t window);
+
+	/// void nvim_win_set_width(Window window, Integer width, )
+	NeovimQt::MsgpackRequest* nvim_win_set_width(int64_t window, int64_t width);
+
+	/// Object nvim_win_get_var(Window window, String name, )
+	NeovimQt::MsgpackRequest* nvim_win_get_var(int64_t window, QByteArray name);
+
+	/// void nvim_win_set_var(Window window, String name, Object value, )
+	NeovimQt::MsgpackRequest* nvim_win_set_var(int64_t window, QByteArray name, QVariant value);
+
+	/// void nvim_win_del_var(Window window, String name, )
+	NeovimQt::MsgpackRequest* nvim_win_del_var(int64_t window, QByteArray name);
+
+	/// DEPRECATED: Object window_set_var(Window window, String name, Object value, )
+	NeovimQt::MsgpackRequest* window_set_var(int64_t window, QByteArray name, QVariant value);
+
+	/// DEPRECATED: Object window_del_var(Window window, String name, )
+	NeovimQt::MsgpackRequest* window_del_var(int64_t window, QByteArray name);
+
+	/// Object nvim_win_get_option(Window window, String name, )
+	NeovimQt::MsgpackRequest* nvim_win_get_option(int64_t window, QByteArray name);
+
+	/// void nvim_win_set_option(Window window, String name, Object value, )
+	NeovimQt::MsgpackRequest* nvim_win_set_option(int64_t window, QByteArray name, QVariant value);
+
+	/// ArrayOf(Integer, 2) nvim_win_get_position(Window window, )
+	NeovimQt::MsgpackRequest* nvim_win_get_position(int64_t window);
+
+	/// Tabpage nvim_win_get_tabpage(Window window, )
+	NeovimQt::MsgpackRequest* nvim_win_get_tabpage(int64_t window);
+
+	/// Integer nvim_win_get_number(Window window, )
+	NeovimQt::MsgpackRequest* nvim_win_get_number(int64_t window);
+
+	/// Boolean nvim_win_is_valid(Window window, )
+	NeovimQt::MsgpackRequest* nvim_win_is_valid(int64_t window);
+
+	/// DEPRECATED: Integer buffer_line_count(Buffer buffer, )
+	NeovimQt::MsgpackRequest* buffer_line_count(int64_t buffer);
+
+	/// DEPRECATED: ArrayOf(String) buffer_get_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, )
+	NeovimQt::MsgpackRequest* buffer_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing);
+
+	/// DEPRECATED: void buffer_set_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ArrayOf(String) replacement, )
+	NeovimQt::MsgpackRequest* buffer_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement);
+
+	/// DEPRECATED: Object buffer_get_var(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* buffer_get_var(int64_t buffer, QByteArray name);
+
+	/// DEPRECATED: Object buffer_get_option(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* buffer_get_option(int64_t buffer, QByteArray name);
+
+	/// DEPRECATED: void buffer_set_option(Buffer buffer, String name, Object value, )
+	NeovimQt::MsgpackRequest* buffer_set_option(int64_t buffer, QByteArray name, QVariant value);
+
+	/// DEPRECATED: Integer buffer_get_number(Buffer buffer, )
+	NeovimQt::MsgpackRequest* buffer_get_number(int64_t buffer);
+
+	/// DEPRECATED: String buffer_get_name(Buffer buffer, )
+	NeovimQt::MsgpackRequest* buffer_get_name(int64_t buffer);
+
+	/// DEPRECATED: void buffer_set_name(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* buffer_set_name(int64_t buffer, QByteArray name);
+
+	/// DEPRECATED: Boolean buffer_is_valid(Buffer buffer, )
+	NeovimQt::MsgpackRequest* buffer_is_valid(int64_t buffer);
+
+	/// DEPRECATED: ArrayOf(Integer, 2) buffer_get_mark(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* buffer_get_mark(int64_t buffer, QByteArray name);
+
+	/// DEPRECATED: Integer buffer_add_highlight(Buffer buffer, Integer ns_id, String hl_group, Integer line, Integer col_start, Integer col_end, )
+	NeovimQt::MsgpackRequest* buffer_add_highlight(int64_t buffer, int64_t ns_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end);
+
+	/// DEPRECATED: void buffer_clear_highlight(Buffer buffer, Integer ns_id, Integer line_start, Integer line_end, )
+	NeovimQt::MsgpackRequest* buffer_clear_highlight(int64_t buffer, int64_t ns_id, int64_t line_start, int64_t line_end);
+
+	/// DEPRECATED: ArrayOf(Window) tabpage_get_windows(Tabpage tabpage, )
+	NeovimQt::MsgpackRequest* tabpage_get_windows(int64_t tabpage);
+
+	/// DEPRECATED: Object tabpage_get_var(Tabpage tabpage, String name, )
+	NeovimQt::MsgpackRequest* tabpage_get_var(int64_t tabpage, QByteArray name);
+
+	/// DEPRECATED: Window tabpage_get_window(Tabpage tabpage, )
+	NeovimQt::MsgpackRequest* tabpage_get_window(int64_t tabpage);
+
+	/// DEPRECATED: Boolean tabpage_is_valid(Tabpage tabpage, )
+	NeovimQt::MsgpackRequest* tabpage_is_valid(int64_t tabpage);
+
+	/// DEPRECATED: void ui_detach()
+	NeovimQt::MsgpackRequest* ui_detach();
+
+	/// DEPRECATED: Object ui_try_resize(Integer width, Integer height, )
+	NeovimQt::MsgpackRequest* ui_try_resize(int64_t width, int64_t height);
+
+	/// DEPRECATED: void vim_command(String command, )
+	NeovimQt::MsgpackRequest* vim_command(QByteArray command);
+
+	/// DEPRECATED: void vim_feedkeys(String keys, String mode, Boolean escape_csi, )
+	NeovimQt::MsgpackRequest* vim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi);
+
+	/// DEPRECATED: Integer vim_input(String keys, )
+	NeovimQt::MsgpackRequest* vim_input(QByteArray keys);
+
+	/// DEPRECATED: String vim_replace_termcodes(String str, Boolean from_part, Boolean do_lt, Boolean special, )
+	NeovimQt::MsgpackRequest* vim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special);
+
+	/// DEPRECATED: String vim_command_output(String command, )
+	NeovimQt::MsgpackRequest* vim_command_output(QByteArray command);
+
+	/// DEPRECATED: Object vim_eval(String expr, )
+	NeovimQt::MsgpackRequest* vim_eval(QByteArray expr);
+
+	/// DEPRECATED: Object vim_call_function(String fn, Array args, )
+	NeovimQt::MsgpackRequest* vim_call_function(QByteArray fn, QVariantList args);
+
+	/// DEPRECATED: Integer vim_strwidth(String text, )
+	NeovimQt::MsgpackRequest* vim_strwidth(QByteArray text);
+
+	/// DEPRECATED: ArrayOf(String) vim_list_runtime_paths()
+	NeovimQt::MsgpackRequest* vim_list_runtime_paths();
+
+	/// DEPRECATED: void vim_change_directory(String dir, )
+	NeovimQt::MsgpackRequest* vim_change_directory(QByteArray dir);
+
+	/// DEPRECATED: String vim_get_current_line()
+	NeovimQt::MsgpackRequest* vim_get_current_line();
+
+	/// DEPRECATED: void vim_set_current_line(String line, )
+	NeovimQt::MsgpackRequest* vim_set_current_line(QByteArray line);
+
+	/// DEPRECATED: void vim_del_current_line()
+	NeovimQt::MsgpackRequest* vim_del_current_line();
+
+	/// DEPRECATED: Object vim_get_var(String name, )
+	NeovimQt::MsgpackRequest* vim_get_var(QByteArray name);
+
+	/// DEPRECATED: Object vim_get_vvar(String name, )
+	NeovimQt::MsgpackRequest* vim_get_vvar(QByteArray name);
+
+	/// DEPRECATED: Object vim_get_option(String name, )
+	NeovimQt::MsgpackRequest* vim_get_option(QByteArray name);
+
+	/// DEPRECATED: void vim_set_option(String name, Object value, )
+	NeovimQt::MsgpackRequest* vim_set_option(QByteArray name, QVariant value);
+
+	/// DEPRECATED: void vim_out_write(String str, )
+	NeovimQt::MsgpackRequest* vim_out_write(QByteArray str);
+
+	/// DEPRECATED: void vim_err_write(String str, )
+	NeovimQt::MsgpackRequest* vim_err_write(QByteArray str);
+
+	/// DEPRECATED: void vim_report_error(String str, )
+	NeovimQt::MsgpackRequest* vim_report_error(QByteArray str);
+
+	/// DEPRECATED: ArrayOf(Buffer) vim_get_buffers()
+	NeovimQt::MsgpackRequest* vim_get_buffers();
+
+	/// DEPRECATED: Buffer vim_get_current_buffer()
+	NeovimQt::MsgpackRequest* vim_get_current_buffer();
+
+	/// DEPRECATED: void vim_set_current_buffer(Buffer buffer, )
+	NeovimQt::MsgpackRequest* vim_set_current_buffer(int64_t buffer);
+
+	/// DEPRECATED: ArrayOf(Window) vim_get_windows()
+	NeovimQt::MsgpackRequest* vim_get_windows();
+
+	/// DEPRECATED: Window vim_get_current_window()
+	NeovimQt::MsgpackRequest* vim_get_current_window();
+
+	/// DEPRECATED: void vim_set_current_window(Window window, )
+	NeovimQt::MsgpackRequest* vim_set_current_window(int64_t window);
+
+	/// DEPRECATED: ArrayOf(Tabpage) vim_get_tabpages()
+	NeovimQt::MsgpackRequest* vim_get_tabpages();
+
+	/// DEPRECATED: Tabpage vim_get_current_tabpage()
+	NeovimQt::MsgpackRequest* vim_get_current_tabpage();
+
+	/// DEPRECATED: void vim_set_current_tabpage(Tabpage tabpage, )
+	NeovimQt::MsgpackRequest* vim_set_current_tabpage(int64_t tabpage);
+
+	/// DEPRECATED: void vim_subscribe(String event, )
+	NeovimQt::MsgpackRequest* vim_subscribe(QByteArray event);
+
+	/// DEPRECATED: void vim_unsubscribe(String event, )
+	NeovimQt::MsgpackRequest* vim_unsubscribe(QByteArray event);
+
+	/// DEPRECATED: Integer vim_name_to_color(String name, )
+	NeovimQt::MsgpackRequest* vim_name_to_color(QByteArray name);
+
+	/// DEPRECATED: Dictionary vim_get_color_map()
+	NeovimQt::MsgpackRequest* vim_get_color_map();
+
+	/// DEPRECATED: Buffer window_get_buffer(Window window, )
+	NeovimQt::MsgpackRequest* window_get_buffer(int64_t window);
+
+	/// DEPRECATED: ArrayOf(Integer, 2) window_get_cursor(Window window, )
+	NeovimQt::MsgpackRequest* window_get_cursor(int64_t window);
+
+	/// DEPRECATED: void window_set_cursor(Window window, ArrayOf(Integer, 2) pos, )
+	NeovimQt::MsgpackRequest* window_set_cursor(int64_t window, QPoint pos);
+
+	/// DEPRECATED: Integer window_get_height(Window window, )
+	NeovimQt::MsgpackRequest* window_get_height(int64_t window);
+
+	/// DEPRECATED: void window_set_height(Window window, Integer height, )
+	NeovimQt::MsgpackRequest* window_set_height(int64_t window, int64_t height);
+
+	/// DEPRECATED: Integer window_get_width(Window window, )
+	NeovimQt::MsgpackRequest* window_get_width(int64_t window);
+
+	/// DEPRECATED: void window_set_width(Window window, Integer width, )
+	NeovimQt::MsgpackRequest* window_set_width(int64_t window, int64_t width);
+
+	/// DEPRECATED: Object window_get_var(Window window, String name, )
+	NeovimQt::MsgpackRequest* window_get_var(int64_t window, QByteArray name);
+
+	/// DEPRECATED: Object window_get_option(Window window, String name, )
+	NeovimQt::MsgpackRequest* window_get_option(int64_t window, QByteArray name);
+
+	/// DEPRECATED: void window_set_option(Window window, String name, Object value, )
+	NeovimQt::MsgpackRequest* window_set_option(int64_t window, QByteArray name, QVariant value);
+
+	/// DEPRECATED: ArrayOf(Integer, 2) window_get_position(Window window, )
+	NeovimQt::MsgpackRequest* window_get_position(int64_t window);
+
+	/// DEPRECATED: Tabpage window_get_tabpage(Window window, )
+	NeovimQt::MsgpackRequest* window_get_tabpage(int64_t window);
+
+	/// DEPRECATED: Boolean window_is_valid(Window window, )
+	NeovimQt::MsgpackRequest* window_is_valid(int64_t window);
+
 
 signals:
 	void on_nvim_buf_line_count(int64_t);
@@ -1229,5 +1341,5 @@ signals:
 	void err_window_is_valid(const QString&, const QVariant&);
 
 };
-} // namespace
-#endif
+
+} // namespace NeovimQt

--- a/src/auto/neovimapi6.cpp
+++ b/src/auto/neovimapi6.cpp
@@ -1,15 +1,15 @@
-// Auto generated 2019-01-13 02:04:50.926393 from nvim API level:6
+// Auto generated 2020-09-09 13:30:54.415020 from nvim API level:6
 #include "auto/neovimapi6.h"
-#include "neovimconnector.h"
-#include "msgpackrequest.h"
 #include "msgpackiodevice.h"
+#include "msgpackrequest.h"
+#include "neovimconnector.h"
 #include "util.h"
 
 namespace NeovimQt {
 /* Unpack Neovim EXT types Window, Buffer Tabpage which are all
  * uint64_t see Neovim:msgpack_rpc_to_
  */
-QVariant unpackBufferApi6(MsgpackIODevice *dev, const char* in, quint32 size)
+static QVariant unpackBufferApi6(MsgpackIODevice *dev, const char* in, uint32_t size) noexcept
 {
 	msgpack_unpacked result;
 	msgpack_unpacked_init(&result);
@@ -20,10 +20,10 @@ QVariant unpackBufferApi6(MsgpackIODevice *dev, const char* in, quint32 size)
 	if (ret == MSGPACK_UNPACK_SUCCESS) {
 		switch (result.data.type) {
 			case MSGPACK_OBJECT_NEGATIVE_INTEGER:
-				variant = (qint64)result.data.via.i64;
+				variant.setValue<int64_t>(result.data.via.i64);
 				break;
 			case MSGPACK_OBJECT_POSITIVE_INTEGER:
-				variant = (quint64)result.data.via.u64;
+				variant.setValue<uint64_t>(result.data.via.u64);
 				break;
 			default:
 				// TODO it would be nice if we could call back MsgpackIoDevice method or primitive types here
@@ -34,1824 +34,2205 @@ QVariant unpackBufferApi6(MsgpackIODevice *dev, const char* in, quint32 size)
 	msgpack_unpacked_destroy(&result);
 	return variant;
 }
-#define unpackWindowApi6 unpackBufferApi6
-#define unpackTabpageApi6 unpackBufferApi6
 
-NeovimApi6::NeovimApi6(NeovimConnector *c)
-:m_c(c)
+static QVariant unpackWindowApi6(MsgpackIODevice *dev, const char* in, uint32_t size) noexcept
+{
+	return unpackBufferApi6(dev, in, size);
+}
+
+static QVariant unpackTabpageApi6(MsgpackIODevice *dev, const char* in, uint32_t size) noexcept
+{
+	return unpackBufferApi6(dev, in, size);
+}
+
+NeovimApi6::NeovimApi6(NeovimConnector *c) noexcept
+	: m_connector{ c }
 {
 	// EXT types
-		m_c->m_dev->registerExtType(0, unpackBufferApi6);
-		m_c->m_dev->registerExtType(1, unpackWindowApi6);
-		m_c->m_dev->registerExtType(2, unpackTabpageApi6);
-		connect(m_c->m_dev, &MsgpackIODevice::notification,
-			this, &NeovimApi6::neovimNotification);
+	m_connector->m_dev->registerExtType(0, unpackBufferApi6);
+	m_connector->m_dev->registerExtType(1, unpackWindowApi6);
+	m_connector->m_dev->registerExtType(2, unpackTabpageApi6);
+	connect(m_connector->m_dev, &MsgpackIODevice::notification,
+		this, &NeovimApi6::neovimNotification);
 }
 
 // Slots
 MsgpackRequest* NeovimApi6::nvim_buf_line_count(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_line_count", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_line_count", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_BUF_LINE_COUNT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::buffer_get_line(int64_t buffer, int64_t index)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_line", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_get_line", 2) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_BUFFER_GET_LINE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(index);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(index);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_buf_attach(int64_t buffer, bool send_buffer, QVariantMap opts)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_attach", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_attach", 3) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_BUF_ATTACH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(send_buffer);
-	m_c->m_dev->send(opts);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(send_buffer);
+	m_connector->m_dev->send(opts);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_buf_detach(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_detach", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_detach", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_BUF_DETACH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::buffer_set_line(int64_t buffer, int64_t index, QByteArray line)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_set_line", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_set_line", 3) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_BUFFER_SET_LINE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(index);
-	m_c->m_dev->send(line);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(index);
+	m_connector->m_dev->send(line);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::buffer_del_line(int64_t buffer, int64_t index)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_del_line", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_del_line", 2) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_BUFFER_DEL_LINE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(index);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(index);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::buffer_get_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_line_slice", 5);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_get_line_slice", 5) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_BUFFER_GET_LINE_SLICE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(start);
-	m_c->m_dev->send(end);
-	m_c->m_dev->send(include_start);
-	m_c->m_dev->send(include_end);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(start);
+	m_connector->m_dev->send(end);
+	m_connector->m_dev->send(include_start);
+	m_connector->m_dev->send(include_end);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_buf_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_get_lines", 4);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_get_lines", 4) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_BUF_GET_LINES);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(start);
-	m_c->m_dev->send(end);
-	m_c->m_dev->send(strict_indexing);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(start);
+	m_connector->m_dev->send(end);
+	m_connector->m_dev->send(strict_indexing);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::buffer_set_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end, QList<QByteArray> replacement)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_set_line_slice", 6);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_set_line_slice", 6) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_BUFFER_SET_LINE_SLICE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(start);
-	m_c->m_dev->send(end);
-	m_c->m_dev->send(include_start);
-	m_c->m_dev->send(include_end);
-	m_c->m_dev->sendArrayOf(replacement);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(start);
+	m_connector->m_dev->send(end);
+	m_connector->m_dev->send(include_start);
+	m_connector->m_dev->send(include_end);
+	m_connector->m_dev->sendArrayOf(replacement);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_buf_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_set_lines", 5);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_set_lines", 5) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_BUF_SET_LINES);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(start);
-	m_c->m_dev->send(end);
-	m_c->m_dev->send(strict_indexing);
-	m_c->m_dev->sendArrayOf(replacement);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(start);
+	m_connector->m_dev->send(end);
+	m_connector->m_dev->send(strict_indexing);
+	m_connector->m_dev->sendArrayOf(replacement);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_buf_get_offset(int64_t buffer, int64_t index)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_get_offset", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_get_offset", 2) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_BUF_GET_OFFSET);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(index);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(index);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_buf_get_var(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_get_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_get_var", 2) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_BUF_GET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_buf_get_changedtick(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_get_changedtick", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_get_changedtick", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_BUF_GET_CHANGEDTICK);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_buf_get_keymap(int64_t buffer, QByteArray mode)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_get_keymap", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_get_keymap", 2) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_BUF_GET_KEYMAP);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(mode);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(mode);
 	return r;
 }
+
+MsgpackRequest* NeovimApi6::nvim_buf_set_keymap(int64_t buffer, QByteArray mode, QByteArray lhs, QByteArray rhs, QVariantMap opts)
+{
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_set_keymap", 5) };
+	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_BUF_SET_KEYMAP);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(mode);
+	m_connector->m_dev->send(lhs);
+	m_connector->m_dev->send(rhs);
+	m_connector->m_dev->send(opts);
+	return r;
+}
+
+MsgpackRequest* NeovimApi6::nvim_buf_del_keymap(int64_t buffer, QByteArray mode, QByteArray lhs)
+{
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_del_keymap", 3) };
+	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_BUF_DEL_KEYMAP);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(mode);
+	m_connector->m_dev->send(lhs);
+	return r;
+}
+
 MsgpackRequest* NeovimApi6::nvim_buf_get_commands(int64_t buffer, QVariantMap opts)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_get_commands", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_get_commands", 2) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_BUF_GET_COMMANDS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(opts);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(opts);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_buf_set_var(int64_t buffer, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_set_var", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_set_var", 3) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_BUF_SET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_buf_del_var(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_del_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_del_var", 2) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_BUF_DEL_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::buffer_set_var(int64_t buffer, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_set_var", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_set_var", 3) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_BUFFER_SET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::buffer_del_var(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_del_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_del_var", 2) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_BUFFER_DEL_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_buf_get_option(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_get_option", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_get_option", 2) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_BUF_GET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_buf_set_option(int64_t buffer, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_set_option", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_set_option", 3) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_BUF_SET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_buf_get_number(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_get_number", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_get_number", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_BUF_GET_NUMBER);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_buf_get_name(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_get_name", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_get_name", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_BUF_GET_NAME);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_buf_set_name(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_set_name", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_set_name", 2) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_BUF_SET_NAME);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_buf_is_loaded(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_is_loaded", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_is_loaded", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_BUF_IS_LOADED);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_buf_is_valid(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_is_valid", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_is_valid", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_BUF_IS_VALID);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::buffer_insert(int64_t buffer, int64_t lnum, QList<QByteArray> lines)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_insert", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_insert", 3) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_BUFFER_INSERT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(lnum);
-	m_c->m_dev->sendArrayOf(lines);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(lnum);
+	m_connector->m_dev->sendArrayOf(lines);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_buf_get_mark(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_get_mark", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_get_mark", 2) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_BUF_GET_MARK);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_buf_add_highlight(int64_t buffer, int64_t ns_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_add_highlight", 6);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_add_highlight", 6) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_BUF_ADD_HIGHLIGHT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(ns_id);
-	m_c->m_dev->send(hl_group);
-	m_c->m_dev->send(line);
-	m_c->m_dev->send(col_start);
-	m_c->m_dev->send(col_end);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(ns_id);
+	m_connector->m_dev->send(hl_group);
+	m_connector->m_dev->send(line);
+	m_connector->m_dev->send(col_start);
+	m_connector->m_dev->send(col_end);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_buf_clear_namespace(int64_t buffer, int64_t ns_id, int64_t line_start, int64_t line_end)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_clear_namespace", 4);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_clear_namespace", 4) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_BUF_CLEAR_NAMESPACE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(ns_id);
-	m_c->m_dev->send(line_start);
-	m_c->m_dev->send(line_end);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(ns_id);
+	m_connector->m_dev->send(line_start);
+	m_connector->m_dev->send(line_end);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_buf_clear_highlight(int64_t buffer, int64_t ns_id, int64_t line_start, int64_t line_end)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_clear_highlight", 4);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_clear_highlight", 4) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_BUF_CLEAR_HIGHLIGHT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(ns_id);
-	m_c->m_dev->send(line_start);
-	m_c->m_dev->send(line_end);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(ns_id);
+	m_connector->m_dev->send(line_start);
+	m_connector->m_dev->send(line_end);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_buf_set_virtual_text(int64_t buffer, int64_t ns_id, int64_t line, QVariantList chunks, QVariantMap opts)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_set_virtual_text", 5);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_buf_set_virtual_text", 5) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_BUF_SET_VIRTUAL_TEXT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(ns_id);
-	m_c->m_dev->send(line);
-	m_c->m_dev->send(chunks);
-	m_c->m_dev->send(opts);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(ns_id);
+	m_connector->m_dev->send(line);
+	m_connector->m_dev->send(chunks);
+	m_connector->m_dev->send(opts);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_tabpage_list_wins(int64_t tabpage)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_tabpage_list_wins", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_tabpage_list_wins", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_TABPAGE_LIST_WINS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(tabpage);
+	m_connector->m_dev->send(tabpage);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_tabpage_get_var(int64_t tabpage, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_tabpage_get_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_tabpage_get_var", 2) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_TABPAGE_GET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(tabpage);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(tabpage);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_tabpage_set_var", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_tabpage_set_var", 3) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_TABPAGE_SET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(tabpage);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(tabpage);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_tabpage_del_var(int64_t tabpage, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_tabpage_del_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_tabpage_del_var", 2) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_TABPAGE_DEL_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(tabpage);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(tabpage);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("tabpage_set_var", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("tabpage_set_var", 3) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_TABPAGE_SET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(tabpage);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(tabpage);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::tabpage_del_var(int64_t tabpage, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("tabpage_del_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("tabpage_del_var", 2) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_TABPAGE_DEL_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(tabpage);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(tabpage);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_tabpage_get_win(int64_t tabpage)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_tabpage_get_win", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_tabpage_get_win", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_TABPAGE_GET_WIN);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(tabpage);
+	m_connector->m_dev->send(tabpage);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_tabpage_get_number(int64_t tabpage)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_tabpage_get_number", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_tabpage_get_number", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_TABPAGE_GET_NUMBER);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(tabpage);
+	m_connector->m_dev->send(tabpage);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_tabpage_is_valid(int64_t tabpage)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_tabpage_is_valid", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_tabpage_is_valid", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_TABPAGE_IS_VALID);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(tabpage);
+	m_connector->m_dev->send(tabpage);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_ui_attach(int64_t width, int64_t height, QVariantMap options)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_ui_attach", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_ui_attach", 3) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_UI_ATTACH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(width);
-	m_c->m_dev->send(height);
-	m_c->m_dev->send(options);
+	m_connector->m_dev->send(width);
+	m_connector->m_dev->send(height);
+	m_connector->m_dev->send(options);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::ui_attach(int64_t width, int64_t height, bool enable_rgb)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("ui_attach", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("ui_attach", 3) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_UI_ATTACH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(width);
-	m_c->m_dev->send(height);
-	m_c->m_dev->send(enable_rgb);
+	m_connector->m_dev->send(width);
+	m_connector->m_dev->send(height);
+	m_connector->m_dev->send(enable_rgb);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_ui_detach()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_ui_detach", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_ui_detach", 0) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_UI_DETACH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_ui_try_resize(int64_t width, int64_t height)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_ui_try_resize", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_ui_try_resize", 2) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_UI_TRY_RESIZE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(width);
-	m_c->m_dev->send(height);
+	m_connector->m_dev->send(width);
+	m_connector->m_dev->send(height);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_ui_set_option(QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_ui_set_option", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_ui_set_option", 2) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_UI_SET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_ui_try_resize_grid(int64_t grid, int64_t width, int64_t height)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_ui_try_resize_grid", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_ui_try_resize_grid", 3) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_UI_TRY_RESIZE_GRID);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(grid);
-	m_c->m_dev->send(width);
-	m_c->m_dev->send(height);
+	m_connector->m_dev->send(grid);
+	m_connector->m_dev->send(width);
+	m_connector->m_dev->send(height);
 	return r;
 }
+
+MsgpackRequest* NeovimApi6::nvim_ui_pum_set_height(int64_t height)
+{
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_ui_pum_set_height", 1) };
+	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_UI_PUM_SET_HEIGHT);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
+	m_connector->m_dev->send(height);
+	return r;
+}
+
 MsgpackRequest* NeovimApi6::nvim_command(QByteArray command)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_command", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_command", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_COMMAND);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(command);
+	m_connector->m_dev->send(command);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_get_hl_by_name(QByteArray name, bool rgb)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_hl_by_name", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_hl_by_name", 2) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_GET_HL_BY_NAME);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(rgb);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(rgb);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_get_hl_by_id(int64_t hl_id, bool rgb)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_hl_by_id", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_hl_by_id", 2) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_GET_HL_BY_ID);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(hl_id);
-	m_c->m_dev->send(rgb);
+	m_connector->m_dev->send(hl_id);
+	m_connector->m_dev->send(rgb);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_feedkeys", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_feedkeys", 3) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_FEEDKEYS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(keys);
-	m_c->m_dev->send(mode);
-	m_c->m_dev->send(escape_csi);
+	m_connector->m_dev->send(keys);
+	m_connector->m_dev->send(mode);
+	m_connector->m_dev->send(escape_csi);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_input(QByteArray keys)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_input", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_input", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_INPUT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(keys);
+	m_connector->m_dev->send(keys);
 	return r;
 }
+
+MsgpackRequest* NeovimApi6::nvim_input_mouse(QByteArray button, QByteArray action, QByteArray modifier, int64_t grid, int64_t row, int64_t col)
+{
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_input_mouse", 6) };
+	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_INPUT_MOUSE);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
+	m_connector->m_dev->send(button);
+	m_connector->m_dev->send(action);
+	m_connector->m_dev->send(modifier);
+	m_connector->m_dev->send(grid);
+	m_connector->m_dev->send(row);
+	m_connector->m_dev->send(col);
+	return r;
+}
+
 MsgpackRequest* NeovimApi6::nvim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_replace_termcodes", 4);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_replace_termcodes", 4) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_REPLACE_TERMCODES);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(str);
-	m_c->m_dev->send(from_part);
-	m_c->m_dev->send(do_lt);
-	m_c->m_dev->send(special);
+	m_connector->m_dev->send(str);
+	m_connector->m_dev->send(from_part);
+	m_connector->m_dev->send(do_lt);
+	m_connector->m_dev->send(special);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_command_output(QByteArray command)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_command_output", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_command_output", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_COMMAND_OUTPUT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(command);
+	m_connector->m_dev->send(command);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_eval(QByteArray expr)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_eval", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_eval", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_EVAL);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(expr);
+	m_connector->m_dev->send(expr);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_execute_lua(QByteArray code, QVariantList args)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_execute_lua", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_execute_lua", 2) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_EXECUTE_LUA);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(code);
-	m_c->m_dev->send(args);
+	m_connector->m_dev->send(code);
+	m_connector->m_dev->send(args);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_call_function(QByteArray fn, QVariantList args)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_call_function", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_call_function", 2) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_CALL_FUNCTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(fn);
-	m_c->m_dev->send(args);
+	m_connector->m_dev->send(fn);
+	m_connector->m_dev->send(args);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_call_dict_function(QVariant dict, QByteArray fn, QVariantList args)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_call_dict_function", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_call_dict_function", 3) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_CALL_DICT_FUNCTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(dict);
-	m_c->m_dev->send(fn);
-	m_c->m_dev->send(args);
+	m_connector->m_dev->send(dict);
+	m_connector->m_dev->send(fn);
+	m_connector->m_dev->send(args);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_strwidth(QByteArray text)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_strwidth", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_strwidth", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_STRWIDTH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(text);
+	m_connector->m_dev->send(text);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_list_runtime_paths()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_list_runtime_paths", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_list_runtime_paths", 0) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_LIST_RUNTIME_PATHS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_set_current_dir(QByteArray dir)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_set_current_dir", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_set_current_dir", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_SET_CURRENT_DIR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(dir);
+	m_connector->m_dev->send(dir);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_get_current_line()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_current_line", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_current_line", 0) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_GET_CURRENT_LINE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_set_current_line(QByteArray line)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_set_current_line", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_set_current_line", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_SET_CURRENT_LINE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(line);
+	m_connector->m_dev->send(line);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_del_current_line()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_del_current_line", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_del_current_line", 0) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_DEL_CURRENT_LINE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_get_var(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_var", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_var", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_GET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_set_var(QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_set_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_set_var", 2) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_SET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_del_var(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_del_var", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_del_var", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_DEL_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::vim_set_var(QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_set_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_set_var", 2) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_VIM_SET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::vim_del_var(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_del_var", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_del_var", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_VIM_DEL_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_get_vvar(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_vvar", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_vvar", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_GET_VVAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
+MsgpackRequest* NeovimApi6::nvim_set_vvar(QByteArray name, QVariant value)
+{
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_set_vvar", 2) };
+	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_SET_VVAR);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
+	return r;
+}
+
 MsgpackRequest* NeovimApi6::nvim_get_option(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_option", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_option", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_GET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_set_option(QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_set_option", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_set_option", 2) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_SET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_out_write(QByteArray str)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_out_write", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_out_write", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_OUT_WRITE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(str);
+	m_connector->m_dev->send(str);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_err_write(QByteArray str)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_err_write", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_err_write", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_ERR_WRITE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(str);
+	m_connector->m_dev->send(str);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_err_writeln(QByteArray str)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_err_writeln", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_err_writeln", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_ERR_WRITELN);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(str);
+	m_connector->m_dev->send(str);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_list_bufs()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_list_bufs", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_list_bufs", 0) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_LIST_BUFS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_get_current_buf()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_current_buf", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_current_buf", 0) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_GET_CURRENT_BUF);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_set_current_buf(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_set_current_buf", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_set_current_buf", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_SET_CURRENT_BUF);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_list_wins()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_list_wins", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_list_wins", 0) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_LIST_WINS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_get_current_win()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_current_win", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_current_win", 0) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_GET_CURRENT_WIN);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_set_current_win(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_set_current_win", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_set_current_win", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_SET_CURRENT_WIN);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
+MsgpackRequest* NeovimApi6::nvim_create_buf(bool listed, bool scratch)
+{
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_create_buf", 2) };
+	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_CREATE_BUF);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
+	m_connector->m_dev->send(listed);
+	m_connector->m_dev->send(scratch);
+	return r;
+}
+
+MsgpackRequest* NeovimApi6::nvim_open_win(int64_t buffer, bool enter, QVariantMap config)
+{
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_open_win", 3) };
+	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_OPEN_WIN);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(enter);
+	m_connector->m_dev->send(config);
+	return r;
+}
+
 MsgpackRequest* NeovimApi6::nvim_list_tabpages()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_list_tabpages", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_list_tabpages", 0) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_LIST_TABPAGES);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_get_current_tabpage()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_current_tabpage", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_current_tabpage", 0) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_GET_CURRENT_TABPAGE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_set_current_tabpage(int64_t tabpage)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_set_current_tabpage", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_set_current_tabpage", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_SET_CURRENT_TABPAGE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(tabpage);
+	m_connector->m_dev->send(tabpage);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_create_namespace(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_create_namespace", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_create_namespace", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_CREATE_NAMESPACE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_get_namespaces()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_namespaces", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_namespaces", 0) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_GET_NAMESPACES);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
 	return r;
 }
+
+MsgpackRequest* NeovimApi6::nvim_paste(QByteArray data, bool crlf, int64_t phase)
+{
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_paste", 3) };
+	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_PASTE);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
+	m_connector->m_dev->send(data);
+	m_connector->m_dev->send(crlf);
+	m_connector->m_dev->send(phase);
+	return r;
+}
+
+MsgpackRequest* NeovimApi6::nvim_put(QList<QByteArray> lines, QByteArray type, bool after, bool follow)
+{
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_put", 4) };
+	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_PUT);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
+	m_connector->m_dev->sendArrayOf(lines);
+	m_connector->m_dev->send(type);
+	m_connector->m_dev->send(after);
+	m_connector->m_dev->send(follow);
+	return r;
+}
+
 MsgpackRequest* NeovimApi6::nvim_subscribe(QByteArray event)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_subscribe", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_subscribe", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_SUBSCRIBE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(event);
+	m_connector->m_dev->send(event);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_unsubscribe(QByteArray event)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_unsubscribe", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_unsubscribe", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_UNSUBSCRIBE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(event);
+	m_connector->m_dev->send(event);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_get_color_by_name(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_color_by_name", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_color_by_name", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_GET_COLOR_BY_NAME);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_get_color_map()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_color_map", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_color_map", 0) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_GET_COLOR_MAP);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
 	return r;
 }
+
+MsgpackRequest* NeovimApi6::nvim_get_context(QVariantMap opts)
+{
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_context", 1) };
+	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_GET_CONTEXT);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
+	m_connector->m_dev->send(opts);
+	return r;
+}
+
+MsgpackRequest* NeovimApi6::nvim_load_context(QVariantMap dict)
+{
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_load_context", 1) };
+	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_LOAD_CONTEXT);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
+	m_connector->m_dev->send(dict);
+	return r;
+}
+
 MsgpackRequest* NeovimApi6::nvim_get_mode()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_mode", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_mode", 0) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_GET_MODE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_get_keymap(QByteArray mode)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_keymap", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_keymap", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_GET_KEYMAP);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(mode);
+	m_connector->m_dev->send(mode);
 	return r;
 }
+
+MsgpackRequest* NeovimApi6::nvim_set_keymap(QByteArray mode, QByteArray lhs, QByteArray rhs, QVariantMap opts)
+{
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_set_keymap", 4) };
+	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_SET_KEYMAP);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
+	m_connector->m_dev->send(mode);
+	m_connector->m_dev->send(lhs);
+	m_connector->m_dev->send(rhs);
+	m_connector->m_dev->send(opts);
+	return r;
+}
+
+MsgpackRequest* NeovimApi6::nvim_del_keymap(QByteArray mode, QByteArray lhs)
+{
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_del_keymap", 2) };
+	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_DEL_KEYMAP);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
+	m_connector->m_dev->send(mode);
+	m_connector->m_dev->send(lhs);
+	return r;
+}
+
 MsgpackRequest* NeovimApi6::nvim_get_commands(QVariantMap opts)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_commands", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_commands", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_GET_COMMANDS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(opts);
+	m_connector->m_dev->send(opts);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_get_api_info()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_api_info", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_api_info", 0) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_GET_API_INFO);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_set_client_info(QByteArray name, QVariantMap version, QByteArray type, QVariantMap methods, QVariantMap attributes)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_set_client_info", 5);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_set_client_info", 5) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_SET_CLIENT_INFO);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(version);
-	m_c->m_dev->send(type);
-	m_c->m_dev->send(methods);
-	m_c->m_dev->send(attributes);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(version);
+	m_connector->m_dev->send(type);
+	m_connector->m_dev->send(methods);
+	m_connector->m_dev->send(attributes);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_get_chan_info(int64_t chan)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_chan_info", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_chan_info", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_GET_CHAN_INFO);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(chan);
+	m_connector->m_dev->send(chan);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_list_chans()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_list_chans", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_list_chans", 0) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_LIST_CHANS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_call_atomic(QVariantList calls)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_call_atomic", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_call_atomic", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_CALL_ATOMIC);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(calls);
+	m_connector->m_dev->send(calls);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_parse_expression(QByteArray expr, QByteArray flags, bool highlight)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_parse_expression", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_parse_expression", 3) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_PARSE_EXPRESSION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(expr);
-	m_c->m_dev->send(flags);
-	m_c->m_dev->send(highlight);
+	m_connector->m_dev->send(expr);
+	m_connector->m_dev->send(flags);
+	m_connector->m_dev->send(highlight);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_list_uis()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_list_uis", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_list_uis", 0) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_LIST_UIS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_get_proc_children(int64_t pid)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_proc_children", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_proc_children", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_GET_PROC_CHILDREN);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(pid);
+	m_connector->m_dev->send(pid);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_get_proc(int64_t pid)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_proc", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_get_proc", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_GET_PROC);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(pid);
+	m_connector->m_dev->send(pid);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_select_popupmenu_item(int64_t item, bool insert, bool finish, QVariantMap opts)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_select_popupmenu_item", 4);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_select_popupmenu_item", 4) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_SELECT_POPUPMENU_ITEM);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(item);
-	m_c->m_dev->send(insert);
-	m_c->m_dev->send(finish);
-	m_c->m_dev->send(opts);
+	m_connector->m_dev->send(item);
+	m_connector->m_dev->send(insert);
+	m_connector->m_dev->send(finish);
+	m_connector->m_dev->send(opts);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_win_get_buf(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_buf", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_get_buf", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_WIN_GET_BUF);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_win_set_buf(int64_t window, int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_set_buf", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_set_buf", 2) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_WIN_SET_BUF);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_win_get_cursor(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_cursor", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_get_cursor", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_WIN_GET_CURSOR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_win_set_cursor(int64_t window, QPoint pos)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_set_cursor", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_set_cursor", 2) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_WIN_SET_CURSOR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(pos);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(pos);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_win_get_height(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_height", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_get_height", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_WIN_GET_HEIGHT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_win_set_height(int64_t window, int64_t height)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_set_height", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_set_height", 2) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_WIN_SET_HEIGHT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(height);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(height);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_win_get_width(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_width", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_get_width", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_WIN_GET_WIDTH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_win_set_width(int64_t window, int64_t width)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_set_width", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_set_width", 2) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_WIN_SET_WIDTH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(width);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(width);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_win_get_var(int64_t window, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_get_var", 2) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_WIN_GET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_win_set_var(int64_t window, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_set_var", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_set_var", 3) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_WIN_SET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_win_del_var(int64_t window, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_del_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_del_var", 2) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_WIN_DEL_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::window_set_var(int64_t window, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_set_var", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_set_var", 3) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_WINDOW_SET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::window_del_var(int64_t window, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_del_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_del_var", 2) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_WINDOW_DEL_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_win_get_option(int64_t window, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_option", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_get_option", 2) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_WIN_GET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_win_set_option(int64_t window, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_set_option", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_set_option", 3) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_WIN_SET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_win_get_position(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_position", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_get_position", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_WIN_GET_POSITION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_win_get_tabpage(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_tabpage", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_get_tabpage", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_WIN_GET_TABPAGE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_win_get_number(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_number", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_get_number", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_WIN_GET_NUMBER);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::nvim_win_is_valid(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_is_valid", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_is_valid", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_WIN_IS_VALID);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
+MsgpackRequest* NeovimApi6::nvim_win_set_config(int64_t window, QVariantMap config)
+{
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_set_config", 2) };
+	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_WIN_SET_CONFIG);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(config);
+	return r;
+}
+
+MsgpackRequest* NeovimApi6::nvim_win_get_config(int64_t window)
+{
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_get_config", 1) };
+	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_WIN_GET_CONFIG);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
+	m_connector->m_dev->send(window);
+	return r;
+}
+
+MsgpackRequest* NeovimApi6::nvim_win_close(int64_t window, bool force)
+{
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("nvim_win_close", 2) };
+	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_WIN_CLOSE);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(force);
+	return r;
+}
+
 MsgpackRequest* NeovimApi6::buffer_line_count(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_line_count", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_line_count", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_BUFFER_LINE_COUNT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::buffer_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_lines", 4);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_get_lines", 4) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_BUFFER_GET_LINES);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(start);
-	m_c->m_dev->send(end);
-	m_c->m_dev->send(strict_indexing);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(start);
+	m_connector->m_dev->send(end);
+	m_connector->m_dev->send(strict_indexing);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::buffer_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_set_lines", 5);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_set_lines", 5) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_BUFFER_SET_LINES);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(start);
-	m_c->m_dev->send(end);
-	m_c->m_dev->send(strict_indexing);
-	m_c->m_dev->sendArrayOf(replacement);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(start);
+	m_connector->m_dev->send(end);
+	m_connector->m_dev->send(strict_indexing);
+	m_connector->m_dev->sendArrayOf(replacement);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::buffer_get_var(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_get_var", 2) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_BUFFER_GET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::buffer_get_option(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_option", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_get_option", 2) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_BUFFER_GET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::buffer_set_option(int64_t buffer, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_set_option", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_set_option", 3) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_BUFFER_SET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::buffer_get_number(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_number", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_get_number", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_BUFFER_GET_NUMBER);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::buffer_get_name(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_name", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_get_name", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_BUFFER_GET_NAME);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::buffer_set_name(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_set_name", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_set_name", 2) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_BUFFER_SET_NAME);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::buffer_is_valid(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_is_valid", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_is_valid", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_BUFFER_IS_VALID);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::buffer_get_mark(int64_t buffer, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_get_mark", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_get_mark", 2) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_BUFFER_GET_MARK);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::buffer_add_highlight(int64_t buffer, int64_t ns_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_add_highlight", 6);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_add_highlight", 6) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_BUFFER_ADD_HIGHLIGHT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(ns_id);
-	m_c->m_dev->send(hl_group);
-	m_c->m_dev->send(line);
-	m_c->m_dev->send(col_start);
-	m_c->m_dev->send(col_end);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(ns_id);
+	m_connector->m_dev->send(hl_group);
+	m_connector->m_dev->send(line);
+	m_connector->m_dev->send(col_start);
+	m_connector->m_dev->send(col_end);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::buffer_clear_highlight(int64_t buffer, int64_t ns_id, int64_t line_start, int64_t line_end)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("buffer_clear_highlight", 4);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("buffer_clear_highlight", 4) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_BUFFER_CLEAR_HIGHLIGHT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(buffer);
-	m_c->m_dev->send(ns_id);
-	m_c->m_dev->send(line_start);
-	m_c->m_dev->send(line_end);
+	m_connector->m_dev->send(buffer);
+	m_connector->m_dev->send(ns_id);
+	m_connector->m_dev->send(line_start);
+	m_connector->m_dev->send(line_end);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::tabpage_get_windows(int64_t tabpage)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("tabpage_get_windows", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("tabpage_get_windows", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_TABPAGE_GET_WINDOWS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(tabpage);
+	m_connector->m_dev->send(tabpage);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::tabpage_get_var(int64_t tabpage, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("tabpage_get_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("tabpage_get_var", 2) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_TABPAGE_GET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(tabpage);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(tabpage);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::tabpage_get_window(int64_t tabpage)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("tabpage_get_window", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("tabpage_get_window", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_TABPAGE_GET_WINDOW);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(tabpage);
+	m_connector->m_dev->send(tabpage);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::tabpage_is_valid(int64_t tabpage)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("tabpage_is_valid", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("tabpage_is_valid", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_TABPAGE_IS_VALID);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(tabpage);
+	m_connector->m_dev->send(tabpage);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::ui_detach()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("ui_detach", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("ui_detach", 0) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_UI_DETACH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::ui_try_resize(int64_t width, int64_t height)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("ui_try_resize", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("ui_try_resize", 2) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_UI_TRY_RESIZE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(width);
-	m_c->m_dev->send(height);
+	m_connector->m_dev->send(width);
+	m_connector->m_dev->send(height);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::vim_command(QByteArray command)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_command", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_command", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_VIM_COMMAND);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(command);
+	m_connector->m_dev->send(command);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::vim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_feedkeys", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_feedkeys", 3) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_VIM_FEEDKEYS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(keys);
-	m_c->m_dev->send(mode);
-	m_c->m_dev->send(escape_csi);
+	m_connector->m_dev->send(keys);
+	m_connector->m_dev->send(mode);
+	m_connector->m_dev->send(escape_csi);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::vim_input(QByteArray keys)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_input", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_input", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_VIM_INPUT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(keys);
+	m_connector->m_dev->send(keys);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::vim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_replace_termcodes", 4);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_replace_termcodes", 4) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_VIM_REPLACE_TERMCODES);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(str);
-	m_c->m_dev->send(from_part);
-	m_c->m_dev->send(do_lt);
-	m_c->m_dev->send(special);
+	m_connector->m_dev->send(str);
+	m_connector->m_dev->send(from_part);
+	m_connector->m_dev->send(do_lt);
+	m_connector->m_dev->send(special);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::vim_command_output(QByteArray command)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_command_output", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_command_output", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_VIM_COMMAND_OUTPUT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(command);
+	m_connector->m_dev->send(command);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::vim_eval(QByteArray expr)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_eval", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_eval", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_VIM_EVAL);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(expr);
+	m_connector->m_dev->send(expr);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::vim_call_function(QByteArray fn, QVariantList args)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_call_function", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_call_function", 2) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_VIM_CALL_FUNCTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(fn);
-	m_c->m_dev->send(args);
+	m_connector->m_dev->send(fn);
+	m_connector->m_dev->send(args);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::vim_strwidth(QByteArray text)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_strwidth", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_strwidth", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_VIM_STRWIDTH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(text);
+	m_connector->m_dev->send(text);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::vim_list_runtime_paths()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_list_runtime_paths", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_list_runtime_paths", 0) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_VIM_LIST_RUNTIME_PATHS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::vim_change_directory(QByteArray dir)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_change_directory", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_change_directory", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_VIM_CHANGE_DIRECTORY);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(dir);
+	m_connector->m_dev->send(dir);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::vim_get_current_line()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_current_line", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_current_line", 0) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_VIM_GET_CURRENT_LINE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::vim_set_current_line(QByteArray line)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_set_current_line", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_set_current_line", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_VIM_SET_CURRENT_LINE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(line);
+	m_connector->m_dev->send(line);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::vim_del_current_line()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_del_current_line", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_del_current_line", 0) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_VIM_DEL_CURRENT_LINE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::vim_get_var(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_var", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_var", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_VIM_GET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::vim_get_vvar(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_vvar", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_vvar", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_VIM_GET_VVAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::vim_get_option(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_option", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_option", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_VIM_GET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::vim_set_option(QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_set_option", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_set_option", 2) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_VIM_SET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::vim_out_write(QByteArray str)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_out_write", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_out_write", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_VIM_OUT_WRITE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(str);
+	m_connector->m_dev->send(str);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::vim_err_write(QByteArray str)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_err_write", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_err_write", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_VIM_ERR_WRITE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(str);
+	m_connector->m_dev->send(str);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::vim_report_error(QByteArray str)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_report_error", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_report_error", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_VIM_REPORT_ERROR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(str);
+	m_connector->m_dev->send(str);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::vim_get_buffers()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_buffers", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_buffers", 0) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_VIM_GET_BUFFERS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::vim_get_current_buffer()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_current_buffer", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_current_buffer", 0) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_VIM_GET_CURRENT_BUFFER);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::vim_set_current_buffer(int64_t buffer)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_set_current_buffer", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_set_current_buffer", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_VIM_SET_CURRENT_BUFFER);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(buffer);
+	m_connector->m_dev->send(buffer);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::vim_get_windows()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_windows", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_windows", 0) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_VIM_GET_WINDOWS);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::vim_get_current_window()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_current_window", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_current_window", 0) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_VIM_GET_CURRENT_WINDOW);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::vim_set_current_window(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_set_current_window", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_set_current_window", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_VIM_SET_CURRENT_WINDOW);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::vim_get_tabpages()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_tabpages", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_tabpages", 0) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_VIM_GET_TABPAGES);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::vim_get_current_tabpage()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_current_tabpage", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_current_tabpage", 0) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_VIM_GET_CURRENT_TABPAGE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::vim_set_current_tabpage(int64_t tabpage)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_set_current_tabpage", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_set_current_tabpage", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_VIM_SET_CURRENT_TABPAGE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(tabpage);
+	m_connector->m_dev->send(tabpage);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::vim_subscribe(QByteArray event)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_subscribe", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_subscribe", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_VIM_SUBSCRIBE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(event);
+	m_connector->m_dev->send(event);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::vim_unsubscribe(QByteArray event)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_unsubscribe", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_unsubscribe", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_VIM_UNSUBSCRIBE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(event);
+	m_connector->m_dev->send(event);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::vim_name_to_color(QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_name_to_color", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_name_to_color", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_VIM_NAME_TO_COLOR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::vim_get_color_map()
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("vim_get_color_map", 0);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("vim_get_color_map", 0) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_VIM_GET_COLOR_MAP);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::window_get_buffer(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_buffer", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_get_buffer", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_WINDOW_GET_BUFFER);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::window_get_cursor(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_cursor", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_get_cursor", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_WINDOW_GET_CURSOR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::window_set_cursor(int64_t window, QPoint pos)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_set_cursor", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_set_cursor", 2) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_WINDOW_SET_CURSOR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(pos);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(pos);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::window_get_height(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_height", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_get_height", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_WINDOW_GET_HEIGHT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::window_set_height(int64_t window, int64_t height)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_set_height", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_set_height", 2) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_WINDOW_SET_HEIGHT);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(height);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(height);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::window_get_width(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_width", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_get_width", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_WINDOW_GET_WIDTH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::window_set_width(int64_t window, int64_t width)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_set_width", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_set_width", 2) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_WINDOW_SET_WIDTH);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(width);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(width);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::window_get_var(int64_t window, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_var", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_get_var", 2) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_WINDOW_GET_VAR);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::window_get_option(int64_t window, QByteArray name)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_option", 2);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_get_option", 2) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_WINDOW_GET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::window_set_option(int64_t window, QByteArray name, QVariant value)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_set_option", 3);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_set_option", 3) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_WINDOW_SET_OPTION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(window);
-	m_c->m_dev->send(name);
-	m_c->m_dev->send(value);
+	m_connector->m_dev->send(window);
+	m_connector->m_dev->send(name);
+	m_connector->m_dev->send(value);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::window_get_position(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_position", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_get_position", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_WINDOW_GET_POSITION);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::window_get_tabpage(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_get_tabpage", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_get_tabpage", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_WINDOW_GET_TABPAGE);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
+
 MsgpackRequest* NeovimApi6::window_is_valid(int64_t window)
 {
-	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("window_is_valid", 1);
+	MsgpackRequest* r{ m_connector->m_dev->startRequestUnchecked("window_is_valid", 1) };
 	r->setFunction(NeovimApi6::NEOVIM_FN_WINDOW_IS_VALID);
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
-	m_c->m_dev->send(window);
+	m_connector->m_dev->send(window);
 	return r;
 }
 
+
 // Handlers
 
-void NeovimApi6::handleResponseError(quint32 msgid, quint64 fun, const QVariant& res)
+void NeovimApi6::handleResponseError(uint32_t msgid, uint64_t fun, const QVariant& res)
 {
 
 	// TODO: support Neovim error types Exception/Validation/etc
@@ -1859,7 +2240,7 @@ void NeovimApi6::handleResponseError(quint32 msgid, quint64 fun, const QVariant&
 	const QVariantList asList = res.toList();
 	if (asList.size() >= 2) {
 		if (asList.at(1).canConvert<QByteArray>()) {
-			errMsg = m_c->m_dev->decode(asList.at(1).toByteArray());
+			errMsg = m_connector->m_dev->decode(asList.at(1).toByteArray());
 		} else {
 			errMsg = tr("Received unsupported Neovim error type");
 		}
@@ -1907,6 +2288,12 @@ void NeovimApi6::handleResponseError(quint32 msgid, quint64 fun, const QVariant&
 		break;
 	case NeovimApi6::NEOVIM_FN_NVIM_BUF_GET_KEYMAP:
 		emit err_nvim_buf_get_keymap(errMsg, res);
+		break;
+	case NeovimApi6::NEOVIM_FN_NVIM_BUF_SET_KEYMAP:
+		emit err_nvim_buf_set_keymap(errMsg, res);
+		break;
+	case NeovimApi6::NEOVIM_FN_NVIM_BUF_DEL_KEYMAP:
+		emit err_nvim_buf_del_keymap(errMsg, res);
 		break;
 	case NeovimApi6::NEOVIM_FN_NVIM_BUF_GET_COMMANDS:
 		emit err_nvim_buf_get_commands(errMsg, res);
@@ -2007,6 +2394,9 @@ void NeovimApi6::handleResponseError(quint32 msgid, quint64 fun, const QVariant&
 	case NeovimApi6::NEOVIM_FN_NVIM_UI_TRY_RESIZE_GRID:
 		emit err_nvim_ui_try_resize_grid(errMsg, res);
 		break;
+	case NeovimApi6::NEOVIM_FN_NVIM_UI_PUM_SET_HEIGHT:
+		emit err_nvim_ui_pum_set_height(errMsg, res);
+		break;
 	case NeovimApi6::NEOVIM_FN_NVIM_COMMAND:
 		emit err_nvim_command(errMsg, res);
 		break;
@@ -2021,6 +2411,9 @@ void NeovimApi6::handleResponseError(quint32 msgid, quint64 fun, const QVariant&
 		break;
 	case NeovimApi6::NEOVIM_FN_NVIM_INPUT:
 		emit err_nvim_input(errMsg, res);
+		break;
+	case NeovimApi6::NEOVIM_FN_NVIM_INPUT_MOUSE:
+		emit err_nvim_input_mouse(errMsg, res);
 		break;
 	case NeovimApi6::NEOVIM_FN_NVIM_REPLACE_TERMCODES:
 		emit err_nvim_replace_termcodes(errMsg, res);
@@ -2076,6 +2469,9 @@ void NeovimApi6::handleResponseError(quint32 msgid, quint64 fun, const QVariant&
 	case NeovimApi6::NEOVIM_FN_NVIM_GET_VVAR:
 		emit err_nvim_get_vvar(errMsg, res);
 		break;
+	case NeovimApi6::NEOVIM_FN_NVIM_SET_VVAR:
+		emit err_nvim_set_vvar(errMsg, res);
+		break;
 	case NeovimApi6::NEOVIM_FN_NVIM_GET_OPTION:
 		emit err_nvim_get_option(errMsg, res);
 		break;
@@ -2109,6 +2505,12 @@ void NeovimApi6::handleResponseError(quint32 msgid, quint64 fun, const QVariant&
 	case NeovimApi6::NEOVIM_FN_NVIM_SET_CURRENT_WIN:
 		emit err_nvim_set_current_win(errMsg, res);
 		break;
+	case NeovimApi6::NEOVIM_FN_NVIM_CREATE_BUF:
+		emit err_nvim_create_buf(errMsg, res);
+		break;
+	case NeovimApi6::NEOVIM_FN_NVIM_OPEN_WIN:
+		emit err_nvim_open_win(errMsg, res);
+		break;
 	case NeovimApi6::NEOVIM_FN_NVIM_LIST_TABPAGES:
 		emit err_nvim_list_tabpages(errMsg, res);
 		break;
@@ -2124,6 +2526,12 @@ void NeovimApi6::handleResponseError(quint32 msgid, quint64 fun, const QVariant&
 	case NeovimApi6::NEOVIM_FN_NVIM_GET_NAMESPACES:
 		emit err_nvim_get_namespaces(errMsg, res);
 		break;
+	case NeovimApi6::NEOVIM_FN_NVIM_PASTE:
+		emit err_nvim_paste(errMsg, res);
+		break;
+	case NeovimApi6::NEOVIM_FN_NVIM_PUT:
+		emit err_nvim_put(errMsg, res);
+		break;
 	case NeovimApi6::NEOVIM_FN_NVIM_SUBSCRIBE:
 		emit err_nvim_subscribe(errMsg, res);
 		break;
@@ -2136,11 +2544,23 @@ void NeovimApi6::handleResponseError(quint32 msgid, quint64 fun, const QVariant&
 	case NeovimApi6::NEOVIM_FN_NVIM_GET_COLOR_MAP:
 		emit err_nvim_get_color_map(errMsg, res);
 		break;
+	case NeovimApi6::NEOVIM_FN_NVIM_GET_CONTEXT:
+		emit err_nvim_get_context(errMsg, res);
+		break;
+	case NeovimApi6::NEOVIM_FN_NVIM_LOAD_CONTEXT:
+		emit err_nvim_load_context(errMsg, res);
+		break;
 	case NeovimApi6::NEOVIM_FN_NVIM_GET_MODE:
 		emit err_nvim_get_mode(errMsg, res);
 		break;
 	case NeovimApi6::NEOVIM_FN_NVIM_GET_KEYMAP:
 		emit err_nvim_get_keymap(errMsg, res);
+		break;
+	case NeovimApi6::NEOVIM_FN_NVIM_SET_KEYMAP:
+		emit err_nvim_set_keymap(errMsg, res);
+		break;
+	case NeovimApi6::NEOVIM_FN_NVIM_DEL_KEYMAP:
+		emit err_nvim_del_keymap(errMsg, res);
 		break;
 	case NeovimApi6::NEOVIM_FN_NVIM_GET_COMMANDS:
 		emit err_nvim_get_commands(errMsg, res);
@@ -2231,6 +2651,15 @@ void NeovimApi6::handleResponseError(quint32 msgid, quint64 fun, const QVariant&
 		break;
 	case NeovimApi6::NEOVIM_FN_NVIM_WIN_IS_VALID:
 		emit err_nvim_win_is_valid(errMsg, res);
+		break;
+	case NeovimApi6::NEOVIM_FN_NVIM_WIN_SET_CONFIG:
+		emit err_nvim_win_set_config(errMsg, res);
+		break;
+	case NeovimApi6::NEOVIM_FN_NVIM_WIN_GET_CONFIG:
+		emit err_nvim_win_get_config(errMsg, res);
+		break;
+	case NeovimApi6::NEOVIM_FN_NVIM_WIN_CLOSE:
+		emit err_nvim_win_close(errMsg, res);
 		break;
 	case NeovimApi6::NEOVIM_FN_BUFFER_LINE_COUNT:
 		emit err_buffer_line_count(errMsg, res);
@@ -2428,1855 +2857,1987 @@ void NeovimApi6::handleResponseError(quint32 msgid, quint64 fun, const QVariant&
 		emit err_window_is_valid(errMsg, res);
 		break;
 	default:
-		m_c->setError(NeovimConnector::RuntimeMsgpackError, QString("Received error for function that should not fail: %s").arg(fun));
+		m_connector->setError(NeovimConnector::RuntimeMsgpackError, QString("Received error for function that should not fail: %s").arg(fun));
 	}
 }
 
-void NeovimApi6::handleResponse(quint32 msgid, quint64 fun, const QVariant& res)
+void NeovimApi6::handleResponse(uint32_t msgid, uint64_t fun, const QVariant& res)
 {
 	switch(fun) {
-	case NeovimApi6::NEOVIM_FN_NVIM_BUF_LINE_COUNT:
+		case NeovimApi6::NEOVIM_FN_NVIM_BUF_LINE_COUNT:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_line_count");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_line_count");
 				return;
-			} else {
-				emit on_nvim_buf_line_count(data);
 			}
 
+			emit on_nvim_buf_line_count(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_BUFFER_GET_LINE:
+
+		case NeovimApi6::NEOVIM_FN_BUFFER_GET_LINE:
 		{
 			QByteArray data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_line");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_line");
 				return;
-			} else {
-				emit on_buffer_get_line(data);
 			}
 
+			emit on_buffer_get_line(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_BUF_ATTACH:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_BUF_ATTACH:
 		{
 			bool data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_attach");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_attach");
 				return;
-			} else {
-				emit on_nvim_buf_attach(data);
 			}
 
+			emit on_nvim_buf_attach(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_BUF_DETACH:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_BUF_DETACH:
 		{
 			bool data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_detach");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_detach");
 				return;
-			} else {
-				emit on_nvim_buf_detach(data);
 			}
 
+			emit on_nvim_buf_detach(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_BUFFER_SET_LINE:
+
+		case NeovimApi6::NEOVIM_FN_BUFFER_SET_LINE:
 		{
 			emit on_buffer_set_line();
-
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_BUFFER_DEL_LINE:
+
+		case NeovimApi6::NEOVIM_FN_BUFFER_DEL_LINE:
 		{
 			emit on_buffer_del_line();
-
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_BUFFER_GET_LINE_SLICE:
+
+		case NeovimApi6::NEOVIM_FN_BUFFER_GET_LINE_SLICE:
 		{
 			QList<QByteArray> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_line_slice");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_line_slice");
 				return;
-			} else {
-				emit on_buffer_get_line_slice(data);
 			}
 
+			emit on_buffer_get_line_slice(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_BUF_GET_LINES:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_BUF_GET_LINES:
 		{
 			QList<QByteArray> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_lines");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_lines");
 				return;
-			} else {
-				emit on_nvim_buf_get_lines(data);
 			}
 
+			emit on_nvim_buf_get_lines(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_BUFFER_SET_LINE_SLICE:
+
+		case NeovimApi6::NEOVIM_FN_BUFFER_SET_LINE_SLICE:
 		{
 			emit on_buffer_set_line_slice();
-
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_BUF_SET_LINES:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_BUF_SET_LINES:
 		{
 			emit on_nvim_buf_set_lines();
-
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_BUF_GET_OFFSET:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_BUF_GET_OFFSET:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_offset");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_offset");
 				return;
-			} else {
-				emit on_nvim_buf_get_offset(data);
 			}
 
+			emit on_nvim_buf_get_offset(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_BUF_GET_VAR:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_BUF_GET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_var");
 				return;
-			} else {
-				emit on_nvim_buf_get_var(data);
 			}
 
+			emit on_nvim_buf_get_var(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_BUF_GET_CHANGEDTICK:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_BUF_GET_CHANGEDTICK:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_changedtick");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_changedtick");
 				return;
-			} else {
-				emit on_nvim_buf_get_changedtick(data);
 			}
 
+			emit on_nvim_buf_get_changedtick(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_BUF_GET_KEYMAP:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_BUF_GET_KEYMAP:
 		{
 			QList<QVariantMap> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_keymap");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_keymap");
 				return;
-			} else {
-				emit on_nvim_buf_get_keymap(data);
 			}
 
+			emit on_nvim_buf_get_keymap(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_BUF_GET_COMMANDS:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_BUF_SET_KEYMAP:
+		{
+			emit on_nvim_buf_set_keymap();
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_NVIM_BUF_DEL_KEYMAP:
+		{
+			emit on_nvim_buf_del_keymap();
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_NVIM_BUF_GET_COMMANDS:
 		{
 			QVariantMap data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_commands");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_commands");
 				return;
-			} else {
-				emit on_nvim_buf_get_commands(data);
 			}
 
+			emit on_nvim_buf_get_commands(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_BUF_SET_VAR:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_BUF_SET_VAR:
 		{
 			emit on_nvim_buf_set_var();
-
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_BUF_DEL_VAR:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_BUF_DEL_VAR:
 		{
 			emit on_nvim_buf_del_var();
-
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_BUFFER_SET_VAR:
+
+		case NeovimApi6::NEOVIM_FN_BUFFER_SET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_set_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_set_var");
 				return;
-			} else {
-				emit on_buffer_set_var(data);
 			}
 
+			emit on_buffer_set_var(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_BUFFER_DEL_VAR:
+
+		case NeovimApi6::NEOVIM_FN_BUFFER_DEL_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_del_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_del_var");
 				return;
-			} else {
-				emit on_buffer_del_var(data);
 			}
 
+			emit on_buffer_del_var(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_BUF_GET_OPTION:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_BUF_GET_OPTION:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_option");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_option");
 				return;
-			} else {
-				emit on_nvim_buf_get_option(data);
 			}
 
+			emit on_nvim_buf_get_option(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_BUF_SET_OPTION:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_BUF_SET_OPTION:
 		{
 			emit on_nvim_buf_set_option();
-
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_BUF_GET_NUMBER:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_BUF_GET_NUMBER:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_number");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_number");
 				return;
-			} else {
-				emit on_nvim_buf_get_number(data);
 			}
 
+			emit on_nvim_buf_get_number(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_BUF_GET_NAME:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_BUF_GET_NAME:
 		{
 			QByteArray data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_name");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_name");
 				return;
-			} else {
-				emit on_nvim_buf_get_name(data);
 			}
 
+			emit on_nvim_buf_get_name(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_BUF_SET_NAME:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_BUF_SET_NAME:
 		{
 			emit on_nvim_buf_set_name();
-
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_BUF_IS_LOADED:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_BUF_IS_LOADED:
 		{
 			bool data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_is_loaded");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_is_loaded");
 				return;
-			} else {
-				emit on_nvim_buf_is_loaded(data);
 			}
 
+			emit on_nvim_buf_is_loaded(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_BUF_IS_VALID:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_BUF_IS_VALID:
 		{
 			bool data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_is_valid");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_is_valid");
 				return;
-			} else {
-				emit on_nvim_buf_is_valid(data);
 			}
 
+			emit on_nvim_buf_is_valid(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_BUFFER_INSERT:
+
+		case NeovimApi6::NEOVIM_FN_BUFFER_INSERT:
 		{
 			emit on_buffer_insert();
-
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_BUF_GET_MARK:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_BUF_GET_MARK:
 		{
 			QPoint data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_mark");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_get_mark");
 				return;
-			} else {
-				emit on_nvim_buf_get_mark(data);
 			}
 
+			emit on_nvim_buf_get_mark(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_BUF_ADD_HIGHLIGHT:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_BUF_ADD_HIGHLIGHT:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_add_highlight");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_add_highlight");
 				return;
-			} else {
-				emit on_nvim_buf_add_highlight(data);
 			}
 
+			emit on_nvim_buf_add_highlight(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_BUF_CLEAR_NAMESPACE:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_BUF_CLEAR_NAMESPACE:
 		{
 			emit on_nvim_buf_clear_namespace();
-
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_BUF_CLEAR_HIGHLIGHT:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_BUF_CLEAR_HIGHLIGHT:
 		{
 			emit on_nvim_buf_clear_highlight();
-
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_BUF_SET_VIRTUAL_TEXT:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_BUF_SET_VIRTUAL_TEXT:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_set_virtual_text");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_buf_set_virtual_text");
 				return;
-			} else {
-				emit on_nvim_buf_set_virtual_text(data);
 			}
 
+			emit on_nvim_buf_set_virtual_text(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_TABPAGE_LIST_WINS:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_TABPAGE_LIST_WINS:
 		{
 			QList<int64_t> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_list_wins");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_list_wins");
 				return;
-			} else {
-				emit on_nvim_tabpage_list_wins(data);
 			}
 
+			emit on_nvim_tabpage_list_wins(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_TABPAGE_GET_VAR:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_TABPAGE_GET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_get_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_get_var");
 				return;
-			} else {
-				emit on_nvim_tabpage_get_var(data);
 			}
 
+			emit on_nvim_tabpage_get_var(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_TABPAGE_SET_VAR:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_TABPAGE_SET_VAR:
 		{
 			emit on_nvim_tabpage_set_var();
-
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_TABPAGE_DEL_VAR:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_TABPAGE_DEL_VAR:
 		{
 			emit on_nvim_tabpage_del_var();
-
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_TABPAGE_SET_VAR:
+
+		case NeovimApi6::NEOVIM_FN_TABPAGE_SET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_set_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_set_var");
 				return;
-			} else {
-				emit on_tabpage_set_var(data);
 			}
 
+			emit on_tabpage_set_var(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_TABPAGE_DEL_VAR:
+
+		case NeovimApi6::NEOVIM_FN_TABPAGE_DEL_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_del_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_del_var");
 				return;
-			} else {
-				emit on_tabpage_del_var(data);
 			}
 
+			emit on_tabpage_del_var(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_TABPAGE_GET_WIN:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_TABPAGE_GET_WIN:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_get_win");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_get_win");
 				return;
-			} else {
-				emit on_nvim_tabpage_get_win(data);
 			}
 
+			emit on_nvim_tabpage_get_win(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_TABPAGE_GET_NUMBER:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_TABPAGE_GET_NUMBER:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_get_number");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_get_number");
 				return;
-			} else {
-				emit on_nvim_tabpage_get_number(data);
 			}
 
+			emit on_nvim_tabpage_get_number(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_TABPAGE_IS_VALID:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_TABPAGE_IS_VALID:
 		{
 			bool data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_is_valid");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_tabpage_is_valid");
 				return;
-			} else {
-				emit on_nvim_tabpage_is_valid(data);
 			}
 
+			emit on_nvim_tabpage_is_valid(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_UI_ATTACH:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_UI_ATTACH:
 		{
 			emit on_nvim_ui_attach();
-
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_UI_ATTACH:
+
+		case NeovimApi6::NEOVIM_FN_UI_ATTACH:
 		{
 			emit on_ui_attach();
-
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_UI_DETACH:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_UI_DETACH:
 		{
 			emit on_nvim_ui_detach();
-
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_UI_TRY_RESIZE:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_UI_TRY_RESIZE:
 		{
 			emit on_nvim_ui_try_resize();
-
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_UI_SET_OPTION:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_UI_SET_OPTION:
 		{
 			emit on_nvim_ui_set_option();
-
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_UI_TRY_RESIZE_GRID:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_UI_TRY_RESIZE_GRID:
 		{
 			emit on_nvim_ui_try_resize_grid();
-
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_COMMAND:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_UI_PUM_SET_HEIGHT:
+		{
+			emit on_nvim_ui_pum_set_height();
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_NVIM_COMMAND:
 		{
 			emit on_nvim_command();
-
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_GET_HL_BY_NAME:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_GET_HL_BY_NAME:
 		{
 			QVariantMap data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_hl_by_name");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_hl_by_name");
 				return;
-			} else {
-				emit on_nvim_get_hl_by_name(data);
 			}
 
+			emit on_nvim_get_hl_by_name(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_GET_HL_BY_ID:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_GET_HL_BY_ID:
 		{
 			QVariantMap data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_hl_by_id");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_hl_by_id");
 				return;
-			} else {
-				emit on_nvim_get_hl_by_id(data);
 			}
 
+			emit on_nvim_get_hl_by_id(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_FEEDKEYS:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_FEEDKEYS:
 		{
 			emit on_nvim_feedkeys();
-
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_INPUT:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_INPUT:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_input");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_input");
 				return;
-			} else {
-				emit on_nvim_input(data);
 			}
 
+			emit on_nvim_input(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_REPLACE_TERMCODES:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_INPUT_MOUSE:
+		{
+			emit on_nvim_input_mouse();
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_NVIM_REPLACE_TERMCODES:
 		{
 			QByteArray data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_replace_termcodes");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_replace_termcodes");
 				return;
-			} else {
-				emit on_nvim_replace_termcodes(data);
 			}
 
+			emit on_nvim_replace_termcodes(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_COMMAND_OUTPUT:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_COMMAND_OUTPUT:
 		{
 			QByteArray data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_command_output");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_command_output");
 				return;
-			} else {
-				emit on_nvim_command_output(data);
 			}
 
+			emit on_nvim_command_output(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_EVAL:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_EVAL:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_eval");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_eval");
 				return;
-			} else {
-				emit on_nvim_eval(data);
 			}
 
+			emit on_nvim_eval(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_EXECUTE_LUA:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_EXECUTE_LUA:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_execute_lua");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_execute_lua");
 				return;
-			} else {
-				emit on_nvim_execute_lua(data);
 			}
 
+			emit on_nvim_execute_lua(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_CALL_FUNCTION:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_CALL_FUNCTION:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_call_function");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_call_function");
 				return;
-			} else {
-				emit on_nvim_call_function(data);
 			}
 
+			emit on_nvim_call_function(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_CALL_DICT_FUNCTION:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_CALL_DICT_FUNCTION:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_call_dict_function");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_call_dict_function");
 				return;
-			} else {
-				emit on_nvim_call_dict_function(data);
 			}
 
+			emit on_nvim_call_dict_function(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_STRWIDTH:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_STRWIDTH:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_strwidth");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_strwidth");
 				return;
-			} else {
-				emit on_nvim_strwidth(data);
 			}
 
+			emit on_nvim_strwidth(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_LIST_RUNTIME_PATHS:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_LIST_RUNTIME_PATHS:
 		{
 			QList<QByteArray> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_runtime_paths");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_runtime_paths");
 				return;
-			} else {
-				emit on_nvim_list_runtime_paths(data);
 			}
 
+			emit on_nvim_list_runtime_paths(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_SET_CURRENT_DIR:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_SET_CURRENT_DIR:
 		{
 			emit on_nvim_set_current_dir();
-
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_GET_CURRENT_LINE:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_GET_CURRENT_LINE:
 		{
 			QByteArray data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_current_line");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_current_line");
 				return;
-			} else {
-				emit on_nvim_get_current_line(data);
 			}
 
+			emit on_nvim_get_current_line(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_SET_CURRENT_LINE:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_SET_CURRENT_LINE:
 		{
 			emit on_nvim_set_current_line();
-
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_DEL_CURRENT_LINE:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_DEL_CURRENT_LINE:
 		{
 			emit on_nvim_del_current_line();
-
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_GET_VAR:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_GET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_var");
 				return;
-			} else {
-				emit on_nvim_get_var(data);
 			}
 
+			emit on_nvim_get_var(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_SET_VAR:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_SET_VAR:
 		{
 			emit on_nvim_set_var();
-
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_DEL_VAR:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_DEL_VAR:
 		{
 			emit on_nvim_del_var();
-
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_VIM_SET_VAR:
+
+		case NeovimApi6::NEOVIM_FN_VIM_SET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_set_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_set_var");
 				return;
-			} else {
-				emit on_vim_set_var(data);
 			}
 
+			emit on_vim_set_var(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_VIM_DEL_VAR:
+
+		case NeovimApi6::NEOVIM_FN_VIM_DEL_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_del_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_del_var");
 				return;
-			} else {
-				emit on_vim_del_var(data);
 			}
 
+			emit on_vim_del_var(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_GET_VVAR:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_GET_VVAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_vvar");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_vvar");
 				return;
-			} else {
-				emit on_nvim_get_vvar(data);
 			}
 
+			emit on_nvim_get_vvar(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_GET_OPTION:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_SET_VVAR:
+		{
+			emit on_nvim_set_vvar();
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_NVIM_GET_OPTION:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_option");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_option");
 				return;
-			} else {
-				emit on_nvim_get_option(data);
 			}
 
+			emit on_nvim_get_option(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_SET_OPTION:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_SET_OPTION:
 		{
 			emit on_nvim_set_option();
-
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_OUT_WRITE:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_OUT_WRITE:
 		{
 			emit on_nvim_out_write();
-
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_ERR_WRITE:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_ERR_WRITE:
 		{
 			emit on_nvim_err_write();
-
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_ERR_WRITELN:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_ERR_WRITELN:
 		{
 			emit on_nvim_err_writeln();
-
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_LIST_BUFS:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_LIST_BUFS:
 		{
 			QList<int64_t> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_bufs");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_bufs");
 				return;
-			} else {
-				emit on_nvim_list_bufs(data);
 			}
 
+			emit on_nvim_list_bufs(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_GET_CURRENT_BUF:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_GET_CURRENT_BUF:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_current_buf");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_current_buf");
 				return;
-			} else {
-				emit on_nvim_get_current_buf(data);
 			}
 
+			emit on_nvim_get_current_buf(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_SET_CURRENT_BUF:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_SET_CURRENT_BUF:
 		{
 			emit on_nvim_set_current_buf();
-
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_LIST_WINS:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_LIST_WINS:
 		{
 			QList<int64_t> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_wins");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_wins");
 				return;
-			} else {
-				emit on_nvim_list_wins(data);
 			}
 
+			emit on_nvim_list_wins(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_GET_CURRENT_WIN:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_GET_CURRENT_WIN:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_current_win");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_current_win");
 				return;
-			} else {
-				emit on_nvim_get_current_win(data);
 			}
 
+			emit on_nvim_get_current_win(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_SET_CURRENT_WIN:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_SET_CURRENT_WIN:
 		{
 			emit on_nvim_set_current_win();
-
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_LIST_TABPAGES:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_CREATE_BUF:
+		{
+			int64_t data;
+			if (decode(res, data)) {
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_create_buf");
+				return;
+			}
+
+			emit on_nvim_create_buf(data);
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_NVIM_OPEN_WIN:
+		{
+			int64_t data;
+			if (decode(res, data)) {
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_open_win");
+				return;
+			}
+
+			emit on_nvim_open_win(data);
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_NVIM_LIST_TABPAGES:
 		{
 			QList<int64_t> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_tabpages");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_tabpages");
 				return;
-			} else {
-				emit on_nvim_list_tabpages(data);
 			}
 
+			emit on_nvim_list_tabpages(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_GET_CURRENT_TABPAGE:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_GET_CURRENT_TABPAGE:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_current_tabpage");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_current_tabpage");
 				return;
-			} else {
-				emit on_nvim_get_current_tabpage(data);
 			}
 
+			emit on_nvim_get_current_tabpage(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_SET_CURRENT_TABPAGE:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_SET_CURRENT_TABPAGE:
 		{
 			emit on_nvim_set_current_tabpage();
-
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_CREATE_NAMESPACE:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_CREATE_NAMESPACE:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_create_namespace");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_create_namespace");
 				return;
-			} else {
-				emit on_nvim_create_namespace(data);
 			}
 
+			emit on_nvim_create_namespace(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_GET_NAMESPACES:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_GET_NAMESPACES:
 		{
 			QVariantMap data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_namespaces");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_namespaces");
 				return;
-			} else {
-				emit on_nvim_get_namespaces(data);
 			}
 
+			emit on_nvim_get_namespaces(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_SUBSCRIBE:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_PASTE:
+		{
+			bool data;
+			if (decode(res, data)) {
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_paste");
+				return;
+			}
+
+			emit on_nvim_paste(data);
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_NVIM_PUT:
+		{
+			emit on_nvim_put();
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_NVIM_SUBSCRIBE:
 		{
 			emit on_nvim_subscribe();
-
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_UNSUBSCRIBE:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_UNSUBSCRIBE:
 		{
 			emit on_nvim_unsubscribe();
-
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_GET_COLOR_BY_NAME:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_GET_COLOR_BY_NAME:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_color_by_name");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_color_by_name");
 				return;
-			} else {
-				emit on_nvim_get_color_by_name(data);
 			}
 
+			emit on_nvim_get_color_by_name(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_GET_COLOR_MAP:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_GET_COLOR_MAP:
 		{
 			QVariantMap data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_color_map");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_color_map");
 				return;
-			} else {
-				emit on_nvim_get_color_map(data);
 			}
 
+			emit on_nvim_get_color_map(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_GET_MODE:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_GET_CONTEXT:
 		{
 			QVariantMap data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_mode");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_context");
 				return;
-			} else {
-				emit on_nvim_get_mode(data);
 			}
 
+			emit on_nvim_get_context(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_GET_KEYMAP:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_LOAD_CONTEXT:
+		{
+			QVariant data;
+			if (decode(res, data)) {
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_load_context");
+				return;
+			}
+
+			emit on_nvim_load_context(data);
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_NVIM_GET_MODE:
+		{
+			QVariantMap data;
+			if (decode(res, data)) {
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_mode");
+				return;
+			}
+
+			emit on_nvim_get_mode(data);
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_NVIM_GET_KEYMAP:
 		{
 			QList<QVariantMap> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_keymap");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_keymap");
 				return;
-			} else {
-				emit on_nvim_get_keymap(data);
 			}
 
+			emit on_nvim_get_keymap(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_GET_COMMANDS:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_SET_KEYMAP:
+		{
+			emit on_nvim_set_keymap();
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_NVIM_DEL_KEYMAP:
+		{
+			emit on_nvim_del_keymap();
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_NVIM_GET_COMMANDS:
 		{
 			QVariantMap data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_commands");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_commands");
 				return;
-			} else {
-				emit on_nvim_get_commands(data);
 			}
 
+			emit on_nvim_get_commands(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_GET_API_INFO:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_GET_API_INFO:
 		{
 			QVariantList data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_api_info");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_api_info");
 				return;
-			} else {
-				emit on_nvim_get_api_info(data);
 			}
 
+			emit on_nvim_get_api_info(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_SET_CLIENT_INFO:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_SET_CLIENT_INFO:
 		{
 			emit on_nvim_set_client_info();
-
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_GET_CHAN_INFO:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_GET_CHAN_INFO:
 		{
 			QVariantMap data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_chan_info");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_chan_info");
 				return;
-			} else {
-				emit on_nvim_get_chan_info(data);
 			}
 
+			emit on_nvim_get_chan_info(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_LIST_CHANS:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_LIST_CHANS:
 		{
 			QVariantList data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_chans");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_chans");
 				return;
-			} else {
-				emit on_nvim_list_chans(data);
 			}
 
+			emit on_nvim_list_chans(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_CALL_ATOMIC:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_CALL_ATOMIC:
 		{
 			QVariantList data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_call_atomic");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_call_atomic");
 				return;
-			} else {
-				emit on_nvim_call_atomic(data);
 			}
 
+			emit on_nvim_call_atomic(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_PARSE_EXPRESSION:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_PARSE_EXPRESSION:
 		{
 			QVariantMap data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_parse_expression");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_parse_expression");
 				return;
-			} else {
-				emit on_nvim_parse_expression(data);
 			}
 
+			emit on_nvim_parse_expression(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_LIST_UIS:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_LIST_UIS:
 		{
 			QVariantList data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_uis");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_list_uis");
 				return;
-			} else {
-				emit on_nvim_list_uis(data);
 			}
 
+			emit on_nvim_list_uis(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_GET_PROC_CHILDREN:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_GET_PROC_CHILDREN:
 		{
 			QVariantList data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_proc_children");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_proc_children");
 				return;
-			} else {
-				emit on_nvim_get_proc_children(data);
 			}
 
+			emit on_nvim_get_proc_children(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_GET_PROC:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_GET_PROC:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_proc");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_proc");
 				return;
-			} else {
-				emit on_nvim_get_proc(data);
 			}
 
+			emit on_nvim_get_proc(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_SELECT_POPUPMENU_ITEM:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_SELECT_POPUPMENU_ITEM:
 		{
 			emit on_nvim_select_popupmenu_item();
-
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_WIN_GET_BUF:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_WIN_GET_BUF:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_buf");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_buf");
 				return;
-			} else {
-				emit on_nvim_win_get_buf(data);
 			}
 
+			emit on_nvim_win_get_buf(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_WIN_SET_BUF:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_WIN_SET_BUF:
 		{
 			emit on_nvim_win_set_buf();
-
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_WIN_GET_CURSOR:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_WIN_GET_CURSOR:
 		{
 			QPoint data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_cursor");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_cursor");
 				return;
-			} else {
-				emit on_nvim_win_get_cursor(data);
 			}
 
+			emit on_nvim_win_get_cursor(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_WIN_SET_CURSOR:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_WIN_SET_CURSOR:
 		{
 			emit on_nvim_win_set_cursor();
-
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_WIN_GET_HEIGHT:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_WIN_GET_HEIGHT:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_height");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_height");
 				return;
-			} else {
-				emit on_nvim_win_get_height(data);
 			}
 
+			emit on_nvim_win_get_height(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_WIN_SET_HEIGHT:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_WIN_SET_HEIGHT:
 		{
 			emit on_nvim_win_set_height();
-
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_WIN_GET_WIDTH:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_WIN_GET_WIDTH:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_width");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_width");
 				return;
-			} else {
-				emit on_nvim_win_get_width(data);
 			}
 
+			emit on_nvim_win_get_width(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_WIN_SET_WIDTH:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_WIN_SET_WIDTH:
 		{
 			emit on_nvim_win_set_width();
-
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_WIN_GET_VAR:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_WIN_GET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_var");
 				return;
-			} else {
-				emit on_nvim_win_get_var(data);
 			}
 
+			emit on_nvim_win_get_var(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_WIN_SET_VAR:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_WIN_SET_VAR:
 		{
 			emit on_nvim_win_set_var();
-
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_WIN_DEL_VAR:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_WIN_DEL_VAR:
 		{
 			emit on_nvim_win_del_var();
-
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_WINDOW_SET_VAR:
+
+		case NeovimApi6::NEOVIM_FN_WINDOW_SET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_set_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_set_var");
 				return;
-			} else {
-				emit on_window_set_var(data);
 			}
 
+			emit on_window_set_var(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_WINDOW_DEL_VAR:
+
+		case NeovimApi6::NEOVIM_FN_WINDOW_DEL_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_del_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_del_var");
 				return;
-			} else {
-				emit on_window_del_var(data);
 			}
 
+			emit on_window_del_var(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_WIN_GET_OPTION:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_WIN_GET_OPTION:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_option");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_option");
 				return;
-			} else {
-				emit on_nvim_win_get_option(data);
 			}
 
+			emit on_nvim_win_get_option(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_WIN_SET_OPTION:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_WIN_SET_OPTION:
 		{
 			emit on_nvim_win_set_option();
-
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_WIN_GET_POSITION:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_WIN_GET_POSITION:
 		{
 			QPoint data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_position");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_position");
 				return;
-			} else {
-				emit on_nvim_win_get_position(data);
 			}
 
+			emit on_nvim_win_get_position(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_WIN_GET_TABPAGE:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_WIN_GET_TABPAGE:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_tabpage");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_tabpage");
 				return;
-			} else {
-				emit on_nvim_win_get_tabpage(data);
 			}
 
+			emit on_nvim_win_get_tabpage(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_WIN_GET_NUMBER:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_WIN_GET_NUMBER:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_number");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_number");
 				return;
-			} else {
-				emit on_nvim_win_get_number(data);
 			}
 
+			emit on_nvim_win_get_number(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_NVIM_WIN_IS_VALID:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_WIN_IS_VALID:
 		{
 			bool data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_is_valid");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_is_valid");
 				return;
-			} else {
-				emit on_nvim_win_is_valid(data);
 			}
 
+			emit on_nvim_win_is_valid(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_BUFFER_LINE_COUNT:
-		{
-			int64_t data;
-			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_line_count");
-				return;
-			} else {
-				emit on_buffer_line_count(data);
-			}
 
-		}
-		break;
-	case NeovimApi6::NEOVIM_FN_BUFFER_GET_LINES:
+		case NeovimApi6::NEOVIM_FN_NVIM_WIN_SET_CONFIG:
 		{
-			QList<QByteArray> data;
-			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_lines");
-				return;
-			} else {
-				emit on_buffer_get_lines(data);
-			}
-
+			emit on_nvim_win_set_config();
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_BUFFER_SET_LINES:
-		{
-			emit on_buffer_set_lines();
 
-		}
-		break;
-	case NeovimApi6::NEOVIM_FN_BUFFER_GET_VAR:
-		{
-			QVariant data;
-			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_var");
-				return;
-			} else {
-				emit on_buffer_get_var(data);
-			}
-
-		}
-		break;
-	case NeovimApi6::NEOVIM_FN_BUFFER_GET_OPTION:
-		{
-			QVariant data;
-			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_option");
-				return;
-			} else {
-				emit on_buffer_get_option(data);
-			}
-
-		}
-		break;
-	case NeovimApi6::NEOVIM_FN_BUFFER_SET_OPTION:
-		{
-			emit on_buffer_set_option();
-
-		}
-		break;
-	case NeovimApi6::NEOVIM_FN_BUFFER_GET_NUMBER:
-		{
-			int64_t data;
-			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_number");
-				return;
-			} else {
-				emit on_buffer_get_number(data);
-			}
-
-		}
-		break;
-	case NeovimApi6::NEOVIM_FN_BUFFER_GET_NAME:
-		{
-			QByteArray data;
-			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_name");
-				return;
-			} else {
-				emit on_buffer_get_name(data);
-			}
-
-		}
-		break;
-	case NeovimApi6::NEOVIM_FN_BUFFER_SET_NAME:
-		{
-			emit on_buffer_set_name();
-
-		}
-		break;
-	case NeovimApi6::NEOVIM_FN_BUFFER_IS_VALID:
-		{
-			bool data;
-			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_is_valid");
-				return;
-			} else {
-				emit on_buffer_is_valid(data);
-			}
-
-		}
-		break;
-	case NeovimApi6::NEOVIM_FN_BUFFER_GET_MARK:
-		{
-			QPoint data;
-			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_mark");
-				return;
-			} else {
-				emit on_buffer_get_mark(data);
-			}
-
-		}
-		break;
-	case NeovimApi6::NEOVIM_FN_BUFFER_ADD_HIGHLIGHT:
-		{
-			int64_t data;
-			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_add_highlight");
-				return;
-			} else {
-				emit on_buffer_add_highlight(data);
-			}
-
-		}
-		break;
-	case NeovimApi6::NEOVIM_FN_BUFFER_CLEAR_HIGHLIGHT:
-		{
-			emit on_buffer_clear_highlight();
-
-		}
-		break;
-	case NeovimApi6::NEOVIM_FN_TABPAGE_GET_WINDOWS:
-		{
-			QList<int64_t> data;
-			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_get_windows");
-				return;
-			} else {
-				emit on_tabpage_get_windows(data);
-			}
-
-		}
-		break;
-	case NeovimApi6::NEOVIM_FN_TABPAGE_GET_VAR:
-		{
-			QVariant data;
-			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_get_var");
-				return;
-			} else {
-				emit on_tabpage_get_var(data);
-			}
-
-		}
-		break;
-	case NeovimApi6::NEOVIM_FN_TABPAGE_GET_WINDOW:
-		{
-			int64_t data;
-			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_get_window");
-				return;
-			} else {
-				emit on_tabpage_get_window(data);
-			}
-
-		}
-		break;
-	case NeovimApi6::NEOVIM_FN_TABPAGE_IS_VALID:
-		{
-			bool data;
-			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_is_valid");
-				return;
-			} else {
-				emit on_tabpage_is_valid(data);
-			}
-
-		}
-		break;
-	case NeovimApi6::NEOVIM_FN_UI_DETACH:
-		{
-			emit on_ui_detach();
-
-		}
-		break;
-	case NeovimApi6::NEOVIM_FN_UI_TRY_RESIZE:
-		{
-			QVariant data;
-			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for ui_try_resize");
-				return;
-			} else {
-				emit on_ui_try_resize(data);
-			}
-
-		}
-		break;
-	case NeovimApi6::NEOVIM_FN_VIM_COMMAND:
-		{
-			emit on_vim_command();
-
-		}
-		break;
-	case NeovimApi6::NEOVIM_FN_VIM_FEEDKEYS:
-		{
-			emit on_vim_feedkeys();
-
-		}
-		break;
-	case NeovimApi6::NEOVIM_FN_VIM_INPUT:
-		{
-			int64_t data;
-			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_input");
-				return;
-			} else {
-				emit on_vim_input(data);
-			}
-
-		}
-		break;
-	case NeovimApi6::NEOVIM_FN_VIM_REPLACE_TERMCODES:
-		{
-			QByteArray data;
-			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_replace_termcodes");
-				return;
-			} else {
-				emit on_vim_replace_termcodes(data);
-			}
-
-		}
-		break;
-	case NeovimApi6::NEOVIM_FN_VIM_COMMAND_OUTPUT:
-		{
-			QByteArray data;
-			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_command_output");
-				return;
-			} else {
-				emit on_vim_command_output(data);
-			}
-
-		}
-		break;
-	case NeovimApi6::NEOVIM_FN_VIM_EVAL:
-		{
-			QVariant data;
-			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_eval");
-				return;
-			} else {
-				emit on_vim_eval(data);
-			}
-
-		}
-		break;
-	case NeovimApi6::NEOVIM_FN_VIM_CALL_FUNCTION:
-		{
-			QVariant data;
-			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_call_function");
-				return;
-			} else {
-				emit on_vim_call_function(data);
-			}
-
-		}
-		break;
-	case NeovimApi6::NEOVIM_FN_VIM_STRWIDTH:
-		{
-			int64_t data;
-			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_strwidth");
-				return;
-			} else {
-				emit on_vim_strwidth(data);
-			}
-
-		}
-		break;
-	case NeovimApi6::NEOVIM_FN_VIM_LIST_RUNTIME_PATHS:
-		{
-			QList<QByteArray> data;
-			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_list_runtime_paths");
-				return;
-			} else {
-				emit on_vim_list_runtime_paths(data);
-			}
-
-		}
-		break;
-	case NeovimApi6::NEOVIM_FN_VIM_CHANGE_DIRECTORY:
-		{
-			emit on_vim_change_directory();
-
-		}
-		break;
-	case NeovimApi6::NEOVIM_FN_VIM_GET_CURRENT_LINE:
-		{
-			QByteArray data;
-			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_current_line");
-				return;
-			} else {
-				emit on_vim_get_current_line(data);
-			}
-
-		}
-		break;
-	case NeovimApi6::NEOVIM_FN_VIM_SET_CURRENT_LINE:
-		{
-			emit on_vim_set_current_line();
-
-		}
-		break;
-	case NeovimApi6::NEOVIM_FN_VIM_DEL_CURRENT_LINE:
-		{
-			emit on_vim_del_current_line();
-
-		}
-		break;
-	case NeovimApi6::NEOVIM_FN_VIM_GET_VAR:
-		{
-			QVariant data;
-			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_var");
-				return;
-			} else {
-				emit on_vim_get_var(data);
-			}
-
-		}
-		break;
-	case NeovimApi6::NEOVIM_FN_VIM_GET_VVAR:
-		{
-			QVariant data;
-			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_vvar");
-				return;
-			} else {
-				emit on_vim_get_vvar(data);
-			}
-
-		}
-		break;
-	case NeovimApi6::NEOVIM_FN_VIM_GET_OPTION:
-		{
-			QVariant data;
-			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_option");
-				return;
-			} else {
-				emit on_vim_get_option(data);
-			}
-
-		}
-		break;
-	case NeovimApi6::NEOVIM_FN_VIM_SET_OPTION:
-		{
-			emit on_vim_set_option();
-
-		}
-		break;
-	case NeovimApi6::NEOVIM_FN_VIM_OUT_WRITE:
-		{
-			emit on_vim_out_write();
-
-		}
-		break;
-	case NeovimApi6::NEOVIM_FN_VIM_ERR_WRITE:
-		{
-			emit on_vim_err_write();
-
-		}
-		break;
-	case NeovimApi6::NEOVIM_FN_VIM_REPORT_ERROR:
-		{
-			emit on_vim_report_error();
-
-		}
-		break;
-	case NeovimApi6::NEOVIM_FN_VIM_GET_BUFFERS:
-		{
-			QList<int64_t> data;
-			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_buffers");
-				return;
-			} else {
-				emit on_vim_get_buffers(data);
-			}
-
-		}
-		break;
-	case NeovimApi6::NEOVIM_FN_VIM_GET_CURRENT_BUFFER:
-		{
-			int64_t data;
-			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_current_buffer");
-				return;
-			} else {
-				emit on_vim_get_current_buffer(data);
-			}
-
-		}
-		break;
-	case NeovimApi6::NEOVIM_FN_VIM_SET_CURRENT_BUFFER:
-		{
-			emit on_vim_set_current_buffer();
-
-		}
-		break;
-	case NeovimApi6::NEOVIM_FN_VIM_GET_WINDOWS:
-		{
-			QList<int64_t> data;
-			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_windows");
-				return;
-			} else {
-				emit on_vim_get_windows(data);
-			}
-
-		}
-		break;
-	case NeovimApi6::NEOVIM_FN_VIM_GET_CURRENT_WINDOW:
-		{
-			int64_t data;
-			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_current_window");
-				return;
-			} else {
-				emit on_vim_get_current_window(data);
-			}
-
-		}
-		break;
-	case NeovimApi6::NEOVIM_FN_VIM_SET_CURRENT_WINDOW:
-		{
-			emit on_vim_set_current_window();
-
-		}
-		break;
-	case NeovimApi6::NEOVIM_FN_VIM_GET_TABPAGES:
-		{
-			QList<int64_t> data;
-			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_tabpages");
-				return;
-			} else {
-				emit on_vim_get_tabpages(data);
-			}
-
-		}
-		break;
-	case NeovimApi6::NEOVIM_FN_VIM_GET_CURRENT_TABPAGE:
-		{
-			int64_t data;
-			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_current_tabpage");
-				return;
-			} else {
-				emit on_vim_get_current_tabpage(data);
-			}
-
-		}
-		break;
-	case NeovimApi6::NEOVIM_FN_VIM_SET_CURRENT_TABPAGE:
-		{
-			emit on_vim_set_current_tabpage();
-
-		}
-		break;
-	case NeovimApi6::NEOVIM_FN_VIM_SUBSCRIBE:
-		{
-			emit on_vim_subscribe();
-
-		}
-		break;
-	case NeovimApi6::NEOVIM_FN_VIM_UNSUBSCRIBE:
-		{
-			emit on_vim_unsubscribe();
-
-		}
-		break;
-	case NeovimApi6::NEOVIM_FN_VIM_NAME_TO_COLOR:
-		{
-			int64_t data;
-			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_name_to_color");
-				return;
-			} else {
-				emit on_vim_name_to_color(data);
-			}
-
-		}
-		break;
-	case NeovimApi6::NEOVIM_FN_VIM_GET_COLOR_MAP:
+		case NeovimApi6::NEOVIM_FN_NVIM_WIN_GET_CONFIG:
 		{
 			QVariantMap data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_color_map");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_config");
 				return;
-			} else {
-				emit on_vim_get_color_map(data);
 			}
 
+			emit on_nvim_win_get_config(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_WINDOW_GET_BUFFER:
+
+		case NeovimApi6::NEOVIM_FN_NVIM_WIN_CLOSE:
+		{
+			emit on_nvim_win_close();
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_BUFFER_LINE_COUNT:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_buffer");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_line_count");
 				return;
-			} else {
-				emit on_window_get_buffer(data);
 			}
 
+			emit on_buffer_line_count(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_WINDOW_GET_CURSOR:
+
+		case NeovimApi6::NEOVIM_FN_BUFFER_GET_LINES:
 		{
-			QPoint data;
+			QList<QByteArray> data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_cursor");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_lines");
 				return;
-			} else {
-				emit on_window_get_cursor(data);
 			}
 
+			emit on_buffer_get_lines(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_WINDOW_SET_CURSOR:
-		{
-			emit on_window_set_cursor();
 
-		}
-		break;
-	case NeovimApi6::NEOVIM_FN_WINDOW_GET_HEIGHT:
+		case NeovimApi6::NEOVIM_FN_BUFFER_SET_LINES:
 		{
-			int64_t data;
-			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_height");
-				return;
-			} else {
-				emit on_window_get_height(data);
-			}
-
+			emit on_buffer_set_lines();
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_WINDOW_SET_HEIGHT:
-		{
-			emit on_window_set_height();
 
-		}
-		break;
-	case NeovimApi6::NEOVIM_FN_WINDOW_GET_WIDTH:
-		{
-			int64_t data;
-			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_width");
-				return;
-			} else {
-				emit on_window_get_width(data);
-			}
-
-		}
-		break;
-	case NeovimApi6::NEOVIM_FN_WINDOW_SET_WIDTH:
-		{
-			emit on_window_set_width();
-
-		}
-		break;
-	case NeovimApi6::NEOVIM_FN_WINDOW_GET_VAR:
+		case NeovimApi6::NEOVIM_FN_BUFFER_GET_VAR:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_var");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_var");
 				return;
-			} else {
-				emit on_window_get_var(data);
 			}
 
+			emit on_buffer_get_var(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_WINDOW_GET_OPTION:
+
+		case NeovimApi6::NEOVIM_FN_BUFFER_GET_OPTION:
 		{
 			QVariant data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_option");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_option");
 				return;
-			} else {
-				emit on_window_get_option(data);
 			}
 
+			emit on_buffer_get_option(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_WINDOW_SET_OPTION:
-		{
-			emit on_window_set_option();
 
-		}
-		break;
-	case NeovimApi6::NEOVIM_FN_WINDOW_GET_POSITION:
+		case NeovimApi6::NEOVIM_FN_BUFFER_SET_OPTION:
 		{
-			QPoint data;
-			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_position");
-				return;
-			} else {
-				emit on_window_get_position(data);
-			}
-
+			emit on_buffer_set_option();
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_WINDOW_GET_TABPAGE:
+
+		case NeovimApi6::NEOVIM_FN_BUFFER_GET_NUMBER:
 		{
 			int64_t data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_tabpage");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_number");
 				return;
-			} else {
-				emit on_window_get_tabpage(data);
 			}
 
+			emit on_buffer_get_number(data);
 		}
 		break;
-	case NeovimApi6::NEOVIM_FN_WINDOW_IS_VALID:
+
+		case NeovimApi6::NEOVIM_FN_BUFFER_GET_NAME:
+		{
+			QByteArray data;
+			if (decode(res, data)) {
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_name");
+				return;
+			}
+
+			emit on_buffer_get_name(data);
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_BUFFER_SET_NAME:
+		{
+			emit on_buffer_set_name();
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_BUFFER_IS_VALID:
 		{
 			bool data;
 			if (decode(res, data)) {
-				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_is_valid");
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_is_valid");
 				return;
-			} else {
-				emit on_window_is_valid(data);
 			}
 
+			emit on_buffer_is_valid(data);
 		}
 		break;
+
+		case NeovimApi6::NEOVIM_FN_BUFFER_GET_MARK:
+		{
+			QPoint data;
+			if (decode(res, data)) {
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_get_mark");
+				return;
+			}
+
+			emit on_buffer_get_mark(data);
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_BUFFER_ADD_HIGHLIGHT:
+		{
+			int64_t data;
+			if (decode(res, data)) {
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for buffer_add_highlight");
+				return;
+			}
+
+			emit on_buffer_add_highlight(data);
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_BUFFER_CLEAR_HIGHLIGHT:
+		{
+			emit on_buffer_clear_highlight();
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_TABPAGE_GET_WINDOWS:
+		{
+			QList<int64_t> data;
+			if (decode(res, data)) {
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_get_windows");
+				return;
+			}
+
+			emit on_tabpage_get_windows(data);
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_TABPAGE_GET_VAR:
+		{
+			QVariant data;
+			if (decode(res, data)) {
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_get_var");
+				return;
+			}
+
+			emit on_tabpage_get_var(data);
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_TABPAGE_GET_WINDOW:
+		{
+			int64_t data;
+			if (decode(res, data)) {
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_get_window");
+				return;
+			}
+
+			emit on_tabpage_get_window(data);
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_TABPAGE_IS_VALID:
+		{
+			bool data;
+			if (decode(res, data)) {
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for tabpage_is_valid");
+				return;
+			}
+
+			emit on_tabpage_is_valid(data);
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_UI_DETACH:
+		{
+			emit on_ui_detach();
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_UI_TRY_RESIZE:
+		{
+			QVariant data;
+			if (decode(res, data)) {
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for ui_try_resize");
+				return;
+			}
+
+			emit on_ui_try_resize(data);
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_VIM_COMMAND:
+		{
+			emit on_vim_command();
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_VIM_FEEDKEYS:
+		{
+			emit on_vim_feedkeys();
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_VIM_INPUT:
+		{
+			int64_t data;
+			if (decode(res, data)) {
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_input");
+				return;
+			}
+
+			emit on_vim_input(data);
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_VIM_REPLACE_TERMCODES:
+		{
+			QByteArray data;
+			if (decode(res, data)) {
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_replace_termcodes");
+				return;
+			}
+
+			emit on_vim_replace_termcodes(data);
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_VIM_COMMAND_OUTPUT:
+		{
+			QByteArray data;
+			if (decode(res, data)) {
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_command_output");
+				return;
+			}
+
+			emit on_vim_command_output(data);
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_VIM_EVAL:
+		{
+			QVariant data;
+			if (decode(res, data)) {
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_eval");
+				return;
+			}
+
+			emit on_vim_eval(data);
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_VIM_CALL_FUNCTION:
+		{
+			QVariant data;
+			if (decode(res, data)) {
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_call_function");
+				return;
+			}
+
+			emit on_vim_call_function(data);
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_VIM_STRWIDTH:
+		{
+			int64_t data;
+			if (decode(res, data)) {
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_strwidth");
+				return;
+			}
+
+			emit on_vim_strwidth(data);
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_VIM_LIST_RUNTIME_PATHS:
+		{
+			QList<QByteArray> data;
+			if (decode(res, data)) {
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_list_runtime_paths");
+				return;
+			}
+
+			emit on_vim_list_runtime_paths(data);
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_VIM_CHANGE_DIRECTORY:
+		{
+			emit on_vim_change_directory();
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_VIM_GET_CURRENT_LINE:
+		{
+			QByteArray data;
+			if (decode(res, data)) {
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_current_line");
+				return;
+			}
+
+			emit on_vim_get_current_line(data);
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_VIM_SET_CURRENT_LINE:
+		{
+			emit on_vim_set_current_line();
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_VIM_DEL_CURRENT_LINE:
+		{
+			emit on_vim_del_current_line();
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_VIM_GET_VAR:
+		{
+			QVariant data;
+			if (decode(res, data)) {
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_var");
+				return;
+			}
+
+			emit on_vim_get_var(data);
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_VIM_GET_VVAR:
+		{
+			QVariant data;
+			if (decode(res, data)) {
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_vvar");
+				return;
+			}
+
+			emit on_vim_get_vvar(data);
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_VIM_GET_OPTION:
+		{
+			QVariant data;
+			if (decode(res, data)) {
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_option");
+				return;
+			}
+
+			emit on_vim_get_option(data);
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_VIM_SET_OPTION:
+		{
+			emit on_vim_set_option();
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_VIM_OUT_WRITE:
+		{
+			emit on_vim_out_write();
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_VIM_ERR_WRITE:
+		{
+			emit on_vim_err_write();
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_VIM_REPORT_ERROR:
+		{
+			emit on_vim_report_error();
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_VIM_GET_BUFFERS:
+		{
+			QList<int64_t> data;
+			if (decode(res, data)) {
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_buffers");
+				return;
+			}
+
+			emit on_vim_get_buffers(data);
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_VIM_GET_CURRENT_BUFFER:
+		{
+			int64_t data;
+			if (decode(res, data)) {
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_current_buffer");
+				return;
+			}
+
+			emit on_vim_get_current_buffer(data);
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_VIM_SET_CURRENT_BUFFER:
+		{
+			emit on_vim_set_current_buffer();
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_VIM_GET_WINDOWS:
+		{
+			QList<int64_t> data;
+			if (decode(res, data)) {
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_windows");
+				return;
+			}
+
+			emit on_vim_get_windows(data);
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_VIM_GET_CURRENT_WINDOW:
+		{
+			int64_t data;
+			if (decode(res, data)) {
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_current_window");
+				return;
+			}
+
+			emit on_vim_get_current_window(data);
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_VIM_SET_CURRENT_WINDOW:
+		{
+			emit on_vim_set_current_window();
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_VIM_GET_TABPAGES:
+		{
+			QList<int64_t> data;
+			if (decode(res, data)) {
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_tabpages");
+				return;
+			}
+
+			emit on_vim_get_tabpages(data);
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_VIM_GET_CURRENT_TABPAGE:
+		{
+			int64_t data;
+			if (decode(res, data)) {
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_current_tabpage");
+				return;
+			}
+
+			emit on_vim_get_current_tabpage(data);
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_VIM_SET_CURRENT_TABPAGE:
+		{
+			emit on_vim_set_current_tabpage();
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_VIM_SUBSCRIBE:
+		{
+			emit on_vim_subscribe();
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_VIM_UNSUBSCRIBE:
+		{
+			emit on_vim_unsubscribe();
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_VIM_NAME_TO_COLOR:
+		{
+			int64_t data;
+			if (decode(res, data)) {
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_name_to_color");
+				return;
+			}
+
+			emit on_vim_name_to_color(data);
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_VIM_GET_COLOR_MAP:
+		{
+			QVariantMap data;
+			if (decode(res, data)) {
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for vim_get_color_map");
+				return;
+			}
+
+			emit on_vim_get_color_map(data);
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_WINDOW_GET_BUFFER:
+		{
+			int64_t data;
+			if (decode(res, data)) {
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_buffer");
+				return;
+			}
+
+			emit on_window_get_buffer(data);
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_WINDOW_GET_CURSOR:
+		{
+			QPoint data;
+			if (decode(res, data)) {
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_cursor");
+				return;
+			}
+
+			emit on_window_get_cursor(data);
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_WINDOW_SET_CURSOR:
+		{
+			emit on_window_set_cursor();
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_WINDOW_GET_HEIGHT:
+		{
+			int64_t data;
+			if (decode(res, data)) {
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_height");
+				return;
+			}
+
+			emit on_window_get_height(data);
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_WINDOW_SET_HEIGHT:
+		{
+			emit on_window_set_height();
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_WINDOW_GET_WIDTH:
+		{
+			int64_t data;
+			if (decode(res, data)) {
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_width");
+				return;
+			}
+
+			emit on_window_get_width(data);
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_WINDOW_SET_WIDTH:
+		{
+			emit on_window_set_width();
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_WINDOW_GET_VAR:
+		{
+			QVariant data;
+			if (decode(res, data)) {
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_var");
+				return;
+			}
+
+			emit on_window_get_var(data);
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_WINDOW_GET_OPTION:
+		{
+			QVariant data;
+			if (decode(res, data)) {
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_option");
+				return;
+			}
+
+			emit on_window_get_option(data);
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_WINDOW_SET_OPTION:
+		{
+			emit on_window_set_option();
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_WINDOW_GET_POSITION:
+		{
+			QPoint data;
+			if (decode(res, data)) {
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_position");
+				return;
+			}
+
+			emit on_window_get_position(data);
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_WINDOW_GET_TABPAGE:
+		{
+			int64_t data;
+			if (decode(res, data)) {
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_get_tabpage");
+				return;
+			}
+
+			emit on_window_get_tabpage(data);
+		}
+		break;
+
+		case NeovimApi6::NEOVIM_FN_WINDOW_IS_VALID:
+		{
+			bool data;
+			if (decode(res, data)) {
+				m_connector->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for window_is_valid");
+				return;
+			}
+
+			emit on_window_is_valid(data);
+		}
+		break;
+
 	default:
 		qWarning() << "Received unexpected response";
 	}
@@ -4290,880 +4851,1577 @@ void NeovimApi6::handleResponse(quint32 msgid, quint64 fun, const QVariant& res)
  *
  * Returns false if there is an API mismatch
  */
-bool NeovimApi6::checkFunctions(const QVariantList& ftable)
+/*static*/ bool NeovimApi6::checkFunctions(const QVariantList& ftable) noexcept
 {
-
-	QList<Function> required;
-	required
-		<< Function("Integer", "nvim_buf_line_count",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("String", "buffer_get_line",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						, false)
-		<< Function("Boolean", "nvim_buf_attach",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Boolean")
-						<< QString("Dictionary")
-						, false)
-		<< Function("Boolean", "nvim_buf_detach",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("void", "buffer_set_line",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("String")
-						, false)
-		<< Function("void", "buffer_del_line",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						, false)
-		<< Function("ArrayOf(String)", "buffer_get_line_slice",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Boolean")
-						<< QString("Boolean")
-						, false)
-		<< Function("ArrayOf(String)", "nvim_buf_get_lines",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Boolean")
-						, false)
-		<< Function("void", "buffer_set_line_slice",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Boolean")
-						<< QString("Boolean")
-						<< QString("ArrayOf(String)")
-						, false)
-		<< Function("void", "nvim_buf_set_lines",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Boolean")
-						<< QString("ArrayOf(String)")
-						, false)
-		<< Function("Integer", "nvim_buf_get_offset",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						, false)
-		<< Function("Object", "nvim_buf_get_var",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("Integer", "nvim_buf_get_changedtick",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("ArrayOf(Dictionary)", "nvim_buf_get_keymap",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("Dictionary", "nvim_buf_get_commands",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Dictionary")
-						, false)
-		<< Function("void", "nvim_buf_set_var",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("void", "nvim_buf_del_var",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("Object", "buffer_set_var",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("Object", "buffer_del_var",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("Object", "nvim_buf_get_option",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_buf_set_option",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("Integer", "nvim_buf_get_number",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("String", "nvim_buf_get_name",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("void", "nvim_buf_set_name",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("Boolean", "nvim_buf_is_loaded",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("Boolean", "nvim_buf_is_valid",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("void", "buffer_insert",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("ArrayOf(String)")
-						, false)
-		<< Function("ArrayOf(Integer, 2)", "nvim_buf_get_mark",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("Integer", "nvim_buf_add_highlight",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("String")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Integer")
-						, false)
-		<< Function("void", "nvim_buf_clear_namespace",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Integer")
-						, false)
-		<< Function("void", "nvim_buf_clear_highlight",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Integer")
-						, false)
-		<< Function("Integer", "nvim_buf_set_virtual_text",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Array")
-						<< QString("Dictionary")
-						, false)
-		<< Function("ArrayOf(Window)", "nvim_tabpage_list_wins",
-			QList<QString>()
-						<< QString("Tabpage")
-						, false)
-		<< Function("Object", "nvim_tabpage_get_var",
-			QList<QString>()
-						<< QString("Tabpage")
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_tabpage_set_var",
-			QList<QString>()
-						<< QString("Tabpage")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("void", "nvim_tabpage_del_var",
-			QList<QString>()
-						<< QString("Tabpage")
-						<< QString("String")
-						, false)
-		<< Function("Object", "tabpage_set_var",
-			QList<QString>()
-						<< QString("Tabpage")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("Object", "tabpage_del_var",
-			QList<QString>()
-						<< QString("Tabpage")
-						<< QString("String")
-						, false)
-		<< Function("Window", "nvim_tabpage_get_win",
-			QList<QString>()
-						<< QString("Tabpage")
-						, false)
-		<< Function("Integer", "nvim_tabpage_get_number",
-			QList<QString>()
-						<< QString("Tabpage")
-						, false)
-		<< Function("Boolean", "nvim_tabpage_is_valid",
-			QList<QString>()
-						<< QString("Tabpage")
-						, false)
-		<< Function("void", "nvim_ui_attach",
-			QList<QString>()
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Dictionary")
-						, false)
-		<< Function("void", "ui_attach",
-			QList<QString>()
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Boolean")
-						, false)
-		<< Function("void", "nvim_ui_detach",
-			QList<QString>()
-						, false)
-		<< Function("void", "nvim_ui_try_resize",
-			QList<QString>()
-						<< QString("Integer")
-						<< QString("Integer")
-						, false)
-		<< Function("void", "nvim_ui_set_option",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("void", "nvim_ui_try_resize_grid",
-			QList<QString>()
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Integer")
-						, false)
-		<< Function("void", "nvim_command",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Dictionary", "nvim_get_hl_by_name",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Boolean")
-						, false)
-		<< Function("Dictionary", "nvim_get_hl_by_id",
-			QList<QString>()
-						<< QString("Integer")
-						<< QString("Boolean")
-						, false)
-		<< Function("void", "nvim_feedkeys",
-			QList<QString>()
-						<< QString("String")
-						<< QString("String")
-						<< QString("Boolean")
-						, false)
-		<< Function("Integer", "nvim_input",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("String", "nvim_replace_termcodes",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Boolean")
-						<< QString("Boolean")
-						<< QString("Boolean")
-						, false)
-		<< Function("String", "nvim_command_output",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Object", "nvim_eval",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Object", "nvim_execute_lua",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Array")
-						, false)
-		<< Function("Object", "nvim_call_function",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Array")
-						, false)
-		<< Function("Object", "nvim_call_dict_function",
-			QList<QString>()
-						<< QString("Object")
-						<< QString("String")
-						<< QString("Array")
-						, false)
-		<< Function("Integer", "nvim_strwidth",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("ArrayOf(String)", "nvim_list_runtime_paths",
-			QList<QString>()
-						, false)
-		<< Function("void", "nvim_set_current_dir",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("String", "nvim_get_current_line",
-			QList<QString>()
-						, false)
-		<< Function("void", "nvim_set_current_line",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_del_current_line",
-			QList<QString>()
-						, false)
-		<< Function("Object", "nvim_get_var",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_set_var",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("void", "nvim_del_var",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Object", "vim_set_var",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("Object", "vim_del_var",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Object", "nvim_get_vvar",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Object", "nvim_get_option",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_set_option",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("void", "nvim_out_write",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_err_write",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_err_writeln",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("ArrayOf(Buffer)", "nvim_list_bufs",
-			QList<QString>()
-						, false)
-		<< Function("Buffer", "nvim_get_current_buf",
-			QList<QString>()
-						, false)
-		<< Function("void", "nvim_set_current_buf",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("ArrayOf(Window)", "nvim_list_wins",
-			QList<QString>()
-						, false)
-		<< Function("Window", "nvim_get_current_win",
-			QList<QString>()
-						, false)
-		<< Function("void", "nvim_set_current_win",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("ArrayOf(Tabpage)", "nvim_list_tabpages",
-			QList<QString>()
-						, false)
-		<< Function("Tabpage", "nvim_get_current_tabpage",
-			QList<QString>()
-						, false)
-		<< Function("void", "nvim_set_current_tabpage",
-			QList<QString>()
-						<< QString("Tabpage")
-						, false)
-		<< Function("Integer", "nvim_create_namespace",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Dictionary", "nvim_get_namespaces",
-			QList<QString>()
-						, false)
-		<< Function("void", "nvim_subscribe",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_unsubscribe",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Integer", "nvim_get_color_by_name",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Dictionary", "nvim_get_color_map",
-			QList<QString>()
-						, false)
-		<< Function("Dictionary", "nvim_get_mode",
-			QList<QString>()
-						, false)
-		<< Function("ArrayOf(Dictionary)", "nvim_get_keymap",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Dictionary", "nvim_get_commands",
-			QList<QString>()
-						<< QString("Dictionary")
-						, false)
-		<< Function("Array", "nvim_get_api_info",
-			QList<QString>()
-						, false)
-		<< Function("void", "nvim_set_client_info",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Dictionary")
-						<< QString("String")
-						<< QString("Dictionary")
-						<< QString("Dictionary")
-						, false)
-		<< Function("Dictionary", "nvim_get_chan_info",
-			QList<QString>()
-						<< QString("Integer")
-						, false)
-		<< Function("Array", "nvim_list_chans",
-			QList<QString>()
-						, false)
-		<< Function("Array", "nvim_call_atomic",
-			QList<QString>()
-						<< QString("Array")
-						, false)
-		<< Function("Dictionary", "nvim_parse_expression",
-			QList<QString>()
-						<< QString("String")
-						<< QString("String")
-						<< QString("Boolean")
-						, false)
-		<< Function("Array", "nvim_list_uis",
-			QList<QString>()
-						, false)
-		<< Function("Array", "nvim_get_proc_children",
-			QList<QString>()
-						<< QString("Integer")
-						, false)
-		<< Function("Object", "nvim_get_proc",
-			QList<QString>()
-						<< QString("Integer")
-						, false)
-		<< Function("void", "nvim_select_popupmenu_item",
-			QList<QString>()
-						<< QString("Integer")
-						<< QString("Boolean")
-						<< QString("Boolean")
-						<< QString("Dictionary")
-						, false)
-		<< Function("Buffer", "nvim_win_get_buf",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("void", "nvim_win_set_buf",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("Buffer")
-						, false)
-		<< Function("ArrayOf(Integer, 2)", "nvim_win_get_cursor",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("void", "nvim_win_set_cursor",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("ArrayOf(Integer, 2)")
-						, false)
-		<< Function("Integer", "nvim_win_get_height",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("void", "nvim_win_set_height",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("Integer")
-						, false)
-		<< Function("Integer", "nvim_win_get_width",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("void", "nvim_win_set_width",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("Integer")
-						, false)
-		<< Function("Object", "nvim_win_get_var",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_win_set_var",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("void", "nvim_win_del_var",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						, false)
-		<< Function("Object", "window_set_var",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("Object", "window_del_var",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						, false)
-		<< Function("Object", "nvim_win_get_option",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						, false)
-		<< Function("void", "nvim_win_set_option",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("ArrayOf(Integer, 2)", "nvim_win_get_position",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("Tabpage", "nvim_win_get_tabpage",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("Integer", "nvim_win_get_number",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("Boolean", "nvim_win_is_valid",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("Integer", "buffer_line_count",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("ArrayOf(String)", "buffer_get_lines",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Boolean")
-						, false)
-		<< Function("void", "buffer_set_lines",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Boolean")
-						<< QString("ArrayOf(String)")
-						, false)
-		<< Function("Object", "buffer_get_var",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("Object", "buffer_get_option",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("void", "buffer_set_option",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("Integer", "buffer_get_number",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("String", "buffer_get_name",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("void", "buffer_set_name",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("Boolean", "buffer_is_valid",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("ArrayOf(Integer, 2)", "buffer_get_mark",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("String")
-						, false)
-		<< Function("Integer", "buffer_add_highlight",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("String")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Integer")
-						, false)
-		<< Function("void", "buffer_clear_highlight",
-			QList<QString>()
-						<< QString("Buffer")
-						<< QString("Integer")
-						<< QString("Integer")
-						<< QString("Integer")
-						, false)
-		<< Function("ArrayOf(Window)", "tabpage_get_windows",
-			QList<QString>()
-						<< QString("Tabpage")
-						, false)
-		<< Function("Object", "tabpage_get_var",
-			QList<QString>()
-						<< QString("Tabpage")
-						<< QString("String")
-						, false)
-		<< Function("Window", "tabpage_get_window",
-			QList<QString>()
-						<< QString("Tabpage")
-						, false)
-		<< Function("Boolean", "tabpage_is_valid",
-			QList<QString>()
-						<< QString("Tabpage")
-						, false)
-		<< Function("void", "ui_detach",
-			QList<QString>()
-						, false)
-		<< Function("Object", "ui_try_resize",
-			QList<QString>()
-						<< QString("Integer")
-						<< QString("Integer")
-						, false)
-		<< Function("void", "vim_command",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "vim_feedkeys",
-			QList<QString>()
-						<< QString("String")
-						<< QString("String")
-						<< QString("Boolean")
-						, false)
-		<< Function("Integer", "vim_input",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("String", "vim_replace_termcodes",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Boolean")
-						<< QString("Boolean")
-						<< QString("Boolean")
-						, false)
-		<< Function("String", "vim_command_output",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Object", "vim_eval",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Object", "vim_call_function",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Array")
-						, false)
-		<< Function("Integer", "vim_strwidth",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("ArrayOf(String)", "vim_list_runtime_paths",
-			QList<QString>()
-						, false)
-		<< Function("void", "vim_change_directory",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("String", "vim_get_current_line",
-			QList<QString>()
-						, false)
-		<< Function("void", "vim_set_current_line",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "vim_del_current_line",
-			QList<QString>()
-						, false)
-		<< Function("Object", "vim_get_var",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Object", "vim_get_vvar",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Object", "vim_get_option",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "vim_set_option",
-			QList<QString>()
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("void", "vim_out_write",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "vim_err_write",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "vim_report_error",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("ArrayOf(Buffer)", "vim_get_buffers",
-			QList<QString>()
-						, false)
-		<< Function("Buffer", "vim_get_current_buffer",
-			QList<QString>()
-						, false)
-		<< Function("void", "vim_set_current_buffer",
-			QList<QString>()
-						<< QString("Buffer")
-						, false)
-		<< Function("ArrayOf(Window)", "vim_get_windows",
-			QList<QString>()
-						, false)
-		<< Function("Window", "vim_get_current_window",
-			QList<QString>()
-						, false)
-		<< Function("void", "vim_set_current_window",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("ArrayOf(Tabpage)", "vim_get_tabpages",
-			QList<QString>()
-						, false)
-		<< Function("Tabpage", "vim_get_current_tabpage",
-			QList<QString>()
-						, false)
-		<< Function("void", "vim_set_current_tabpage",
-			QList<QString>()
-						<< QString("Tabpage")
-						, false)
-		<< Function("void", "vim_subscribe",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("void", "vim_unsubscribe",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Integer", "vim_name_to_color",
-			QList<QString>()
-						<< QString("String")
-						, false)
-		<< Function("Dictionary", "vim_get_color_map",
-			QList<QString>()
-						, false)
-		<< Function("Buffer", "window_get_buffer",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("ArrayOf(Integer, 2)", "window_get_cursor",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("void", "window_set_cursor",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("ArrayOf(Integer, 2)")
-						, false)
-		<< Function("Integer", "window_get_height",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("void", "window_set_height",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("Integer")
-						, false)
-		<< Function("Integer", "window_get_width",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("void", "window_set_width",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("Integer")
-						, false)
-		<< Function("Object", "window_get_var",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						, false)
-		<< Function("Object", "window_get_option",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						, false)
-		<< Function("void", "window_set_option",
-			QList<QString>()
-						<< QString("Window")
-						<< QString("String")
-						<< QString("Object")
-						, false)
-		<< Function("ArrayOf(Integer, 2)", "window_get_position",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("Tabpage", "window_get_tabpage",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		<< Function("Boolean", "window_is_valid",
-			QList<QString>()
-						<< QString("Window")
-						, false)
-		;
-
+	static const QList<Function> required{
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_buf_line_count"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("String"),
+				QStringLiteral("buffer_get_line"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Boolean"),
+				QStringLiteral("nvim_buf_attach"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("Dictionary"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Boolean"),
+				QStringLiteral("nvim_buf_detach"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("buffer_set_line"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("buffer_del_line"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(String)"),
+				QStringLiteral("buffer_get_line_slice"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(String)"),
+				QStringLiteral("nvim_buf_get_lines"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("buffer_set_line_slice"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("ArrayOf(String)"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_buf_set_lines"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("ArrayOf(String)"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_buf_get_offset"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_buf_get_var"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_buf_get_changedtick"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Dictionary)"),
+				QStringLiteral("nvim_buf_get_keymap"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_buf_set_keymap"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					QStringLiteral("String"),
+					QStringLiteral("String"),
+					QStringLiteral("Dictionary"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_buf_del_keymap"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Dictionary"),
+				QStringLiteral("nvim_buf_get_commands"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Dictionary"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_buf_set_var"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_buf_del_var"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("buffer_set_var"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("buffer_del_var"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_buf_get_option"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_buf_set_option"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_buf_get_number"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("String"),
+				QStringLiteral("nvim_buf_get_name"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_buf_set_name"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Boolean"),
+				QStringLiteral("nvim_buf_is_loaded"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Boolean"),
+				QStringLiteral("nvim_buf_is_valid"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("buffer_insert"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("ArrayOf(String)"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Integer, 2)"),
+				QStringLiteral("nvim_buf_get_mark"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_buf_add_highlight"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("String"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_buf_clear_namespace"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_buf_clear_highlight"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_buf_set_virtual_text"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Array"),
+					QStringLiteral("Dictionary"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Window)"),
+				QStringLiteral("nvim_tabpage_list_wins"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_tabpage_get_var"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_tabpage_set_var"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_tabpage_del_var"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("tabpage_set_var"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("tabpage_del_var"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Window"),
+				QStringLiteral("nvim_tabpage_get_win"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_tabpage_get_number"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Boolean"),
+				QStringLiteral("nvim_tabpage_is_valid"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_ui_attach"),
+				QStringList{
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Dictionary"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("ui_attach"),
+				QStringList{
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_ui_detach"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_ui_try_resize"),
+				QStringList{
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_ui_set_option"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_ui_try_resize_grid"),
+				QStringList{
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_ui_pum_set_height"),
+				QStringList{
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_command"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Dictionary"),
+				QStringLiteral("nvim_get_hl_by_name"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Dictionary"),
+				QStringLiteral("nvim_get_hl_by_id"),
+				QStringList{
+					QStringLiteral("Integer"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_feedkeys"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("String"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_input"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_input_mouse"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("String"),
+					QStringLiteral("String"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("String"),
+				QStringLiteral("nvim_replace_termcodes"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("String"),
+				QStringLiteral("nvim_command_output"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_eval"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_execute_lua"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Array"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_call_function"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Array"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_call_dict_function"),
+				QStringList{
+					QStringLiteral("Object"),
+					QStringLiteral("String"),
+					QStringLiteral("Array"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_strwidth"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(String)"),
+				QStringLiteral("nvim_list_runtime_paths"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_set_current_dir"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("String"),
+				QStringLiteral("nvim_get_current_line"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_set_current_line"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_del_current_line"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_get_var"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_set_var"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_del_var"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("vim_set_var"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("vim_del_var"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_get_vvar"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_set_vvar"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_get_option"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_set_option"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_out_write"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_err_write"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_err_writeln"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Buffer)"),
+				QStringLiteral("nvim_list_bufs"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Buffer"),
+				QStringLiteral("nvim_get_current_buf"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_set_current_buf"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Window)"),
+				QStringLiteral("nvim_list_wins"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Window"),
+				QStringLiteral("nvim_get_current_win"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_set_current_win"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Buffer"),
+				QStringLiteral("nvim_create_buf"),
+				QStringList{
+					QStringLiteral("Boolean"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Window"),
+				QStringLiteral("nvim_open_win"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("Dictionary"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Tabpage)"),
+				QStringLiteral("nvim_list_tabpages"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Tabpage"),
+				QStringLiteral("nvim_get_current_tabpage"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_set_current_tabpage"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_create_namespace"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Dictionary"),
+				QStringLiteral("nvim_get_namespaces"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Boolean"),
+				QStringLiteral("nvim_paste"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_put"),
+				QStringList{
+					QStringLiteral("ArrayOf(String)"),
+					QStringLiteral("String"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_subscribe"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_unsubscribe"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_get_color_by_name"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Dictionary"),
+				QStringLiteral("nvim_get_color_map"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Dictionary"),
+				QStringLiteral("nvim_get_context"),
+				QStringList{
+					QStringLiteral("Dictionary"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_load_context"),
+				QStringList{
+					QStringLiteral("Dictionary"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Dictionary"),
+				QStringLiteral("nvim_get_mode"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Dictionary)"),
+				QStringLiteral("nvim_get_keymap"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_set_keymap"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("String"),
+					QStringLiteral("String"),
+					QStringLiteral("Dictionary"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_del_keymap"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Dictionary"),
+				QStringLiteral("nvim_get_commands"),
+				QStringList{
+					QStringLiteral("Dictionary"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Array"),
+				QStringLiteral("nvim_get_api_info"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_set_client_info"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Dictionary"),
+					QStringLiteral("String"),
+					QStringLiteral("Dictionary"),
+					QStringLiteral("Dictionary"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Dictionary"),
+				QStringLiteral("nvim_get_chan_info"),
+				QStringList{
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Array"),
+				QStringLiteral("nvim_list_chans"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Array"),
+				QStringLiteral("nvim_call_atomic"),
+				QStringList{
+					QStringLiteral("Array"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Dictionary"),
+				QStringLiteral("nvim_parse_expression"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("String"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Array"),
+				QStringLiteral("nvim_list_uis"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Array"),
+				QStringLiteral("nvim_get_proc_children"),
+				QStringList{
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_get_proc"),
+				QStringList{
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_select_popupmenu_item"),
+				QStringList{
+					QStringLiteral("Integer"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("Dictionary"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Buffer"),
+				QStringLiteral("nvim_win_get_buf"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_win_set_buf"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Integer, 2)"),
+				QStringLiteral("nvim_win_get_cursor"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_win_set_cursor"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("ArrayOf(Integer, 2)"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_win_get_height"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_win_set_height"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_win_get_width"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_win_set_width"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_win_get_var"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_win_set_var"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_win_del_var"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("window_set_var"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("window_del_var"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("nvim_win_get_option"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_win_set_option"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Integer, 2)"),
+				QStringLiteral("nvim_win_get_position"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Tabpage"),
+				QStringLiteral("nvim_win_get_tabpage"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("nvim_win_get_number"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Boolean"),
+				QStringLiteral("nvim_win_is_valid"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_win_set_config"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("Dictionary"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Dictionary"),
+				QStringLiteral("nvim_win_get_config"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("nvim_win_close"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("buffer_line_count"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(String)"),
+				QStringLiteral("buffer_get_lines"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("buffer_set_lines"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("ArrayOf(String)"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("buffer_get_var"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("buffer_get_option"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("buffer_set_option"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("buffer_get_number"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("String"),
+				QStringLiteral("buffer_get_name"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("buffer_set_name"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Boolean"),
+				QStringLiteral("buffer_is_valid"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Integer, 2)"),
+				QStringLiteral("buffer_get_mark"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("buffer_add_highlight"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("String"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("buffer_clear_highlight"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Window)"),
+				QStringLiteral("tabpage_get_windows"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("tabpage_get_var"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Window"),
+				QStringLiteral("tabpage_get_window"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Boolean"),
+				QStringLiteral("tabpage_is_valid"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("ui_detach"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("ui_try_resize"),
+				QStringList{
+					QStringLiteral("Integer"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_command"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_feedkeys"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("String"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("vim_input"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("String"),
+				QStringLiteral("vim_replace_termcodes"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("Boolean"),
+					QStringLiteral("Boolean"),
+					}
+				, false },
+			Function{
+				QStringLiteral("String"),
+				QStringLiteral("vim_command_output"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("vim_eval"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("vim_call_function"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Array"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("vim_strwidth"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(String)"),
+				QStringLiteral("vim_list_runtime_paths"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_change_directory"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("String"),
+				QStringLiteral("vim_get_current_line"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_set_current_line"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_del_current_line"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("vim_get_var"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("vim_get_vvar"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("vim_get_option"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_set_option"),
+				QStringList{
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_out_write"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_err_write"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_report_error"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Buffer)"),
+				QStringLiteral("vim_get_buffers"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Buffer"),
+				QStringLiteral("vim_get_current_buffer"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_set_current_buffer"),
+				QStringList{
+					QStringLiteral("Buffer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Window)"),
+				QStringLiteral("vim_get_windows"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Window"),
+				QStringLiteral("vim_get_current_window"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_set_current_window"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Tabpage)"),
+				QStringLiteral("vim_get_tabpages"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Tabpage"),
+				QStringLiteral("vim_get_current_tabpage"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_set_current_tabpage"),
+				QStringList{
+					QStringLiteral("Tabpage"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_subscribe"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("vim_unsubscribe"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("vim_name_to_color"),
+				QStringList{
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Dictionary"),
+				QStringLiteral("vim_get_color_map"),
+				QStringList{
+					}
+				, false },
+			Function{
+				QStringLiteral("Buffer"),
+				QStringLiteral("window_get_buffer"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Integer, 2)"),
+				QStringLiteral("window_get_cursor"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("window_set_cursor"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("ArrayOf(Integer, 2)"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("window_get_height"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("window_set_height"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Integer"),
+				QStringLiteral("window_get_width"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("window_set_width"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("Integer"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("window_get_var"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Object"),
+				QStringLiteral("window_get_option"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					}
+				, false },
+			Function{
+				QStringLiteral("void"),
+				QStringLiteral("window_set_option"),
+				QStringList{
+					QStringLiteral("Window"),
+					QStringLiteral("String"),
+					QStringLiteral("Object"),
+					}
+				, false },
+			Function{
+				QStringLiteral("ArrayOf(Integer, 2)"),
+				QStringLiteral("window_get_position"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Tabpage"),
+				QStringLiteral("window_get_tabpage"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+			Function{
+				QStringLiteral("Boolean"),
+				QStringLiteral("window_is_valid"),
+				QStringList{
+					QStringLiteral("Window"),
+					}
+				, false },
+		};
 
 	QList<Function> supported;
-	foreach(const QVariant& val, ftable) {
+	supported.reserve(ftable.size());
+	for(const auto& val : ftable) {
 		auto f = Function::fromVariant(val);
 		if (!f.isValid()) {
 			qDebug() << "Invalid function in metadata" << f;
@@ -5177,7 +6435,7 @@ bool NeovimApi6::checkFunctions(const QVariantList& ftable)
 	}
 
 	bool ok = true;
-	foreach(const Function& f, required) {
+	for(const auto& f : required) {
 		if (!supported.contains(f)) {
 			qDebug() << "- instance DOES NOT support API6:" << f;
 			ok = false;

--- a/src/auto/neovimapi6.cpp
+++ b/src/auto/neovimapi6.cpp
@@ -1,4 +1,4 @@
-// Auto generated 2020-09-09 13:30:54.415020 from nvim API level:6
+// Auto generated 2020-09-09 15:16:43.068844 from nvim API level:6
 #include "auto/neovimapi6.h"
 #include "msgpackiodevice.h"
 #include "msgpackrequest.h"
@@ -6419,7 +6419,7 @@ void NeovimApi6::handleResponse(uint32_t msgid, uint64_t fun, const QVariant& re
 				, false },
 		};
 
-	QList<Function> supported;
+	QVector<Function> supported;
 	supported.reserve(ftable.size());
 	for(const auto& val : ftable) {
 		auto f = Function::fromVariant(val);

--- a/src/auto/neovimapi6.h
+++ b/src/auto/neovimapi6.h
@@ -1,4 +1,4 @@
-// Auto generated 2020-09-09 13:30:54.433410 from nvim API level:6
+// Auto generated 2020-09-09 15:16:43.088117 from nvim API level:6
 #pragma once
 
 #include <QObject>

--- a/src/auto/neovimapi6.h
+++ b/src/auto/neovimapi6.h
@@ -1,682 +1,860 @@
-// Auto generated 2019-01-13 02:04:50.898803 from nvim API level:6
-#ifndef NEOVIM_QT_NEOVIMAPI6
-#define NEOVIM_QT_NEOVIMAPI6
-#include "msgpack.h"
+// Auto generated 2020-09-09 13:30:54.433410 from nvim API level:6
+#pragma once
+
 #include <QObject>
-#include <QVariant>
 #include <QPoint>
+#include <QVariant>
+
 #include "function.h"
+#include "msgpack.h"
 
 namespace NeovimQt {
+
 class NeovimConnector;
 class MsgpackRequest;
 
-class NeovimApi6: public QObject
+class NeovimApi6 : public QObject
 {
 	Q_OBJECT
-	Q_ENUMS(FunctionId)
 
 public:
-
 	enum FunctionId {
-		NEOVIM_FN_NULL=0,
-				NEOVIM_FN_NVIM_BUF_LINE_COUNT,
-				NEOVIM_FN_BUFFER_GET_LINE,
-				NEOVIM_FN_NVIM_BUF_ATTACH,
-				NEOVIM_FN_NVIM_BUF_DETACH,
-				NEOVIM_FN_BUFFER_SET_LINE,
-				NEOVIM_FN_BUFFER_DEL_LINE,
-				NEOVIM_FN_BUFFER_GET_LINE_SLICE,
-				NEOVIM_FN_NVIM_BUF_GET_LINES,
-				NEOVIM_FN_BUFFER_SET_LINE_SLICE,
-				NEOVIM_FN_NVIM_BUF_SET_LINES,
-				NEOVIM_FN_NVIM_BUF_GET_OFFSET,
-				NEOVIM_FN_NVIM_BUF_GET_VAR,
-				NEOVIM_FN_NVIM_BUF_GET_CHANGEDTICK,
-				NEOVIM_FN_NVIM_BUF_GET_KEYMAP,
-				NEOVIM_FN_NVIM_BUF_GET_COMMANDS,
-				NEOVIM_FN_NVIM_BUF_SET_VAR,
-				NEOVIM_FN_NVIM_BUF_DEL_VAR,
-				NEOVIM_FN_BUFFER_SET_VAR,
-				NEOVIM_FN_BUFFER_DEL_VAR,
-				NEOVIM_FN_NVIM_BUF_GET_OPTION,
-				NEOVIM_FN_NVIM_BUF_SET_OPTION,
-				NEOVIM_FN_NVIM_BUF_GET_NUMBER,
-				NEOVIM_FN_NVIM_BUF_GET_NAME,
-				NEOVIM_FN_NVIM_BUF_SET_NAME,
-				NEOVIM_FN_NVIM_BUF_IS_LOADED,
-				NEOVIM_FN_NVIM_BUF_IS_VALID,
-				NEOVIM_FN_BUFFER_INSERT,
-				NEOVIM_FN_NVIM_BUF_GET_MARK,
-				NEOVIM_FN_NVIM_BUF_ADD_HIGHLIGHT,
-				NEOVIM_FN_NVIM_BUF_CLEAR_NAMESPACE,
-				NEOVIM_FN_NVIM_BUF_CLEAR_HIGHLIGHT,
-				NEOVIM_FN_NVIM_BUF_SET_VIRTUAL_TEXT,
-				NEOVIM_FN_NVIM_TABPAGE_LIST_WINS,
-				NEOVIM_FN_NVIM_TABPAGE_GET_VAR,
-				NEOVIM_FN_NVIM_TABPAGE_SET_VAR,
-				NEOVIM_FN_NVIM_TABPAGE_DEL_VAR,
-				NEOVIM_FN_TABPAGE_SET_VAR,
-				NEOVIM_FN_TABPAGE_DEL_VAR,
-				NEOVIM_FN_NVIM_TABPAGE_GET_WIN,
-				NEOVIM_FN_NVIM_TABPAGE_GET_NUMBER,
-				NEOVIM_FN_NVIM_TABPAGE_IS_VALID,
-				NEOVIM_FN_NVIM_UI_ATTACH,
-				NEOVIM_FN_UI_ATTACH,
-				NEOVIM_FN_NVIM_UI_DETACH,
-				NEOVIM_FN_NVIM_UI_TRY_RESIZE,
-				NEOVIM_FN_NVIM_UI_SET_OPTION,
-				NEOVIM_FN_NVIM_UI_TRY_RESIZE_GRID,
-				NEOVIM_FN_NVIM_COMMAND,
-				NEOVIM_FN_NVIM_GET_HL_BY_NAME,
-				NEOVIM_FN_NVIM_GET_HL_BY_ID,
-				NEOVIM_FN_NVIM_FEEDKEYS,
-				NEOVIM_FN_NVIM_INPUT,
-				NEOVIM_FN_NVIM_REPLACE_TERMCODES,
-				NEOVIM_FN_NVIM_COMMAND_OUTPUT,
-				NEOVIM_FN_NVIM_EVAL,
-				NEOVIM_FN_NVIM_EXECUTE_LUA,
-				NEOVIM_FN_NVIM_CALL_FUNCTION,
-				NEOVIM_FN_NVIM_CALL_DICT_FUNCTION,
-				NEOVIM_FN_NVIM_STRWIDTH,
-				NEOVIM_FN_NVIM_LIST_RUNTIME_PATHS,
-				NEOVIM_FN_NVIM_SET_CURRENT_DIR,
-				NEOVIM_FN_NVIM_GET_CURRENT_LINE,
-				NEOVIM_FN_NVIM_SET_CURRENT_LINE,
-				NEOVIM_FN_NVIM_DEL_CURRENT_LINE,
-				NEOVIM_FN_NVIM_GET_VAR,
-				NEOVIM_FN_NVIM_SET_VAR,
-				NEOVIM_FN_NVIM_DEL_VAR,
-				NEOVIM_FN_VIM_SET_VAR,
-				NEOVIM_FN_VIM_DEL_VAR,
-				NEOVIM_FN_NVIM_GET_VVAR,
-				NEOVIM_FN_NVIM_GET_OPTION,
-				NEOVIM_FN_NVIM_SET_OPTION,
-				NEOVIM_FN_NVIM_OUT_WRITE,
-				NEOVIM_FN_NVIM_ERR_WRITE,
-				NEOVIM_FN_NVIM_ERR_WRITELN,
-				NEOVIM_FN_NVIM_LIST_BUFS,
-				NEOVIM_FN_NVIM_GET_CURRENT_BUF,
-				NEOVIM_FN_NVIM_SET_CURRENT_BUF,
-				NEOVIM_FN_NVIM_LIST_WINS,
-				NEOVIM_FN_NVIM_GET_CURRENT_WIN,
-				NEOVIM_FN_NVIM_SET_CURRENT_WIN,
-				NEOVIM_FN_NVIM_LIST_TABPAGES,
-				NEOVIM_FN_NVIM_GET_CURRENT_TABPAGE,
-				NEOVIM_FN_NVIM_SET_CURRENT_TABPAGE,
-				NEOVIM_FN_NVIM_CREATE_NAMESPACE,
-				NEOVIM_FN_NVIM_GET_NAMESPACES,
-				NEOVIM_FN_NVIM_SUBSCRIBE,
-				NEOVIM_FN_NVIM_UNSUBSCRIBE,
-				NEOVIM_FN_NVIM_GET_COLOR_BY_NAME,
-				NEOVIM_FN_NVIM_GET_COLOR_MAP,
-				NEOVIM_FN_NVIM_GET_MODE,
-				NEOVIM_FN_NVIM_GET_KEYMAP,
-				NEOVIM_FN_NVIM_GET_COMMANDS,
-				NEOVIM_FN_NVIM_GET_API_INFO,
-				NEOVIM_FN_NVIM_SET_CLIENT_INFO,
-				NEOVIM_FN_NVIM_GET_CHAN_INFO,
-				NEOVIM_FN_NVIM_LIST_CHANS,
-				NEOVIM_FN_NVIM_CALL_ATOMIC,
-				NEOVIM_FN_NVIM_PARSE_EXPRESSION,
-				NEOVIM_FN_NVIM_LIST_UIS,
-				NEOVIM_FN_NVIM_GET_PROC_CHILDREN,
-				NEOVIM_FN_NVIM_GET_PROC,
-				NEOVIM_FN_NVIM_SELECT_POPUPMENU_ITEM,
-				NEOVIM_FN_NVIM_WIN_GET_BUF,
-				NEOVIM_FN_NVIM_WIN_SET_BUF,
-				NEOVIM_FN_NVIM_WIN_GET_CURSOR,
-				NEOVIM_FN_NVIM_WIN_SET_CURSOR,
-				NEOVIM_FN_NVIM_WIN_GET_HEIGHT,
-				NEOVIM_FN_NVIM_WIN_SET_HEIGHT,
-				NEOVIM_FN_NVIM_WIN_GET_WIDTH,
-				NEOVIM_FN_NVIM_WIN_SET_WIDTH,
-				NEOVIM_FN_NVIM_WIN_GET_VAR,
-				NEOVIM_FN_NVIM_WIN_SET_VAR,
-				NEOVIM_FN_NVIM_WIN_DEL_VAR,
-				NEOVIM_FN_WINDOW_SET_VAR,
-				NEOVIM_FN_WINDOW_DEL_VAR,
-				NEOVIM_FN_NVIM_WIN_GET_OPTION,
-				NEOVIM_FN_NVIM_WIN_SET_OPTION,
-				NEOVIM_FN_NVIM_WIN_GET_POSITION,
-				NEOVIM_FN_NVIM_WIN_GET_TABPAGE,
-				NEOVIM_FN_NVIM_WIN_GET_NUMBER,
-				NEOVIM_FN_NVIM_WIN_IS_VALID,
-				NEOVIM_FN_BUFFER_LINE_COUNT,
-				NEOVIM_FN_BUFFER_GET_LINES,
-				NEOVIM_FN_BUFFER_SET_LINES,
-				NEOVIM_FN_BUFFER_GET_VAR,
-				NEOVIM_FN_BUFFER_GET_OPTION,
-				NEOVIM_FN_BUFFER_SET_OPTION,
-				NEOVIM_FN_BUFFER_GET_NUMBER,
-				NEOVIM_FN_BUFFER_GET_NAME,
-				NEOVIM_FN_BUFFER_SET_NAME,
-				NEOVIM_FN_BUFFER_IS_VALID,
-				NEOVIM_FN_BUFFER_GET_MARK,
-				NEOVIM_FN_BUFFER_ADD_HIGHLIGHT,
-				NEOVIM_FN_BUFFER_CLEAR_HIGHLIGHT,
-				NEOVIM_FN_TABPAGE_GET_WINDOWS,
-				NEOVIM_FN_TABPAGE_GET_VAR,
-				NEOVIM_FN_TABPAGE_GET_WINDOW,
-				NEOVIM_FN_TABPAGE_IS_VALID,
-				NEOVIM_FN_UI_DETACH,
-				NEOVIM_FN_UI_TRY_RESIZE,
-				NEOVIM_FN_VIM_COMMAND,
-				NEOVIM_FN_VIM_FEEDKEYS,
-				NEOVIM_FN_VIM_INPUT,
-				NEOVIM_FN_VIM_REPLACE_TERMCODES,
-				NEOVIM_FN_VIM_COMMAND_OUTPUT,
-				NEOVIM_FN_VIM_EVAL,
-				NEOVIM_FN_VIM_CALL_FUNCTION,
-				NEOVIM_FN_VIM_STRWIDTH,
-				NEOVIM_FN_VIM_LIST_RUNTIME_PATHS,
-				NEOVIM_FN_VIM_CHANGE_DIRECTORY,
-				NEOVIM_FN_VIM_GET_CURRENT_LINE,
-				NEOVIM_FN_VIM_SET_CURRENT_LINE,
-				NEOVIM_FN_VIM_DEL_CURRENT_LINE,
-				NEOVIM_FN_VIM_GET_VAR,
-				NEOVIM_FN_VIM_GET_VVAR,
-				NEOVIM_FN_VIM_GET_OPTION,
-				NEOVIM_FN_VIM_SET_OPTION,
-				NEOVIM_FN_VIM_OUT_WRITE,
-				NEOVIM_FN_VIM_ERR_WRITE,
-				NEOVIM_FN_VIM_REPORT_ERROR,
-				NEOVIM_FN_VIM_GET_BUFFERS,
-				NEOVIM_FN_VIM_GET_CURRENT_BUFFER,
-				NEOVIM_FN_VIM_SET_CURRENT_BUFFER,
-				NEOVIM_FN_VIM_GET_WINDOWS,
-				NEOVIM_FN_VIM_GET_CURRENT_WINDOW,
-				NEOVIM_FN_VIM_SET_CURRENT_WINDOW,
-				NEOVIM_FN_VIM_GET_TABPAGES,
-				NEOVIM_FN_VIM_GET_CURRENT_TABPAGE,
-				NEOVIM_FN_VIM_SET_CURRENT_TABPAGE,
-				NEOVIM_FN_VIM_SUBSCRIBE,
-				NEOVIM_FN_VIM_UNSUBSCRIBE,
-				NEOVIM_FN_VIM_NAME_TO_COLOR,
-				NEOVIM_FN_VIM_GET_COLOR_MAP,
-				NEOVIM_FN_WINDOW_GET_BUFFER,
-				NEOVIM_FN_WINDOW_GET_CURSOR,
-				NEOVIM_FN_WINDOW_SET_CURSOR,
-				NEOVIM_FN_WINDOW_GET_HEIGHT,
-				NEOVIM_FN_WINDOW_SET_HEIGHT,
-				NEOVIM_FN_WINDOW_GET_WIDTH,
-				NEOVIM_FN_WINDOW_SET_WIDTH,
-				NEOVIM_FN_WINDOW_GET_VAR,
-				NEOVIM_FN_WINDOW_GET_OPTION,
-				NEOVIM_FN_WINDOW_SET_OPTION,
-				NEOVIM_FN_WINDOW_GET_POSITION,
-				NEOVIM_FN_WINDOW_GET_TABPAGE,
-				NEOVIM_FN_WINDOW_IS_VALID,
+		NEOVIM_FN_NULL,
+		NEOVIM_FN_NVIM_BUF_LINE_COUNT,
+		NEOVIM_FN_BUFFER_GET_LINE,
+		NEOVIM_FN_NVIM_BUF_ATTACH,
+		NEOVIM_FN_NVIM_BUF_DETACH,
+		NEOVIM_FN_BUFFER_SET_LINE,
+		NEOVIM_FN_BUFFER_DEL_LINE,
+		NEOVIM_FN_BUFFER_GET_LINE_SLICE,
+		NEOVIM_FN_NVIM_BUF_GET_LINES,
+		NEOVIM_FN_BUFFER_SET_LINE_SLICE,
+		NEOVIM_FN_NVIM_BUF_SET_LINES,
+		NEOVIM_FN_NVIM_BUF_GET_OFFSET,
+		NEOVIM_FN_NVIM_BUF_GET_VAR,
+		NEOVIM_FN_NVIM_BUF_GET_CHANGEDTICK,
+		NEOVIM_FN_NVIM_BUF_GET_KEYMAP,
+		NEOVIM_FN_NVIM_BUF_SET_KEYMAP,
+		NEOVIM_FN_NVIM_BUF_DEL_KEYMAP,
+		NEOVIM_FN_NVIM_BUF_GET_COMMANDS,
+		NEOVIM_FN_NVIM_BUF_SET_VAR,
+		NEOVIM_FN_NVIM_BUF_DEL_VAR,
+		NEOVIM_FN_BUFFER_SET_VAR,
+		NEOVIM_FN_BUFFER_DEL_VAR,
+		NEOVIM_FN_NVIM_BUF_GET_OPTION,
+		NEOVIM_FN_NVIM_BUF_SET_OPTION,
+		NEOVIM_FN_NVIM_BUF_GET_NUMBER,
+		NEOVIM_FN_NVIM_BUF_GET_NAME,
+		NEOVIM_FN_NVIM_BUF_SET_NAME,
+		NEOVIM_FN_NVIM_BUF_IS_LOADED,
+		NEOVIM_FN_NVIM_BUF_IS_VALID,
+		NEOVIM_FN_BUFFER_INSERT,
+		NEOVIM_FN_NVIM_BUF_GET_MARK,
+		NEOVIM_FN_NVIM_BUF_ADD_HIGHLIGHT,
+		NEOVIM_FN_NVIM_BUF_CLEAR_NAMESPACE,
+		NEOVIM_FN_NVIM_BUF_CLEAR_HIGHLIGHT,
+		NEOVIM_FN_NVIM_BUF_SET_VIRTUAL_TEXT,
+		NEOVIM_FN_NVIM_TABPAGE_LIST_WINS,
+		NEOVIM_FN_NVIM_TABPAGE_GET_VAR,
+		NEOVIM_FN_NVIM_TABPAGE_SET_VAR,
+		NEOVIM_FN_NVIM_TABPAGE_DEL_VAR,
+		NEOVIM_FN_TABPAGE_SET_VAR,
+		NEOVIM_FN_TABPAGE_DEL_VAR,
+		NEOVIM_FN_NVIM_TABPAGE_GET_WIN,
+		NEOVIM_FN_NVIM_TABPAGE_GET_NUMBER,
+		NEOVIM_FN_NVIM_TABPAGE_IS_VALID,
+		NEOVIM_FN_NVIM_UI_ATTACH,
+		NEOVIM_FN_UI_ATTACH,
+		NEOVIM_FN_NVIM_UI_DETACH,
+		NEOVIM_FN_NVIM_UI_TRY_RESIZE,
+		NEOVIM_FN_NVIM_UI_SET_OPTION,
+		NEOVIM_FN_NVIM_UI_TRY_RESIZE_GRID,
+		NEOVIM_FN_NVIM_UI_PUM_SET_HEIGHT,
+		NEOVIM_FN_NVIM_COMMAND,
+		NEOVIM_FN_NVIM_GET_HL_BY_NAME,
+		NEOVIM_FN_NVIM_GET_HL_BY_ID,
+		NEOVIM_FN_NVIM_FEEDKEYS,
+		NEOVIM_FN_NVIM_INPUT,
+		NEOVIM_FN_NVIM_INPUT_MOUSE,
+		NEOVIM_FN_NVIM_REPLACE_TERMCODES,
+		NEOVIM_FN_NVIM_COMMAND_OUTPUT,
+		NEOVIM_FN_NVIM_EVAL,
+		NEOVIM_FN_NVIM_EXECUTE_LUA,
+		NEOVIM_FN_NVIM_CALL_FUNCTION,
+		NEOVIM_FN_NVIM_CALL_DICT_FUNCTION,
+		NEOVIM_FN_NVIM_STRWIDTH,
+		NEOVIM_FN_NVIM_LIST_RUNTIME_PATHS,
+		NEOVIM_FN_NVIM_SET_CURRENT_DIR,
+		NEOVIM_FN_NVIM_GET_CURRENT_LINE,
+		NEOVIM_FN_NVIM_SET_CURRENT_LINE,
+		NEOVIM_FN_NVIM_DEL_CURRENT_LINE,
+		NEOVIM_FN_NVIM_GET_VAR,
+		NEOVIM_FN_NVIM_SET_VAR,
+		NEOVIM_FN_NVIM_DEL_VAR,
+		NEOVIM_FN_VIM_SET_VAR,
+		NEOVIM_FN_VIM_DEL_VAR,
+		NEOVIM_FN_NVIM_GET_VVAR,
+		NEOVIM_FN_NVIM_SET_VVAR,
+		NEOVIM_FN_NVIM_GET_OPTION,
+		NEOVIM_FN_NVIM_SET_OPTION,
+		NEOVIM_FN_NVIM_OUT_WRITE,
+		NEOVIM_FN_NVIM_ERR_WRITE,
+		NEOVIM_FN_NVIM_ERR_WRITELN,
+		NEOVIM_FN_NVIM_LIST_BUFS,
+		NEOVIM_FN_NVIM_GET_CURRENT_BUF,
+		NEOVIM_FN_NVIM_SET_CURRENT_BUF,
+		NEOVIM_FN_NVIM_LIST_WINS,
+		NEOVIM_FN_NVIM_GET_CURRENT_WIN,
+		NEOVIM_FN_NVIM_SET_CURRENT_WIN,
+		NEOVIM_FN_NVIM_CREATE_BUF,
+		NEOVIM_FN_NVIM_OPEN_WIN,
+		NEOVIM_FN_NVIM_LIST_TABPAGES,
+		NEOVIM_FN_NVIM_GET_CURRENT_TABPAGE,
+		NEOVIM_FN_NVIM_SET_CURRENT_TABPAGE,
+		NEOVIM_FN_NVIM_CREATE_NAMESPACE,
+		NEOVIM_FN_NVIM_GET_NAMESPACES,
+		NEOVIM_FN_NVIM_PASTE,
+		NEOVIM_FN_NVIM_PUT,
+		NEOVIM_FN_NVIM_SUBSCRIBE,
+		NEOVIM_FN_NVIM_UNSUBSCRIBE,
+		NEOVIM_FN_NVIM_GET_COLOR_BY_NAME,
+		NEOVIM_FN_NVIM_GET_COLOR_MAP,
+		NEOVIM_FN_NVIM_GET_CONTEXT,
+		NEOVIM_FN_NVIM_LOAD_CONTEXT,
+		NEOVIM_FN_NVIM_GET_MODE,
+		NEOVIM_FN_NVIM_GET_KEYMAP,
+		NEOVIM_FN_NVIM_SET_KEYMAP,
+		NEOVIM_FN_NVIM_DEL_KEYMAP,
+		NEOVIM_FN_NVIM_GET_COMMANDS,
+		NEOVIM_FN_NVIM_GET_API_INFO,
+		NEOVIM_FN_NVIM_SET_CLIENT_INFO,
+		NEOVIM_FN_NVIM_GET_CHAN_INFO,
+		NEOVIM_FN_NVIM_LIST_CHANS,
+		NEOVIM_FN_NVIM_CALL_ATOMIC,
+		NEOVIM_FN_NVIM_PARSE_EXPRESSION,
+		NEOVIM_FN_NVIM_LIST_UIS,
+		NEOVIM_FN_NVIM_GET_PROC_CHILDREN,
+		NEOVIM_FN_NVIM_GET_PROC,
+		NEOVIM_FN_NVIM_SELECT_POPUPMENU_ITEM,
+		NEOVIM_FN_NVIM_WIN_GET_BUF,
+		NEOVIM_FN_NVIM_WIN_SET_BUF,
+		NEOVIM_FN_NVIM_WIN_GET_CURSOR,
+		NEOVIM_FN_NVIM_WIN_SET_CURSOR,
+		NEOVIM_FN_NVIM_WIN_GET_HEIGHT,
+		NEOVIM_FN_NVIM_WIN_SET_HEIGHT,
+		NEOVIM_FN_NVIM_WIN_GET_WIDTH,
+		NEOVIM_FN_NVIM_WIN_SET_WIDTH,
+		NEOVIM_FN_NVIM_WIN_GET_VAR,
+		NEOVIM_FN_NVIM_WIN_SET_VAR,
+		NEOVIM_FN_NVIM_WIN_DEL_VAR,
+		NEOVIM_FN_WINDOW_SET_VAR,
+		NEOVIM_FN_WINDOW_DEL_VAR,
+		NEOVIM_FN_NVIM_WIN_GET_OPTION,
+		NEOVIM_FN_NVIM_WIN_SET_OPTION,
+		NEOVIM_FN_NVIM_WIN_GET_POSITION,
+		NEOVIM_FN_NVIM_WIN_GET_TABPAGE,
+		NEOVIM_FN_NVIM_WIN_GET_NUMBER,
+		NEOVIM_FN_NVIM_WIN_IS_VALID,
+		NEOVIM_FN_NVIM_WIN_SET_CONFIG,
+		NEOVIM_FN_NVIM_WIN_GET_CONFIG,
+		NEOVIM_FN_NVIM_WIN_CLOSE,
+		NEOVIM_FN_BUFFER_LINE_COUNT,
+		NEOVIM_FN_BUFFER_GET_LINES,
+		NEOVIM_FN_BUFFER_SET_LINES,
+		NEOVIM_FN_BUFFER_GET_VAR,
+		NEOVIM_FN_BUFFER_GET_OPTION,
+		NEOVIM_FN_BUFFER_SET_OPTION,
+		NEOVIM_FN_BUFFER_GET_NUMBER,
+		NEOVIM_FN_BUFFER_GET_NAME,
+		NEOVIM_FN_BUFFER_SET_NAME,
+		NEOVIM_FN_BUFFER_IS_VALID,
+		NEOVIM_FN_BUFFER_GET_MARK,
+		NEOVIM_FN_BUFFER_ADD_HIGHLIGHT,
+		NEOVIM_FN_BUFFER_CLEAR_HIGHLIGHT,
+		NEOVIM_FN_TABPAGE_GET_WINDOWS,
+		NEOVIM_FN_TABPAGE_GET_VAR,
+		NEOVIM_FN_TABPAGE_GET_WINDOW,
+		NEOVIM_FN_TABPAGE_IS_VALID,
+		NEOVIM_FN_UI_DETACH,
+		NEOVIM_FN_UI_TRY_RESIZE,
+		NEOVIM_FN_VIM_COMMAND,
+		NEOVIM_FN_VIM_FEEDKEYS,
+		NEOVIM_FN_VIM_INPUT,
+		NEOVIM_FN_VIM_REPLACE_TERMCODES,
+		NEOVIM_FN_VIM_COMMAND_OUTPUT,
+		NEOVIM_FN_VIM_EVAL,
+		NEOVIM_FN_VIM_CALL_FUNCTION,
+		NEOVIM_FN_VIM_STRWIDTH,
+		NEOVIM_FN_VIM_LIST_RUNTIME_PATHS,
+		NEOVIM_FN_VIM_CHANGE_DIRECTORY,
+		NEOVIM_FN_VIM_GET_CURRENT_LINE,
+		NEOVIM_FN_VIM_SET_CURRENT_LINE,
+		NEOVIM_FN_VIM_DEL_CURRENT_LINE,
+		NEOVIM_FN_VIM_GET_VAR,
+		NEOVIM_FN_VIM_GET_VVAR,
+		NEOVIM_FN_VIM_GET_OPTION,
+		NEOVIM_FN_VIM_SET_OPTION,
+		NEOVIM_FN_VIM_OUT_WRITE,
+		NEOVIM_FN_VIM_ERR_WRITE,
+		NEOVIM_FN_VIM_REPORT_ERROR,
+		NEOVIM_FN_VIM_GET_BUFFERS,
+		NEOVIM_FN_VIM_GET_CURRENT_BUFFER,
+		NEOVIM_FN_VIM_SET_CURRENT_BUFFER,
+		NEOVIM_FN_VIM_GET_WINDOWS,
+		NEOVIM_FN_VIM_GET_CURRENT_WINDOW,
+		NEOVIM_FN_VIM_SET_CURRENT_WINDOW,
+		NEOVIM_FN_VIM_GET_TABPAGES,
+		NEOVIM_FN_VIM_GET_CURRENT_TABPAGE,
+		NEOVIM_FN_VIM_SET_CURRENT_TABPAGE,
+		NEOVIM_FN_VIM_SUBSCRIBE,
+		NEOVIM_FN_VIM_UNSUBSCRIBE,
+		NEOVIM_FN_VIM_NAME_TO_COLOR,
+		NEOVIM_FN_VIM_GET_COLOR_MAP,
+		NEOVIM_FN_WINDOW_GET_BUFFER,
+		NEOVIM_FN_WINDOW_GET_CURSOR,
+		NEOVIM_FN_WINDOW_SET_CURSOR,
+		NEOVIM_FN_WINDOW_GET_HEIGHT,
+		NEOVIM_FN_WINDOW_SET_HEIGHT,
+		NEOVIM_FN_WINDOW_GET_WIDTH,
+		NEOVIM_FN_WINDOW_SET_WIDTH,
+		NEOVIM_FN_WINDOW_GET_VAR,
+		NEOVIM_FN_WINDOW_GET_OPTION,
+		NEOVIM_FN_WINDOW_SET_OPTION,
+		NEOVIM_FN_WINDOW_GET_POSITION,
+		NEOVIM_FN_WINDOW_GET_TABPAGE,
+		NEOVIM_FN_WINDOW_IS_VALID,
 			};
+	Q_ENUM(FunctionId)
 
-	static bool checkFunctions(const QVariantList& ftable);
-	static FunctionId functionId(const Function& f);
+	static bool checkFunctions(const QVariantList& ftable) noexcept;
 
-	NeovimApi6(NeovimConnector *);
+	static FunctionId functionId(const Function& f) noexcept;
+
+	NeovimApi6(NeovimConnector* c) noexcept;
+
 protected slots:
-	void handleResponse(quint32 id, quint64 fun, const QVariant&);
-	void handleResponseError(quint32 id, quint64 fun, const QVariant&);
+	void handleResponse(uint32_t id, uint64_t fun, const QVariant&);
+
+	void handleResponseError(uint32_t id, uint64_t fun, const QVariant&);
+
 signals:
 	void error(const QString& errmsg, const QVariant& errObj);
+
 	void neovimNotification(const QByteArray &name, const QVariantList& args);
+
 private:
-	NeovimConnector *m_c;
+	NeovimConnector* m_connector;
+
 public slots:
-	// Integer nvim_buf_line_count(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_line_count(int64_t buffer);
-	// DEPRECATED
-	// String buffer_get_line(Buffer buffer, Integer index, ) 
-	MsgpackRequest* buffer_get_line(int64_t buffer, int64_t index);
-	// Boolean nvim_buf_attach(Buffer buffer, Boolean send_buffer, Dictionary opts, ) 
-	MsgpackRequest* nvim_buf_attach(int64_t buffer, bool send_buffer, QVariantMap opts);
-	// Boolean nvim_buf_detach(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_detach(int64_t buffer);
-	// DEPRECATED
-	// void buffer_set_line(Buffer buffer, Integer index, String line, ) 
-	MsgpackRequest* buffer_set_line(int64_t buffer, int64_t index, QByteArray line);
-	// DEPRECATED
-	// void buffer_del_line(Buffer buffer, Integer index, ) 
-	MsgpackRequest* buffer_del_line(int64_t buffer, int64_t index);
-	// DEPRECATED
-	// ArrayOf(String) buffer_get_line_slice(Buffer buffer, Integer start, Integer end, Boolean include_start, Boolean include_end, ) 
-	MsgpackRequest* buffer_get_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end);
-	// ArrayOf(String) nvim_buf_get_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ) 
-	MsgpackRequest* nvim_buf_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing);
-	// DEPRECATED
-	// void buffer_set_line_slice(Buffer buffer, Integer start, Integer end, Boolean include_start, Boolean include_end, ArrayOf(String) replacement, ) 
-	MsgpackRequest* buffer_set_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end, QList<QByteArray> replacement);
-	// void nvim_buf_set_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ArrayOf(String) replacement, ) 
-	MsgpackRequest* nvim_buf_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement);
-	// Integer nvim_buf_get_offset(Buffer buffer, Integer index, ) 
-	MsgpackRequest* nvim_buf_get_offset(int64_t buffer, int64_t index);
-	// Object nvim_buf_get_var(Buffer buffer, String name, ) 
-	MsgpackRequest* nvim_buf_get_var(int64_t buffer, QByteArray name);
-	// Integer nvim_buf_get_changedtick(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_get_changedtick(int64_t buffer);
-	// ArrayOf(Dictionary) nvim_buf_get_keymap(Buffer buffer, String mode, ) 
-	MsgpackRequest* nvim_buf_get_keymap(int64_t buffer, QByteArray mode);
-	// Dictionary nvim_buf_get_commands(Buffer buffer, Dictionary opts, ) 
-	MsgpackRequest* nvim_buf_get_commands(int64_t buffer, QVariantMap opts);
-	// void nvim_buf_set_var(Buffer buffer, String name, Object value, ) 
-	MsgpackRequest* nvim_buf_set_var(int64_t buffer, QByteArray name, QVariant value);
-	// void nvim_buf_del_var(Buffer buffer, String name, ) 
-	MsgpackRequest* nvim_buf_del_var(int64_t buffer, QByteArray name);
-	// DEPRECATED
-	// Object buffer_set_var(Buffer buffer, String name, Object value, ) 
-	MsgpackRequest* buffer_set_var(int64_t buffer, QByteArray name, QVariant value);
-	// DEPRECATED
-	// Object buffer_del_var(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_del_var(int64_t buffer, QByteArray name);
-	// Object nvim_buf_get_option(Buffer buffer, String name, ) 
-	MsgpackRequest* nvim_buf_get_option(int64_t buffer, QByteArray name);
-	// void nvim_buf_set_option(Buffer buffer, String name, Object value, ) 
-	MsgpackRequest* nvim_buf_set_option(int64_t buffer, QByteArray name, QVariant value);
-	// DEPRECATED
-	// Integer nvim_buf_get_number(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_get_number(int64_t buffer);
-	// String nvim_buf_get_name(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_get_name(int64_t buffer);
-	// void nvim_buf_set_name(Buffer buffer, String name, ) 
-	MsgpackRequest* nvim_buf_set_name(int64_t buffer, QByteArray name);
-	// Boolean nvim_buf_is_loaded(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_is_loaded(int64_t buffer);
-	// Boolean nvim_buf_is_valid(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_is_valid(int64_t buffer);
-	// DEPRECATED
-	// void buffer_insert(Buffer buffer, Integer lnum, ArrayOf(String) lines, ) 
-	MsgpackRequest* buffer_insert(int64_t buffer, int64_t lnum, QList<QByteArray> lines);
-	// ArrayOf(Integer, 2) nvim_buf_get_mark(Buffer buffer, String name, ) 
-	MsgpackRequest* nvim_buf_get_mark(int64_t buffer, QByteArray name);
-	// Integer nvim_buf_add_highlight(Buffer buffer, Integer ns_id, String hl_group, Integer line, Integer col_start, Integer col_end, ) 
-	MsgpackRequest* nvim_buf_add_highlight(int64_t buffer, int64_t ns_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end);
-	// void nvim_buf_clear_namespace(Buffer buffer, Integer ns_id, Integer line_start, Integer line_end, ) 
-	MsgpackRequest* nvim_buf_clear_namespace(int64_t buffer, int64_t ns_id, int64_t line_start, int64_t line_end);
-	// void nvim_buf_clear_highlight(Buffer buffer, Integer ns_id, Integer line_start, Integer line_end, ) 
-	MsgpackRequest* nvim_buf_clear_highlight(int64_t buffer, int64_t ns_id, int64_t line_start, int64_t line_end);
-	// Integer nvim_buf_set_virtual_text(Buffer buffer, Integer ns_id, Integer line, Array chunks, Dictionary opts, ) 
-	MsgpackRequest* nvim_buf_set_virtual_text(int64_t buffer, int64_t ns_id, int64_t line, QVariantList chunks, QVariantMap opts);
-	// ArrayOf(Window) nvim_tabpage_list_wins(Tabpage tabpage, ) 
-	MsgpackRequest* nvim_tabpage_list_wins(int64_t tabpage);
-	// Object nvim_tabpage_get_var(Tabpage tabpage, String name, ) 
-	MsgpackRequest* nvim_tabpage_get_var(int64_t tabpage, QByteArray name);
-	// void nvim_tabpage_set_var(Tabpage tabpage, String name, Object value, ) 
-	MsgpackRequest* nvim_tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value);
-	// void nvim_tabpage_del_var(Tabpage tabpage, String name, ) 
-	MsgpackRequest* nvim_tabpage_del_var(int64_t tabpage, QByteArray name);
-	// DEPRECATED
-	// Object tabpage_set_var(Tabpage tabpage, String name, Object value, ) 
-	MsgpackRequest* tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value);
-	// DEPRECATED
-	// Object tabpage_del_var(Tabpage tabpage, String name, ) 
-	MsgpackRequest* tabpage_del_var(int64_t tabpage, QByteArray name);
-	// Window nvim_tabpage_get_win(Tabpage tabpage, ) 
-	MsgpackRequest* nvim_tabpage_get_win(int64_t tabpage);
-	// Integer nvim_tabpage_get_number(Tabpage tabpage, ) 
-	MsgpackRequest* nvim_tabpage_get_number(int64_t tabpage);
-	// Boolean nvim_tabpage_is_valid(Tabpage tabpage, ) 
-	MsgpackRequest* nvim_tabpage_is_valid(int64_t tabpage);
-	// void nvim_ui_attach(Integer width, Integer height, Dictionary options, ) 
-	MsgpackRequest* nvim_ui_attach(int64_t width, int64_t height, QVariantMap options);
-	// DEPRECATED
-	// void ui_attach(Integer width, Integer height, Boolean enable_rgb, ) 
-	MsgpackRequest* ui_attach(int64_t width, int64_t height, bool enable_rgb);
-	// void nvim_ui_detach() 
-	MsgpackRequest* nvim_ui_detach();
-	// void nvim_ui_try_resize(Integer width, Integer height, ) 
-	MsgpackRequest* nvim_ui_try_resize(int64_t width, int64_t height);
-	// void nvim_ui_set_option(String name, Object value, ) 
-	MsgpackRequest* nvim_ui_set_option(QByteArray name, QVariant value);
-	// void nvim_ui_try_resize_grid(Integer grid, Integer width, Integer height, ) 
-	MsgpackRequest* nvim_ui_try_resize_grid(int64_t grid, int64_t width, int64_t height);
-	// void nvim_command(String command, ) 
-	MsgpackRequest* nvim_command(QByteArray command);
-	// Dictionary nvim_get_hl_by_name(String name, Boolean rgb, ) 
-	MsgpackRequest* nvim_get_hl_by_name(QByteArray name, bool rgb);
-	// Dictionary nvim_get_hl_by_id(Integer hl_id, Boolean rgb, ) 
-	MsgpackRequest* nvim_get_hl_by_id(int64_t hl_id, bool rgb);
-	// void nvim_feedkeys(String keys, String mode, Boolean escape_csi, ) 
-	MsgpackRequest* nvim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi);
-	// Integer nvim_input(String keys, ) 
-	MsgpackRequest* nvim_input(QByteArray keys);
-	// String nvim_replace_termcodes(String str, Boolean from_part, Boolean do_lt, Boolean special, ) 
-	MsgpackRequest* nvim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special);
-	// String nvim_command_output(String command, ) 
-	MsgpackRequest* nvim_command_output(QByteArray command);
-	// Object nvim_eval(String expr, ) 
-	MsgpackRequest* nvim_eval(QByteArray expr);
-	// Object nvim_execute_lua(String code, Array args, ) 
-	MsgpackRequest* nvim_execute_lua(QByteArray code, QVariantList args);
-	// Object nvim_call_function(String fn, Array args, ) 
-	MsgpackRequest* nvim_call_function(QByteArray fn, QVariantList args);
-	// Object nvim_call_dict_function(Object dict, String fn, Array args, ) 
-	MsgpackRequest* nvim_call_dict_function(QVariant dict, QByteArray fn, QVariantList args);
-	// Integer nvim_strwidth(String text, ) 
-	MsgpackRequest* nvim_strwidth(QByteArray text);
-	// ArrayOf(String) nvim_list_runtime_paths() 
-	MsgpackRequest* nvim_list_runtime_paths();
-	// void nvim_set_current_dir(String dir, ) 
-	MsgpackRequest* nvim_set_current_dir(QByteArray dir);
-	// String nvim_get_current_line() 
-	MsgpackRequest* nvim_get_current_line();
-	// void nvim_set_current_line(String line, ) 
-	MsgpackRequest* nvim_set_current_line(QByteArray line);
-	// void nvim_del_current_line() 
-	MsgpackRequest* nvim_del_current_line();
-	// Object nvim_get_var(String name, ) 
-	MsgpackRequest* nvim_get_var(QByteArray name);
-	// void nvim_set_var(String name, Object value, ) 
-	MsgpackRequest* nvim_set_var(QByteArray name, QVariant value);
-	// void nvim_del_var(String name, ) 
-	MsgpackRequest* nvim_del_var(QByteArray name);
-	// DEPRECATED
-	// Object vim_set_var(String name, Object value, ) 
-	MsgpackRequest* vim_set_var(QByteArray name, QVariant value);
-	// DEPRECATED
-	// Object vim_del_var(String name, ) 
-	MsgpackRequest* vim_del_var(QByteArray name);
-	// Object nvim_get_vvar(String name, ) 
-	MsgpackRequest* nvim_get_vvar(QByteArray name);
-	// Object nvim_get_option(String name, ) 
-	MsgpackRequest* nvim_get_option(QByteArray name);
-	// void nvim_set_option(String name, Object value, ) 
-	MsgpackRequest* nvim_set_option(QByteArray name, QVariant value);
-	// void nvim_out_write(String str, ) 
-	MsgpackRequest* nvim_out_write(QByteArray str);
-	// void nvim_err_write(String str, ) 
-	MsgpackRequest* nvim_err_write(QByteArray str);
-	// void nvim_err_writeln(String str, ) 
-	MsgpackRequest* nvim_err_writeln(QByteArray str);
-	// ArrayOf(Buffer) nvim_list_bufs() 
-	MsgpackRequest* nvim_list_bufs();
-	// Buffer nvim_get_current_buf() 
-	MsgpackRequest* nvim_get_current_buf();
-	// void nvim_set_current_buf(Buffer buffer, ) 
-	MsgpackRequest* nvim_set_current_buf(int64_t buffer);
-	// ArrayOf(Window) nvim_list_wins() 
-	MsgpackRequest* nvim_list_wins();
-	// Window nvim_get_current_win() 
-	MsgpackRequest* nvim_get_current_win();
-	// void nvim_set_current_win(Window window, ) 
-	MsgpackRequest* nvim_set_current_win(int64_t window);
-	// ArrayOf(Tabpage) nvim_list_tabpages() 
-	MsgpackRequest* nvim_list_tabpages();
-	// Tabpage nvim_get_current_tabpage() 
-	MsgpackRequest* nvim_get_current_tabpage();
-	// void nvim_set_current_tabpage(Tabpage tabpage, ) 
-	MsgpackRequest* nvim_set_current_tabpage(int64_t tabpage);
-	// Integer nvim_create_namespace(String name, ) 
-	MsgpackRequest* nvim_create_namespace(QByteArray name);
-	// Dictionary nvim_get_namespaces() 
-	MsgpackRequest* nvim_get_namespaces();
-	// void nvim_subscribe(String event, ) 
-	MsgpackRequest* nvim_subscribe(QByteArray event);
-	// void nvim_unsubscribe(String event, ) 
-	MsgpackRequest* nvim_unsubscribe(QByteArray event);
-	// Integer nvim_get_color_by_name(String name, ) 
-	MsgpackRequest* nvim_get_color_by_name(QByteArray name);
-	// Dictionary nvim_get_color_map() 
-	MsgpackRequest* nvim_get_color_map();
-	// Dictionary nvim_get_mode() 
-	MsgpackRequest* nvim_get_mode();
-	// ArrayOf(Dictionary) nvim_get_keymap(String mode, ) 
-	MsgpackRequest* nvim_get_keymap(QByteArray mode);
-	// Dictionary nvim_get_commands(Dictionary opts, ) 
-	MsgpackRequest* nvim_get_commands(QVariantMap opts);
-	// Array nvim_get_api_info() 
-	MsgpackRequest* nvim_get_api_info();
-	// void nvim_set_client_info(String name, Dictionary version, String type, Dictionary methods, Dictionary attributes, ) 
-	MsgpackRequest* nvim_set_client_info(QByteArray name, QVariantMap version, QByteArray type, QVariantMap methods, QVariantMap attributes);
-	// Dictionary nvim_get_chan_info(Integer chan, ) 
-	MsgpackRequest* nvim_get_chan_info(int64_t chan);
-	// Array nvim_list_chans() 
-	MsgpackRequest* nvim_list_chans();
-	// Array nvim_call_atomic(Array calls, ) 
-	MsgpackRequest* nvim_call_atomic(QVariantList calls);
-	// Dictionary nvim_parse_expression(String expr, String flags, Boolean highlight, ) 
-	MsgpackRequest* nvim_parse_expression(QByteArray expr, QByteArray flags, bool highlight);
-	// Array nvim_list_uis() 
-	MsgpackRequest* nvim_list_uis();
-	// Array nvim_get_proc_children(Integer pid, ) 
-	MsgpackRequest* nvim_get_proc_children(int64_t pid);
-	// Object nvim_get_proc(Integer pid, ) 
-	MsgpackRequest* nvim_get_proc(int64_t pid);
-	// void nvim_select_popupmenu_item(Integer item, Boolean insert, Boolean finish, Dictionary opts, ) 
-	MsgpackRequest* nvim_select_popupmenu_item(int64_t item, bool insert, bool finish, QVariantMap opts);
-	// Buffer nvim_win_get_buf(Window window, ) 
-	MsgpackRequest* nvim_win_get_buf(int64_t window);
-	// void nvim_win_set_buf(Window window, Buffer buffer, ) 
-	MsgpackRequest* nvim_win_set_buf(int64_t window, int64_t buffer);
-	// ArrayOf(Integer, 2) nvim_win_get_cursor(Window window, ) 
-	MsgpackRequest* nvim_win_get_cursor(int64_t window);
-	// void nvim_win_set_cursor(Window window, ArrayOf(Integer, 2) pos, ) 
-	MsgpackRequest* nvim_win_set_cursor(int64_t window, QPoint pos);
-	// Integer nvim_win_get_height(Window window, ) 
-	MsgpackRequest* nvim_win_get_height(int64_t window);
-	// void nvim_win_set_height(Window window, Integer height, ) 
-	MsgpackRequest* nvim_win_set_height(int64_t window, int64_t height);
-	// Integer nvim_win_get_width(Window window, ) 
-	MsgpackRequest* nvim_win_get_width(int64_t window);
-	// void nvim_win_set_width(Window window, Integer width, ) 
-	MsgpackRequest* nvim_win_set_width(int64_t window, int64_t width);
-	// Object nvim_win_get_var(Window window, String name, ) 
-	MsgpackRequest* nvim_win_get_var(int64_t window, QByteArray name);
-	// void nvim_win_set_var(Window window, String name, Object value, ) 
-	MsgpackRequest* nvim_win_set_var(int64_t window, QByteArray name, QVariant value);
-	// void nvim_win_del_var(Window window, String name, ) 
-	MsgpackRequest* nvim_win_del_var(int64_t window, QByteArray name);
-	// DEPRECATED
-	// Object window_set_var(Window window, String name, Object value, ) 
-	MsgpackRequest* window_set_var(int64_t window, QByteArray name, QVariant value);
-	// DEPRECATED
-	// Object window_del_var(Window window, String name, ) 
-	MsgpackRequest* window_del_var(int64_t window, QByteArray name);
-	// Object nvim_win_get_option(Window window, String name, ) 
-	MsgpackRequest* nvim_win_get_option(int64_t window, QByteArray name);
-	// void nvim_win_set_option(Window window, String name, Object value, ) 
-	MsgpackRequest* nvim_win_set_option(int64_t window, QByteArray name, QVariant value);
-	// ArrayOf(Integer, 2) nvim_win_get_position(Window window, ) 
-	MsgpackRequest* nvim_win_get_position(int64_t window);
-	// Tabpage nvim_win_get_tabpage(Window window, ) 
-	MsgpackRequest* nvim_win_get_tabpage(int64_t window);
-	// Integer nvim_win_get_number(Window window, ) 
-	MsgpackRequest* nvim_win_get_number(int64_t window);
-	// Boolean nvim_win_is_valid(Window window, ) 
-	MsgpackRequest* nvim_win_is_valid(int64_t window);
-	// DEPRECATED
-	// Integer buffer_line_count(Buffer buffer, ) 
-	MsgpackRequest* buffer_line_count(int64_t buffer);
-	// DEPRECATED
-	// ArrayOf(String) buffer_get_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ) 
-	MsgpackRequest* buffer_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing);
-	// DEPRECATED
-	// void buffer_set_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ArrayOf(String) replacement, ) 
-	MsgpackRequest* buffer_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement);
-	// DEPRECATED
-	// Object buffer_get_var(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_get_var(int64_t buffer, QByteArray name);
-	// DEPRECATED
-	// Object buffer_get_option(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_get_option(int64_t buffer, QByteArray name);
-	// DEPRECATED
-	// void buffer_set_option(Buffer buffer, String name, Object value, ) 
-	MsgpackRequest* buffer_set_option(int64_t buffer, QByteArray name, QVariant value);
-	// DEPRECATED
-	// Integer buffer_get_number(Buffer buffer, ) 
-	MsgpackRequest* buffer_get_number(int64_t buffer);
-	// DEPRECATED
-	// String buffer_get_name(Buffer buffer, ) 
-	MsgpackRequest* buffer_get_name(int64_t buffer);
-	// DEPRECATED
-	// void buffer_set_name(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_set_name(int64_t buffer, QByteArray name);
-	// DEPRECATED
-	// Boolean buffer_is_valid(Buffer buffer, ) 
-	MsgpackRequest* buffer_is_valid(int64_t buffer);
-	// DEPRECATED
-	// ArrayOf(Integer, 2) buffer_get_mark(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_get_mark(int64_t buffer, QByteArray name);
-	// DEPRECATED
-	// Integer buffer_add_highlight(Buffer buffer, Integer ns_id, String hl_group, Integer line, Integer col_start, Integer col_end, ) 
-	MsgpackRequest* buffer_add_highlight(int64_t buffer, int64_t ns_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end);
-	// DEPRECATED
-	// void buffer_clear_highlight(Buffer buffer, Integer ns_id, Integer line_start, Integer line_end, ) 
-	MsgpackRequest* buffer_clear_highlight(int64_t buffer, int64_t ns_id, int64_t line_start, int64_t line_end);
-	// DEPRECATED
-	// ArrayOf(Window) tabpage_get_windows(Tabpage tabpage, ) 
-	MsgpackRequest* tabpage_get_windows(int64_t tabpage);
-	// DEPRECATED
-	// Object tabpage_get_var(Tabpage tabpage, String name, ) 
-	MsgpackRequest* tabpage_get_var(int64_t tabpage, QByteArray name);
-	// DEPRECATED
-	// Window tabpage_get_window(Tabpage tabpage, ) 
-	MsgpackRequest* tabpage_get_window(int64_t tabpage);
-	// DEPRECATED
-	// Boolean tabpage_is_valid(Tabpage tabpage, ) 
-	MsgpackRequest* tabpage_is_valid(int64_t tabpage);
-	// DEPRECATED
-	// void ui_detach() 
-	MsgpackRequest* ui_detach();
-	// DEPRECATED
-	// Object ui_try_resize(Integer width, Integer height, ) 
-	MsgpackRequest* ui_try_resize(int64_t width, int64_t height);
-	// DEPRECATED
-	// void vim_command(String command, ) 
-	MsgpackRequest* vim_command(QByteArray command);
-	// DEPRECATED
-	// void vim_feedkeys(String keys, String mode, Boolean escape_csi, ) 
-	MsgpackRequest* vim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi);
-	// DEPRECATED
-	// Integer vim_input(String keys, ) 
-	MsgpackRequest* vim_input(QByteArray keys);
-	// DEPRECATED
-	// String vim_replace_termcodes(String str, Boolean from_part, Boolean do_lt, Boolean special, ) 
-	MsgpackRequest* vim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special);
-	// DEPRECATED
-	// String vim_command_output(String command, ) 
-	MsgpackRequest* vim_command_output(QByteArray command);
-	// DEPRECATED
-	// Object vim_eval(String expr, ) 
-	MsgpackRequest* vim_eval(QByteArray expr);
-	// DEPRECATED
-	// Object vim_call_function(String fn, Array args, ) 
-	MsgpackRequest* vim_call_function(QByteArray fn, QVariantList args);
-	// DEPRECATED
-	// Integer vim_strwidth(String text, ) 
-	MsgpackRequest* vim_strwidth(QByteArray text);
-	// DEPRECATED
-	// ArrayOf(String) vim_list_runtime_paths() 
-	MsgpackRequest* vim_list_runtime_paths();
-	// DEPRECATED
-	// void vim_change_directory(String dir, ) 
-	MsgpackRequest* vim_change_directory(QByteArray dir);
-	// DEPRECATED
-	// String vim_get_current_line() 
-	MsgpackRequest* vim_get_current_line();
-	// DEPRECATED
-	// void vim_set_current_line(String line, ) 
-	MsgpackRequest* vim_set_current_line(QByteArray line);
-	// DEPRECATED
-	// void vim_del_current_line() 
-	MsgpackRequest* vim_del_current_line();
-	// DEPRECATED
-	// Object vim_get_var(String name, ) 
-	MsgpackRequest* vim_get_var(QByteArray name);
-	// DEPRECATED
-	// Object vim_get_vvar(String name, ) 
-	MsgpackRequest* vim_get_vvar(QByteArray name);
-	// DEPRECATED
-	// Object vim_get_option(String name, ) 
-	MsgpackRequest* vim_get_option(QByteArray name);
-	// DEPRECATED
-	// void vim_set_option(String name, Object value, ) 
-	MsgpackRequest* vim_set_option(QByteArray name, QVariant value);
-	// DEPRECATED
-	// void vim_out_write(String str, ) 
-	MsgpackRequest* vim_out_write(QByteArray str);
-	// DEPRECATED
-	// void vim_err_write(String str, ) 
-	MsgpackRequest* vim_err_write(QByteArray str);
-	// DEPRECATED
-	// void vim_report_error(String str, ) 
-	MsgpackRequest* vim_report_error(QByteArray str);
-	// DEPRECATED
-	// ArrayOf(Buffer) vim_get_buffers() 
-	MsgpackRequest* vim_get_buffers();
-	// DEPRECATED
-	// Buffer vim_get_current_buffer() 
-	MsgpackRequest* vim_get_current_buffer();
-	// DEPRECATED
-	// void vim_set_current_buffer(Buffer buffer, ) 
-	MsgpackRequest* vim_set_current_buffer(int64_t buffer);
-	// DEPRECATED
-	// ArrayOf(Window) vim_get_windows() 
-	MsgpackRequest* vim_get_windows();
-	// DEPRECATED
-	// Window vim_get_current_window() 
-	MsgpackRequest* vim_get_current_window();
-	// DEPRECATED
-	// void vim_set_current_window(Window window, ) 
-	MsgpackRequest* vim_set_current_window(int64_t window);
-	// DEPRECATED
-	// ArrayOf(Tabpage) vim_get_tabpages() 
-	MsgpackRequest* vim_get_tabpages();
-	// DEPRECATED
-	// Tabpage vim_get_current_tabpage() 
-	MsgpackRequest* vim_get_current_tabpage();
-	// DEPRECATED
-	// void vim_set_current_tabpage(Tabpage tabpage, ) 
-	MsgpackRequest* vim_set_current_tabpage(int64_t tabpage);
-	// DEPRECATED
-	// void vim_subscribe(String event, ) 
-	MsgpackRequest* vim_subscribe(QByteArray event);
-	// DEPRECATED
-	// void vim_unsubscribe(String event, ) 
-	MsgpackRequest* vim_unsubscribe(QByteArray event);
-	// DEPRECATED
-	// Integer vim_name_to_color(String name, ) 
-	MsgpackRequest* vim_name_to_color(QByteArray name);
-	// DEPRECATED
-	// Dictionary vim_get_color_map() 
-	MsgpackRequest* vim_get_color_map();
-	// DEPRECATED
-	// Buffer window_get_buffer(Window window, ) 
-	MsgpackRequest* window_get_buffer(int64_t window);
-	// DEPRECATED
-	// ArrayOf(Integer, 2) window_get_cursor(Window window, ) 
-	MsgpackRequest* window_get_cursor(int64_t window);
-	// DEPRECATED
-	// void window_set_cursor(Window window, ArrayOf(Integer, 2) pos, ) 
-	MsgpackRequest* window_set_cursor(int64_t window, QPoint pos);
-	// DEPRECATED
-	// Integer window_get_height(Window window, ) 
-	MsgpackRequest* window_get_height(int64_t window);
-	// DEPRECATED
-	// void window_set_height(Window window, Integer height, ) 
-	MsgpackRequest* window_set_height(int64_t window, int64_t height);
-	// DEPRECATED
-	// Integer window_get_width(Window window, ) 
-	MsgpackRequest* window_get_width(int64_t window);
-	// DEPRECATED
-	// void window_set_width(Window window, Integer width, ) 
-	MsgpackRequest* window_set_width(int64_t window, int64_t width);
-	// DEPRECATED
-	// Object window_get_var(Window window, String name, ) 
-	MsgpackRequest* window_get_var(int64_t window, QByteArray name);
-	// DEPRECATED
-	// Object window_get_option(Window window, String name, ) 
-	MsgpackRequest* window_get_option(int64_t window, QByteArray name);
-	// DEPRECATED
-	// void window_set_option(Window window, String name, Object value, ) 
-	MsgpackRequest* window_set_option(int64_t window, QByteArray name, QVariant value);
-	// DEPRECATED
-	// ArrayOf(Integer, 2) window_get_position(Window window, ) 
-	MsgpackRequest* window_get_position(int64_t window);
-	// DEPRECATED
-	// Tabpage window_get_tabpage(Window window, ) 
-	MsgpackRequest* window_get_tabpage(int64_t window);
-	// DEPRECATED
-	// Boolean window_is_valid(Window window, ) 
-	MsgpackRequest* window_is_valid(int64_t window);
+	/// Integer nvim_buf_line_count(Buffer buffer, )
+	NeovimQt::MsgpackRequest* nvim_buf_line_count(int64_t buffer);
+
+	/// DEPRECATED: String buffer_get_line(Buffer buffer, Integer index, )
+	NeovimQt::MsgpackRequest* buffer_get_line(int64_t buffer, int64_t index);
+
+	/// Boolean nvim_buf_attach(Buffer buffer, Boolean send_buffer, Dictionary opts, )
+	NeovimQt::MsgpackRequest* nvim_buf_attach(int64_t buffer, bool send_buffer, QVariantMap opts);
+
+	/// Boolean nvim_buf_detach(Buffer buffer, )
+	NeovimQt::MsgpackRequest* nvim_buf_detach(int64_t buffer);
+
+	/// DEPRECATED: void buffer_set_line(Buffer buffer, Integer index, String line, )
+	NeovimQt::MsgpackRequest* buffer_set_line(int64_t buffer, int64_t index, QByteArray line);
+
+	/// DEPRECATED: void buffer_del_line(Buffer buffer, Integer index, )
+	NeovimQt::MsgpackRequest* buffer_del_line(int64_t buffer, int64_t index);
+
+	/// DEPRECATED: ArrayOf(String) buffer_get_line_slice(Buffer buffer, Integer start, Integer end, Boolean include_start, Boolean include_end, )
+	NeovimQt::MsgpackRequest* buffer_get_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end);
+
+	/// ArrayOf(String) nvim_buf_get_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, )
+	NeovimQt::MsgpackRequest* nvim_buf_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing);
+
+	/// DEPRECATED: void buffer_set_line_slice(Buffer buffer, Integer start, Integer end, Boolean include_start, Boolean include_end, ArrayOf(String) replacement, )
+	NeovimQt::MsgpackRequest* buffer_set_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end, QList<QByteArray> replacement);
+
+	/// void nvim_buf_set_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ArrayOf(String) replacement, )
+	NeovimQt::MsgpackRequest* nvim_buf_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement);
+
+	/// Integer nvim_buf_get_offset(Buffer buffer, Integer index, )
+	NeovimQt::MsgpackRequest* nvim_buf_get_offset(int64_t buffer, int64_t index);
+
+	/// Object nvim_buf_get_var(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* nvim_buf_get_var(int64_t buffer, QByteArray name);
+
+	/// Integer nvim_buf_get_changedtick(Buffer buffer, )
+	NeovimQt::MsgpackRequest* nvim_buf_get_changedtick(int64_t buffer);
+
+	/// ArrayOf(Dictionary) nvim_buf_get_keymap(Buffer buffer, String mode, )
+	NeovimQt::MsgpackRequest* nvim_buf_get_keymap(int64_t buffer, QByteArray mode);
+
+	/// void nvim_buf_set_keymap(Buffer buffer, String mode, String lhs, String rhs, Dictionary opts, )
+	NeovimQt::MsgpackRequest* nvim_buf_set_keymap(int64_t buffer, QByteArray mode, QByteArray lhs, QByteArray rhs, QVariantMap opts);
+
+	/// void nvim_buf_del_keymap(Buffer buffer, String mode, String lhs, )
+	NeovimQt::MsgpackRequest* nvim_buf_del_keymap(int64_t buffer, QByteArray mode, QByteArray lhs);
+
+	/// Dictionary nvim_buf_get_commands(Buffer buffer, Dictionary opts, )
+	NeovimQt::MsgpackRequest* nvim_buf_get_commands(int64_t buffer, QVariantMap opts);
+
+	/// void nvim_buf_set_var(Buffer buffer, String name, Object value, )
+	NeovimQt::MsgpackRequest* nvim_buf_set_var(int64_t buffer, QByteArray name, QVariant value);
+
+	/// void nvim_buf_del_var(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* nvim_buf_del_var(int64_t buffer, QByteArray name);
+
+	/// DEPRECATED: Object buffer_set_var(Buffer buffer, String name, Object value, )
+	NeovimQt::MsgpackRequest* buffer_set_var(int64_t buffer, QByteArray name, QVariant value);
+
+	/// DEPRECATED: Object buffer_del_var(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* buffer_del_var(int64_t buffer, QByteArray name);
+
+	/// Object nvim_buf_get_option(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* nvim_buf_get_option(int64_t buffer, QByteArray name);
+
+	/// void nvim_buf_set_option(Buffer buffer, String name, Object value, )
+	NeovimQt::MsgpackRequest* nvim_buf_set_option(int64_t buffer, QByteArray name, QVariant value);
+
+	/// DEPRECATED: Integer nvim_buf_get_number(Buffer buffer, )
+	NeovimQt::MsgpackRequest* nvim_buf_get_number(int64_t buffer);
+
+	/// String nvim_buf_get_name(Buffer buffer, )
+	NeovimQt::MsgpackRequest* nvim_buf_get_name(int64_t buffer);
+
+	/// void nvim_buf_set_name(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* nvim_buf_set_name(int64_t buffer, QByteArray name);
+
+	/// Boolean nvim_buf_is_loaded(Buffer buffer, )
+	NeovimQt::MsgpackRequest* nvim_buf_is_loaded(int64_t buffer);
+
+	/// Boolean nvim_buf_is_valid(Buffer buffer, )
+	NeovimQt::MsgpackRequest* nvim_buf_is_valid(int64_t buffer);
+
+	/// DEPRECATED: void buffer_insert(Buffer buffer, Integer lnum, ArrayOf(String) lines, )
+	NeovimQt::MsgpackRequest* buffer_insert(int64_t buffer, int64_t lnum, QList<QByteArray> lines);
+
+	/// ArrayOf(Integer, 2) nvim_buf_get_mark(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* nvim_buf_get_mark(int64_t buffer, QByteArray name);
+
+	/// Integer nvim_buf_add_highlight(Buffer buffer, Integer ns_id, String hl_group, Integer line, Integer col_start, Integer col_end, )
+	NeovimQt::MsgpackRequest* nvim_buf_add_highlight(int64_t buffer, int64_t ns_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end);
+
+	/// void nvim_buf_clear_namespace(Buffer buffer, Integer ns_id, Integer line_start, Integer line_end, )
+	NeovimQt::MsgpackRequest* nvim_buf_clear_namespace(int64_t buffer, int64_t ns_id, int64_t line_start, int64_t line_end);
+
+	/// void nvim_buf_clear_highlight(Buffer buffer, Integer ns_id, Integer line_start, Integer line_end, )
+	NeovimQt::MsgpackRequest* nvim_buf_clear_highlight(int64_t buffer, int64_t ns_id, int64_t line_start, int64_t line_end);
+
+	/// Integer nvim_buf_set_virtual_text(Buffer buffer, Integer ns_id, Integer line, Array chunks, Dictionary opts, )
+	NeovimQt::MsgpackRequest* nvim_buf_set_virtual_text(int64_t buffer, int64_t ns_id, int64_t line, QVariantList chunks, QVariantMap opts);
+
+	/// ArrayOf(Window) nvim_tabpage_list_wins(Tabpage tabpage, )
+	NeovimQt::MsgpackRequest* nvim_tabpage_list_wins(int64_t tabpage);
+
+	/// Object nvim_tabpage_get_var(Tabpage tabpage, String name, )
+	NeovimQt::MsgpackRequest* nvim_tabpage_get_var(int64_t tabpage, QByteArray name);
+
+	/// void nvim_tabpage_set_var(Tabpage tabpage, String name, Object value, )
+	NeovimQt::MsgpackRequest* nvim_tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value);
+
+	/// void nvim_tabpage_del_var(Tabpage tabpage, String name, )
+	NeovimQt::MsgpackRequest* nvim_tabpage_del_var(int64_t tabpage, QByteArray name);
+
+	/// DEPRECATED: Object tabpage_set_var(Tabpage tabpage, String name, Object value, )
+	NeovimQt::MsgpackRequest* tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value);
+
+	/// DEPRECATED: Object tabpage_del_var(Tabpage tabpage, String name, )
+	NeovimQt::MsgpackRequest* tabpage_del_var(int64_t tabpage, QByteArray name);
+
+	/// Window nvim_tabpage_get_win(Tabpage tabpage, )
+	NeovimQt::MsgpackRequest* nvim_tabpage_get_win(int64_t tabpage);
+
+	/// Integer nvim_tabpage_get_number(Tabpage tabpage, )
+	NeovimQt::MsgpackRequest* nvim_tabpage_get_number(int64_t tabpage);
+
+	/// Boolean nvim_tabpage_is_valid(Tabpage tabpage, )
+	NeovimQt::MsgpackRequest* nvim_tabpage_is_valid(int64_t tabpage);
+
+	/// void nvim_ui_attach(Integer width, Integer height, Dictionary options, )
+	NeovimQt::MsgpackRequest* nvim_ui_attach(int64_t width, int64_t height, QVariantMap options);
+
+	/// DEPRECATED: void ui_attach(Integer width, Integer height, Boolean enable_rgb, )
+	NeovimQt::MsgpackRequest* ui_attach(int64_t width, int64_t height, bool enable_rgb);
+
+	/// void nvim_ui_detach()
+	NeovimQt::MsgpackRequest* nvim_ui_detach();
+
+	/// void nvim_ui_try_resize(Integer width, Integer height, )
+	NeovimQt::MsgpackRequest* nvim_ui_try_resize(int64_t width, int64_t height);
+
+	/// void nvim_ui_set_option(String name, Object value, )
+	NeovimQt::MsgpackRequest* nvim_ui_set_option(QByteArray name, QVariant value);
+
+	/// void nvim_ui_try_resize_grid(Integer grid, Integer width, Integer height, )
+	NeovimQt::MsgpackRequest* nvim_ui_try_resize_grid(int64_t grid, int64_t width, int64_t height);
+
+	/// void nvim_ui_pum_set_height(Integer height, )
+	NeovimQt::MsgpackRequest* nvim_ui_pum_set_height(int64_t height);
+
+	/// void nvim_command(String command, )
+	NeovimQt::MsgpackRequest* nvim_command(QByteArray command);
+
+	/// Dictionary nvim_get_hl_by_name(String name, Boolean rgb, )
+	NeovimQt::MsgpackRequest* nvim_get_hl_by_name(QByteArray name, bool rgb);
+
+	/// Dictionary nvim_get_hl_by_id(Integer hl_id, Boolean rgb, )
+	NeovimQt::MsgpackRequest* nvim_get_hl_by_id(int64_t hl_id, bool rgb);
+
+	/// void nvim_feedkeys(String keys, String mode, Boolean escape_csi, )
+	NeovimQt::MsgpackRequest* nvim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi);
+
+	/// Integer nvim_input(String keys, )
+	NeovimQt::MsgpackRequest* nvim_input(QByteArray keys);
+
+	/// void nvim_input_mouse(String button, String action, String modifier, Integer grid, Integer row, Integer col, )
+	NeovimQt::MsgpackRequest* nvim_input_mouse(QByteArray button, QByteArray action, QByteArray modifier, int64_t grid, int64_t row, int64_t col);
+
+	/// String nvim_replace_termcodes(String str, Boolean from_part, Boolean do_lt, Boolean special, )
+	NeovimQt::MsgpackRequest* nvim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special);
+
+	/// String nvim_command_output(String command, )
+	NeovimQt::MsgpackRequest* nvim_command_output(QByteArray command);
+
+	/// Object nvim_eval(String expr, )
+	NeovimQt::MsgpackRequest* nvim_eval(QByteArray expr);
+
+	/// Object nvim_execute_lua(String code, Array args, )
+	NeovimQt::MsgpackRequest* nvim_execute_lua(QByteArray code, QVariantList args);
+
+	/// Object nvim_call_function(String fn, Array args, )
+	NeovimQt::MsgpackRequest* nvim_call_function(QByteArray fn, QVariantList args);
+
+	/// Object nvim_call_dict_function(Object dict, String fn, Array args, )
+	NeovimQt::MsgpackRequest* nvim_call_dict_function(QVariant dict, QByteArray fn, QVariantList args);
+
+	/// Integer nvim_strwidth(String text, )
+	NeovimQt::MsgpackRequest* nvim_strwidth(QByteArray text);
+
+	/// ArrayOf(String) nvim_list_runtime_paths()
+	NeovimQt::MsgpackRequest* nvim_list_runtime_paths();
+
+	/// void nvim_set_current_dir(String dir, )
+	NeovimQt::MsgpackRequest* nvim_set_current_dir(QByteArray dir);
+
+	/// String nvim_get_current_line()
+	NeovimQt::MsgpackRequest* nvim_get_current_line();
+
+	/// void nvim_set_current_line(String line, )
+	NeovimQt::MsgpackRequest* nvim_set_current_line(QByteArray line);
+
+	/// void nvim_del_current_line()
+	NeovimQt::MsgpackRequest* nvim_del_current_line();
+
+	/// Object nvim_get_var(String name, )
+	NeovimQt::MsgpackRequest* nvim_get_var(QByteArray name);
+
+	/// void nvim_set_var(String name, Object value, )
+	NeovimQt::MsgpackRequest* nvim_set_var(QByteArray name, QVariant value);
+
+	/// void nvim_del_var(String name, )
+	NeovimQt::MsgpackRequest* nvim_del_var(QByteArray name);
+
+	/// DEPRECATED: Object vim_set_var(String name, Object value, )
+	NeovimQt::MsgpackRequest* vim_set_var(QByteArray name, QVariant value);
+
+	/// DEPRECATED: Object vim_del_var(String name, )
+	NeovimQt::MsgpackRequest* vim_del_var(QByteArray name);
+
+	/// Object nvim_get_vvar(String name, )
+	NeovimQt::MsgpackRequest* nvim_get_vvar(QByteArray name);
+
+	/// void nvim_set_vvar(String name, Object value, )
+	NeovimQt::MsgpackRequest* nvim_set_vvar(QByteArray name, QVariant value);
+
+	/// Object nvim_get_option(String name, )
+	NeovimQt::MsgpackRequest* nvim_get_option(QByteArray name);
+
+	/// void nvim_set_option(String name, Object value, )
+	NeovimQt::MsgpackRequest* nvim_set_option(QByteArray name, QVariant value);
+
+	/// void nvim_out_write(String str, )
+	NeovimQt::MsgpackRequest* nvim_out_write(QByteArray str);
+
+	/// void nvim_err_write(String str, )
+	NeovimQt::MsgpackRequest* nvim_err_write(QByteArray str);
+
+	/// void nvim_err_writeln(String str, )
+	NeovimQt::MsgpackRequest* nvim_err_writeln(QByteArray str);
+
+	/// ArrayOf(Buffer) nvim_list_bufs()
+	NeovimQt::MsgpackRequest* nvim_list_bufs();
+
+	/// Buffer nvim_get_current_buf()
+	NeovimQt::MsgpackRequest* nvim_get_current_buf();
+
+	/// void nvim_set_current_buf(Buffer buffer, )
+	NeovimQt::MsgpackRequest* nvim_set_current_buf(int64_t buffer);
+
+	/// ArrayOf(Window) nvim_list_wins()
+	NeovimQt::MsgpackRequest* nvim_list_wins();
+
+	/// Window nvim_get_current_win()
+	NeovimQt::MsgpackRequest* nvim_get_current_win();
+
+	/// void nvim_set_current_win(Window window, )
+	NeovimQt::MsgpackRequest* nvim_set_current_win(int64_t window);
+
+	/// Buffer nvim_create_buf(Boolean listed, Boolean scratch, )
+	NeovimQt::MsgpackRequest* nvim_create_buf(bool listed, bool scratch);
+
+	/// Window nvim_open_win(Buffer buffer, Boolean enter, Dictionary config, )
+	NeovimQt::MsgpackRequest* nvim_open_win(int64_t buffer, bool enter, QVariantMap config);
+
+	/// ArrayOf(Tabpage) nvim_list_tabpages()
+	NeovimQt::MsgpackRequest* nvim_list_tabpages();
+
+	/// Tabpage nvim_get_current_tabpage()
+	NeovimQt::MsgpackRequest* nvim_get_current_tabpage();
+
+	/// void nvim_set_current_tabpage(Tabpage tabpage, )
+	NeovimQt::MsgpackRequest* nvim_set_current_tabpage(int64_t tabpage);
+
+	/// Integer nvim_create_namespace(String name, )
+	NeovimQt::MsgpackRequest* nvim_create_namespace(QByteArray name);
+
+	/// Dictionary nvim_get_namespaces()
+	NeovimQt::MsgpackRequest* nvim_get_namespaces();
+
+	/// Boolean nvim_paste(String data, Boolean crlf, Integer phase, )
+	NeovimQt::MsgpackRequest* nvim_paste(QByteArray data, bool crlf, int64_t phase);
+
+	/// void nvim_put(ArrayOf(String) lines, String type, Boolean after, Boolean follow, )
+	NeovimQt::MsgpackRequest* nvim_put(QList<QByteArray> lines, QByteArray type, bool after, bool follow);
+
+	/// void nvim_subscribe(String event, )
+	NeovimQt::MsgpackRequest* nvim_subscribe(QByteArray event);
+
+	/// void nvim_unsubscribe(String event, )
+	NeovimQt::MsgpackRequest* nvim_unsubscribe(QByteArray event);
+
+	/// Integer nvim_get_color_by_name(String name, )
+	NeovimQt::MsgpackRequest* nvim_get_color_by_name(QByteArray name);
+
+	/// Dictionary nvim_get_color_map()
+	NeovimQt::MsgpackRequest* nvim_get_color_map();
+
+	/// Dictionary nvim_get_context(Dictionary opts, )
+	NeovimQt::MsgpackRequest* nvim_get_context(QVariantMap opts);
+
+	/// Object nvim_load_context(Dictionary dict, )
+	NeovimQt::MsgpackRequest* nvim_load_context(QVariantMap dict);
+
+	/// Dictionary nvim_get_mode()
+	NeovimQt::MsgpackRequest* nvim_get_mode();
+
+	/// ArrayOf(Dictionary) nvim_get_keymap(String mode, )
+	NeovimQt::MsgpackRequest* nvim_get_keymap(QByteArray mode);
+
+	/// void nvim_set_keymap(String mode, String lhs, String rhs, Dictionary opts, )
+	NeovimQt::MsgpackRequest* nvim_set_keymap(QByteArray mode, QByteArray lhs, QByteArray rhs, QVariantMap opts);
+
+	/// void nvim_del_keymap(String mode, String lhs, )
+	NeovimQt::MsgpackRequest* nvim_del_keymap(QByteArray mode, QByteArray lhs);
+
+	/// Dictionary nvim_get_commands(Dictionary opts, )
+	NeovimQt::MsgpackRequest* nvim_get_commands(QVariantMap opts);
+
+	/// Array nvim_get_api_info()
+	NeovimQt::MsgpackRequest* nvim_get_api_info();
+
+	/// void nvim_set_client_info(String name, Dictionary version, String type, Dictionary methods, Dictionary attributes, )
+	NeovimQt::MsgpackRequest* nvim_set_client_info(QByteArray name, QVariantMap version, QByteArray type, QVariantMap methods, QVariantMap attributes);
+
+	/// Dictionary nvim_get_chan_info(Integer chan, )
+	NeovimQt::MsgpackRequest* nvim_get_chan_info(int64_t chan);
+
+	/// Array nvim_list_chans()
+	NeovimQt::MsgpackRequest* nvim_list_chans();
+
+	/// Array nvim_call_atomic(Array calls, )
+	NeovimQt::MsgpackRequest* nvim_call_atomic(QVariantList calls);
+
+	/// Dictionary nvim_parse_expression(String expr, String flags, Boolean highlight, )
+	NeovimQt::MsgpackRequest* nvim_parse_expression(QByteArray expr, QByteArray flags, bool highlight);
+
+	/// Array nvim_list_uis()
+	NeovimQt::MsgpackRequest* nvim_list_uis();
+
+	/// Array nvim_get_proc_children(Integer pid, )
+	NeovimQt::MsgpackRequest* nvim_get_proc_children(int64_t pid);
+
+	/// Object nvim_get_proc(Integer pid, )
+	NeovimQt::MsgpackRequest* nvim_get_proc(int64_t pid);
+
+	/// void nvim_select_popupmenu_item(Integer item, Boolean insert, Boolean finish, Dictionary opts, )
+	NeovimQt::MsgpackRequest* nvim_select_popupmenu_item(int64_t item, bool insert, bool finish, QVariantMap opts);
+
+	/// Buffer nvim_win_get_buf(Window window, )
+	NeovimQt::MsgpackRequest* nvim_win_get_buf(int64_t window);
+
+	/// void nvim_win_set_buf(Window window, Buffer buffer, )
+	NeovimQt::MsgpackRequest* nvim_win_set_buf(int64_t window, int64_t buffer);
+
+	/// ArrayOf(Integer, 2) nvim_win_get_cursor(Window window, )
+	NeovimQt::MsgpackRequest* nvim_win_get_cursor(int64_t window);
+
+	/// void nvim_win_set_cursor(Window window, ArrayOf(Integer, 2) pos, )
+	NeovimQt::MsgpackRequest* nvim_win_set_cursor(int64_t window, QPoint pos);
+
+	/// Integer nvim_win_get_height(Window window, )
+	NeovimQt::MsgpackRequest* nvim_win_get_height(int64_t window);
+
+	/// void nvim_win_set_height(Window window, Integer height, )
+	NeovimQt::MsgpackRequest* nvim_win_set_height(int64_t window, int64_t height);
+
+	/// Integer nvim_win_get_width(Window window, )
+	NeovimQt::MsgpackRequest* nvim_win_get_width(int64_t window);
+
+	/// void nvim_win_set_width(Window window, Integer width, )
+	NeovimQt::MsgpackRequest* nvim_win_set_width(int64_t window, int64_t width);
+
+	/// Object nvim_win_get_var(Window window, String name, )
+	NeovimQt::MsgpackRequest* nvim_win_get_var(int64_t window, QByteArray name);
+
+	/// void nvim_win_set_var(Window window, String name, Object value, )
+	NeovimQt::MsgpackRequest* nvim_win_set_var(int64_t window, QByteArray name, QVariant value);
+
+	/// void nvim_win_del_var(Window window, String name, )
+	NeovimQt::MsgpackRequest* nvim_win_del_var(int64_t window, QByteArray name);
+
+	/// DEPRECATED: Object window_set_var(Window window, String name, Object value, )
+	NeovimQt::MsgpackRequest* window_set_var(int64_t window, QByteArray name, QVariant value);
+
+	/// DEPRECATED: Object window_del_var(Window window, String name, )
+	NeovimQt::MsgpackRequest* window_del_var(int64_t window, QByteArray name);
+
+	/// Object nvim_win_get_option(Window window, String name, )
+	NeovimQt::MsgpackRequest* nvim_win_get_option(int64_t window, QByteArray name);
+
+	/// void nvim_win_set_option(Window window, String name, Object value, )
+	NeovimQt::MsgpackRequest* nvim_win_set_option(int64_t window, QByteArray name, QVariant value);
+
+	/// ArrayOf(Integer, 2) nvim_win_get_position(Window window, )
+	NeovimQt::MsgpackRequest* nvim_win_get_position(int64_t window);
+
+	/// Tabpage nvim_win_get_tabpage(Window window, )
+	NeovimQt::MsgpackRequest* nvim_win_get_tabpage(int64_t window);
+
+	/// Integer nvim_win_get_number(Window window, )
+	NeovimQt::MsgpackRequest* nvim_win_get_number(int64_t window);
+
+	/// Boolean nvim_win_is_valid(Window window, )
+	NeovimQt::MsgpackRequest* nvim_win_is_valid(int64_t window);
+
+	/// void nvim_win_set_config(Window window, Dictionary config, )
+	NeovimQt::MsgpackRequest* nvim_win_set_config(int64_t window, QVariantMap config);
+
+	/// Dictionary nvim_win_get_config(Window window, )
+	NeovimQt::MsgpackRequest* nvim_win_get_config(int64_t window);
+
+	/// void nvim_win_close(Window window, Boolean force, )
+	NeovimQt::MsgpackRequest* nvim_win_close(int64_t window, bool force);
+
+	/// DEPRECATED: Integer buffer_line_count(Buffer buffer, )
+	NeovimQt::MsgpackRequest* buffer_line_count(int64_t buffer);
+
+	/// DEPRECATED: ArrayOf(String) buffer_get_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, )
+	NeovimQt::MsgpackRequest* buffer_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing);
+
+	/// DEPRECATED: void buffer_set_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ArrayOf(String) replacement, )
+	NeovimQt::MsgpackRequest* buffer_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement);
+
+	/// DEPRECATED: Object buffer_get_var(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* buffer_get_var(int64_t buffer, QByteArray name);
+
+	/// DEPRECATED: Object buffer_get_option(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* buffer_get_option(int64_t buffer, QByteArray name);
+
+	/// DEPRECATED: void buffer_set_option(Buffer buffer, String name, Object value, )
+	NeovimQt::MsgpackRequest* buffer_set_option(int64_t buffer, QByteArray name, QVariant value);
+
+	/// DEPRECATED: Integer buffer_get_number(Buffer buffer, )
+	NeovimQt::MsgpackRequest* buffer_get_number(int64_t buffer);
+
+	/// DEPRECATED: String buffer_get_name(Buffer buffer, )
+	NeovimQt::MsgpackRequest* buffer_get_name(int64_t buffer);
+
+	/// DEPRECATED: void buffer_set_name(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* buffer_set_name(int64_t buffer, QByteArray name);
+
+	/// DEPRECATED: Boolean buffer_is_valid(Buffer buffer, )
+	NeovimQt::MsgpackRequest* buffer_is_valid(int64_t buffer);
+
+	/// DEPRECATED: ArrayOf(Integer, 2) buffer_get_mark(Buffer buffer, String name, )
+	NeovimQt::MsgpackRequest* buffer_get_mark(int64_t buffer, QByteArray name);
+
+	/// DEPRECATED: Integer buffer_add_highlight(Buffer buffer, Integer ns_id, String hl_group, Integer line, Integer col_start, Integer col_end, )
+	NeovimQt::MsgpackRequest* buffer_add_highlight(int64_t buffer, int64_t ns_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end);
+
+	/// DEPRECATED: void buffer_clear_highlight(Buffer buffer, Integer ns_id, Integer line_start, Integer line_end, )
+	NeovimQt::MsgpackRequest* buffer_clear_highlight(int64_t buffer, int64_t ns_id, int64_t line_start, int64_t line_end);
+
+	/// DEPRECATED: ArrayOf(Window) tabpage_get_windows(Tabpage tabpage, )
+	NeovimQt::MsgpackRequest* tabpage_get_windows(int64_t tabpage);
+
+	/// DEPRECATED: Object tabpage_get_var(Tabpage tabpage, String name, )
+	NeovimQt::MsgpackRequest* tabpage_get_var(int64_t tabpage, QByteArray name);
+
+	/// DEPRECATED: Window tabpage_get_window(Tabpage tabpage, )
+	NeovimQt::MsgpackRequest* tabpage_get_window(int64_t tabpage);
+
+	/// DEPRECATED: Boolean tabpage_is_valid(Tabpage tabpage, )
+	NeovimQt::MsgpackRequest* tabpage_is_valid(int64_t tabpage);
+
+	/// DEPRECATED: void ui_detach()
+	NeovimQt::MsgpackRequest* ui_detach();
+
+	/// DEPRECATED: Object ui_try_resize(Integer width, Integer height, )
+	NeovimQt::MsgpackRequest* ui_try_resize(int64_t width, int64_t height);
+
+	/// DEPRECATED: void vim_command(String command, )
+	NeovimQt::MsgpackRequest* vim_command(QByteArray command);
+
+	/// DEPRECATED: void vim_feedkeys(String keys, String mode, Boolean escape_csi, )
+	NeovimQt::MsgpackRequest* vim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi);
+
+	/// DEPRECATED: Integer vim_input(String keys, )
+	NeovimQt::MsgpackRequest* vim_input(QByteArray keys);
+
+	/// DEPRECATED: String vim_replace_termcodes(String str, Boolean from_part, Boolean do_lt, Boolean special, )
+	NeovimQt::MsgpackRequest* vim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special);
+
+	/// DEPRECATED: String vim_command_output(String command, )
+	NeovimQt::MsgpackRequest* vim_command_output(QByteArray command);
+
+	/// DEPRECATED: Object vim_eval(String expr, )
+	NeovimQt::MsgpackRequest* vim_eval(QByteArray expr);
+
+	/// DEPRECATED: Object vim_call_function(String fn, Array args, )
+	NeovimQt::MsgpackRequest* vim_call_function(QByteArray fn, QVariantList args);
+
+	/// DEPRECATED: Integer vim_strwidth(String text, )
+	NeovimQt::MsgpackRequest* vim_strwidth(QByteArray text);
+
+	/// DEPRECATED: ArrayOf(String) vim_list_runtime_paths()
+	NeovimQt::MsgpackRequest* vim_list_runtime_paths();
+
+	/// DEPRECATED: void vim_change_directory(String dir, )
+	NeovimQt::MsgpackRequest* vim_change_directory(QByteArray dir);
+
+	/// DEPRECATED: String vim_get_current_line()
+	NeovimQt::MsgpackRequest* vim_get_current_line();
+
+	/// DEPRECATED: void vim_set_current_line(String line, )
+	NeovimQt::MsgpackRequest* vim_set_current_line(QByteArray line);
+
+	/// DEPRECATED: void vim_del_current_line()
+	NeovimQt::MsgpackRequest* vim_del_current_line();
+
+	/// DEPRECATED: Object vim_get_var(String name, )
+	NeovimQt::MsgpackRequest* vim_get_var(QByteArray name);
+
+	/// DEPRECATED: Object vim_get_vvar(String name, )
+	NeovimQt::MsgpackRequest* vim_get_vvar(QByteArray name);
+
+	/// DEPRECATED: Object vim_get_option(String name, )
+	NeovimQt::MsgpackRequest* vim_get_option(QByteArray name);
+
+	/// DEPRECATED: void vim_set_option(String name, Object value, )
+	NeovimQt::MsgpackRequest* vim_set_option(QByteArray name, QVariant value);
+
+	/// DEPRECATED: void vim_out_write(String str, )
+	NeovimQt::MsgpackRequest* vim_out_write(QByteArray str);
+
+	/// DEPRECATED: void vim_err_write(String str, )
+	NeovimQt::MsgpackRequest* vim_err_write(QByteArray str);
+
+	/// DEPRECATED: void vim_report_error(String str, )
+	NeovimQt::MsgpackRequest* vim_report_error(QByteArray str);
+
+	/// DEPRECATED: ArrayOf(Buffer) vim_get_buffers()
+	NeovimQt::MsgpackRequest* vim_get_buffers();
+
+	/// DEPRECATED: Buffer vim_get_current_buffer()
+	NeovimQt::MsgpackRequest* vim_get_current_buffer();
+
+	/// DEPRECATED: void vim_set_current_buffer(Buffer buffer, )
+	NeovimQt::MsgpackRequest* vim_set_current_buffer(int64_t buffer);
+
+	/// DEPRECATED: ArrayOf(Window) vim_get_windows()
+	NeovimQt::MsgpackRequest* vim_get_windows();
+
+	/// DEPRECATED: Window vim_get_current_window()
+	NeovimQt::MsgpackRequest* vim_get_current_window();
+
+	/// DEPRECATED: void vim_set_current_window(Window window, )
+	NeovimQt::MsgpackRequest* vim_set_current_window(int64_t window);
+
+	/// DEPRECATED: ArrayOf(Tabpage) vim_get_tabpages()
+	NeovimQt::MsgpackRequest* vim_get_tabpages();
+
+	/// DEPRECATED: Tabpage vim_get_current_tabpage()
+	NeovimQt::MsgpackRequest* vim_get_current_tabpage();
+
+	/// DEPRECATED: void vim_set_current_tabpage(Tabpage tabpage, )
+	NeovimQt::MsgpackRequest* vim_set_current_tabpage(int64_t tabpage);
+
+	/// DEPRECATED: void vim_subscribe(String event, )
+	NeovimQt::MsgpackRequest* vim_subscribe(QByteArray event);
+
+	/// DEPRECATED: void vim_unsubscribe(String event, )
+	NeovimQt::MsgpackRequest* vim_unsubscribe(QByteArray event);
+
+	/// DEPRECATED: Integer vim_name_to_color(String name, )
+	NeovimQt::MsgpackRequest* vim_name_to_color(QByteArray name);
+
+	/// DEPRECATED: Dictionary vim_get_color_map()
+	NeovimQt::MsgpackRequest* vim_get_color_map();
+
+	/// DEPRECATED: Buffer window_get_buffer(Window window, )
+	NeovimQt::MsgpackRequest* window_get_buffer(int64_t window);
+
+	/// DEPRECATED: ArrayOf(Integer, 2) window_get_cursor(Window window, )
+	NeovimQt::MsgpackRequest* window_get_cursor(int64_t window);
+
+	/// DEPRECATED: void window_set_cursor(Window window, ArrayOf(Integer, 2) pos, )
+	NeovimQt::MsgpackRequest* window_set_cursor(int64_t window, QPoint pos);
+
+	/// DEPRECATED: Integer window_get_height(Window window, )
+	NeovimQt::MsgpackRequest* window_get_height(int64_t window);
+
+	/// DEPRECATED: void window_set_height(Window window, Integer height, )
+	NeovimQt::MsgpackRequest* window_set_height(int64_t window, int64_t height);
+
+	/// DEPRECATED: Integer window_get_width(Window window, )
+	NeovimQt::MsgpackRequest* window_get_width(int64_t window);
+
+	/// DEPRECATED: void window_set_width(Window window, Integer width, )
+	NeovimQt::MsgpackRequest* window_set_width(int64_t window, int64_t width);
+
+	/// DEPRECATED: Object window_get_var(Window window, String name, )
+	NeovimQt::MsgpackRequest* window_get_var(int64_t window, QByteArray name);
+
+	/// DEPRECATED: Object window_get_option(Window window, String name, )
+	NeovimQt::MsgpackRequest* window_get_option(int64_t window, QByteArray name);
+
+	/// DEPRECATED: void window_set_option(Window window, String name, Object value, )
+	NeovimQt::MsgpackRequest* window_set_option(int64_t window, QByteArray name, QVariant value);
+
+	/// DEPRECATED: ArrayOf(Integer, 2) window_get_position(Window window, )
+	NeovimQt::MsgpackRequest* window_get_position(int64_t window);
+
+	/// DEPRECATED: Tabpage window_get_tabpage(Window window, )
+	NeovimQt::MsgpackRequest* window_get_tabpage(int64_t window);
+
+	/// DEPRECATED: Boolean window_is_valid(Window window, )
+	NeovimQt::MsgpackRequest* window_is_valid(int64_t window);
+
 
 signals:
 	void on_nvim_buf_line_count(int64_t);
@@ -720,6 +898,12 @@ signals:
 
 	void on_nvim_buf_get_keymap(QList<QVariantMap>);
 	void err_nvim_buf_get_keymap(const QString&, const QVariant&);
+
+	void on_nvim_buf_set_keymap(void);
+	void err_nvim_buf_set_keymap(const QString&, const QVariant&);
+
+	void on_nvim_buf_del_keymap(void);
+	void err_nvim_buf_del_keymap(const QString&, const QVariant&);
 
 	void on_nvim_buf_get_commands(QVariantMap);
 	void err_nvim_buf_get_commands(const QString&, const QVariant&);
@@ -820,6 +1004,9 @@ signals:
 	void on_nvim_ui_try_resize_grid(void);
 	void err_nvim_ui_try_resize_grid(const QString&, const QVariant&);
 
+	void on_nvim_ui_pum_set_height(void);
+	void err_nvim_ui_pum_set_height(const QString&, const QVariant&);
+
 	void on_nvim_command(void);
 	void err_nvim_command(const QString&, const QVariant&);
 
@@ -834,6 +1021,9 @@ signals:
 
 	void on_nvim_input(int64_t);
 	void err_nvim_input(const QString&, const QVariant&);
+
+	void on_nvim_input_mouse(void);
+	void err_nvim_input_mouse(const QString&, const QVariant&);
 
 	void on_nvim_replace_termcodes(QByteArray);
 	void err_nvim_replace_termcodes(const QString&, const QVariant&);
@@ -889,6 +1079,9 @@ signals:
 	void on_nvim_get_vvar(QVariant);
 	void err_nvim_get_vvar(const QString&, const QVariant&);
 
+	void on_nvim_set_vvar(void);
+	void err_nvim_set_vvar(const QString&, const QVariant&);
+
 	void on_nvim_get_option(QVariant);
 	void err_nvim_get_option(const QString&, const QVariant&);
 
@@ -922,6 +1115,12 @@ signals:
 	void on_nvim_set_current_win(void);
 	void err_nvim_set_current_win(const QString&, const QVariant&);
 
+	void on_nvim_create_buf(int64_t);
+	void err_nvim_create_buf(const QString&, const QVariant&);
+
+	void on_nvim_open_win(int64_t);
+	void err_nvim_open_win(const QString&, const QVariant&);
+
 	void on_nvim_list_tabpages(QList<int64_t>);
 	void err_nvim_list_tabpages(const QString&, const QVariant&);
 
@@ -937,6 +1136,12 @@ signals:
 	void on_nvim_get_namespaces(QVariantMap);
 	void err_nvim_get_namespaces(const QString&, const QVariant&);
 
+	void on_nvim_paste(bool);
+	void err_nvim_paste(const QString&, const QVariant&);
+
+	void on_nvim_put(void);
+	void err_nvim_put(const QString&, const QVariant&);
+
 	void on_nvim_subscribe(void);
 	void err_nvim_subscribe(const QString&, const QVariant&);
 
@@ -949,11 +1154,23 @@ signals:
 	void on_nvim_get_color_map(QVariantMap);
 	void err_nvim_get_color_map(const QString&, const QVariant&);
 
+	void on_nvim_get_context(QVariantMap);
+	void err_nvim_get_context(const QString&, const QVariant&);
+
+	void on_nvim_load_context(QVariant);
+	void err_nvim_load_context(const QString&, const QVariant&);
+
 	void on_nvim_get_mode(QVariantMap);
 	void err_nvim_get_mode(const QString&, const QVariant&);
 
 	void on_nvim_get_keymap(QList<QVariantMap>);
 	void err_nvim_get_keymap(const QString&, const QVariant&);
+
+	void on_nvim_set_keymap(void);
+	void err_nvim_set_keymap(const QString&, const QVariant&);
+
+	void on_nvim_del_keymap(void);
+	void err_nvim_del_keymap(const QString&, const QVariant&);
 
 	void on_nvim_get_commands(QVariantMap);
 	void err_nvim_get_commands(const QString&, const QVariant&);
@@ -1044,6 +1261,15 @@ signals:
 
 	void on_nvim_win_is_valid(bool);
 	void err_nvim_win_is_valid(const QString&, const QVariant&);
+
+	void on_nvim_win_set_config(void);
+	void err_nvim_win_set_config(const QString&, const QVariant&);
+
+	void on_nvim_win_get_config(QVariantMap);
+	void err_nvim_win_get_config(const QString&, const QVariant&);
+
+	void on_nvim_win_close(void);
+	void err_nvim_win_close(const QString&, const QVariant&);
 
 	void on_buffer_line_count(int64_t);
 	void err_buffer_line_count(const QString&, const QVariant&);
@@ -1241,5 +1467,5 @@ signals:
 	void err_window_is_valid(const QString&, const QVariant&);
 
 };
-} // namespace
-#endif
+
+} // namespace NeovimQt

--- a/src/function.cpp
+++ b/src/function.cpp
@@ -156,8 +156,7 @@ QList<QPair<QString,QString> > Function::parseParameters(const QVariantList& obj
 		}
 
 		for (int j=0; j<params.size(); j+=2) {
-			QByteArray type, name;
-			if (!params.at(j).canConvert<QByteArray>() || 
+			if (!params.at(j).canConvert<QByteArray>() ||
 					!params.at(j+1).canConvert<QByteArray>()) {
 				return fail;
 			}

--- a/src/function.cpp
+++ b/src/function.cpp
@@ -58,7 +58,7 @@ bool Function::isValid() const
  * Two functions are considered identical if their names
  * argument and return types, and error status are identical
  */
-bool Function::operator==(const Function& other)
+bool Function::operator==(const Function& other) const noexcept
 {
 	if ( this->name != other.name ) {
 		return false;

--- a/src/function.cpp
+++ b/src/function.cpp
@@ -173,14 +173,14 @@ QString Function::signature() const
 {
 	QStringList sigparams;
 	foreach(const StringPair p, parameters) {
-		sigparams.append(QString("%1 %2").arg(p.first).arg(p.second));
+		sigparams.append(QString("%1 %2").arg(p.first, p.second));
 	}
 
 	QString notes;
 	if (can_fail) {
 		notes += " !fail";
 	}
-	return  QString("%1 %2(%3)%4").arg(return_type).arg(name).arg(sigparams.join(", ")).arg(notes);
+	return  QString("%1 %2(%3)%4").arg(return_type, name, sigparams.join(", "), notes);
 }
 
 } // Namespace

--- a/src/function.h
+++ b/src/function.h
@@ -12,7 +12,6 @@
 namespace NeovimQt {
 
 class Function {
-	Q_ENUMS(FunctionId)
 public:
 
 	Function();

--- a/src/function.h
+++ b/src/function.h
@@ -18,7 +18,7 @@ public:
 	Function(const QString& ret, const QString& name, QList<QPair<QString,QString> > params, bool can_fail);
 	Function(const QString& ret, const QString& name, QList<QString> paramTypes, bool can_fail);
 	bool isValid() const;
-	bool operator==(const Function& other);
+	bool operator==(const Function& other) const noexcept;
 	static Function fromVariant(const QVariant&);
 	static QList<QPair<QString,QString> > parseParameters(const QVariantList& obj);
 

--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -118,8 +118,8 @@ void App::showUi() noexcept
 #else
 	NeovimQt::MainWindow *win = new NeovimQt::MainWindow(m_connector.get(), opts);
 
-	QObject::connect(instance(), SIGNAL(openFilesTriggered(const QList<QUrl>)),
-		win->shell(), SLOT(openFiles(const QList<QUrl>)));
+	QObject::connect(instance(), SIGNAL(openFilesTriggered(QList<QUrl>)),
+		win->shell(), SLOT(openFiles(QList<QUrl>)));
 
 	// Window geometry should be restored only when the user does not specify
 	// one of the following command line arguments. Argument "maximized" can

--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -65,7 +65,7 @@ App::App(int &argc, char ** argv) noexcept
 	}
 #endif
 
-	if (!qgetenv("NVIM_QT_LOG").isEmpty()) {
+	if (!qEnvironmentVariableIsEmpty("NVIM_QT_LOG")) {
 		qInstallMessageHandler(logger);
 	}
 

--- a/src/gui/input.cpp
+++ b/src/gui/input.cpp
@@ -77,7 +77,7 @@ static QVariant GetButtonName(
 			return QStringLiteral("Middle");
 
 		case Qt::NoButton:
-			return QStringLiteral("");
+			return QLatin1String{""};
 
 		default:
 			return {}; // Invalid

--- a/src/gui/input.cpp
+++ b/src/gui/input.cpp
@@ -116,17 +116,13 @@ QString convertMouse(
 		return {};
 	}
 
-	return QString{ "<%1%2%3><%4,%5>" }
-		.arg(GetModifierPrefix(mod))
-		.arg(varButtonName.toString())
-		.arg(GetEventString(type))
-		.arg(pos.x())
-		.arg(pos.y());
+	return QString{ "<%1%2%3><%4,%5>" }.arg(GetModifierPrefix(mod), varButtonName.toString(), GetEventString(type))
+		.arg(pos.x(), pos.y());
 }
 
 QString ToKeyString(const QString& modPrefix, const QString& key) noexcept
 {
-	return QString{ "<%1%2>" }.arg(modPrefix).arg(key);
+	return QString{ "<%1%2>" }.arg(modPrefix, key);
 }
 
 QString convertKey(const QKeyEvent& ev) noexcept

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -91,10 +91,10 @@ void MainWindow::init(NeovimConnector *c)
 	m_stack.insertWidget(1, m_window);
 	m_stack.setCurrentIndex(1);
 
-	connect(m_shell, SIGNAL(neovimAttached(bool)),
-			this, SLOT(neovimAttachmentChanged(bool)));
-	connect(m_shell, SIGNAL(neovimTitleChanged(QString)),
-			this, SLOT(neovimSetTitle(QString)));
+	connect(m_shell, &Shell::neovimAttachedChanged,
+			this, &MainWindow::neovimAttachmentChanged);
+	connect(m_shell, &Shell::neovimTitleChanged,
+			this, &MainWindow::neovimSetTitle);
 	connect(m_shell, &Shell::neovimResized,
 			this, &MainWindow::neovimWidgetResized);
 	connect(m_shell, &Shell::neovimMaximized,

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -93,8 +93,8 @@ void MainWindow::init(NeovimConnector *c)
 
 	connect(m_shell, SIGNAL(neovimAttached(bool)),
 			this, SLOT(neovimAttachmentChanged(bool)));
-	connect(m_shell, SIGNAL(neovimTitleChanged(const QString &)),
-			this, SLOT(neovimSetTitle(const QString &)));
+	connect(m_shell, SIGNAL(neovimTitleChanged(QString)),
+			this, SLOT(neovimSetTitle(QString)));
 	connect(m_shell, &Shell::neovimResized,
 			this, &MainWindow::neovimWidgetResized);
 	connect(m_shell, &Shell::neovimMaximized,

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -147,11 +147,6 @@ void MainWindow::init(NeovimConnector *c)
 	}
 }
 
-bool MainWindow::neovimAttached() const
-{
-	return (m_shell != NULL && m_shell->neovimAttached());
-}
-
 /** The Neovim process has exited */
 void MainWindow::neovimExited(int status)
 {
@@ -304,7 +299,6 @@ void MainWindow::showIfDelayed()
 
 void MainWindow::neovimAttachmentChanged(bool attached)
 {
-	emit neovimAttached(attached);
 	if (attached) {
 		if (isWindow() && m_shell != NULL) {
 			m_shell->updateGuiWindowState(windowState());
@@ -313,6 +307,8 @@ void MainWindow::neovimAttachmentChanged(bool attached)
 		m_tabline->deleteLater();
 		m_tabline_bar->deleteLater();
 	}
+
+	emit neovimAttached(attached);
 }
 
 Shell* MainWindow::shell()

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -36,7 +36,7 @@ public:
 	Shell* shell();
 	void restoreWindowGeometry();
 public slots:
-	void delayedShow(DelayedShow type=DelayedShow::Normal);
+	void delayedShow(NeovimQt::MainWindow::DelayedShow type = DelayedShow::Normal);
 signals:
 	void neovimAttached(bool);
 protected:
@@ -56,7 +56,7 @@ private slots:
 	void neovimAttachmentChanged(bool);
 	void neovimIsUnsupported();
 	void neovimShowtablineSet(int);
-	void neovimTablineUpdate(int64_t curtab, QList<Tab> tabs);
+	void neovimTablineUpdate(int64_t curtab, QList<NeovimQt::Tab> tabs);
 	void neovimShowContextMenu();
 	void neovimSendCut();
 	void neovimSendCopy();

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -27,7 +27,12 @@ public:
 	};
 
 	MainWindow(NeovimConnector *, ShellOptions opts, QWidget *parent=0);
-	bool neovimAttached() const;
+
+	bool isNeovimAttached() const
+	{
+		return m_shell && m_shell->isNeovimAttached();
+	}
+
 	Shell* shell();
 	void restoreWindowGeometry();
 public slots:

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -568,7 +568,6 @@ void Shell::handlePopupMenuShow(const QVariantList& opargs)
 	for (const auto& v : items) {
 		QVariantList item = v.toList();
 		// Item is (text, kind, extra, info)
-		QString text = item.value(0).toString();
 		if (item.size() < 4
 			|| item.isEmpty()
 			|| item.value(0).toString().isEmpty()) {

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -58,7 +58,7 @@ Shell::Shell(NeovimConnector *nvim, ShellOptions opts, QWidget *parent)
 	connect(this, &ShellWidget::shellFontChanged,
 			this, &Shell::fontChanged);
 	connect(this, &ShellWidget::fontError,
-			this, &Shell::fontError);
+			this, &Shell::handleFontError);
 
 	m_nvim->setRequestHandler(new ShellRequestHandler(this));
 
@@ -67,7 +67,7 @@ Shell::Shell(NeovimConnector *nvim, ShellOptions opts, QWidget *parent)
 	}
 }
 
-void Shell::fontError(const QString& msg)
+void Shell::handleFontError(const QString& msg)
 {
 	if (isNeovimAttached()) {
 		m_nvim->api0()->vim_report_error(m_nvim->encode(msg));

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -1354,14 +1354,12 @@ void Shell::wheelEvent(QWheelEvent *ev)
 	QString inp;
 	if (scroll_delta.y() != 0) {
 		inp += QString("<%1ScrollWheel%2><%3,%4>")
-			.arg(Input::GetModifierPrefix(ev->modifiers()))
-			.arg(scroll_delta.y() > 0 ? "Up" : "Down")
-			.arg(pos.x()).arg(pos.y());
+			.arg(Input::GetModifierPrefix(ev->modifiers()), scroll_delta.y() > 0 ? "Up" : "Down")
+			.arg(pos.x(), pos.y());
 	}
 	if (scroll_delta.x() != 0) {
 		inp += QString("<%1ScrollWheel%2><%3,%4>")
-			.arg(Input::GetModifierPrefix(ev->modifiers()))
-			.arg(scroll_delta.x() > 0 ? "Left" : "Right")
+			.arg(Input::GetModifierPrefix(ev->modifiers()), (scroll_delta.x() > 0) ? "Left" : "Right")
 			.arg(pos.x()).arg(pos.y());
 	}
 	m_nvim->api0()->vim_input(inp.toLatin1());

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -43,15 +43,28 @@ public:
 class Shell: public ShellWidget
 {
 	Q_OBJECT
-	Q_PROPERTY(bool neovimBusy READ neovimBusy() NOTIFY neovimBusy())
-	Q_PROPERTY(bool neovimAttached READ neovimAttached() NOTIFY neovimAttached())
+
+	Q_PROPERTY(bool neovimBusy MEMBER m_neovimBusy \
+		READ isNeovimBusy NOTIFY neovimBusyChanged)
+
+	Q_PROPERTY(bool neovimAttached MEMBER m_attached \
+		READ isNeovimAttached WRITE setAttached NOTIFY neovimAttachedChanged)
+
 public:
 	Shell(NeovimConnector *nvim, ShellOptions opts, QWidget *parent=0);
 	~Shell();
 	QSize sizeIncrement() const;
 	virtual QVariant inputMethodQuery(Qt::InputMethodQuery) const Q_DECL_OVERRIDE;
-	bool neovimBusy() const;
-	bool neovimAttached() const;
+
+	bool isNeovimBusy() const
+	{
+		return m_neovimBusy;
+	}
+
+	bool isNeovimAttached() const
+	{
+		return m_attached;
+	}
 
 	PopupMenu& getPopupMenu() noexcept
 	{
@@ -79,9 +92,9 @@ public:
 
 signals:
 	void neovimTitleChanged(const QString &title);
-	void neovimBusy(bool);
+	void neovimBusyChanged(bool);
 	void neovimResized(int rows, int cols);
-	void neovimAttached(bool);
+	void neovimAttachedChanged(bool);
 	void neovimMaximized(bool);
 	void neovimSuspend();
 	void neovimFullScreen(bool);
@@ -187,7 +200,7 @@ protected:
 	QString neovimErrorToString(const QVariant& err);
 
 private slots:
-        void setAttached(bool attached=true);
+	void setAttached(bool isAttached);
 
 private:
 	bool m_attached{ false };

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -133,7 +133,7 @@ protected slots:
 	void mouseClickReset();
 	void mouseClickIncrement(Qt::MouseButton bt);
 	void init();
-	void fontError(const QString& msg);
+	void handleFontError(const QString& msg);
 	void updateWindowId();
 	void updateClientInfo();
 	void handleGinitError(quint32 msgid, quint64 fun, const QVariant& err);

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -105,7 +105,7 @@ signals:
 	void neovimExtPopupmenuSet(bool);
 	/// The tabline needs updating. curtab is the handle of the current tab (not its index)
 	/// as seen in Tab::tab.
-	void neovimTablineUpdate(int64_t curtab, QList<Tab> tabs);
+	void neovimTablineUpdate(int64_t curtab, QList<NeovimQt::Tab> tabs);
 	void neovimShowtablineSet(int);
 	void neovimShowContextMenu();
 	void fontChanged();

--- a/src/gui/shellwidget/shellwidget.cpp
+++ b/src/gui/shellwidget/shellwidget.cpp
@@ -643,7 +643,7 @@ QVariant ShellWidget::TryGetQFontFromDescription(const QString& fdesc) const noe
 	qreal pointSizeF = curFont.pointSizeF();
 	int weight = -1;
 	bool italic = false;
-	for (const auto& attr : attrs) {
+	for (const auto& attr : qAsConst(attrs)) {
 		if (attr.size() >= 2 && attr[0] == 'h') {
 			bool ok{ false };
 			qreal height = attr.midRef(1).toFloat(&ok);

--- a/src/gui/shellwidget/shellwidget.cpp
+++ b/src/gui/shellwidget/shellwidget.cpp
@@ -227,7 +227,7 @@ QFont ShellWidget::GetCellFont(const Cell& cell) const noexcept
 
 	// Issue #575: Clear style name. The KDE/Plasma theme plugin may set this
 	// but we want to match the family name with the bold/italic attributes.
-	cellFont.setStyleName(QStringLiteral(""));
+	cellFont.setStyleName({});
 
 	cellFont.setStyleHint(QFont::TypeWriter, QFont::StyleStrategy(QFont::PreferDefault | QFont::ForceIntegerMetrics));
 	cellFont.setFixedPitch(true);

--- a/src/gui/shellwidget/shellwidget.cpp
+++ b/src/gui/shellwidget/shellwidget.cpp
@@ -646,7 +646,7 @@ QVariant ShellWidget::TryGetQFontFromDescription(const QString& fdesc) const noe
 	for (const auto& attr : attrs) {
 		if (attr.size() >= 2 && attr[0] == 'h') {
 			bool ok{ false };
-			qreal height = attr.mid(1).toFloat(&ok);
+			qreal height = attr.midRef(1).toFloat(&ok);
 			if (!ok || height < 0) {
 				return QStringLiteral("Invalid font height");
 			}
@@ -658,7 +658,7 @@ QVariant ShellWidget::TryGetQFontFromDescription(const QString& fdesc) const noe
 		} else if (attr == "sb") {
 			weight = QFont::DemiBold;
 		} else if (attr.length() > 0 && attr.at(0) == 'w') {
-			weight = (attr.right(attr.length()-1)).toInt();
+			weight = (attr.rightRef(attr.length()-1)).toInt();
 			if (weight < 0 || weight > 99) {
 				return QStringLiteral("Invalid font weight");
 			}

--- a/src/gui/shellwidget/shellwidget.h
+++ b/src/gui/shellwidget/shellwidget.h
@@ -9,11 +9,7 @@
 class ShellWidget: public QWidget
 {
 	Q_OBJECT
-	Q_PROPERTY(QColor background READ background WRITE setBackground)
-	Q_PROPERTY(QColor foreground READ foreground WRITE setForeground)
-	Q_PROPERTY(int rows READ rows)
-	Q_PROPERTY(int columns READ columns)
-	Q_PROPERTY(QSize cellSize READ cellSize)
+
 public:
 	ShellWidget(QWidget *parent=0);
 

--- a/src/msgpackiodevice.h
+++ b/src/msgpackiodevice.h
@@ -9,7 +9,8 @@ namespace NeovimQt {
 
 class MsgpackRequest;
 class MsgpackRequestHandler;
-class MsgpackIODevice: public QObject
+
+class MsgpackIODevice : public QObject
 {
 	Q_OBJECT
 	Q_PROPERTY(MsgpackError error READ errorCause NOTIFY error)
@@ -21,11 +22,7 @@ public:
 		InvalidMsgpack,
 		UnsupportedEncoding,
 	};
-#ifdef Q_ENUM
 	Q_ENUM(MsgpackError)
-#else
-	Q_ENUMS(MsgpackError)
-#endif
 	MsgpackIODevice(QIODevice *, QObject *parent=0);
 	~MsgpackIODevice();
         static MsgpackIODevice* fromStdinOut(QObject *parent=0);
@@ -69,7 +66,7 @@ public:
 
 	QList<quint32> pendingRequests() const;
 signals:
-	void error(MsgpackError);
+	void error(NeovimQt::MsgpackIODevice::MsgpackError);
 	/** A notification with the given name and arguments was received */
 	void notification(const QByteArray &name, const QVariantList& args);
 
@@ -92,7 +89,7 @@ protected:
 	bool decodeMsgpack(const msgpack_object& in, QPoint& out);
 
 protected slots:
-	void setError(MsgpackError err, const QString& msg);
+	void setError(NeovimQt::MsgpackIODevice::MsgpackError err, const QString& msg);
 
 	void dataAvailable();
 	void dataAvailableStdin(const QByteArray&);

--- a/src/msgpackiodevice.h
+++ b/src/msgpackiodevice.h
@@ -14,7 +14,7 @@ class MsgpackIODevice : public QObject
 {
 	Q_OBJECT
 	Q_PROPERTY(MsgpackError error READ errorCause NOTIFY error)
-	Q_PROPERTY(QByteArray encoding READ encoding WRITE setEncoding)
+
 public:
 	enum MsgpackError {
 		NoError=0,
@@ -69,6 +69,7 @@ signals:
 	void error(NeovimQt::MsgpackIODevice::MsgpackError);
 	/** A notification with the given name and arguments was received */
 	void notification(const QByteArray &name, const QVariantList& args);
+	void encodingChanged();
 
 protected:
 	void sendError(const msgpack_object& req, const QString& msg);

--- a/src/neovimconnector.cpp
+++ b/src/neovimconnector.cpp
@@ -353,7 +353,7 @@ NeovimConnector* NeovimConnector::connectToNeovim(const QString& server)
 	int colon_pos = addr.lastIndexOf(':');
 	if (colon_pos != -1 && colon_pos != 0 && addr[colon_pos-1] != ':') {
 		bool ok;
-		int port = addr.mid(colon_pos+1).toInt(&ok);
+		int port = addr.midRef(colon_pos+1).toInt(&ok);
 		if (ok) {
 			QString host = addr.mid(0, colon_pos);
 			return connectToHost(host, port);

--- a/src/neovimconnector.cpp
+++ b/src/neovimconnector.cpp
@@ -278,7 +278,7 @@ NeovimConnector* NeovimConnector::spawn(const QStringList& params, const QString
 
 	connect(p, SIGNAL(error(QProcess::ProcessError)),
 			c, SLOT(processError(QProcess::ProcessError)));
-	connect(p, SIGNAL(finished(int, QProcess::ExitStatus)),
+	connect(p, SIGNAL(finished(int,QProcess::ExitStatus)),
 			c, SIGNAL(processExited(int)));
 	connect(p, &QProcess::started,
 			c, &NeovimConnector::discoverMetadata);

--- a/src/neovimconnector.h
+++ b/src/neovimconnector.h
@@ -49,11 +49,7 @@ public:
 		MsgpackError,
 		RuntimeMsgpackError,
 	};
-#ifdef Q_ENUM
 	Q_ENUM(NeovimError)
-#else
-	Q_ENUMS(NeovimError)
-#endif
 
 	/** Underlying connection used to read Neovim */
         enum NeovimConnectionType {
@@ -103,7 +99,7 @@ public:
 signals:
 	/** Emitted when Neovim is ready @see ready */
 	void ready();
-	void error(NeovimError);
+	void error(NeovimQt::NeovimConnector::NeovimError);
 	void processExited(int exitCode);
 
 public slots:

--- a/test/tst_encoding.cpp
+++ b/test/tst_encoding.cpp
@@ -4,6 +4,8 @@
 #include <neovimconnector.h>
 #include <util.h>
 
+#include "common.h"
+
 class TestEncoding: public QObject
 {
 	Q_OBJECT
@@ -12,32 +14,22 @@ private slots:
 	void encodeString();
 	void map();
 	void stringsAreBinaryNotUtf8();
+
 protected:
-	NeovimQt::NeovimConnector *m_c;
+	NeovimQt::NeovimConnector* m_c;
 };
 
 void TestEncoding::encodeString()
 {
 	QMetaObject::Connection conn;
-	m_c->neovimObject()->vim_set_var("testing-neovim-qt", QString("value"));
-	m_c->neovimObject()->vim_get_var("testing-neovim-qt");
-	conn = connect(m_c->neovimObject(), &NeovimQt::NeovimApi1::on_vim_get_var,
+	m_c->api1()->vim_set_var("testing-neovim-qt", QString("value"));
+	m_c->api1()->vim_get_var("testing-neovim-qt");
+	QSignalSpy onVimGetVar{ m_c->api1(), &NeovimQt::NeovimApi1::on_vim_get_var };
+	conn = connect(m_c->api1(), &NeovimQt::NeovimApi1::on_vim_get_var,
 			[](const QVariant& v) {
 				QVERIFY(v == QByteArray("value"));
 			});
-	QTest::qWait(500);
-	disconnect(conn);
-
-	bool var_set = false;
-	m_c->neovimObject()->vim_set_var("testing-neovim-qt", QByteArray("value"));
-	m_c->neovimObject()->vim_get_var("testing-neovim-qt");
-	conn = connect(m_c->neovimObject(), &NeovimQt::NeovimApi1::on_vim_get_var,
-			[&var_set](const QVariant& v) {
-				var_set = true;
-				QVERIFY(v == QVariant(QByteArray("value")));
-			});
-	QTest::qWait(500);
-	QVERIFY(var_set);
+	QVERIFY(SPYWAIT(onVimGetVar));
 	disconnect(conn);
 }
 
@@ -46,13 +38,20 @@ void TestEncoding::map()
 	QMetaObject::Connection conn;
 	QVariantMap map;
 	map.insert("answer", 42);
-	m_c->neovimObject()->vim_set_var("test-map", map);
-	m_c->neovimObject()->vim_get_var("test-map");
-	conn = connect(m_c->neovimObject(), &NeovimQt::NeovimApi1::on_vim_get_var,
+
+	m_c->api1()->vim_set_var("test-map", map);
+	QSignalSpy onVimSetVar{ m_c->api1(), &NeovimQt::NeovimApi1::on_vim_set_var };
+	QVERIFY(SPYWAIT(onVimSetVar));
+
+	m_c->api1()->vim_get_var("test-map");
+	QSignalSpy onVimGetVar{ m_c->api1(), &NeovimQt::NeovimApi1::on_vim_get_var };
+	conn = connect(m_c->api1(), &NeovimQt::NeovimApi1::on_vim_get_var,
 			[map](const QVariant& v) {
+				qDebug() << "Expected:" << map;
+				qDebug() << "Observed:" << v;
 				QVERIFY(v == map);
 			});
-	QTest::qWait(500);
+	QVERIFY(SPYWAIT(onVimGetVar));
 	disconnect(conn);
 }
 
@@ -61,28 +60,29 @@ void TestEncoding::map()
 void TestEncoding::stringsAreBinaryNotUtf8()
 {
 	QByteArray data = "\xc3\x28";
-	m_c->neovimObject()->vim_set_current_line(data);
-	m_c->neovimObject()->vim_get_current_line();
+
+	m_c->api1()->vim_set_current_line(data);
+	QSignalSpy onVimSetCurrentLine{ m_c->api1(), &NeovimQt::NeovimApi1::on_vim_set_current_line};
+	QVERIFY(SPYWAIT(onVimSetCurrentLine));
+
+	m_c->api1()->vim_get_current_line();
 	QMetaObject::Connection conn;
-	conn = connect(m_c->neovimObject(), &NeovimQt::NeovimApi1::on_vim_get_current_line,
+	QSignalSpy onVimGetCurrentLine{ m_c->api1(), &NeovimQt::NeovimApi1::on_vim_get_current_line};
+	conn = connect(m_c->api1(), &NeovimQt::NeovimApi1::on_vim_get_current_line,
 			[data](const QVariant& v) {
 				QCOMPARE(v.toByteArray(), data);
 			});
-	QTest::qWait(500);
+	QVERIFY(SPYWAIT(onVimGetCurrentLine));
 	disconnect(conn);
 }
 
 void TestEncoding::initTestCase()
 {
-	bool ready = false;
 	m_c = NeovimQt::NeovimConnector::spawn({"-u", "NONE"});
 	QVERIFY(m_c->errorCause() == NeovimQt::NeovimConnector::NoError);
-	connect(m_c, &NeovimQt::NeovimConnector::ready,
-		[&ready](){
-			ready = true;
-		});
-	QTest::qWait(1500);
-	QVERIFY(ready);
+	QSignalSpy onReady(m_c, SIGNAL(ready()));
+	QVERIFY(onReady.isValid());
+	QVERIFY(SPYWAIT(onReady));
 }
 
 QTEST_MAIN(TestEncoding)

--- a/test/tst_encoding.cpp
+++ b/test/tst_encoding.cpp
@@ -18,12 +18,11 @@ protected:
 
 void TestEncoding::encodeString()
 {
-	bool failed_to_set = false;
 	QMetaObject::Connection conn;
 	m_c->neovimObject()->vim_set_var("testing-neovim-qt", QString("value"));
 	m_c->neovimObject()->vim_get_var("testing-neovim-qt");
 	conn = connect(m_c->neovimObject(), &NeovimQt::NeovimApi1::on_vim_get_var,
-			[&failed_to_set](const QVariant& v) {
+			[](const QVariant& v) {
 				QVERIFY(v == QByteArray("value"));
 			});
 	QTest::qWait(500);

--- a/test/tst_input_mac.cpp
+++ b/test/tst_input_mac.cpp
@@ -41,9 +41,9 @@ void TestInputMac::LessThanModifierKeys() noexcept
 
 void TestInputMac::SpecialKeys() noexcept
 {
-	const QMap<int, QString>& specialKeys { NeovimQt::Input::GetSpecialKeysMap() };
+	const QList<int> specialKeys{ NeovimQt::Input::GetSpecialKeysMap().keys() };
 
-	for (const auto k : specialKeys.keys()) {
+	for (const auto k : specialKeys) {
 		// On Mac Meta is the Control key, treated as C-.
 		QList<QPair<QKeyEvent, QString>> keyEventList{
 			{ { QEvent::KeyPress, k, Qt::NoModifier, {} },      "<%1>" },

--- a/test/tst_input_unix.cpp
+++ b/test/tst_input_unix.cpp
@@ -26,9 +26,9 @@ void TestInputUnix::LessThanModifierKeys() noexcept
 
 void TestInputUnix::SpecialKeys() noexcept
 {
-	const QMap<int, QString>& specialKeys { NeovimQt::Input::GetSpecialKeysMap() };
+	const QList<int> specialKeys{ NeovimQt::Input::GetSpecialKeysMap().keys() };
 
-	for (const auto k : specialKeys.keys()) {
+	for (const auto k : specialKeys) {
 		// On Mac Meta is the Control key, treated as C-.
 		QList<QPair<QKeyEvent, QString>> keyEventList{
 			{ { QEvent::KeyPress, k, Qt::NoModifier, {} },      "<%1>" },

--- a/test/tst_input_win32.cpp
+++ b/test/tst_input_win32.cpp
@@ -26,9 +26,9 @@ void TestInputWin32::LessThanModifierKeys() noexcept
 
 void TestInputWin32::SpecialKeys() noexcept
 {
-	const QMap<int, QString>& specialKeys { NeovimQt::Input::GetSpecialKeysMap() };
+	const QList<int> specialKeys{ NeovimQt::Input::GetSpecialKeysMap().keys() };
 
-	for (const auto k : specialKeys.keys()) {
+	for (const auto k : specialKeys) {
 		// On Mac Meta is the Control key, treated as C-.
 		QList<QPair<QKeyEvent, QString>> keyEventList{
 			{ { QEvent::KeyPress, k, Qt::NoModifier, {} },      "<%1>" },

--- a/test/tst_shell.cpp
+++ b/test/tst_shell.cpp
@@ -52,7 +52,7 @@ private slots:
 		QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
 		QVERIFY(onAttached.isValid());
 		QVERIFY(SPYWAIT(onAttached));
-		QVERIFY(s->neovimAttached());
+		QVERIFY(s->isNeovimAttached());
 
 		s->repaint();
 
@@ -68,7 +68,7 @@ private slots:
 		QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
 		QVERIFY(onAttached.isValid());
 		QVERIFY(SPYWAIT(onAttached));
-		QVERIFY(s->neovimAttached());
+		QVERIFY(s->isNeovimAttached());
 		checkStartVars(c);
 	}
 
@@ -80,7 +80,7 @@ private slots:
 		QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
 		QVERIFY(onAttached.isValid());
 		QVERIFY(SPYWAIT(onAttached));
-		QVERIFY(s->neovimAttached());
+		QVERIFY(s->isNeovimAttached());
 		checkStartVars(c);
 	}
 
@@ -104,7 +104,7 @@ private slots:
 		QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
 		QVERIFY(onAttached.isValid());
 		QVERIFY(SPYWAIT(onAttached));
-		QVERIFY(s->neovimAttached());
+		QVERIFY(s->isNeovimAttached());
 
 		auto req = c->api0()->vim_command_output(c->encode("echo g:test_gviminit"));
 		QSignalSpy cmd(req, SIGNAL(finished(quint32, quint64, QVariant)));
@@ -129,7 +129,7 @@ private slots:
 		QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
 		QVERIFY(onAttached.isValid());
 		QVERIFY(SPYWAIT(onAttached));
-		QVERIFY(s->neovimAttached());
+		QVERIFY(s->isNeovimAttached());
 
 		QObject::connect(c->neovimObject(), &NeovimApi1::err_vim_command_output, [](QString msg, const QVariant& err) {
 				qDebug() << msg << err;
@@ -223,7 +223,7 @@ private slots:
 		QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
 		QVERIFY(onAttached.isValid());
 		QVERIFY(SPYWAIT(onAttached));
-		QVERIFY(s->neovimAttached());
+		QVERIFY(s->isNeovimAttached());
 
 		QObject::connect(c->neovimObject(), &NeovimApi1::err_vim_command_output, [](QString msg, const QVariant& err) {
 				qDebug() << msg << err;
@@ -284,7 +284,7 @@ private slots:
 		QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
 		QVERIFY(onAttached.isValid());
 		QVERIFY(SPYWAIT(onAttached));
-		QVERIFY(s->neovimAttached());
+		QVERIFY(s->isNeovimAttached());
 
 		QObject::connect(c->neovimObject(), &NeovimApi1::err_vim_command_output, [](QString msg, const QVariant& err) {
 				qDebug() << msg << err;


### PR DESCRIPTION
**Work in Progress**

The KDE project has built a set of `clang-tidy` style rules for Qt: https://github.com/KDE/clazy

We can take advantage of this to improve the compile-time safety and performance of neovim-qt.

Eventually, I would like to add support for clang-tidy too, but adding it here would make this already large Pull even bigger.

**Azure Pipelines:**
I did this work in Azure Pipelines. It is my favorite CI since it supports all platforms in one place (MacOS, Linux, Window), and is free for OpenSource projects. It was mostly to make these changes easier, I was running the CI loop directly on my repo.

Since the work is done, perhaps it is worth checking the YAML into `contrib/azure-pipelines.yml`?

I'm not sure if it switching over, since or current CI stack is working fine...