### PR TITLE
Issue 794: Tavis CI timeout on brew install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: false
 language: cpp
 os:
   - osx
+osx_image: xcode12.2
 compiler:
   - gcc
   - clang


### PR DESCRIPTION
**Issue #794:** Travis uses an old MacOS version by default (10.13) and this is not supported by brew.

We should explicitly set a more recent `osx_image`.