### PR TITLE
Fix Clazy Warning: clazy-qstring-arg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,6 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR
 			"no-overloaded-signal,"
 			"no-qenums,"
 			"no-qgetenv,"
-			"no-qstring-arg,"
 			"no-qstring-ref,"
 			"no-unused-non-trivial-variable,"
 			"level1",

--- a/src/function.cpp
+++ b/src/function.cpp
@@ -174,14 +174,14 @@ QString Function::signature() const
 {
 	QStringList sigparams;
 	foreach(const StringPair p, parameters) {
-		sigparams.append(QString("%1 %2").arg(p.first).arg(p.second));
+		sigparams.append(QString("%1 %2").arg(p.first, p.second));
 	}
 
 	QString notes;
 	if (can_fail) {
 		notes += " !fail";
 	}
-	return  QString("%1 %2(%3)%4").arg(return_type).arg(name).arg(sigparams.join(", ")).arg(notes);
+	return  QString("%1 %2(%3)%4").arg(return_type, name, sigparams.join(", "), notes);
 }
 
 } // Namespace

--- a/src/gui/input.cpp
+++ b/src/gui/input.cpp
@@ -116,17 +116,13 @@ QString convertMouse(
 		return {};
 	}
 
-	return QString{ "<%1%2%3><%4,%5>" }
-		.arg(GetModifierPrefix(mod))
-		.arg(varButtonName.toString())
-		.arg(GetEventString(type))
-		.arg(pos.x())
-		.arg(pos.y());
+	return QString{ "<%1%2%3><%4,%5>" }.arg(GetModifierPrefix(mod), varButtonName.toString(), GetEventString(type))
+		.arg(pos.x(), pos.y());
 }
 
 QString ToKeyString(const QString& modPrefix, const QString& key) noexcept
 {
-	return QString{ "<%1%2>" }.arg(modPrefix).arg(key);
+	return QString{ "<%1%2>" }.arg(modPrefix, key);
 }
 
 QString convertKey(const QKeyEvent& ev) noexcept

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -1356,14 +1356,12 @@ void Shell::wheelEvent(QWheelEvent *ev)
 	QString inp;
 	if (scroll_delta.y() != 0) {
 		inp += QString("<%1ScrollWheel%2><%3,%4>")
-			.arg(Input::GetModifierPrefix(ev->modifiers()))
-			.arg(scroll_delta.y() > 0 ? "Up" : "Down")
-			.arg(pos.x()).arg(pos.y());
+			.arg(Input::GetModifierPrefix(ev->modifiers()), scroll_delta.y() > 0 ? "Up" : "Down")
+			.arg(pos.x(), pos.y());
 	}
 	if (scroll_delta.x() != 0) {
 		inp += QString("<%1ScrollWheel%2><%3,%4>")
-			.arg(Input::GetModifierPrefix(ev->modifiers()))
-			.arg(scroll_delta.x() > 0 ? "Left" : "Right")
+			.arg(Input::GetModifierPrefix(ev->modifiers()), (scroll_delta.x() > 0) ? "Left" : "Right")
 			.arg(pos.x()).arg(pos.y());
 	}
 	m_nvim->api0()->vim_input(inp.toLatin1());


### PR DESCRIPTION
Each call to `.arg` results in a temporary QString.

The following is an anti-pattern:
```C++
QString str{ "<%1 %2, %3> " }.arg(str1).arg(str2).arg(str3);
```

A faster multi-arg API exists, use whenever possible:
```C++
QString str{ "<%1 %2, %3> " }.arg(str1, str2, str3);
```