### PR TITLE
Bump Minimum Qt Version 5.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-2004:202008-01
     working_directory: ~/project
     steps:
       - checkout

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,10 @@ find_package(Qt5Svg REQUIRED)
 find_package(Qt5Test REQUIRED)
 find_package(Qt5Widgets REQUIRED)
 
+if(Qt5Core_VERSION VERSION_LESS 5.8)
+	message(FATAL_ERROR "Minimum supported Qt5 version is 5.8!")
+endif()
+
 # msgpack
 option(USE_SYSTEM_MSGPACK "Use system msgpack libraries " OFF)
 if(USE_SYSTEM_MSGPACK)

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -92,15 +92,11 @@ if(NOT APPLE)
 			DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/scalable/apps/)
 endif()
 
-if(WIN32 AND NOT CMAKE_CROSSCOMPILING)
-	if(Qt5Core_VERSION VERSION_LESS 5.3)
-		message(WARNING "Cannot use windeployqt in Qt 5.2 and earlier")
-	elseif(NOT DEFINED USE_STATIC_QT)
-		include(WinDeployQt)
-		WinDeployQt(TARGET nvim-qt COMPILER_RUNTIME INCLUDE_MODULES ${QTLIBS} EXCLUDE_MODULES webkit webkit2)
-		install(DIRECTORY ${PROJECT_BINARY_DIR}/windeployqt/
-			DESTINATION ${CMAKE_INSTALL_BINDIR})
-	endif()
+if(WIN32 AND NOT CMAKE_CROSSCOMPILING AND NOT DEFINED USE_STATIC_QT)
+	include(WinDeployQt)
+	WinDeployQt(TARGET nvim-qt COMPILER_RUNTIME INCLUDE_MODULES ${QTLIBS} EXCLUDE_MODULES webkit webkit2)
+	install(DIRECTORY ${PROJECT_BINARY_DIR}/windeployqt/
+		DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()
 
 # Generate help tags

--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -337,6 +337,13 @@ static QString GetNeovimVersionInfo(const QString& nvim) noexcept
 	return nvimproc.readAllStandardOutput();
 }
 
+// TODO Issue#752: Remove `endl` and `QT_ENDL` wrapper
+#if (QT_VERSION < QT_VERSION_CHECK(5, 14, 0))
+	#define QT_ENDL endl
+#else
+	#define QT_ENDL Qt::endl
+#endif
+
 void App::showVersionInfo(QCommandLineParser& parser) noexcept
 {
 	QString versionInfo;
@@ -345,18 +352,18 @@ void App::showVersionInfo(QCommandLineParser& parser) noexcept
 	const QString nvimExecutable { (parser.isSet("nvim")) ?
 		parser.value("nvim") : "nvim" };
 
-	out << "NVIM-QT v" << PROJECT_VERSION << endl;
-	out << "Build type: " << CMAKE_BUILD_TYPE << endl;
-	out << "Compilation:" << CMAKE_CXX_FLAGS << endl;
-	out << "Qt Version: " << QT_VERSION_STR << endl;
-	out << "Environment: " << endl;
-	out << "  nvim: " << nvimExecutable << endl;
-	out << "  args: " << getNeovimArgs().join(" ") << endl;
-	out << "  runtime: " << getRuntimePath() << endl;
+	out << "NVIM-QT v" << PROJECT_VERSION << QT_ENDL;
+	out << "Build type: " << CMAKE_BUILD_TYPE << QT_ENDL;
+	out << "Compilation:" << CMAKE_CXX_FLAGS << QT_ENDL;
+	out << "Qt Version: " << QT_VERSION_STR << QT_ENDL;
+	out << "Environment: " << QT_ENDL;
+	out << "  nvim: " << nvimExecutable << QT_ENDL;
+	out << "  args: " << getNeovimArgs().join(" ") << QT_ENDL;
+	out << "  runtime: " << getRuntimePath() << QT_ENDL;
 
-	out << endl;
+	out << QT_ENDL;
 
-	out << GetNeovimVersionInfo(nvimExecutable) << endl;
+	out << GetNeovimVersionInfo(nvimExecutable) << QT_ENDL;
 
 	PrintInfo(versionInfo);
 }

