### PR TITLE
Fix Clazy Warning: clazy-qgetenv

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,6 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR
 			"no-lambda-in-connect,"
 			"no-overloaded-signal,"
 			"no-qenums,"
-			"no-qgetenv,"
 			"no-qstring-ref,"
 			"level1",
 			"no-connect-3arg-lambda,"

--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -65,7 +65,7 @@ App::App(int &argc, char ** argv) noexcept
 	}
 #endif
 
-	if (!qgetenv("NVIM_QT_LOG").isEmpty()) {
+	if (!qEnvironmentVariableIsEmpty("NVIM_QT_LOG")) {
 		qInstallMessageHandler(logger);
 	}
 


### PR DESCRIPTION
According to Qt documentation, `qEnvironmentVariableIsEmpty` is potentially
much faster than `qgetenv(...).isEmpty()` and can't throw exceptions.