### PR TITLE
Remove Duplicate ShellOptions

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -399,6 +399,11 @@ void MainWindow::neovimTablineUpdate(int64_t curtab, QList<Tab> tabs)
 		case 2:
 			m_tabline_bar->setVisible(true);
 			break;
+
+		// Fallback: show tabline for two or more tabs
+		default:
+			m_tabline_bar->setVisible(tabs.size() >= 2);
+			break;
 	}
 }
 

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -8,9 +8,8 @@
 
 namespace NeovimQt {
 
-MainWindow::MainWindow(NeovimConnector* c, ShellOptions opts, QWidget* parent)
+MainWindow::MainWindow(NeovimConnector* c, QWidget* parent)
 	: QMainWindow(parent)
-	, m_shell_options(opts)
 	, m_defaultFont{ font() }
 	, m_defaultPalette{ palette() }
 {
@@ -29,9 +28,12 @@ void MainWindow::init(NeovimConnector *c)
 		m_shell->deleteLater();
 		m_stack.removeWidget(m_shell);
 	}
+
 	if (m_nvim) {
 		m_nvim->deleteLater();
 	}
+
+	m_shell = new Shell(c);
 
 	m_tabline_bar = addToolBar("tabline");
 	m_tabline_bar->setObjectName("tabline");
@@ -50,7 +52,7 @@ void MainWindow::init(NeovimConnector *c)
 			this, &MainWindow::changeTab);
 
 	m_tabline_bar->addWidget(m_tabline);
-	m_tabline_bar->setVisible(m_shell_options.enable_ext_tabline);
+	m_tabline_bar->setVisible(m_shell->GetShellOptions().IsTablineEnabled());
 
 	// Context menu and actions for right-click
 	m_contextMenu = new QMenu();
@@ -68,7 +70,6 @@ void MainWindow::init(NeovimConnector *c)
 	m_nvim = c;
 
 	m_tree = new TreeView(c);
-	m_shell = new Shell(c, m_shell_options);
 
 	// GuiScrollBar
 	m_scrollbar = new ScrollBar{ m_nvim };
@@ -333,23 +334,25 @@ Shell* MainWindow::shell()
 
 void MainWindow::extTablineSet(bool val)
 {
-	bool old = m_shell_options.enable_ext_tabline;
-	m_shell_options.enable_ext_tabline = val;
-	// redraw if state changed
-	if (old != m_shell_options.enable_ext_tabline) {
-		if (!val) m_tabline_bar->setVisible(false);
-		m_nvim->api0()->vim_command("silent! redraw!");
+	ShellOptions& shellOptions{ m_shell->GetShellOptions() };
+
+	// We can ignore events where the value does not change.
+	if (val == shellOptions.IsTablineEnabled()) {
+		return;
 	}
+
+	shellOptions.SetIsTablineEnabled(val);
+	m_nvim->api0()->vim_command("silent! redraw!");
 }
 
 void MainWindow::neovimShowtablineSet(int val)
 {
-	m_shell_options.nvim_show_tabline = val;
+	m_shell->GetShellOptions().SetOptionShowTabline(val);
 }
 
 void MainWindow::neovimTablineUpdate(int64_t curtab, QList<Tab> tabs)
 {
-	if (!m_shell_options.enable_ext_tabline) {
+	if (!m_shell->GetShellOptions().IsTablineEnabled()) {
 		return;
 	}
 
@@ -378,16 +381,25 @@ void MainWindow::neovimTablineUpdate(int64_t curtab, QList<Tab> tabs)
 		}
 	}
 
-	// hide/show the tabline toolbar
-	if (m_shell_options.nvim_show_tabline==0) {
-		m_tabline_bar->setVisible(false);
-	} else if (m_shell_options.nvim_show_tabline==2) {
-		m_tabline_bar->setVisible(true);
-	} else {
-		m_tabline_bar->setVisible(tabs.size() > 1);
-	}
-
 	Q_ASSERT(tabs.size() == m_tabline->count());
+
+	switch(m_shell->GetShellOptions().GetOptionShowTabline())
+	{
+		// Never show tabline
+		case 0:
+			m_tabline_bar->setVisible(false);
+			break;
+
+		// Show tabline for two or more tabs.
+		case 1:
+			m_tabline_bar->setVisible(tabs.size() >= 2);
+			break;
+
+		// Always show tabline
+		case 2:
+			m_tabline_bar->setVisible(true);
+			break;
+	}
 }
 
 void MainWindow::neovimShowContextMenu()
