### PR TITLE
Issue 738: Write QSettings on Gui commands

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -346,6 +346,7 @@ void MainWindow::extTablineSet(bool val)
 
 	shellOptions.SetIsTablineEnabled(val);
 	m_nvim->api0()->vim_command("silent! redraw!");
+	m_tabline_bar->setVisible(val);
 }
 
 void MainWindow::neovimShowtablineSet(int val)

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -94,7 +94,6 @@ signals:
 	/// This signal is emmited if the running neovim version is unsupported by the GUI
 	void neovimIsUnsupported();
 	void neovimExtTablineSet(bool);
-	void neovimExtPopupmenuSet(bool);
 	/// The tabline needs updating. curtab is the handle of the current tab (not its index)
 	/// as seen in Tab::tab.
 	void neovimTablineUpdate(int64_t curtab, QList<Tab> tabs);
@@ -168,6 +167,8 @@ protected:
 	virtual void handleGuiFontWide(const QVariant& value) noexcept;
 	virtual void handleLineSpace(const QVariant& value) noexcept;
 	virtual void handleCloseEvent(const QVariantList &args) noexcept;
+	virtual void handleGuiTabline(const QVariant& value) noexcept;
+	virtual void handleGuiPopupmenu(const QVariant& value) noexcept;
 
 	// Modern 'ext_linegrid' Grid UI Events
 	virtual void handleGridResize(const QVariantList& opargs);


### PR DESCRIPTION
**Issue #738:** Update QSettings on Gui command. Prevent startup flicker.

Some settings like GuiTabline should be set before `ginit.vim` load. Setting these values during `Shell` initialization will prevent UI flicker.

Currently the user can manually specify these options, but we can improve the experience by automatically writing these values during `:Gui{Command}`.

Supported Commands:
 - GuiFont
 - GuiTabline
 - GuiPopupmenu