### PR TITLE
Fix Clazy Warning: clazy-container-anti-pattern

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,6 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR
 		string(CONCAT CLAZY_CHECKS
 			"level0",
 			"no-connect-not-normalized,"
-			"no-container-anti-pattern,"
 			"no-fully-qualified-moc-types,"
 			"no-lambda-in-connect,"
 			"no-overloaded-signal,"

--- a/test/tst_input_mac.cpp
+++ b/test/tst_input_mac.cpp
@@ -41,9 +41,9 @@ void TestInputMac::LessThanModifierKeys() noexcept
 
 void TestInputMac::SpecialKeys() noexcept
 {
-	const QMap<int, QString>& specialKeys { NeovimQt::Input::GetSpecialKeysMap() };
+	const QList<int> specialKeys{ NeovimQt::Input::GetSpecialKeysMap().keys() };
 
-	for (const auto k : specialKeys.keys()) {
+	for (const auto k : specialKeys) {
 		// On Mac Meta is the Control key, treated as C-.
 		QList<QPair<QKeyEvent, QString>> keyEventList{
 			{ { QEvent::KeyPress, k, Qt::NoModifier, {} },      "<%1>" },
@@ -54,7 +54,7 @@ void TestInputMac::SpecialKeys() noexcept
 
 		for (const auto& keyEvent : keyEventList) {
 			QCOMPARE(NeovimQt::Input::convertKey(keyEvent.first),
-				keyEvent.second.arg(specialKeys.value(k)));
+				keyEvent.second.arg(NeovimQt::Input::GetSpecialKeysMap().value(k)));
 		}
 	}
 }

--- a/test/tst_input_unix.cpp
+++ b/test/tst_input_unix.cpp
@@ -26,9 +26,9 @@ void TestInputUnix::LessThanModifierKeys() noexcept
 
 void TestInputUnix::SpecialKeys() noexcept
 {
-	const QMap<int, QString>& specialKeys { NeovimQt::Input::GetSpecialKeysMap() };
+	const QList<int> specialKeys{ NeovimQt::Input::GetSpecialKeysMap().keys() };
 
-	for (const auto k : specialKeys.keys()) {
+	for (const auto k : specialKeys) {
 		// On Mac Meta is the Control key, treated as C-.
 		QList<QPair<QKeyEvent, QString>> keyEventList{
 			{ { QEvent::KeyPress, k, Qt::NoModifier, {} },      "<%1>" },
@@ -39,7 +39,7 @@ void TestInputUnix::SpecialKeys() noexcept
 
 		for (const auto& keyEvent : keyEventList) {
 			QCOMPARE(NeovimQt::Input::convertKey(keyEvent.first),
-				keyEvent.second.arg(specialKeys.value(k)));
+				keyEvent.second.arg(NeovimQt::Input::GetSpecialKeysMap().value(k)));
 		}
 	}
 }

--- a/test/tst_input_win32.cpp
+++ b/test/tst_input_win32.cpp
@@ -26,9 +26,9 @@ void TestInputWin32::LessThanModifierKeys() noexcept
 
 void TestInputWin32::SpecialKeys() noexcept
 {
-	const QMap<int, QString>& specialKeys { NeovimQt::Input::GetSpecialKeysMap() };
+	const QList<int> specialKeys{ NeovimQt::Input::GetSpecialKeysMap().keys() };
 
-	for (const auto k : specialKeys.keys()) {
+	for (const auto k : specialKeys) {
 		// On Mac Meta is the Control key, treated as C-.
 		QList<QPair<QKeyEvent, QString>> keyEventList{
 			{ { QEvent::KeyPress, k, Qt::NoModifier, {} },      "<%1>" },
@@ -39,7 +39,7 @@ void TestInputWin32::SpecialKeys() noexcept
 
 		for (const auto& keyEvent : keyEventList) {
 			QCOMPARE(NeovimQt::Input::convertKey(keyEvent.first),
-				keyEvent.second.arg(specialKeys.value(k)));
+				keyEvent.second.arg(NeovimQt::Input::GetSpecialKeysMap().value(k)));
 		}
 	}
 }


### PR DESCRIPTION
The tst_input_{platform}.cpp code is only using the keys from from QMap<K,V>.

Type QList<K> should be used instead.