### PR TITLE
Fix Clazy Warning: clazy-empty-qstringliteral

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,6 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR
 			"level0",
 			"no-connect-not-normalized,"
 			"no-container-anti-pattern,"
-			"no-empty-qstringliteral,"
 			"no-fully-qualified-moc-types,"
 			"no-lambda-in-connect,"
 			"no-overloaded-signal,"

--- a/src/gui/input.cpp
+++ b/src/gui/input.cpp
@@ -77,7 +77,7 @@ static QVariant GetButtonName(
 			return QStringLiteral("Middle");
 
 		case Qt::NoButton:
-			return QStringLiteral("");
+			return QLatin1String{""};
 
 		default:
 			return {}; // Invalid

--- a/src/gui/shellwidget/shellwidget.cpp
+++ b/src/gui/shellwidget/shellwidget.cpp
@@ -321,7 +321,7 @@ QFont ShellWidget::GetCellFont(const Cell& cell) const noexcept
 
 	// Issue #575: Clear style name. The KDE/Plasma theme plugin may set this
 	// but we want to match the family name with the bold/italic attributes.
-	cellFont.setStyleName(QStringLiteral(""));
+	cellFont.setStyleName({});
 
 	cellFont.setStyleHint(QFont::TypeWriter, QFont::StyleStrategy(QFont::PreferDefault | QFont::ForceIntegerMetrics));
 	cellFont.setFixedPitch(true);


### PR DESCRIPTION
The `QStringLiteral` macro is only useful when it prevents memory allocations.

For an empty string `QString{}` or `QLatin1String("")` are faster depending on the desired behavior for `isNull()` and `isEmpty()`.