### PR TITLE
Issue 833: Handle MacOS German Keyboard AltModifier

### DIFF
--- a/src/gui/input_mac.cpp
+++ b/src/gui/input_mac.cpp
@@ -42,18 +42,53 @@ QString GetModifierPrefix(Qt::KeyboardModifiers mod) noexcept
 	return modprefix;
 }
 
+// Some keyboard locales require Alt to input low-ascii characters (German "{").
+// Other keyboard locales do not require Alt (US "{"). Remove Alt on layouts where
+// the key modifies text input. Qt does not provide a robust layout-detection
+// mechanism. Instead, measure Qt::Key and text mis-match with Alt present.
+//
+// See Pull Requests 837 and 841 for more details.
+static bool IsAsciiCharRequiringAlt(int key, Qt::KeyboardModifiers mod, QChar c) noexcept
+{
+	// Ignore all key events where Alt is not pressed
+	if (!(mod & Qt::AltModifier)) {
+		return false;
+	}
+
+	// These low-ascii characters may require AltModifier on MacOS
+	if ((c == '[' && key != Qt::Key_BracketLeft)
+		|| (c == ']' && key != Qt::Key_BracketRight)
+		|| (c == '{' && key != Qt::Key_BraceLeft)
+		|| (c == '}' && key != Qt::Key_BraceRight)
+		|| (c == '|' && key != Qt::Key_Bar)
+		|| (c == '~' && key != Qt::Key_AsciiTilde)
+		|| (c == '@' && key != Qt::Key_At)) {
+		return true;
+	}
+
+	return false;
+}
+
 QKeyEvent CreatePlatformNormalizedKeyEvent(
 	QEvent::Type type,
 	int key,
 	Qt::KeyboardModifiers mod,
 	const QString& text) noexcept
 {
-	if (!text.isEmpty())
+	if (text.isEmpty())
 	{
-		const QChar c{ text.at(0) };
-		if (c.unicode() >= 0x80 && c.isPrint()) {
-			mod &= ~Qt::AltModifier;
-		}
+		return { type, key, mod, text };
+	}
+
+	const QChar c{ text.at(0) };
+	if (c.unicode() >= 0x80 && c.isPrint()) {
+		mod &= ~Qt::AltModifier;
+	}
+
+	// Issue#833: Some locales require Alt for basic low-ascii characters,
+	// remove AltModifer. Ex) German layouts use Alt for "{".
+	if (IsAsciiCharRequiringAlt(key, mod, c)) {
+		mod &= ~Qt::AltModifier;
 	}
 
 	return { type, key, mod, text };

--- a/test/tst_input_mac.cpp
+++ b/test/tst_input_mac.cpp
@@ -13,6 +13,7 @@ private slots:
 	void KeyboardLayoutUnicodeHexInput() noexcept;
 	void CtrlCaretWellFormed() noexcept;
 	void ShiftModifierLetter() noexcept;
+	void GermanKeyboardLayout() noexcept;
 };
 
 void TestInputMac::AltSpecialCharacters() noexcept
@@ -102,6 +103,30 @@ void TestInputMac::ShiftModifierLetter() noexcept
 	// CTRL + SHIFT + B
 	QKeyEvent evCtrlShiftB{ QEvent::KeyPress, Qt::Key_B, Qt::MetaModifier | Qt::ShiftModifier };
 	QCOMPARE(NeovimQt::Input::convertKey(evCtrlShiftB), QString{ "<C-S-B>" });