--- a/src/gui/input_win32.cpp
+++ b/src/gui/input_win32.cpp
@@ -10,7 +10,7 @@ Qt::KeyboardModifiers ControlModifier() noexcept
 
 Qt::KeyboardModifiers CmdModifier() noexcept
 {
-	return static_cast<Qt::KeyboardModifiers>(0);
+	return Qt::KeyboardModifier::NoModifier;
 }
 
 Qt::Key Key_Control() noexcept

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -15,6 +15,7 @@
 #include "konsole_wcwidth.h"
 #include "util.h"
 #include "version.h"
+#include "helpers.h"
 
 namespace NeovimQt {
 
@@ -1471,8 +1472,8 @@ void Shell::tooltip(const QString& text)
 		m_tooltip->show();
 	}
 
-	m_tooltip->setMinimumWidth( QFontMetrics(m_tooltip->font()).width(text) );
-	m_tooltip->setMaximumWidth( QFontMetrics(m_tooltip->font()).width(text) );
+	m_tooltip->setMinimumWidth(GetHorizontalAdvance(QFontMetrics{ m_tooltip->font() }, text));
+	m_tooltip->setMaximumWidth(GetHorizontalAdvance(QFontMetrics{ m_tooltip->font() }, text));
 	m_tooltip->update();
 }
 

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -1242,20 +1242,12 @@ void Shell::wheelEvent(QWheelEvent *ev)
 	if (!m_attached || !m_mouseEnabled) {
 		return;
 	}
-#if (QT_VERSION < QT_VERSION_CHECK(5, 5, 0))
-	const int defaultDeltasPerStep = 120;
-#else
-	const int defaultDeltasPerStep = QWheelEvent::DefaultDeltasPerStep;
-#endif
 
-	QPointF scroll_delta_f(ev->angleDelta());
-	scroll_delta_f /= defaultDeltasPerStep;
+	QPointF scroll_delta_f{ ev->angleDelta() / QWheelEvent::DefaultDeltasPerStep };
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 7, 0))
 	if (ev->inverted()) {
 		scroll_delta_f = -scroll_delta_f;
 	}
-#endif
 
 	// Reset scroll remainder if we change scroll direction;
 	const int direction_x = normalize(scroll_delta_f.x());

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -1274,8 +1274,16 @@ void Shell::wheelEvent(QWheelEvent *ev)
 		return;
 	}
 
+// TODO Issue#751:  Remove Deprecated code, keep #else below
+#if (QT_VERSION < QT_VERSION_CHECK(5, 14, 0))
 	const QPoint pos(ev->x()/cellSize().width(),
 			ev->y()/cellSize().height());
