### PR TITLE
Issue 833: German Layout Handle {}

### DIFF
--- a/src/gui/input.cpp
+++ b/src/gui/input.cpp
@@ -195,6 +195,12 @@ QString convertKey(const QKeyEvent& ev) noexcept
 		return ToKeyString(GetModifierPrefix(mod), "Bslash");
 	}
 
+	// Issue#833: Handle German layout curly braces
+	if (mod & Qt::AltModifier
+		&& ((key == Qt::Key_8 && text == "{") || (key == Qt::Key_9 && text == "}"))) {
+		mod &= mod & ~Qt::AltModifier;
+	}
+
 	if (text.isEmpty()) {
 		// Ignore all modifier-only key events.
 		//   Issue#344: Ignore Ctrl-Shift, C-S- being treated as C-Space

--- a/test/tst_input_mac.cpp
+++ b/test/tst_input_mac.cpp
@@ -12,6 +12,7 @@ private slots:
 	void SpecialKeys() noexcept;
 	void KeyboardLayoutUnicodeHexInput() noexcept;
 	void CtrlCaretWellFormed() noexcept;
+	void GermanCurlyBraces() noexcept;
 };
 
 void TestInputMac::AltSpecialCharacters() noexcept
@@ -87,6 +88,15 @@ void TestInputMac::CtrlCaretWellFormed() noexcept
 	QKeyEvent evCtrlShiftMeta6{ QEvent::KeyPress, Qt::Key_AsciiCircum,
 		Qt::MetaModifier | Qt::ShiftModifier | Qt::ControlModifier };
 	QCOMPARE(NeovimQt::Input::convertKey(evCtrlShiftMeta6), QString{ "<C-^>" });
+}
+
+void TestInputMac::GermanCurlyBraces() noexcept
+{
+	QKeyEvent evLeftCurlyBrace{ QEvent::KeyPress, Qt::Key_8, Qt::AltModifier, QString{ "{" } };
+	QCOMPARE(NeovimQt::Input::convertKey(evLeftCurlyBrace), QString{ "{" });
+
+	QKeyEvent evRightCurlyBrace{ QEvent::KeyPress, Qt::Key_9, Qt::AltModifier, QString{ "}" } };
+	QCOMPARE(NeovimQt::Input::convertKey(evRightCurlyBrace), QString{ "}" });
 }
 
 #include "tst_input_mac.moc"


### PR DESCRIPTION
**Issue #833:** German Layout Handle {}

We need to remove the `AltModifier` for `{}` keys on German Layouts.

Add handler and test coverage to prevent future breaks.