### PR TITLE
Remove coveralls coverage reports

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,6 @@ jobs:
           name: Install dependencies
           command: |
             sudo apt-get install -y cmake libqt5svg5 libqt5svg5-dev neovim python3-dev python3-jinja2 python3-msgpack python3-pip qt5-default
-            pip install --user cpp-coveralls PyYAML
             sudo apt-get install -y lcov
       - run:
           name: build
@@ -38,9 +37,3 @@ jobs:
       - run:
           name: Upload coverage report to codecov
           command: bash <(curl -s https://codecov.io/bash) -f coverage.info 
-      - run:
-          name: Upload coverage report
-          # trick cpp-coveralls into doing the right thing
-          # https://github.com/eddyxu/cpp-coveralls/issues/143
-          command: TRAVIS_JOB_ID="#${CIRCLE_BUILD_NUM}" ~/.local/bin/cpp-coveralls -y contrib/coveralls-circle.yml -E '.*/build/.*' -E '.*/third-party/.*' -E '.*/test/.*' -E '.*/bindings/.*'
-

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ Neovim client library and GUI, in Qt5.
 [![Build Status](https://circleci.com/gh/equalsraf/neovim-qt.svg?style=svg)](https://circleci.com/gh/equalsraf/neovim-qt)
 [![Build status](https://ci.appveyor.com/api/projects/status/c252f54mfjcuud8x/branch/master?svg=true)](https://ci.appveyor.com/project/equalsraf/neovim-qt/branch/master)
 [![Build Status](https://travis-ci.org/equalsraf/neovim-qt.svg?branch=master)](https://travis-ci.org/equalsraf/neovim-qt)
-[![Coverage Status](https://coveralls.io/repos/github/equalsraf/neovim-qt/badge.svg?branch=master)](https://coveralls.io/github/equalsraf/neovim-qt?branch=master)
 [![codecov Status](https://codecov.io/gh/equalsraf/neovim-qt/branch/master/graph/badge.svg)](https://codecov.io/gh/equalsraf/neovim-qt)
 [![Build Status](https://dev.azure.com/equalsraf/neovim-qt/_apis/build/status/equalsraf.neovim-qt?branchName=master)](https://dev.azure.com/equalsraf/neovim-qt/_build/latest?definitionId=1&branchName=master)
 [![Downloads](https://img.shields.io/github/downloads/equalsraf/neovim-qt/total.svg?maxAge=2592000)](https://github.com/equalsraf/neovim-qt/releases)


### PR DESCRIPTION
Having issues with coveralls for PR opened by other users, we already
enabled codecov, so coveralls can be removed.

https://github.com/equalsraf/neovim-qt/issues/749