### PR TITLE
Issue 817: Change Ctrl + Shift modifier handling

### DIFF
--- a/test/tst_input_mac.cpp
+++ b/test/tst_input_mac.cpp
@@ -12,6 +12,7 @@ private slots:
 	void SpecialKeys() noexcept;
 	void KeyboardLayoutUnicodeHexInput() noexcept;
 	void CtrlCaretWellFormed() noexcept;
+	void ShiftModifierLetter() noexcept;
 };
 
 void TestInputMac::AltSpecialCharacters() noexcept
@@ -73,7 +74,7 @@ void TestInputMac::KeyboardLayoutUnicodeHexInput() noexcept
 
 	QKeyEvent evCtrlAltShiftA{ QEvent::KeyPress, Qt::Key_A,
 		Qt::MetaModifier | Qt::AltModifier | Qt::ShiftModifier };
-	QCOMPARE(NeovimQt::Input::convertKey(evCtrlAltShiftA), QString{ "<C-A-A>" });
+	QCOMPARE(NeovimQt::Input::convertKey(evCtrlAltShiftA), QString{ "<C-S-A-A>" });
 }
 
 void TestInputMac::CtrlCaretWellFormed() noexcept
@@ -87,6 +88,20 @@ void TestInputMac::CtrlCaretWellFormed() noexcept
 	QKeyEvent evCtrlShiftMeta6{ QEvent::KeyPress, Qt::Key_AsciiCircum,
 		Qt::MetaModifier | Qt::ShiftModifier | Qt::ControlModifier };
 	QCOMPARE(NeovimQt::Input::convertKey(evCtrlShiftMeta6), QString{ "<C-^>" });
+}
+
+void TestInputMac::ShiftModifierLetter() noexcept
+{
+	// Issue#817: Shift should be sent if modifier keys are present
+	// For example, Ctrl + Shift + A is <C-S-A> and not <C-A>
+
+	// CTRL + B
+	QKeyEvent evCtrlB{ QEvent::KeyPress, Qt::Key_B, Qt::MetaModifier };
+	QCOMPARE(NeovimQt::Input::convertKey(evCtrlB), QString{ "<C-b>" });
+
+	// CTRL + SHIFT + B
+	QKeyEvent evCtrlShiftB{ QEvent::KeyPress, Qt::Key_B, Qt::MetaModifier | Qt::ShiftModifier };
+	QCOMPARE(NeovimQt::Input::convertKey(evCtrlShiftB), QString{ "<C-S-B>" });
 }
 
 #include "tst_input_mac.moc"

--- a/test/tst_input_unix.cpp
+++ b/test/tst_input_unix.cpp
@@ -10,6 +10,7 @@ private slots:
 	void LessThanModifierKeys() noexcept;
 	void SpecialKeys() noexcept;
 	void CtrlCaretWellFormed() noexcept;
+	void ShiftModifierLetter() noexcept;
 };
 
 void TestInputUnix::LessThanModifierKeys() noexcept
@@ -55,6 +56,18 @@ void TestInputUnix::CtrlCaretWellFormed() noexcept
 	QKeyEvent evCtrlShiftMeta6{ QEvent::KeyPress, Qt::Key_AsciiCircum,
 		Qt::MetaModifier | Qt::ShiftModifier | Qt::ControlModifier , { "\u001E" } };
 	QCOMPARE(NeovimQt::Input::convertKey(evCtrlShiftMeta6), QString{ "<C-^>" });
+}
+
+void TestInputUnix::ShiftModifierLetter() noexcept
+{
+	// CTRL + B
+	QKeyEvent evCtrlB{ QEvent::KeyPress, Qt::Key_B, Qt::ControlModifier, QString{ "\u0002" } };
+	QCOMPARE(NeovimQt::Input::convertKey(evCtrlB), QString{ "<C-b>" });
+
+	// CTRL + SHIFT + B
+	QKeyEvent evCtrlShiftB{ QEvent::KeyPress, Qt::Key_B, Qt::ControlModifier | Qt::ShiftModifier,
+		QString{ "\u0002" } };
+	QCOMPARE(NeovimQt::Input::convertKey(evCtrlShiftB), QString{ "<C-S-B>" });
 }
 
 #include "tst_input_unix.moc"

--- a/test/tst_input_win32.cpp
+++ b/test/tst_input_win32.cpp
@@ -10,6 +10,7 @@ private slots:
 	void LessThanModifierKeys() noexcept;
 	void SpecialKeys() noexcept;
 	void CtrlCaretWellFormed() noexcept;
+	void ShiftModifierLetter() noexcept;
 };
 
 void TestInputWin32::LessThanModifierKeys() noexcept
@@ -51,6 +52,18 @@ void TestInputWin32::CtrlCaretWellFormed() noexcept
 
 	QKeyEvent evCtrlShift6{ QEvent::KeyPress, Qt::Key_AsciiCircum, Qt::ControlModifier | Qt::ShiftModifier, { "\u001E" } };
 	QCOMPARE(NeovimQt::Input::convertKey(evCtrlShift6), QString{ "<C-^>" });
+}
+
+void TestInputWin32::ShiftModifierLetter() noexcept
+{
+	// CTRL + B
+	QKeyEvent evCtrlB{ QEvent::KeyPress, Qt::Key_B, Qt::ControlModifier, QString{ "\u0002" } };
+	QCOMPARE(NeovimQt::Input::convertKey(evCtrlB), QString{ "<C-b>" });
+
+	// CTRL + SHIFT + B
+	QKeyEvent evCtrlShiftB{ QEvent::KeyPress, Qt::Key_B, Qt::ControlModifier | Qt::ShiftModifier,
+		QString{ "\u0002" } };
+	QCOMPARE(NeovimQt::Input::convertKey(evCtrlShiftB), QString{ "<C-S-B>" });
 }
 
 #include "tst_input_win32.moc"


### PR DESCRIPTION
**Issue #817:** Change Ctrl + Shift modifier handling

**FIXME!** This is not production ready... More work needed.

The Ctrl + Shift handling logic is not what nvim expects.

Previously:
```
  CTRL + B: <C-b>
  CTRL + SHIFT + B: <C-B>
```

New:
```
  CTRL + B: <C-b>
  CTRL + SHIFT + B: <C-S-B>
```

The logic has been changed so that if `<C-` or `<A-` are present, we will preserve this shift key. This should prevent SHIFT + B from sending incorrect logic such as `<S-B>`, while preserving all modifiers on command sequences.