### PR TITLE
Issue 818: Add strikethrough support

### DIFF
--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -318,6 +318,7 @@ void Shell::handleHighlightSet(const QVariantMap& attrs)
 	m_font_italic = attrs.value("italic").toBool();
 	m_font_undercurl = attrs.value("undercurl").toBool();
 	m_font_underline = attrs.value("underline").toBool();
+	m_font_strikethrough = attrs.value("strikethrough").toBool();
 }
 
 /// Paint a character and advance the cursor
@@ -341,7 +342,7 @@ void Shell::handlePut(const QVariantList& args)
 		int cols = put(text, m_cursor_pos.y(), m_cursor_pos.x(),
 				m_hg_foreground, m_hg_background, m_hg_special,
 				m_font_bold, m_font_italic,
-				m_font_underline, m_font_undercurl);
+				m_font_underline, m_font_undercurl, m_font_strikethrough);
 		// Move cursor ahead
 		setNeovimCursor(m_cursor_pos.y(), m_cursor_pos.x()+cols);
 	}

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -211,6 +211,7 @@ private:
 	bool m_font_italic{ false };
 	bool m_font_underline{ false };
 	bool m_font_undercurl{ false };
+	bool m_font_strikethrough{ false };
 	bool m_mouseHide{ true };
 
 	// highlight fg/bg - from redraw:highlightset - by default we

--- a/src/gui/shellwidget/cell.cpp
+++ b/src/gui/shellwidget/cell.cpp
@@ -6,7 +6,7 @@
 	invalidCell.m_character = 'X';
 	invalidCell.m_isValid = false;
 	invalidCell.m_highlight = { Qt::white, Qt::red, QColor::Invalid,
-		false, false, false, false, false };
+		false, false, false, false, false, false };
 
 	return invalidCell;
 }

--- a/src/gui/shellwidget/cell.h
+++ b/src/gui/shellwidget/cell.h
@@ -23,10 +23,11 @@ public:
 		bool italic,
 		bool underline,
 		bool undercurl,
+		bool strikethrough,
 		bool reverse) noexcept :
 		Cell{
 			character,
-			{ fgColor, bgColor, spColor, reverse, italic, bold, underline, undercurl } }
+			{ fgColor, bgColor, spColor, reverse, italic, bold, underline, undercurl, strikethrough } }
 	{
 	}
 
@@ -34,7 +35,7 @@ public:
 	Cell(QColor bgColor) noexcept :
 		Cell{
 			' ',
-			{ QColor::Invalid, bgColor, QColor::Invalid, false, false, false, false, false } }
+			{ QColor::Invalid, bgColor, QColor::Invalid, false, false, false, false, false, false } }
 	{
 	}
 
@@ -65,6 +66,8 @@ public:
 	bool IsUnderline() const { return m_highlight.IsUnderline(); }
 
 	bool IsUndercurl() const { return m_highlight.IsUndercurl(); }
+
+	bool IsStrikeThrough() const { return m_highlight.IsStrikeThrough(); }
 
 	/// Checks two cells for style equivalence, ignore differences in `m_character`
 	bool IsStyleEquivalent(const Cell& other) const;

--- a/src/gui/shellwidget/highlight.cpp
+++ b/src/gui/shellwidget/highlight.cpp
@@ -24,6 +24,7 @@ HighlightAttribute::HighlightAttribute(const QVariantMap& rgb_attr) noexcept
 	m_bold = rgb_attr.contains("bold");
 	m_underline = rgb_attr.contains("underline");
 	m_undercurl = rgb_attr.contains("undercurl");
+	m_strikethrough = rgb_attr.contains("strikethrough");
 }
 
 QColor HighlightAttribute::GetForegroundColor() const noexcept {
@@ -51,5 +52,6 @@ bool HighlightAttribute::operator==(const HighlightAttribute& other) const noexc
 		m_italic == other.m_italic &&
 		m_bold == other.m_bold &&
 		m_underline == other.m_underline &&
-		m_undercurl == other.m_undercurl;
+		m_undercurl == other.m_undercurl &&
+		m_strikethrough == other.m_strikethrough;
 }

--- a/src/gui/shellwidget/highlight.h
+++ b/src/gui/shellwidget/highlight.h
@@ -13,7 +13,8 @@ public:
 		bool italic,
 		bool bold,
 		bool underline,
