### PR TITLE
Fix Clazy Warning: clazy-connect-not-normalized

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,6 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR
 	if(ENABLE_CLAZY)
 		string(CONCAT CLAZY_CHECKS
 			"level0",
-			"no-connect-not-normalized,"
 			"no-fully-qualified-moc-types,"
 			"no-lambda-in-connect,"
 			"no-overloaded-signal,"

--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -118,8 +118,8 @@ void App::showUi() noexcept
 #else
 	NeovimQt::MainWindow *win = new NeovimQt::MainWindow(m_connector.get(), opts);
 
-	QObject::connect(instance(), SIGNAL(openFilesTriggered(const QList<QUrl>)),
-		win->shell(), SLOT(openFiles(const QList<QUrl>)));
+	QObject::connect(instance(), SIGNAL(openFilesTriggered(QList<QUrl>)),
+		win->shell(), SLOT(openFiles(QList<QUrl>)));
 
 	// Window geometry should be restored only when the user does not specify
 	// one of the following command line arguments. Argument "maximized" can

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -93,8 +93,8 @@ void MainWindow::init(NeovimConnector *c)
 
 	connect(m_shell, SIGNAL(neovimAttached(bool)),
 			this, SLOT(neovimAttachmentChanged(bool)));
-	connect(m_shell, SIGNAL(neovimTitleChanged(const QString &)),
-			this, SLOT(neovimSetTitle(const QString &)));
+	connect(m_shell, SIGNAL(neovimTitleChanged(QString)),
+			this, SLOT(neovimSetTitle(QString)));
 	connect(m_shell, &Shell::neovimResized,
 			this, &MainWindow::neovimWidgetResized);
 	connect(m_shell, &Shell::neovimMaximized,

--- a/src/neovimconnector.cpp
+++ b/src/neovimconnector.cpp
@@ -278,7 +278,7 @@ NeovimConnector* NeovimConnector::spawn(const QStringList& params, const QString
 
 	connect(p, SIGNAL(error(QProcess::ProcessError)),
 			c, SLOT(processError(QProcess::ProcessError)));
-	connect(p, SIGNAL(finished(int, QProcess::ExitStatus)),
+	connect(p, SIGNAL(finished(int,QProcess::ExitStatus)),
 			c, SIGNAL(processExited(int)));
 	connect(p, &QProcess::started,
 			c, &NeovimConnector::discoverMetadata);


### PR DESCRIPTION
See QMetaObject::normalizedSignature, signal/slot connection should not have
certain modifiers (whitespace, &, const, etc). These can negatively impact
performance.