### PR TITLE
Fix GuiForeground()

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -99,6 +99,8 @@ void MainWindow::init(NeovimConnector *c)
 			this, &MainWindow::neovimWidgetResized);
 	connect(m_shell, &Shell::neovimMaximized,
 			this, &MainWindow::neovimMaximized);
+	connect(m_shell, &Shell::neovimForeground,
+			this, &MainWindow::neovimForeground);
 	connect(m_shell, &Shell::neovimSuspend,
 			this, &MainWindow::neovimSuspend);
 	connect(m_shell, &Shell::neovimFullScreen,
@@ -210,6 +212,13 @@ void MainWindow::neovimMaximized(bool set)
 	} else {
 		setWindowState(windowState() & ~Qt::WindowMaximized);
 	}
+}
+
+void MainWindow::neovimForeground()
+{
+	setWindowState(windowState() & ~Qt::WindowMinimized);
+	show();
+	activateWindow();
 }
 
 void MainWindow::neovimSuspend()

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -41,6 +41,7 @@ private slots:
 	void neovimSetTitle(const QString &title);
 	void neovimWidgetResized();
 	void neovimMaximized(bool);
+	void neovimForeground();
 	void neovimSuspend();
 	void neovimFullScreen(bool);
 	void neovimGuiCloseRequest();

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -750,8 +750,13 @@ void Shell::handleNeovimNotification(const QByteArray &name, const QVariantList&
 		if (guiEvName == "Font") {
 			handleGuiFontFunction(args);
 		} else if (guiEvName == "Foreground" && args.size() == 1) {
-			activateWindow();
-			raise();
+			if (isWindow()) {
+				setWindowState(windowState() & ~Qt::WindowMinimized);
+				show();
+				activateWindow();
+			} else {
+				emit neovimForeground();
+			}
 		} else if (guiEvName == "WindowMaximized" && args.size() == 2) {
 			if (isWindow()) {
 				setWindowState(variant_not_zero(args.at(1)) ?

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -83,6 +83,7 @@ signals:
 	void neovimResized(int rows, int cols);
 	void neovimAttached(bool);
 	void neovimMaximized(bool);
+	void neovimForeground();
 	void neovimSuspend();
 	void neovimFullScreen(bool);
 	void neovimGuiCloseRequest();


### PR DESCRIPTION
There were two issues with the function to bring to foreground:

1. unlike similar functions, when working with a widget there was not
   signal to the parent window
2. the current code doesn't seem to work with some window managers where
   the window remains minimized

-----

I dont see a change in my system, but see https://github.com/equalsraf/neovim-qt/issues/757