### PR TITLE
Fix AppVeyor Break

### DIFF
--- a/contrib/appveyor.yml
+++ b/contrib/appveyor.yml
@@ -6,14 +6,14 @@ image:
 environment:
   matrix:
   - PlatformToolset: MinGW-Win64
-    QTPATH: C:\Qt\5.15.0\mingw81_64
+    QTPATH: C:\Qt\5.15.1\mingw81_64
     GENERATOR: MinGW Makefiles
     RELEASE_ARTIFACT: true
-    CMAKE_PATH_PREFIX: C:\Qt\5.15.0\mingw81_64\lib\cmake
+    CMAKE_PATH_PREFIX: C:\Qt\5.15.1\mingw81_64\lib\cmake
   - PlatformToolset: VisualStudio2019
-    QTPATH: C:\Qt\5.15.0\msvc2019_64
+    QTPATH: C:\Qt\5.15.1\msvc2019_64
     GENERATOR: Visual Studio 16
-    CMAKE_PATH_PREFIX: C:\Qt\5.15.0\msvc2019_64\lib\cmake
+    CMAKE_PATH_PREFIX: C:\Qt\5.15.1\msvc2019_64\lib\cmake
 configuration:
 - RelWithDebInfo
 matrix:
@@ -24,7 +24,7 @@ install:
 - set PATH=%PATH%;%CD%\Neovim\bin;
 - nvim --version
 # sh.exe must not be in the PATH
-- if "%PlatformToolset%"=="MinGW-Win64" set PATH=%PATH%;C:\Qt\5.15.0\mingw81_64\bin;C:\Qt\Tools\mingw810_64\bin;C:\Program Files\Git\usr\bin
+- if "%PlatformToolset%"=="MinGW-Win64" set PATH=%PATH%;C:\Qt\5.15.1\mingw81_64\bin;C:\Qt\Tools\mingw810_64\bin;C:\Program Files\Git\usr\bin
 - if "%PlatformToolset%"=="VisualStudio2019" call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat"
 build_script:
 - cd "%APPVEYOR_BUILD_FOLDER%"


### PR DESCRIPTION
AppVeyor bumped Qt 5.15.0 to 5.15.1, update paths accordingly.