-		bool undercurl) noexcept :
+		bool undercurl,
+		bool strikethrough) noexcept :
 		m_foreground{ foreground },
 		m_background{ background },
 		m_special{ special },
@@ -21,7 +22,8 @@ public:
 		m_italic{ italic },
 		m_bold{ bold },
 		m_underline{ underline },
-		m_undercurl{ undercurl }
+		m_undercurl{ undercurl },
+		m_strikethrough{ strikethrough }
 	{
 	}
 
@@ -47,6 +49,8 @@ public:
 
 	bool IsUndercurl() const noexcept { return m_undercurl; }
 
+	bool IsStrikeThrough() const noexcept { return m_strikethrough; }
+
 	bool operator==(const HighlightAttribute& other) const noexcept;
 
 private:
@@ -59,4 +63,5 @@ private:
 	bool m_bold{ false };
 	bool m_underline{ false };
 	bool m_undercurl{ false };
+	bool m_strikethrough{ false };
 };

--- a/src/gui/shellwidget/shellwidget.cpp
+++ b/src/gui/shellwidget/shellwidget.cpp
@@ -229,14 +229,7 @@ void ShellWidget::paintUnderline(
 		return;
 	}
 
-	QPen pen;
-	if (cell.GetForegroundColor().isValid()) {
-		pen.setColor(cell.GetForegroundColor());
-	} else {
-		pen.setColor(foreground());
-	}
-
-	p.setPen(pen);
+	p.setPen(getForegroundPen(cell));
 
 	p.drawLine(GetUnderline(cellRect));
 }
@@ -297,7 +290,6 @@ void ShellWidget::paintUndercurl(
 	p.drawPath(GetUndercurlPath(cellRect));
 }
 
-// FIXME Copy-Pasted Code! Refactor with Underline? This and below
 static QLine GetStrikeThrough(QRect cellRect) noexcept
 {
 	QPoint start{ cellRect.bottomLeft() };
@@ -318,14 +310,7 @@ void ShellWidget::paintStrikeThrough(
 		return;
 	}
 
-	QPen pen;
-	if (cell.GetForegroundColor().isValid()) {
-		pen.setColor(cell.GetForegroundColor());
-	} else {
-		pen.setColor(foreground());
-	}
-
-	p.setPen(pen);
+	p.setPen(getForegroundPen(cell));
 
 	p.drawLine(GetStrikeThrough(cellRect));
 }
@@ -368,10 +353,10 @@ QFont ShellWidget::GetCellFont(const Cell& cell) const noexcept
 		}
 	}
 
-	cellFont.setBold(cell.IsBold());
-	cellFont.setItalic(cell.IsItalic());
-	// FIXME!
-	//cellFont.setStrikeOut(cell.IsStrikeThrough()); // FIXME :s striktrought in guifont!
+	if (cell.IsBold() || cell.IsItalic()) {
+		cellFont.setBold(cell.IsBold());
+		cellFont.setItalic(cell.IsItalic());
+	}
 
 	// Issue #575: Clear style name. The KDE/Plasma theme plugin may set this
 	// but we want to match the family name with the bold/italic attributes.
@@ -382,6 +367,18 @@ QFont ShellWidget::GetCellFont(const Cell& cell) const noexcept
 	cellFont.setKerning(false);
 
 	return cellFont;
+}
+
+QPen ShellWidget::getForegroundPen(const Cell& cell) noexcept
+{
+	QPen pen;
+	if (cell.GetForegroundColor().isValid()) {
+		pen.setColor(cell.GetForegroundColor());
+	} else {
+		pen.setColor(foreground());
+	}
+
+	return pen;
 }
 
 void ShellWidget::paintForegroundCellText(

--- a/src/gui/shellwidget/shellwidget.h
+++ b/src/gui/shellwidget/shellwidget.h
@@ -180,6 +180,7 @@ private:
 		int cursorPos) noexcept;
 
 	QFont GetCellFont(const Cell& cell) const noexcept;
+	QPen getForegroundPen(const Cell& cell) noexcept;
 
 	ShellContents m_contents{ 0, 0 };
 	QSize m_cellSize;

--- a/src/gui/shellwidget/shellwidget.h
+++ b/src/gui/shellwidget/shellwidget.h
@@ -105,6 +105,7 @@ public slots:
 		bool italic = false,
 		bool underline = false,
 		bool undercurl = false,
