### PR TITLE
Cleanup deprecated code before enabling qt6 builds

### DIFF
--- a/src/function.cpp
+++ b/src/function.cpp
@@ -58,7 +58,7 @@ bool Function::isValid() const
  * Two functions are considered identical if their names
  * argument and return types, and error status are identical
  */
-bool Function::operator==(const Function& other)
+bool Function::operator==(const Function& other) const
 {
 	if ( this->name != other.name ) {
 		return false;

--- a/src/function.h
+++ b/src/function.h
@@ -19,7 +19,7 @@ public:
 	Function(const QString& ret, const QString& name, QList<QPair<QString,QString> > params, bool can_fail);
 	Function(const QString& ret, const QString& name, QList<QString> paramTypes, bool can_fail);
 	bool isValid() const;
-	bool operator==(const Function& other);
+	bool operator==(const Function& other) const;
 	static Function fromVariant(const QVariant&);
 	static QList<QPair<QString,QString> > parseParameters(const QVariantList& obj);
 

--- a/src/gui/errorwidget.h
+++ b/src/gui/errorwidget.h
@@ -3,7 +3,7 @@
 
 #include <QLabel>
 #include <QPushButton>
-#include <QtSvg/QSvgWidget>
+#include <QSvgWidget>
 #include <QWidget>
 
 namespace NeovimQt {

--- a/src/gui/input.cpp
+++ b/src/gui/input.cpp
@@ -73,7 +73,7 @@ static QVariant GetButtonName(
 		case Qt::RightButton:
 			return QStringLiteral("Right");
 
-		case Qt::MidButton:
+		case Qt::MiddleButton:
 			return QStringLiteral("Middle");
 
 		case Qt::NoButton:

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -525,8 +525,6 @@ static QPalette CreatePaletteFromHighlightGroups(const Shell& shell) noexcept
 	const QColor& foreground{ shell.foreground() };
 
 	QPalette palette;
-	palette.setColor(QPalette::Background, background);
-	palette.setColor(QPalette::Foreground, foreground);
 	palette.setColor(QPalette::Window, background);
 	palette.setColor(QPalette::WindowText, foreground);
 	palette.setColor(QPalette::Base, background);

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -79,7 +79,7 @@ void MainWindow::init(NeovimConnector *c)
 	QWidget* shellScrollable{ new QWidget() };
 	QHBoxLayout* layout{ new QHBoxLayout() };
 	layout->setSpacing(0);
-	layout->setMargin(0);
+	layout->setContentsMargins(0, 0, 0, 0);
 	layout->addWidget(m_shell);
 	layout->addWidget(m_scrollbar);
 	shellScrollable->setLayout(layout);

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -1267,8 +1267,8 @@ void Shell::neovimMouseEvent(QMouseEvent *ev)
 			bt = Qt::LeftButton;
 		} else if (ev->buttons() & Qt::RightButton) {
 			bt = Qt::RightButton;
-		} else if (ev->buttons() & Qt::MidButton) {
-			bt = Qt::MidButton;
+		} else if (ev->buttons() & Qt::MiddleButton) {
+			bt = Qt::MiddleButton;
 		} else {
 			return;
 		}

--- a/src/gui/shellwidget/shellwidget.cpp
+++ b/src/gui/shellwidget/shellwidget.cpp
@@ -543,7 +543,7 @@ void ShellWidget::paintForegroundTextBlock(
 
 		// When the cursor IS within the glyph run, decompose individual characters under the cursor.
 		const int cursorGlyphRunPos { cursorPos - glyphsRendered };
-		const QString textGlyphRun{ QStringRef{ &text, glyphsRendered, sizeGlyphRun }.toString() };
+		const QString textGlyphRun{ QStringView{text}.mid(glyphsRendered, sizeGlyphRun).toString() };
 
 		// Compares a glyph run with and without ligatures. Ligature glyphs are detected as differences
 		// in these two lists. A non-empty newCursorGlyphList indicates glyph substitution is required.
@@ -1007,7 +1007,9 @@ QVariant ShellWidget::TryGetQFontFromDescription(const QString& fdesc) const noe
 	for (const auto& attr : attrs) {
 		if (attr.size() >= 2 && attr[0] == 'h') {
 			bool ok{ false };
-			qreal height = attr.midRef(1).toFloat(&ok);
+			// TODO: the additional toString() call is needed to be compatible with
+			// both Qt5/6. Remove when the minimum Qt version is 5.15 or above
+			qreal height = QStringView{attr}.mid(1).toString().toFloat(&ok);
 			if (!ok || height < 0) {
 				return QStringLiteral("Invalid font height");
 			}
@@ -1019,7 +1021,9 @@ QVariant ShellWidget::TryGetQFontFromDescription(const QString& fdesc) const noe
 		} else if (attr == "sb") {
 			weight = QFont::DemiBold;
 		} else if (attr.length() > 0 && attr.at(0) == 'w') {
-			weight = (attr.rightRef(attr.length()-1)).toInt();
+			// TODO: the additional toString() call is needed to be compatible
+			// both Qt5/6. Remove when the minimum Qt version is 5.15 or above
+			weight = (QStringView{attr}.right(attr.length()-1)).toString().toInt();
 			if (weight < 0 || weight > 99) {
 				return QStringLiteral("Invalid font weight");
 			}

--- a/src/gui/shellwidget/shellwidget.cpp
+++ b/src/gui/shellwidget/shellwidget.cpp
@@ -517,7 +517,7 @@ void ShellWidget::paintForegroundTextBlock(
 	int glyphsRendered{ 0 };
 	for (auto& glyphRun : textLayout.glyphRuns()) {
 		auto glyphPositionList{ glyphRun.positions() };
-		int sizeGlyphRun{ glyphPositionList.size() };
+		qsizetype sizeGlyphRun{ glyphPositionList.size() };
 
 		const int cellWidth{ (cell.IsDoubleWidth()) ?
 			m_cellSize.width() * 2 : m_cellSize.width() };

--- a/src/msgpackiodevice.h
+++ b/src/msgpackiodevice.h
@@ -3,6 +3,8 @@
 
 #include <QIODevice>
 #include <QHash>
+#include <QTextCodec>
+#include <QVariant>
 #include <msgpack.h>
 
 namespace NeovimQt {

--- a/src/neovimconnector.cpp
+++ b/src/neovimconnector.cpp
@@ -353,7 +353,9 @@ NeovimConnector* NeovimConnector::connectToNeovim(const QString& server)
 	int colon_pos = addr.lastIndexOf(':');
 	if (colon_pos != -1 && colon_pos != 0 && addr[colon_pos-1] != ':') {
 		bool ok;
-		int port = addr.midRef(colon_pos+1).toInt(&ok);
+		// TODO: the additional toString() call is needed to be compatible with
+		// both Qt5/6. Remove when the minimum Qt version is 5.15 or above
+		int port = QStringView{addr}.mid(colon_pos+1).toString().toInt(&ok);
 		if (ok) {
 			QString host = addr.mid(0, colon_pos);
 			return connectToHost(host, port);

--- a/src/util.h
+++ b/src/util.h
@@ -2,6 +2,7 @@
 #define NEOVIM_QT_UTIL
 
 #include <QDebug>
+#include <QVariant>
 #include <msgpack.h>
 #include "function.h"
 

--- a/test/tst_input.h
+++ b/test/tst_input.h
@@ -1,0 +1,11 @@
+#pragma once
+
+// A class to hold test data. An event type/key/modifiers
+// as used in QKeyEvent and a matching Neovim input string.
+struct InputTest
+{
+	QEvent::Type event_type;
+	int key;
+	Qt::KeyboardModifiers modifiers;
+	QString expected_input;
+};

--- a/test/tst_input_common.cpp
+++ b/test/tst_input_common.cpp
@@ -247,15 +247,15 @@ void TestInputCommon::MouseRightClick() noexcept
 
 void TestInputCommon::MouseMiddleClick() noexcept
 {
-	//Qt::MidButton
+	//Qt::MiddleButton
 	QString middleClickPress{ NeovimQt::Input::convertMouse(
-		Qt::MidButton,
+		Qt::MiddleButton,
 		QEvent::MouseButtonPress,
 		Qt::NoModifier,
 		{ 1, 2 },
 		1 /*clickCount*/) };
 	QString middleClickRelease{ NeovimQt::Input::convertMouse(
-		Qt::MidButton,
+		Qt::MiddleButton,
 		QEvent::MouseButtonRelease,
 		Qt::NoModifier,
 		{ 1, 2 },

--- a/test/tst_input_mac.cpp
+++ b/test/tst_input_mac.cpp
@@ -1,6 +1,7 @@
 #include <QtTest/QtTest>
 
 #include <gui/input.h>
+#include "tst_input.h"
 
 class TestInputMac : public QObject
 {
@@ -46,16 +47,17 @@ void TestInputMac::SpecialKeys() noexcept
 
 	for (const auto k : specialKeys) {
 		// On Mac Meta is the Control key, treated as C-.
-		QList<QPair<QKeyEvent, QString>> keyEventList{
-			{ { QEvent::KeyPress, k, Qt::NoModifier, {} },      "<%1>" },
-			{ { QEvent::KeyPress, k, Qt::ControlModifier, {} }, "<D-%1>" },
-			{ { QEvent::KeyPress, k, Qt::AltModifier, {} },     "<A-%1>" },
-			{ { QEvent::KeyPress, k, Qt::MetaModifier, {} },    "<C-%1>" },
+		QList<InputTest> keyEventList{
+			{ QEvent::KeyPress, k, Qt::NoModifier,       "<%1>" },
+			{ QEvent::KeyPress, k, Qt::ControlModifier,  "<D-%1>" },
+			{ QEvent::KeyPress, k, Qt::AltModifier,      "<A-%1>" },
+			{ QEvent::KeyPress, k, Qt::MetaModifier,     "<C-%1>" },
 		};
 
-		for (const auto& keyEvent : keyEventList) {
-			QCOMPARE(NeovimQt::Input::convertKey(keyEvent.first),
-				keyEvent.second.arg(NeovimQt::Input::GetSpecialKeysMap().value(k)));
+		for (const auto& keyTest : keyEventList) {
+			auto event = QKeyEvent(keyTest.event_type, keyTest.key, keyTest.modifiers);
+			QCOMPARE(NeovimQt::Input::convertKey(event),
+				keyTest.expected_input.arg(NeovimQt::Input::GetSpecialKeysMap().value(k)));
 		}
 	}
 }

--- a/test/tst_input_unix.cpp
+++ b/test/tst_input_unix.cpp
@@ -1,6 +1,7 @@
 #include <QtTest/QtTest>
 
 #include <gui/input.h>
+#include "tst_input.h"
 
 class TestInputUnix : public QObject
 {
@@ -31,16 +32,17 @@ void TestInputUnix::SpecialKeys() noexcept
 
 	for (const auto k : specialKeys) {
 		// On Mac Meta is the Control key, treated as C-.
-		QList<QPair<QKeyEvent, QString>> keyEventList{
-			{ { QEvent::KeyPress, k, Qt::NoModifier, {} },      "<%1>" },
-			{ { QEvent::KeyPress, k, Qt::ControlModifier, {} }, "<C-%1>" },
-			{ { QEvent::KeyPress, k, Qt::AltModifier, {} },     "<A-%1>" },
-			{ { QEvent::KeyPress, k, Qt::MetaModifier, {} },    "<D-%1>" },
+		QList<InputTest> keyEventList{
+			{ QEvent::KeyPress, k, Qt::NoModifier,		"<%1>" },
+			{ QEvent::KeyPress, k, Qt::ControlModifier, "<C-%1>" },
+			{ QEvent::KeyPress, k, Qt::AltModifier,     "<A-%1>" },
+			{ QEvent::KeyPress, k, Qt::MetaModifier,    "<D-%1>" },
 		};
 
-		for (const auto& keyEvent : keyEventList) {
-			QCOMPARE(NeovimQt::Input::convertKey(keyEvent.first),
-				keyEvent.second.arg(NeovimQt::Input::GetSpecialKeysMap().value(k)));
+		for (const auto& keyTest : keyEventList) {
+			auto event = QKeyEvent(keyTest.event_type, keyTest.key, keyTest.modifiers);
+			QCOMPARE(NeovimQt::Input::convertKey(event),
+				keyTest.expected_input.arg(NeovimQt::Input::GetSpecialKeysMap().value(k)));
 		}
 	}
 }

--- a/test/tst_input_win32.cpp
+++ b/test/tst_input_win32.cpp
@@ -1,6 +1,7 @@
 #include <QtTest/QtTest>
 
 #include <gui/input.h>
+#include "tst_input.h"
 
 class TestInputWin32 : public QObject
 {
@@ -31,16 +32,17 @@ void TestInputWin32::SpecialKeys() noexcept
 
 	for (const auto k : specialKeys) {
 		// On Mac Meta is the Control key, treated as C-.
-		QList<QPair<QKeyEvent, QString>> keyEventList{
-			{ { QEvent::KeyPress, k, Qt::NoModifier, {} },      "<%1>" },
-			{ { QEvent::KeyPress, k, Qt::ControlModifier, {} }, "<C-%1>" },
-			{ { QEvent::KeyPress, k, Qt::AltModifier, {} },     "<A-%1>" },
-			{ { QEvent::KeyPress, k, Qt::MetaModifier, {} },    "<%1>" },
+		QList<InputTest> keyEventList{
+			{ QEvent::KeyPress, k, Qt::NoModifier,       "<%1>" },
+			{ QEvent::KeyPress, k, Qt::ControlModifier,  "<C-%1>" },
+			{ QEvent::KeyPress, k, Qt::AltModifier,      "<A-%1>" },
+			{ QEvent::KeyPress, k, Qt::MetaModifier,     "<%1>" },
 		};
 
-		for (const auto& keyEvent : keyEventList) {
-			QCOMPARE(NeovimQt::Input::convertKey(keyEvent.first),
-				keyEvent.second.arg(NeovimQt::Input::GetSpecialKeysMap().value(k)));
+		for (const auto& keyTest : keyEventList) {
+			auto event = QKeyEvent(keyTest.event_type, keyTest.key, keyTest.modifiers);
+			QCOMPARE(NeovimQt::Input::convertKey(event),
+				keyTest.expected_input.arg(NeovimQt::Input::GetSpecialKeysMap().value(k)));
 		}
 	}
 }


### PR DESCRIPTION
While porting for Qt6 https://github.com/equalsraf/neovim-qt/issues/839 I came across some APIs that were deprecated during the Qt5 cycle and removed in Qt6. I have extracted these from https://github.com/equalsraf/neovim-qt/pull/840 and they correspond to changes in Qt6 that would not build, and should not alter the current behavior (i.e. the easy stuff).