### PR TITLE
Fix MacOS TravisCI Brew Break

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,9 @@ before_install:
   - brew update
   # Install Neovim for the unit tests
   - brew install neovim
-  - brew ls | grep -wq cmake || brew install cmake
-  - brew ls | grep -wq qt5 || brew install qt5
-  - brew ls | grep -wq msgpack || brew install msgpack
+  - brew ls --formula | grep -wq cmake || brew install cmake
+  - brew ls --formula | grep -wq qt5 || brew install qt5
+  - brew ls --formula | grep -wq msgpack || brew install msgpack
   # cpp-coveralls https://github.com/eddyxu/cpp-coveralls
   - pip install cpp-coveralls PyYAML
 script:


### PR DESCRIPTION
Travis displays the following error on MacOS:
```
$ brew ls | grep -wq cmake || brew install cmake
Error: Calling `brew list` to only list formulae is disabled! Use `brew list --formula` instead.
```

According to:
https://discourse.brew.sh/t/brew-list-less-fails/9224
"brew list would only list formulae when the output is not to a terminal."

We should add the --formula argument as suggested, this will keep the same
behavior as before the brew terminal API change.

See: https://travis-ci.org/github/equalsraf/neovim-qt/jobs/750891566