### PR TITLE
Add Scroll Event Test Coverage

### DIFF
--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -1354,42 +1354,22 @@ void Shell::wheelEvent(QWheelEvent *ev)
 	const QString evString{ GetWheelEventStringAndSetScrollRemainder(
 		*ev, m_scrollDeltaRemainder, cellSize()) };
 
-	qDebug() << ev;
-	qDebug() << "  angleDelta:" << ev->angleDelta();
-	qDebug() << "  button:" << ev->buttons();
-	qDebug() << "  globalPosition:" << ev->globalPosition();
-	qDebug() << "  inverted:" << ev->inverted();
-	qDebug() << "  phase:" << ev->phase();
-	qDebug() << "  pixelDelta:" << ev->pixelDelta();
-	qDebug() << "  position:" << ev->position();
-	qDebug() << "  source:" << ev->source();
-	qDebug() << "  deltasPerStep:" << QWheelEvent::DefaultDeltasPerStep;
-	qDebug() << "  m_scrollDeltaRemainder:" << QWheelEvent::DefaultDeltasPerStep;
-	if (!evString.isEmpty()) {
-		qDebug() << "  evString:" << evString;
-	}
-	qDebug();
+	// Uncomment for scroll input debugging and unit test writing.
+	// qDebug() << ev;
+	// qDebug() << "  button:" << ev->buttons();
+	// qDebug() << "  globalPosition:" << ev->globalPosition();
+	// qDebug() << "  inverted:" << ev->inverted();
+	// qDebug() << "  phase:" << ev->phase();
+	// qDebug() << "  position:" << ev->position();
+	// qDebug() << "  source:" << ev->source();
+	// qDebug() << "  deltasPerStep:" << QWheelEvent::DefaultDeltasPerStep;
+	// qDebug() << "  m_scrollDeltaRemainder:" << m_scrollDeltaRemainder;
+	// qDebug() << "  evString:" << evString;
 
+	// Skip sending empty strings to Neovim
 	if (evString.isEmpty()) {
 		return;
 	}
-
-	qDebug() << ev;
-	qDebug() << "  angleDelta:" << ev->angleDelta();
-	qDebug() << "  button:" << ev->buttons();
-	qDebug() << "  globalPosition:" << ev->globalPosition();
-	qDebug() << "  inverted:" << ev->inverted();
-	qDebug() << "  phase:" << ev->phase();
-	qDebug() << "  pixelDelta:" << ev->pixelDelta();
-	qDebug() << "  position:" << ev->position();
-	qDebug() << "  source:" << ev->source();
-	qDebug() << "  deltasPerStep:" << QWheelEvent::DefaultDeltasPerStep;
-	qDebug() << "  m_scrollDeltaRemainder:" << m_scrollDeltaRemainder;
-	if (!evString.isEmpty()) {
-		qDebug() << "    evString:" << evString;
-	}
-	qDebug();
-
 
 	m_nvim->api0()->vim_input(evString.toLatin1());
 }

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -1354,9 +1354,42 @@ void Shell::wheelEvent(QWheelEvent *ev)
 	const QString evString{ GetWheelEventStringAndSetScrollRemainder(
 		*ev, m_scrollDeltaRemainder, cellSize()) };
 
+	qDebug() << ev;
+	qDebug() << "  angleDelta:" << ev->angleDelta();
+	qDebug() << "  button:" << ev->buttons();
+	qDebug() << "  globalPosition:" << ev->globalPosition();
+	qDebug() << "  inverted:" << ev->inverted();
+	qDebug() << "  phase:" << ev->phase();
+	qDebug() << "  pixelDelta:" << ev->pixelDelta();
+	qDebug() << "  position:" << ev->position();
+	qDebug() << "  source:" << ev->source();
+	qDebug() << "  deltasPerStep:" << QWheelEvent::DefaultDeltasPerStep;
+	qDebug() << "  m_scrollDeltaRemainder:" << QWheelEvent::DefaultDeltasPerStep;
+	if (!evString.isEmpty()) {
+		qDebug() << "  evString:" << evString;
+	}
+	qDebug();
+
 	if (evString.isEmpty()) {
 		return;
 	}
