### PR TITLE
Short-term workaround for AppVeyor Windows breaks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 2.8.12)
 if (POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)
 endif (POLICY CMP0048)

--- a/contrib/appveyor.yml
+++ b/contrib/appveyor.yml
@@ -6,14 +6,14 @@ image:
 environment:
   matrix:
   - PlatformToolset: MinGW-Win64
-    QTPATH: C:\Qt\5.15.1\mingw81_64
+    QTPATH: C:\Qt\5.15\mingw81_64
     GENERATOR: MinGW Makefiles
     RELEASE_ARTIFACT: true
-    CMAKE_PATH_PREFIX: C:\Qt\5.15.1\mingw81_64\lib\cmake
+    CMAKE_PATH_PREFIX: C:\Qt\5.15\mingw81_64\lib\cmake
   - PlatformToolset: VisualStudio2019
-    QTPATH: C:\Qt\5.15.1\msvc2019_64
+    QTPATH: C:\Qt\5.15\msvc2019_64
     GENERATOR: Visual Studio 16
-    CMAKE_PATH_PREFIX: C:\Qt\5.15.1\msvc2019_64\lib\cmake
+    CMAKE_PATH_PREFIX: C:\Qt\5.15\msvc2019_64\lib\cmake
 configuration:
 - RelWithDebInfo
 matrix:

--- a/contrib/appveyor.yml
+++ b/contrib/appveyor.yml
@@ -19,7 +19,12 @@ configuration:
 matrix:
   fast_finish: false
 install:
-- ps: appveyor DownloadFile -FileName Neovim.zip "https://github.com/neovim/neovim/releases/download/nightly/nvim-win64.zip"
+# Currently Windows Nightly Builds of Neovim are not working.
+# For now, we can test with a 0.4.4 Release Build. Good enough.
+# See: https://github.com/neovim/neovim/issues/13312
+#
+#- ps: appveyor DownloadFile -FileName Neovim.zip "https://github.com/neovim/neovim/releases/download/nightly/nvim-win64.zip"
+- ps: appveyor DownloadFile -FileName Neovim.zip "https://github.com/neovim/neovim/releases/download/v0.4.4/nvim-win64.zip"
 - 7z x Neovim.zip
 - set PATH=%PATH%;%CD%\Neovim\bin;
 - nvim --version

--- a/src/gui/shellwidget/CMakeLists.txt
+++ b/src/gui/shellwidget/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 2.8.12)
 if (POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)
 endif (POLICY CMP0048)

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This is a minimal CMake project to fetch and build third party
 # dependencies
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 2.8.12)
 if (POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)
 endif (POLICY CMP0048)


### PR DESCRIPTION
Upstream, Neovim has been forced to change CI:
https://github.com/neovim/neovim/issues/13312

For now, Windows Nighly Builds are unavailable.

We should test Windows against 0.4.4 in the interim.