### PR TITLE
Fix Clazy Warning: clazy-overloaded-signal

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,6 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR
 			"no-container-anti-pattern,"
 			"no-fully-qualified-moc-types,"
 			"no-lambda-in-connect,"
-			"no-overloaded-signal,"
 			"no-qenums,"
 			"level1",
 			"no-connect-3arg-lambda,"

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -147,11 +147,6 @@ void MainWindow::init(NeovimConnector *c)
 	}
 }
 
-bool MainWindow::neovimAttached() const
-{
-	return (m_shell != NULL && m_shell->neovimAttached());
-}
-
 /** The Neovim process has exited */
 void MainWindow::neovimExited(int status)
 {
@@ -304,7 +299,6 @@ void MainWindow::showIfDelayed()
 
 void MainWindow::neovimAttachmentChanged(bool attached)
 {
-	emit neovimAttached(attached);
 	if (attached) {
 		if (isWindow() && m_shell != NULL) {
 			m_shell->updateGuiWindowState(windowState());
@@ -313,6 +307,8 @@ void MainWindow::neovimAttachmentChanged(bool attached)
 		m_tabline->deleteLater();
 		m_tabline_bar->deleteLater();
 	}
+
+	emit neovimAttached(attached);
 }
 
 Shell* MainWindow::shell()

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -27,7 +27,12 @@ public:
 	};
 
 	MainWindow(NeovimConnector *, ShellOptions opts, QWidget *parent=0);
-	bool neovimAttached() const;
+
+	bool isNeovimAttached() const
+	{
+		return m_shell && m_shell->isNeovimAttached();
+	}
+
 	Shell* shell();
 	void restoreWindowGeometry();
 public slots:

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -43,15 +43,28 @@ public:
 class Shell: public ShellWidget
 {
 	Q_OBJECT
-	Q_PROPERTY(bool neovimBusy READ neovimBusy() NOTIFY neovimBusy())
-	Q_PROPERTY(bool neovimAttached READ neovimAttached() NOTIFY neovimAttached())
+
+	Q_PROPERTY(bool neovimBusy MEMBER m_neovimBusy \
+		READ isNeovimBusy NOTIFY neovimBusyChanged)
+
+	Q_PROPERTY(bool neovimAttached MEMBER m_attached \
+		READ isNeovimAttached WRITE setAttached NOTIFY neovimAttachedChanged)
+
 public:
 	Shell(NeovimConnector *nvim, ShellOptions opts, QWidget *parent=0);
 	~Shell();
 	QSize sizeIncrement() const;
 	virtual QVariant inputMethodQuery(Qt::InputMethodQuery) const Q_DECL_OVERRIDE;
-	bool neovimBusy() const;
-	bool neovimAttached() const;
+
+	bool isNeovimBusy() const
+	{
+		return m_neovimBusy;
+	}
+
+	bool isNeovimAttached() const
+	{
+		return m_attached;
+	}
 
 	PopupMenu& getPopupMenu() noexcept
 	{
@@ -79,9 +92,9 @@ public:
 
 signals:
 	void neovimTitleChanged(const QString &title);
-	void neovimBusy(bool);
+	void neovimBusyChanged(bool);
 	void neovimResized(int rows, int cols);
-	void neovimAttached(bool);
+	void neovimAttachedChanged(bool);
 	void neovimMaximized(bool);
 	void neovimSuspend();
 	void neovimFullScreen(bool);
@@ -187,7 +200,7 @@ protected:
 	QString neovimErrorToString(const QVariant& err);
 
 private slots:
-        void setAttached(bool attached=true);
+	void setAttached(bool isAttached);
 
 private:
 	bool m_attached{ false };

--- a/test/tst_shell.cpp
+++ b/test/tst_shell.cpp
@@ -52,7 +52,7 @@ private slots:
 		QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
 		QVERIFY(onAttached.isValid());
 		QVERIFY(SPYWAIT(onAttached));
-		QVERIFY(s->neovimAttached());
+		QVERIFY(s->isNeovimAttached());
 
 		s->repaint();
 
@@ -68,7 +68,7 @@ private slots:
 		QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
 		QVERIFY(onAttached.isValid());
 		QVERIFY(SPYWAIT(onAttached));
-		QVERIFY(s->neovimAttached());
+		QVERIFY(s->isNeovimAttached());
 		checkStartVars(c);
 	}
 
@@ -80,7 +80,7 @@ private slots:
 		QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
 		QVERIFY(onAttached.isValid());
 		QVERIFY(SPYWAIT(onAttached));
-		QVERIFY(s->neovimAttached());
+		QVERIFY(s->isNeovimAttached());
 		checkStartVars(c);
 	}
 
@@ -104,7 +104,7 @@ private slots:
 		QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
 		QVERIFY(onAttached.isValid());
 		QVERIFY(SPYWAIT(onAttached));
-		QVERIFY(s->neovimAttached());
+		QVERIFY(s->isNeovimAttached());
 
 		auto req = c->api0()->vim_command_output(c->encode("echo g:test_gviminit"));
 		QSignalSpy cmd(req, SIGNAL(finished(quint32, quint64, QVariant)));
@@ -129,7 +129,7 @@ private slots:
 		QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
 		QVERIFY(onAttached.isValid());
 		QVERIFY(SPYWAIT(onAttached));
-		QVERIFY(s->neovimAttached());
+		QVERIFY(s->isNeovimAttached());
 
 		QObject::connect(c->neovimObject(), &NeovimApi1::err_vim_command_output, [](QString msg, const QVariant& err) {
 				qDebug() << msg << err;
@@ -223,7 +223,7 @@ private slots:
 		QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
 		QVERIFY(onAttached.isValid());
 		QVERIFY(SPYWAIT(onAttached));
-		QVERIFY(s->neovimAttached());
+		QVERIFY(s->isNeovimAttached());
 
 		QObject::connect(c->neovimObject(), &NeovimApi1::err_vim_command_output, [](QString msg, const QVariant& err) {
 				qDebug() << msg << err;
@@ -284,7 +284,7 @@ private slots:
 		QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
 		QVERIFY(onAttached.isValid());
 		QVERIFY(SPYWAIT(onAttached));
-		QVERIFY(s->neovimAttached());
+		QVERIFY(s->isNeovimAttached());
 
 		QObject::connect(c->neovimObject(), &NeovimApi1::err_vim_command_output, [](QString msg, const QVariant& err) {
 				qDebug() << msg << err;


### PR DESCRIPTION
Qt signals should not be overloaded, change names.