### PR TITLE
Remove macro constant NVIM_QT_RUNTIME_PATH

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -55,11 +55,6 @@ add_library(neovim-qt-gui
 	${NEOVIM_RCC_SOURCES})
 target_link_libraries(neovim-qt-gui ${QTLIBS} qshellwidget neovim-qt)
 
-if(NOT APPLE)
-	set_property(SOURCE app_runtime.cpp PROPERTY COMPILE_DEFINITIONS
-		NVIM_QT_RUNTIME_PATH="${CMAKE_INSTALL_FULL_DATADIR}/nvim-qt/runtime")
-endif()
-
 add_executable(nvim-qt WIN32 MACOSX_BUNDLE main.cpp
 	${NEOVIM_RCC_SOURCES}
 	${RES_FILE}

--- a/src/gui/app_runtime.cpp
+++ b/src/gui/app_runtime.cpp
@@ -13,10 +13,6 @@ QString App::getRuntimePath() noexcept
 		return path;
 	}
 
-	if (QFileInfo(NVIM_QT_RUNTIME_PATH).isDir()) {
-		return QStringLiteral(NVIM_QT_RUNTIME_PATH);
-	}
-
 	// Look for the runtime relative to the nvim-qt binary
 	const QDir d = QDir{ applicationDirPath() }.filePath("../share/nvim-qt/runtime");
 


### PR DESCRIPTION
As an one of the easiest workaround for #806 , this PR removes macro constant NVIM_QT_RUNTIME_PATH. This works at least in my environment.

Closes #806.