+}
+
+void TestInputMac::GermanKeyboardLayout() noexcept
+{
+	QKeyEvent evOption5{ QEvent::KeyPress, Qt::Key_5, Qt::AltModifier, "[" };
+	QCOMPARE(NeovimQt::Input::convertKey(evOption5), QString{ "[" });
+
+	QKeyEvent evOption6{ QEvent::KeyPress, Qt::Key_6, Qt::AltModifier, "]" };
+	QCOMPARE(NeovimQt::Input::convertKey(evOption6), QString{ "]" });
+
+	QKeyEvent evOption7{ QEvent::KeyPress, Qt::Key_7, Qt::AltModifier, "|" };
+	QCOMPARE(NeovimQt::Input::convertKey(evOption7), QString{ "|" });
+
+	QKeyEvent evOption8{ QEvent::KeyPress, Qt::Key_8, Qt::AltModifier, "{" };
+	QCOMPARE(NeovimQt::Input::convertKey(evOption8), QString{ "{" });
+
+	QKeyEvent evOption9{ QEvent::KeyPress, Qt::Key_9, Qt::AltModifier, "}" };
+	QCOMPARE(NeovimQt::Input::convertKey(evOption9), QString{ "}" });
+
+	QKeyEvent evOptionTilde{ QEvent::KeyPress, Qt::Key_N, Qt::AltModifier, "~" };
+	QCOMPARE(NeovimQt::Input::convertKey(evOptionTilde), QString{ "~" });
+
+	QKeyEvent evOptionAtSign{ QEvent::KeyPress, Qt::Key_L, Qt::AltModifier, "@" };
+	QCOMPARE(NeovimQt::Input::convertKey(evOptionAtSign), QString{ "@" });
 }
 
 #include "tst_input_mac.moc"

--- a/test/tst_input_unix.cpp
+++ b/test/tst_input_unix.cpp
@@ -11,6 +11,7 @@ private slots:
 	void SpecialKeys() noexcept;
 	void CtrlCaretWellFormed() noexcept;
 	void ShiftModifierLetter() noexcept;
+	void GermanKeyboardLayout() noexcept;
 };
 
 void TestInputUnix::LessThanModifierKeys() noexcept
@@ -68,6 +69,30 @@ void TestInputUnix::ShiftModifierLetter() noexcept
 	QKeyEvent evCtrlShiftB{ QEvent::KeyPress, Qt::Key_B, Qt::ControlModifier | Qt::ShiftModifier,
 		QString{ "\u0002" } };
 	QCOMPARE(NeovimQt::Input::convertKey(evCtrlShiftB), QString{ "<C-S-B>" });
+}
+
+void TestInputUnix::GermanKeyboardLayout() noexcept
+{
+	QKeyEvent evOption7{ QEvent::KeyPress, Qt::Key_BraceLeft, Qt::GroupSwitchModifier, "{" };
+	QCOMPARE(NeovimQt::Input::convertKey(evOption7), QString{ "{" });
+
+	QKeyEvent evOption8{ QEvent::KeyPress, Qt::Key_BracketLeft, Qt::GroupSwitchModifier, "[" };
+	QCOMPARE(NeovimQt::Input::convertKey(evOption8), QString{ "[" });
+
+	QKeyEvent evOption9{ QEvent::KeyPress, Qt::Key_BracketRight, Qt::GroupSwitchModifier, "]" };
+	QCOMPARE(NeovimQt::Input::convertKey(evOption9), QString{ "]" });
+
+	QKeyEvent evOption0{ QEvent::KeyPress, Qt::Key_BraceRight, Qt::GroupSwitchModifier, "}" };
+	QCOMPARE(NeovimQt::Input::convertKey(evOption0), QString{ "}" });
+
+	QKeyEvent evOptionQ{ QEvent::KeyPress, Qt::Key_At, Qt::GroupSwitchModifier, "@" };
+	QCOMPARE(NeovimQt::Input::convertKey(evOptionQ), QString{ "@" });
+
+	QKeyEvent evOptionBeta{ QEvent::KeyPress, Qt::Key_Backslash, Qt::GroupSwitchModifier, "\\" };
+	QCOMPARE(NeovimQt::Input::convertKey(evOptionBeta), QString{ "<Bslash>" });
+
+	QKeyEvent evOptionPlus{ QEvent::KeyPress, Qt::Key_AsciiTilde, Qt::GroupSwitchModifier, "~" };
+	QCOMPARE(NeovimQt::Input::convertKey(evOptionPlus), QString{ "~" });
 }
 
 #include "tst_input_unix.moc"