+#else
+	const QPointF mousePos{ ev->position() };
+	const QSize size{ cellSize() };
+	const QPointF pos{ mousePos.x() / size.width(),
+		mousePos.y() / size.height() };
+#endif
 
 	QString inp;
 	if (scroll_delta.y() != 0) {

--- a/src/gui/shellwidget/helpers.cpp
+++ b/src/gui/shellwidget/helpers.cpp
@@ -1,14 +1,39 @@
+#include "helpers.h"
+
+#include <QDebug>
 #include <QImage>
 #include <QPainter>
-#include <QDebug>
-#include "helpers.h"
+
+#include "version.h"
+
+template <class T>
+static int GetHorizontalAdvanceHelper(const QFontMetrics& fm, const T& text) noexcept
+{
+#if (QT_VERSION < QT_VERSION_CHECK(5, 11, 0))
+	return fm.width(text);
+#else
+	return fm.horizontalAdvance(text);
+#endif
+}
+
+// TODO Issue#750: Remove this function, requires Qt 5.11
+int GetHorizontalAdvance(const QFontMetrics& fm, QChar character) noexcept
+{
+	return GetHorizontalAdvanceHelper(fm, character);
+}
+
+// TODO Issue#750: Remove this function, requires Qt 5.11
+int GetHorizontalAdvance(const QFontMetrics& fm, const QString& text) noexcept
+{
+	return GetHorizontalAdvanceHelper(fm, text);
+}
 
 /// Save shell contents into a file, returns file on error (see QImage::save)
 bool saveShellContents(const ShellContents& s, const QString& filename)
 {
 	QFont f;
 	QFontMetrics fm(f);
-	int w = fm.width('W');
+	int w = GetHorizontalAdvance(fm, 'W');
 	int h = fm.height();
 
 	QImage img( s.columns()*w,

--- a/src/gui/shellwidget/helpers.h
+++ b/src/gui/shellwidget/helpers.h
@@ -1,8 +1,13 @@
-#ifndef QSHELLWIDGET2_UTIL
-#define QSHELLWIDGET2_UTIL
+#pragma once
+
+#include <QFontMetrics>
 
 #include "shellcontents.h"
 
-bool saveShellContents(const ShellContents& s, const QString& filename);
+/// Helper for deprecated QFontMetrics::width(...). Eventually remove this code.
+int GetHorizontalAdvance(const QFontMetrics& fm, QChar character) noexcept;
 
-#endif
+/// Helper for deprecated QFontMetrics::width(...). Eventually remove this code.
+int GetHorizontalAdvance(const QFontMetrics& fm, const QString& text) noexcept;
+
+bool saveShellContents(const ShellContents& s, const QString& filename);

--- a/src/gui/shellwidget/shellwidget.cpp
+++ b/src/gui/shellwidget/shellwidget.cpp
@@ -102,7 +102,7 @@ void ShellWidget::setCellSize()
 {
 	QFontMetrics fm(font());
 	m_ascent = fm.ascent();
-	m_cellSize = QSize(fm.width('W'),
+	m_cellSize = QSize(GetHorizontalAdvance(fm, 'W'),
 			qMax(fm.lineSpacing(), fm.height()) + m_lineSpace);
 	setSizeIncrement(m_cellSize);
 }
@@ -707,7 +707,7 @@ QVariant ShellWidget::TryGetQFontFromDescription(const QString& fdesc) const noe
 
 	// Italic
 	if ( fm_italic.averageCharWidth() != fm_italic.maxWidth() ||
-			fm_italic.maxWidth()*2 != fm_italic.width("MM") ) {
+			fm_italic.maxWidth()*2 != GetHorizontalAdvance(fm_italic, "MM") ) {
 		QFontInfo info(fi);
 		qDebug() << fi.family() << "Average and Maximum font width mismatch for Italic font; QFont::exactMatch() is" << fi.exactMatch()
 			<< "Real font is " << info.family() << info.pointSize();
@@ -716,7 +716,7 @@ QVariant ShellWidget::TryGetQFontFromDescription(const QString& fdesc) const noe
 
 	// Bold
 	if ( fm_bold.averageCharWidth() != fm_bold.maxWidth() ||
-			fm_bold.maxWidth()*2 != fm_bold.width("MM") ) {
+			fm_bold.maxWidth()*2 != GetHorizontalAdvance(fm_bold, "MM") ) {
 		QFontInfo info(fb);
 		qDebug() << fb.family() << "Average and Maximum font width mismatch for Bold font; QFont::exactMatch() is" << fb.exactMatch()
 			<< "Real font is " << info.family() << info.pointSize();
@@ -725,7 +725,7 @@ QVariant ShellWidget::TryGetQFontFromDescription(const QString& fdesc) const noe
 
 	// Bold+Italic
 	if ( fm_boldit.averageCharWidth() != fm_boldit.maxWidth() ||
-			fm_boldit.maxWidth()*2 != fm_boldit.width("MM") ) {
+			fm_boldit.maxWidth()*2 != GetHorizontalAdvance(fm_boldit, "MM") ) {
 		QFontInfo info(fbi);
 		qDebug() << fbi.family() << "Average and Maximum font width mismatch for Bold+Italic font; QFont::exactMatch() is" << fbi.exactMatch()
 			<< "Real font is " << info.family() << info.pointSize();

--- a/src/gui/shellwidget/shellwidget.cpp
+++ b/src/gui/shellwidget/shellwidget.cpp
@@ -242,11 +242,11 @@ void ShellWidget::paintEvent(QPaintEvent *ev)
 
 	p.setClipping(true);
 
-	foreach(QRect rect, ev->region().rects()) {
-		int start_row = rect.top() / m_cellSize.height();
-		int end_row = rect.bottom() / m_cellSize.height();
-		int start_col = rect.left() / m_cellSize.width();
-		int end_col = rect.right() / m_cellSize.width();
+	for (auto rect{ ev->region().cbegin() }; rect != ev->region().cend(); rect++) {
+		int start_row = rect->top() / m_cellSize.height();
+		int end_row = rect->bottom() / m_cellSize.height();
+		int start_col = rect->left() / m_cellSize.width();
+		int end_col = rect->right() / m_cellSize.width();
 
 		// Paint margins
 		if (end_col >= m_contents.columns()) {
@@ -347,24 +347,22 @@ void ShellWidget::paintEvent(QPaintEvent *ev)
 
 	p.setClipping(false);
 
-	QRect shellArea = absoluteShellRect(0, 0,
-				m_contents.rows(), m_contents.columns());
-	QRegion margins = QRegion(rect()).subtracted(shellArea);
-	foreach(QRect margin, margins.intersected(ev->region()).rects()) {
-		p.fillRect(margin, background());
+	const QRect shellArea{ absoluteShellRect(0, 0, m_contents.rows(), m_contents.columns()) };
+	const QRegion margins{ QRegion(rect()).subtracted(shellArea) };
+	const QRegion marginsIntersected{ margins.intersected(ev->region()) };
+	for (auto margin{ marginsIntersected.cbegin() }; margin != marginsIntersected.cend(); margin++) {
+		p.fillRect(*margin, background());
 	}
 
-#if 0
-	// Draw DEBUG rulers
-	for (int i=m_cellSize.width(); i<width(); i+=m_cellSize.width()) {
-		p.setPen(QPen(Qt::red, 1,  Qt::DashLine));
-		p.drawLine(i, 0, i, height());
-	}
-	for (int i=m_cellSize.height(); i<width(); i+=m_cellSize.height()) {
-		p.setPen(QPen(Qt::red, 1,  Qt::DashLine));
-		p.drawLine(0, i, width(), i);
-	}
-#endif
+	// Uncomment to draw Debug rulers
+	//for (int i=m_cellSize.width(); i<width(); i+=m_cellSize.width()) {
+	//	p.setPen(QPen(Qt::red, 1,  Qt::DashLine));
+	//	p.drawLine(i, 0, i, height());
+	//}
+	//for (int i=m_cellSize.height(); i<width(); i+=m_cellSize.height()) {
+	//	p.setPen(QPen(Qt::red, 1,  Qt::DashLine));
+	//	p.drawLine(0, i, width(), i);
+	//}
 }
 
 void ShellWidget::resizeEvent(QResizeEvent *ev)


### PR DESCRIPTION
**#Issue #639:** Bump minimum Qt Version

We should bump the minimum Qt version, several APIs in key areas are being deprecated in recent releases. For now 5.8 seems like a good balance. It is available almost everywhere and contains `QRegion` performance along with `QScrollEvent` modifications that are necessary to support most high-resolution touch pads.