+		bool strikethrough = false,
 		bool reverse = false);
 
 	int put(
@@ -167,6 +168,7 @@ private:
 	void paintNeovimCursorForeground(QPainter& p, QRect cellRect, QPoint pos, const QString& character) noexcept;
 	void paintUnderline(QPainter& p, const Cell& cell, QRect cellRect) noexcept;
 	void paintUndercurl(QPainter& p, const Cell& cell, QRect cellRect) noexcept;
+	void paintStrikeThrough(QPainter& p, const Cell& cell, QRect cellRect) noexcept;
 	void paintBackgroundClearCell(QPainter& p, const Cell& cell, QRect cellRect, bool isCursorCell) noexcept;
 	void paintForegroundCellText(QPainter& p, const Cell& cell, QRect cellRect, bool isCursorCell) noexcept;
 

--- a/src/gui/shellwidget/test/bench_cell.cpp
+++ b/src/gui/shellwidget/test/bench_cell.cpp
@@ -12,7 +12,7 @@ class Test: public QObject
 private slots:
 	void benchCell() {
 		QBENCHMARK {
-			Cell c('1', Qt::red, Qt::blue, QColor(), false, false, false, false, false);
+			Cell c('1', Qt::red, Qt::blue, QColor(), false, false, false, false, false, false);
 		}
 	}
 };

--- a/src/gui/shellwidget/test/test_cell.cpp
+++ b/src/gui/shellwidget/test/test_cell.cpp
@@ -29,13 +29,13 @@ private slots:
 	void cellValue() {
 		QBENCHMARK {
 			Cell c('z', Qt::black, Qt::white, QColor(),
-					false, false, false, false, false);
+					false, false, false, false, false, false);
 		}
 	}
 	void cellValueRgb() {
 		QBENCHMARK {
 			Cell c('z', QRgb(33), QRgb(66), QColor(),
-					false, false, false, false, false);
+					false, false, false, false, false, false);
 		}
 	}
 
@@ -70,6 +70,7 @@ void Test::cellOperatorEquals() noexcept
 		false /*italic*/,
 		false /*underline*/,
 		false /*undercurl*/,
+		false /*strikethrough*/,
 		false /*reverse*/ };
 
 	const HighlightAttribute hlTextWhiteFillBlack{
@@ -80,6 +81,7 @@ void Test::cellOperatorEquals() noexcept
 		false /*italic*/,
 		false /*underline*/,
 		false /*undercurl*/,
+		false /*strikethrough*/,
 		false /*reverse*/ };
 
 	const HighlightAttribute hlInvTextWhiteFillBlack{
@@ -90,6 +92,7 @@ void Test::cellOperatorEquals() noexcept
 		false /*italic*/,
 		false /*underline*/,
 		false /*undercurl*/,
+		false /*strikethrough*/,
 		true /*reverse*/ };
 
 	const HighlightAttribute hlBoldTextWhiteFillBlack{
@@ -100,6 +103,7 @@ void Test::cellOperatorEquals() noexcept
 		false /*italic*/,
 		false /*underline*/,
 		false /*undercurl*/,
+		false /*strikethrough*/,
 		false /*reverse*/ };
 
 	bool textDifferent{
@@ -135,6 +139,7 @@ void Test::cellStyleEquivalent() noexcept
 		false /*italic*/,
 		false /*underline*/,
 		false /*undercurl*/,
+		false /*strikethrough*/,
 		false /*reverse*/ };
 
 	const HighlightAttribute styleB{
@@ -145,6 +150,7 @@ void Test::cellStyleEquivalent() noexcept
 		false /*italic*/,
 		false /*underline*/,
 		false /*undercurl*/,
+		false /*strikethrough*/,
 		false /*reverse*/ };
 
 	Cell cellStyleATextA{ 'A', styleA };


### PR DESCRIPTION
**Issue #818:** Vim/Neovim added a new striketrough property. Add support.

See: https://github.com/neovim/neovim/commit/3afb397407af3c94fc82d694186e8d451e625237

We need to update `Cell`, `HighlightAttribute`, and `ShellWidget` to support the new property..

The strikethrough is renered as a Qt Canvas line halfway and one pixel up the cell in that cell's foreground color.