@@ -417,7 +429,7 @@ void MainWindow::neovimSendSelectAll()
 
 void MainWindow::changeTab(int index)
 {
-	if (!m_shell_options.enable_ext_tabline) {
+	if (!m_shell->GetShellOptions().IsTablineEnabled()) {
 		return;
 	}
 

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -26,7 +26,7 @@ public:
 		FullScreen,
 	};
 
-	MainWindow(NeovimConnector *, ShellOptions opts, QWidget *parent=0);
+	MainWindow(NeovimConnector *, QWidget *parent=0);
 	bool neovimAttached() const;
 	Shell* shell();
 	void restoreWindowGeometry();
@@ -80,7 +80,6 @@ private:
 	QStackedWidget m_stack;
 	QTabBar* m_tabline{ nullptr };
 	QToolBar* m_tabline_bar{ nullptr };
-	ShellOptions m_shell_options;
 
 	bool m_neovim_requested_close{ false };
 	QMenu* m_contextMenu{ nullptr };

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -13,11 +13,12 @@
 #include <QMenu>
 
 #include "neovimconnector.h"
-#include "shellwidget/highlight.h"
-#include "shellwidget/shellwidget.h"
-#include "shellwidget/cursor.h"
 #include "popupmenu.h"
 #include "popupmenumodel.h"
+#include "shelloptions.h"
+#include "shellwidget/cursor.h"
+#include "shellwidget/highlight.h"
+#include "shellwidget/shellwidget.h"
 
 namespace NeovimQt {
 
@@ -32,21 +33,13 @@ public:
 	QString name;
 };
 
-class ShellOptions {
-public:
-	bool enable_ext_tabline{ true };
-	bool enable_ext_popupmenu{ true };
-	bool enable_ext_linegrid{ true };
-	int nvim_show_tabline{ 1 };
-};
-
 class Shell: public ShellWidget
 {
 	Q_OBJECT
 	Q_PROPERTY(bool neovimBusy READ neovimBusy() NOTIFY neovimBusy())
 	Q_PROPERTY(bool neovimAttached READ neovimAttached() NOTIFY neovimAttached())
 public:
-	Shell(NeovimConnector *nvim, ShellOptions opts, QWidget *parent=0);
+	Shell(NeovimConnector *nvim, QWidget *parent=0);
 	~Shell();
 	QSize sizeIncrement() const;
 	virtual QVariant inputMethodQuery(Qt::InputMethodQuery) const Q_DECL_OVERRIDE;
@@ -79,6 +72,8 @@ public:
 		const uint64_t hl_id{ m_highlightGroupNameMap.value(name) };
 		return m_highlightMap.contains(hl_id);
 	}
+
+	ShellOptions& GetShellOptions() noexcept { return m_options; }
 
 	/// Dispatches Neovim redraw notifications to T::handleRedraw
 	template <class T>

--- a/src/gui/shelloptions.h
+++ b/src/gui/shelloptions.h
@@ -1,0 +1,24 @@
+#pragma once
+
+namespace NeovimQt {
+
+class ShellOptions final {
+public:
+	bool IsTablineEnabled() const noexcept { return m_isTablineEnabled; }
+	bool IsPopupmenuEnabled() const noexcept { return m_isPopupmenuEnabled; }
+	bool IsLineGridEnabled() const noexcept { return m_isLineGridEnabled; }
+	int GetOptionShowTabline() const noexcept { return m_showtabline; }
+
+	void SetIsTablineEnabled(bool isEnabled) noexcept { m_isTablineEnabled = isEnabled; }
+	void SetIsPopupmenuEnabled(bool isEnabled) noexcept { m_isPopupmenuEnabled = isEnabled; }
+	void SetIsLineGridEnabled(bool isEnabled) noexcept { m_isLineGridEnabled = isEnabled; }
+	void SetOptionShowTabline(int value) noexcept { m_showtabline = value; }
+
+private:
+	bool m_isTablineEnabled{ false };
+	bool m_isPopupmenuEnabled{ false };
+	bool m_isLineGridEnabled{ true };
+	int m_showtabline{ 1 /*TwoOrMore*/ };
+};
+
+} // namespace NeovimQt

--- a/test/tst_shell.cpp
+++ b/test/tst_shell.cpp
@@ -37,7 +37,7 @@ private slots:
 			QVERIFY(onReady.isValid());
 			QVERIFY(SPYWAIT(onReady));
 
-			Shell *s = new Shell(c, ShellOptions());
+			Shell *s = new Shell(c);
 			QSignalSpy onResize(s, SIGNAL(neovimResized(int, int)));
 			QVERIFY(onResize.isValid());
 			QVERIFY(SPYWAIT(onResize));
@@ -48,7 +48,7 @@ private slots:
 		QStringList args;
 		args << "-u" << "NONE";
 		NeovimConnector *c = NeovimConnector::spawn(args);
-		Shell *s = new Shell(c, ShellOptions());
+		Shell *s = new Shell(c);
 		QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
 		QVERIFY(onAttached.isValid());
 		QVERIFY(SPYWAIT(onAttached));
@@ -64,7 +64,7 @@ private slots:
 	void startVarsShellWidget() {
 		QStringList args = {"-u", "NONE"};
 		NeovimConnector *c = NeovimConnector::spawn(args);
-		Shell *s = new Shell(c, ShellOptions());
+		Shell *s = new Shell(c);
 		QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
 		QVERIFY(onAttached.isValid());
 		QVERIFY(SPYWAIT(onAttached));
@@ -75,7 +75,7 @@ private slots:
 	void startVarsMainWindow() {
 		QStringList args = {"-u", "NONE"};
 		NeovimConnector *c = NeovimConnector::spawn(args);
-		MainWindow *s = new MainWindow(c, ShellOptions());
+		MainWindow *s = new MainWindow(c);
 		s->show();
 		QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
 		QVERIFY(onAttached.isValid());
@@ -88,7 +88,7 @@ private slots:
 		QStringList args;
 		args << "-u" << "NONE";
 		NeovimConnector *c = NeovimConnector::spawn(args);
-		Shell *s = new Shell(c, ShellOptions());
+		Shell *s = new Shell(c);
 		QSignalSpy onOptionSet(s, &Shell::neovimExtTablineSet);
 		QVERIFY(onOptionSet.isValid());
 		QVERIFY(SPYWAIT(onOptionSet));
@@ -99,7 +99,7 @@ private slots:
 		QStringList args;
 		args << "-u" << "NONE";
 		NeovimConnector *c = NeovimConnector::spawn(args);
-		Shell *s = new Shell(c, ShellOptions());
+		Shell *s = new Shell(c);
 
 		QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
 		QVERIFY(onAttached.isValid());
@@ -125,7 +125,7 @@ private slots:
 		QStringList args = {"-u", "NONE",
 			"--cmd", "set rtp+=" + fi.absoluteFilePath()};
 		NeovimConnector *c = NeovimConnector::spawn(args);
-		MainWindow *s = new MainWindow(c, ShellOptions());
+		MainWindow *s = new MainWindow(c);
 		QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
 		QVERIFY(onAttached.isValid());
 		QVERIFY(SPYWAIT(onAttached));
@@ -219,7 +219,7 @@ private slots:
 		QStringList args = {"-u", "NONE",
 			"--cmd", "set rtp+=" + fi.absoluteFilePath()};
 		NeovimConnector *c = NeovimConnector::spawn(args);
-		MainWindow *s = new MainWindow(c, ShellOptions());
+		MainWindow *s = new MainWindow(c);
 		QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
 		QVERIFY(onAttached.isValid());
 		QVERIFY(SPYWAIT(onAttached));
@@ -280,7 +280,7 @@ private slots:
 		QStringList args = {"-u", "NONE",
 			"--cmd", "set rtp+=" + fi.absoluteFilePath()};
 		NeovimConnector *c = NeovimConnector::spawn(args);
-		MainWindow *s = new MainWindow(c, ShellOptions());
+		MainWindow *s = new MainWindow(c);
 		QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
 		QVERIFY(onAttached.isValid());
 		QVERIFY(SPYWAIT(onAttached));


### PR DESCRIPTION
Removes duplicate `ShellOptions` objects stored between `MainWindow` and `Shell`. Now only one objects exists, and is associated with `Shell`. `MainWindow` now requests any required info from the associated `Shell` object.

Some secondary improvements:
- Set GuiTabline/GuiPopupmenu off by default. Users overwhelmingly prefer TUI, lots of user feedback here.
- Removes arguments `no-ext-tabline` and `no-ext-popupmenu`. Not necessary with `QSettings` changes.