### PR TITLE
GuiRenderLigatures cursor must respect busy mode

### DIFF
--- a/src/gui/shellwidget/shellwidget.cpp
+++ b/src/gui/shellwidget/shellwidget.cpp
@@ -499,7 +499,8 @@ void ShellWidget::paintForegroundTextBlock(
 				DistributeGlyphPositions(std::move(glyphPositionList), cellWidth));
 		}
 
-		const bool isCursorVisibleInGlyphRun{ cursorPos >= 0
+		const bool isCursorVisibleInGlyphRun{ m_cursor.IsVisible()
+			&& cursorPos >= 0
 			&& cursorPos < sizeGlyphRun + glyphsRendered
 			&& cursorPos >= glyphsRendered };
 


### PR DESCRIPTION
Regression of Issue #663 when `:GuiRenderLigatures 1`.

The cursor's visibility should be checked before rendering.

Without this fix, strange cursor behavior is observed in `:terminal`.