--- a/test/tst_input_win32.cpp
+++ b/test/tst_input_win32.cpp
@@ -11,6 +11,7 @@ private slots:
 	void SpecialKeys() noexcept;
 	void CtrlCaretWellFormed() noexcept;
 	void ShiftModifierLetter() noexcept;
+	void GermanKeyboardLayout() noexcept;
 };
 
 void TestInputWin32::LessThanModifierKeys() noexcept
@@ -64,6 +65,33 @@ void TestInputWin32::ShiftModifierLetter() noexcept
 	QKeyEvent evCtrlShiftB{ QEvent::KeyPress, Qt::Key_B, Qt::ControlModifier | Qt::ShiftModifier,
 		QString{ "\u0002" } };
 	QCOMPARE(NeovimQt::Input::convertKey(evCtrlShiftB), QString{ "<C-S-B>" });
+}
+
+void TestInputWin32::GermanKeyboardLayout() noexcept
+{
+	QKeyEvent evAlt7{ QEvent::KeyPress, Qt::Key_BraceLeft, Qt::ControlModifier | Qt::AltModifier, "{" };
+	QCOMPARE(NeovimQt::Input::convertKey(evAlt7), QString{ "{" });
+
+	QKeyEvent evAlt8{ QEvent::KeyPress, Qt::Key_BracketLeft, Qt::ControlModifier | Qt::AltModifier, "[" };
+	QCOMPARE(NeovimQt::Input::convertKey(evAlt8), QString{ "[" });
+
+	QKeyEvent evAlt9{ QEvent::KeyPress, Qt::Key_BracketRight, Qt::ControlModifier | Qt::AltModifier, "]" };
+	QCOMPARE(NeovimQt::Input::convertKey(evAlt9), QString{ "]" });
+
+	QKeyEvent evAlt0{ QEvent::KeyPress, Qt::Key_BraceRight, Qt::ControlModifier | Qt::AltModifier, "}" };
+	QCOMPARE(NeovimQt::Input::convertKey(evAlt0), QString{ "}" });
+
+	QKeyEvent evKeyAt{ QEvent::KeyPress, Qt::Key_At, Qt::ControlModifier | Qt::AltModifier, "@" };
+	QCOMPARE(NeovimQt::Input::convertKey(evKeyAt), QString{ "@" });
+
+	QKeyEvent evKeyBSlash{ QEvent::KeyPress, Qt::Key_Backslash, Qt::ControlModifier | Qt::AltModifier, "\\" };
+	QCOMPARE(NeovimQt::Input::convertKey(evKeyBSlash), QString{ "<Bslash>" });
+
+	QKeyEvent evKeyTilde{ QEvent::KeyPress, Qt::Key_AsciiTilde, Qt::ControlModifier | Qt::AltModifier, "~" };
+	QCOMPARE(NeovimQt::Input::convertKey(evKeyTilde), QString{ "~" });
+
+	QKeyEvent evLeftAlt8{ QEvent::KeyPress, Qt::Key_8, Qt::AltModifier, "8" };
+	QCOMPARE(NeovimQt::Input::convertKey(evLeftAlt8), QString{ "<A-8>" });
 }
 
 #include "tst_input_win32.moc"


### PR DESCRIPTION
**Issue #833**: Fix German MacOS AltModifier low-ascii keys.

Some layouts require Alt to input low-ascii characters (German "{").
Other keyboard layouts do not require Alt (US "{").

`AltModifier` should be removed for the former but not the later. Unfortunately, Qt does not provide robust keyboard layout detection. See #836.

We can indirectly detect this scenario by comparing `Qt::Key` and text values. `AltModifier` will be removed for a subset of known characters whenever `Qt::Key` does not directly map to text.