+
+	qDebug() << ev;
+	qDebug() << "  angleDelta:" << ev->angleDelta();
+	qDebug() << "  button:" << ev->buttons();
+	qDebug() << "  globalPosition:" << ev->globalPosition();
+	qDebug() << "  inverted:" << ev->inverted();
+	qDebug() << "  phase:" << ev->phase();
+	qDebug() << "  pixelDelta:" << ev->pixelDelta();
+	qDebug() << "  position:" << ev->position();
+	qDebug() << "  source:" << ev->source();
+	qDebug() << "  deltasPerStep:" << QWheelEvent::DefaultDeltasPerStep;
+	qDebug() << "  m_scrollDeltaRemainder:" << m_scrollDeltaRemainder;
+	if (!evString.isEmpty()) {
+		qDebug() << "    evString:" << evString;
+	}
+	qDebug();
+
 
 	m_nvim->api0()->vim_input(evString.toLatin1());
 }
@@ -1374,13 +1407,8 @@ void Shell::wheelEvent(QWheelEvent *ev)
 	scrollRemainderOut.rx() = scrollRemainderAndEvent.x() % deltasPerStep;
 	scrollRemainderOut.ry() = scrollRemainderAndEvent.y() % deltasPerStep;
 
-	const bool isScrollDeltaOverflow{ scrollRemainderAndEvent.x() >= deltasPerStep
-		|| scrollRemainderAndEvent.x() <= -deltasPerStep
-		|| scrollRemainderAndEvent.y() >= deltasPerStep
-		|| scrollRemainderAndEvent.y() <= -deltasPerStep };
-
-	if (!isScrollDeltaOverflow)
-	{
+	// FIXME Comment
+	if (scrollRemainderAndEvent == scrollRemainderOut) {
 		return {};
 	}
 
@@ -1394,18 +1422,18 @@ void Shell::wheelEvent(QWheelEvent *ev)
 	QPoint evCellPos{ evPos.x() / cellSize.width(), evPos.y() / cellSize.height() };
 
 	QString wheelEventString;
-	if (scrollRemainderAndEvent.y() > 0) {
+	if (scrollRemainderAndEvent.y() >= deltasPerStep) {
 		wheelEventString += QStringLiteral("<%1ScrollWheelUp><%2,%3>");
 	}
-	else if (scrollRemainderAndEvent.y() < 0) {
+	else if (scrollRemainderAndEvent.y() <= -deltasPerStep) {
 		wheelEventString += QStringLiteral("<%1ScrollWheelDown><%2,%3>");
 	}
 
-	if (scrollRemainderAndEvent.x() < 0) {
-		wheelEventString += QStringLiteral("<%1ScrollWheelRight><%2,%3>");
-	}
-	else if (scrollRemainderAndEvent.x() > 0) {
+	if (scrollRemainderAndEvent.x() >= deltasPerStep) {
 		wheelEventString += QStringLiteral("<%1ScrollWheelLeft><%2,%3>");
+	}
+	else if (scrollRemainderAndEvent.x() <= -deltasPerStep) {
+		wheelEventString += QStringLiteral("<%1ScrollWheelRight><%2,%3>");
 	}
 
 	return wheelEventString.arg(Input::GetModifierPrefix(ev.modifiers())).arg(evCellPos.x()).arg(evCellPos.y());

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -38,6 +38,7 @@ add_xtest(tst_callallmethods)
 add_xtest(tst_encoding)
 add_xtest(tst_msgpackiodevice)
 add_xtest_gui(tst_shell)
+add_xtest_gui(tst_scroll)
 add_xtest_gui(tst_main)
 
 # Platform Specific Input Tests

--- a/test/tst_scroll.cpp
+++ b/test/tst_scroll.cpp
@@ -1,0 +1,291 @@
+#include <gui/input.h>
+#include <gui/shell.h>
+#include <QtTest/QtTest>
+
+#include "common.h"
+
+#if defined(Q_OS_WIN) && defined(USE_STATIC_QT)
+#include <QtPlugin>
+Q_IMPORT_PLUGIN (QWindowsIntegrationPlugin);
+#endif
+
+namespace NeovimQt {
+
+// FIXME Comment?
+constexpr QSize cellSize{ 10, 10 };
+constexpr int deltasPerStep { 120 };
+constexpr int scrollEventSize{ 8 };
+constexpr int eventsPerScroll{ deltasPerStep / scrollEventSize };
+
+class TestScroll : public QObject
+{
+	Q_OBJECT
+
+private slots:
+	void ScrollUp() noexcept;
+	void ScrollDown() noexcept;
+	void ScrollLeft() noexcept;
+	void ScrollRight() noexcept;
+	void ScrollDiagonal() noexcept;
+	void ScrollAccumulation() noexcept;
+	void ScrollModifiers() noexcept;
+	void ScrollHighResolution() noexcept;
+	void ScrollInvertedEvents() noexcept;
+};
+
+static void RepeatWheelEventsNTimesAndAssertEmpty(
+	uint32_t repeatCount,
+	QPoint& scrollRemainder,
+	const std::vector<QWheelEvent>& evList) noexcept
+{
+	for (uint32_t i = 0; i < repeatCount; i++) {
+		for (const auto& ev : evList) {
+			const QString evEmptyString{ Shell::GetWheelEventStringAndSetScrollRemainder(
+				ev, scrollRemainder, cellSize, deltasPerStep) };
+			QVERIFY(evEmptyString.isEmpty());
+		}
+	}
+}
+
+void TestScroll::ScrollUp() noexcept
+{
+	const QWheelEvent evScrollUp{
+		QPointF{ 100.0, 100.0 } /*pos*/,
+		QPointF{ 200.0, 200.0 } /*globalPos*/,
+		QPoint{ 0, 0 } /*pixelDelta*/,
+		QPoint{ 0, scrollEventSize } /*angleDelta*/,
+		Qt::NoButton /*buttons*/,
+		Qt::NoModifier/*modifiers*/,
+		Qt::NoScrollPhase,
+		false /*inverted*/
+	};
+
+	QPoint scrollRemainder{ 100, 0 };
+
+	RepeatWheelEventsNTimesAndAssertEmpty(eventsPerScroll - 1, scrollRemainder, { evScrollUp } );
+
+	const QString evStringScrollUp{ Shell::GetWheelEventStringAndSetScrollRemainder(
+		evScrollUp, scrollRemainder, cellSize, deltasPerStep) };
+
+	QCOMPARE(evStringScrollUp, QString{ "<ScrollWheelUp><10,10>" });
+}
+
+void TestScroll::ScrollDown() noexcept
+{
+	const QWheelEvent evScrollDown{
+		QPointF{ 120.0, 199.0 } /*pos*/,
+		QPointF{ 200.0, 200.0 } /*globalPos*/,
+		QPoint{ 0, 0 } /*pixelDelta*/,
+		QPoint{ 0, -scrollEventSize } /*angleDelta*/,
+		Qt::NoButton /*buttons*/,
+		Qt::NoModifier /*modifiers*/,
+		Qt::NoScrollPhase,
+		false /*inverted*/
+	};
+
+	QPoint scrollRemainder{ 100, 0 };
+
+	RepeatWheelEventsNTimesAndAssertEmpty(eventsPerScroll - 1, scrollRemainder, { evScrollDown } );
+
+	const QString evStringScrollDown{ Shell::GetWheelEventStringAndSetScrollRemainder(
+		evScrollDown, scrollRemainder, cellSize, deltasPerStep) };
+
+	QCOMPARE(evStringScrollDown, QString{ "<ScrollWheelDown><12,19>" });
+}
+
+void TestScroll::ScrollLeft() noexcept
+{
+	const QWheelEvent evScrollLeft{
+		QPointF{ 9.0, 5.0 } /*pos*/,
+		QPointF{ 200.0, 200.0 } /*globalPos*/,
+		QPoint{ 0, 0 } /*pixelDelta*/,
+		QPoint{ scrollEventSize, 0 } /*angleDelta*/,
+		Qt::NoButton /*buttons*/,
+		Qt::NoModifier /*modifiers*/,
+		Qt::NoScrollPhase,
+		false /*inverted*/
+	};
+
+	QPoint scrollRemainder{ 0, 100 };
+
+	RepeatWheelEventsNTimesAndAssertEmpty(eventsPerScroll - 1, scrollRemainder, { evScrollLeft});
+
+	const QString evStringScrollLeft{ Shell::GetWheelEventStringAndSetScrollRemainder(
+		evScrollLeft, scrollRemainder, cellSize, deltasPerStep) };
+
+	QCOMPARE(evStringScrollLeft, QString{ "<ScrollWheelLeft><0,0>" });
+}
+
+void TestScroll::ScrollRight() noexcept
+{
+	const QWheelEvent evScrollRight{
+		QPointF{ 300.0, 150.0 } /*pos*/,
+		QPointF{ 200.0, 200.0 } /*globalPos*/,
+		QPoint{ 0, 0 } /*pixelDelta*/,
+		QPoint{ -scrollEventSize, 0 } /*angleDelta*/,
+		Qt::NoButton /*buttons*/,
+		Qt::NoModifier /*modifiers*/,
+		Qt::NoScrollPhase,
+		false /*inverted*/
+	};
+
+	QPoint scrollRemainder{ 0, 100 };
+
+	RepeatWheelEventsNTimesAndAssertEmpty(eventsPerScroll - 1, scrollRemainder, { evScrollRight });
+
+	const QString evStringScrollRight{ Shell::GetWheelEventStringAndSetScrollRemainder(
+		evScrollRight, scrollRemainder, cellSize, deltasPerStep) };
+
+	QCOMPARE(evStringScrollRight, QString{ "<ScrollWheelRight><30,15>" });
+}
+
+void TestScroll::ScrollDiagonal() noexcept
+{
+	// Combined Event: Up + Left
+	const QWheelEvent evScrollUpLeft{
+		QPointF{ 100.0, 100.0 } /*pos*/,
+		QPointF{ 200.0, 200.0 } /*globalPos*/,
+		QPoint{ 0, 0 } /*pixelDelta*/,
+		QPoint{ scrollEventSize, scrollEventSize } /*angleDelta*/,
+		Qt::NoButton /*buttons*/,
+		Qt::NoModifier /*modifiers*/,
+		Qt::NoScrollPhase,
+		false /*inverted*/
+	};
+
+	QPoint scrollRemainder{ 0, 0 };
+
+	RepeatWheelEventsNTimesAndAssertEmpty(eventsPerScroll - 1, scrollRemainder, { evScrollUpLeft });
+
+	const QString evStringScrollUpLeft{ Shell::GetWheelEventStringAndSetScrollRemainder(
+		evScrollUpLeft, scrollRemainder, cellSize, deltasPerStep) };
+
+	QCOMPARE(evStringScrollUpLeft, QString{ "<ScrollWheelUp><10,10><ScrollWheelLeft><10,10>" });
+
+	// Combined Event: Down + Right
+	const QWheelEvent evScrollDownRight{
+		QPointF{ 100.0, 100.0 } /*pos*/,
+		QPointF{ 200.0, 200.0 } /*globalPos*/,
+		QPoint{ 0, 0 } /*pixelDelta*/,
+		QPoint{ -scrollEventSize, -scrollEventSize } /*angleDelta*/,
+		Qt::NoButton /*buttons*/,
+		Qt::NoModifier /*modifiers*/,
+		Qt::NoScrollPhase,
+		false /*inverted*/
+	};
+
+	scrollRemainder = { 0, 0 };
+
+	RepeatWheelEventsNTimesAndAssertEmpty(eventsPerScroll - 1, scrollRemainder, { evScrollDownRight});
+
+	const QString evStringScrollDownRight{ Shell::GetWheelEventStringAndSetScrollRemainder(
+		evScrollDownRight, scrollRemainder, cellSize, deltasPerStep) };
+
+	QCOMPARE(evStringScrollDownRight, QString{ "<ScrollWheelDown><10,10><ScrollWheelRight><10,10>" });
+}
+
+void TestScroll::ScrollAccumulation() noexcept
+{
+	const QWheelEvent evScrollUp{
+		QPointF{ 100.0, 100.0 } /*pos*/,
+		QPointF{ 200.0, 200.0 } /*globalPos*/,
+		QPoint{ 0, 0 } /*pixelDelta*/,
+		QPoint{ 0, scrollEventSize } /*angleDelta*/,
+		Qt::NoButton /*buttons*/,
+		Qt::NoModifier/*modifiers*/,
+		Qt::NoScrollPhase,
+		false /*inverted*/
+	};
+
+	const QWheelEvent evScrollDown{
+		QPointF{ 200.0, 200.0 } /*pos*/,
+		QPointF{ 200.0, 200.0 } /*globalPos*/,
+		QPoint{ 0, 0 } /*pixelDelta*/,
+		QPoint{ 0, -scrollEventSize } /*angleDelta*/,
+		Qt::NoButton /*buttons*/,
+		Qt::NoModifier/*modifiers*/,
+		Qt::NoScrollPhase,
+		false /*inverted*/
+	};
+
+	QPoint scrollRemainder;
+
+	RepeatWheelEventsNTimesAndAssertEmpty(eventsPerScroll - 1, scrollRemainder, { evScrollUp, evScrollDown, evScrollUp });
+
+	const QString evStringScrollUp{ Shell::GetWheelEventStringAndSetScrollRemainder(
+		evScrollUp, scrollRemainder, cellSize, deltasPerStep) };
+
+	QCOMPARE(evStringScrollUp, QString{ "<ScrollWheelUp><10,10>" });
+}
+
+void TestScroll::ScrollModifiers() noexcept
+{
+	// Shift Modifier
+	const QWheelEvent evScrollShiftDown{
+		QPointF{ 0.0, 0.0 } /*pos*/,
+		QPointF{ 200.0, 200.0 } /*globalPos*/,
+		QPoint{ 0, 0 } /*pixelDelta*/,
+		QPoint{ 0, -deltasPerStep} /*angleDelta*/,
+		Qt::NoButton /*buttons*/,
+		Qt::ShiftModifier/*modifiers*/,
+		Qt::NoScrollPhase,
+		false /*inverted*/
+	};
+
+	QPoint scrollRemainder;
+
+	const QString evStringScrollShiftDown{ Shell::GetWheelEventStringAndSetScrollRemainder(
+		evScrollShiftDown, scrollRemainder, cellSize, deltasPerStep) };
+
+	QCOMPARE(evStringScrollShiftDown, QString{ "<S-ScrollWheelDown><0,0>" });
+
+	// Control Modifier
+	const QWheelEvent evScrollCtrlDown{
+		QPointF{ 0.0, 0.0 } /*pos*/,
+		QPointF{ 200.0, 200.0 } /*globalPos*/,
+		QPoint{ 0, 0 } /*pixelDelta*/,
+		QPoint{ 0, -deltasPerStep} /*angleDelta*/,
+		Qt::NoButton /*buttons*/,
+		Input::ControlModifier() /*modifiers*/,
+		Qt::NoScrollPhase,
+		false /*inverted*/
+	};
+
+	const QString evStringScrollCtrlDown{ Shell::GetWheelEventStringAndSetScrollRemainder(
+		evScrollCtrlDown, scrollRemainder, cellSize, deltasPerStep) };
+
+	QCOMPARE(evStringScrollCtrlDown, QString{ "<C-ScrollWheelDown><0,0>" });
+
+	// Alt Modifier
+	const QWheelEvent evScrollAltDown{
+		QPointF{ 0.0, 0.0 } /*pos*/,
+		QPointF{ 200.0, 200.0 } /*globalPos*/,
+		QPoint{ 0, 0 } /*pixelDelta*/,
+		QPoint{ 0, -deltasPerStep} /*angleDelta*/,
+		Qt::NoButton /*buttons*/,
+		Qt::AltModifier /*modifiers*/,
+		Qt::NoScrollPhase,
+		false /*inverted*/
+	};
+
+	const QString evStringScrollAltDown{ Shell::GetWheelEventStringAndSetScrollRemainder(
+		evScrollAltDown, scrollRemainder, cellSize, deltasPerStep) };
+
+	QCOMPARE(evStringScrollAltDown, QString{ "<A-ScrollWheelDown><0,0>" });
+}
+
+void TestScroll::ScrollHighResolution() noexcept
+{
+	QVERIFY(false);
+}
+
+void TestScroll::ScrollInvertedEvents() noexcept
+{
+	QVERIFY(false);
+}
+
+} // Namespace NeovimQt
+
+QTEST_MAIN(NeovimQt::TestScroll)
+
+#include "tst_scroll.moc"


### PR DESCRIPTION
Adds test coverage for QWheelEvent to Neovim input string conversion.

There have been a handful of scrolling related issues lately:
#784
#785
#696
#630 

Following the pattern we used to fix keyboard input, we should add test coverage for mouse/scrolling input.

These event conversions should be deterministic and highly testable. If we can capture several input samples from users, we can ensure this area works properly and does not suffer future regressions.