### PR TITLE
Issue784: ScrollWheel Event Malformed

### DIFF
--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -58,6 +58,14 @@ public:
 		return m_pum;
 	}
 
+	/// Convert QWheelEvent to Neovim wheel event string. Testable.
+	/// NOTE: Sums and stores partial wheel events in outparam `scrollRemainderOut`
+	static QString GetWheelEventStringAndSetScrollRemainder(
+		const QWheelEvent& ev,
+		QPoint& scrollRemainderOut,
+		QSize cellSize,
+		int deltasPerStep = QWheelEvent::DefaultDeltasPerStep) noexcept;
+
 	/// Lookup highlight by name from hl_group_set
 	HighlightAttribute GetHighlightGroup(const QString& name) const noexcept
 	{
@@ -229,8 +237,7 @@ private:
 	uint8_t m_mouseclick_count{ 0 };
 	Qt::MouseButton m_mouseclick_pending;
 	// Accumulates remainder of steppy scroll
-	QPointF m_scroll_remainder;
-	QPoint m_scroll_last_direction;
+	QPoint m_scrollDeltaRemainder;
 
 	// Properties
 	bool m_neovimBusy{ false };


### PR DESCRIPTION
**Issue #784:** We send invalid scroll events with floating point positions.

Bad output example:
`<ScrollWheelRight><86.25,28.8667>`.

There is a floating-point error. Likely introduced in: Qt Version bump, 3a59d6b, 6e30998.

Refactor the code to make it testable, and correct the rounding error.