### PR TITLE
Generate installer in Appveyor builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,4 +120,3 @@ if (PYTHONINTERP_FOUND)
 endif()
 
 include(CPackOptions)
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,6 @@ endif (POLICY CMP0048)
 # 9999 = Development Pre-Release
 project(neovim-qt VERSION 0.2.17.9999)
 
-INCLUDE(CPack)
-
 if(NOT EXISTS ${NEOVIM_EXEC})
 	set(NEOVIM_EXEC nvim)
 endif()
@@ -121,4 +119,5 @@ if (PYTHONINTERP_FOUND)
 		)
 endif()
 
+include(CPackOptions)
 

--- a/cmake/CPackOptions.cmake
+++ b/cmake/CPackOptions.cmake
@@ -1,0 +1,16 @@
+
+# Name packages as neovim-qt-installer
+set(CPACK_PACKAGE_FILE_NAME "${CMAKE_PROJECT_NAME}-installer")
+
+# WIX cannot handle a license file without a supported extension
+set(PACKAGE_LICENSE_TXT "${PROJECT_BINARY_DIR}/LICENSE.txt")
+file(COPY ${PROJECT_SOURCE_DIR}/LICENSE DESTINATION ${PROJECT_BINARY_DIR})
+file(RENAME "${PROJECT_BINARY_DIR}/LICENSE" ${PACKAGE_LICENSE_TXT})
+set(CPACK_RESOURCE_FILE_LICENSE ${PACKAGE_LICENSE_TXT})
+# Used by Wix installer to detect upgrades
+set(CPACK_WIX_UPGRADE_GUID "b3357595-f87b-4706-85b0-e2630d989979")
+# Pack Wix settings with additional options
+set(CPACK_WIX_PATCH_FILE "${PROJECT_SOURCE_DIR}/contrib/wix_patch.xml")
+set(CPACK_WIX_PRODUCT_ICON "${PROJECT_SOURCE_DIR}/third-party/neovim.ico")
+
+include(CPack)

--- a/contrib/appveyor.yml
+++ b/contrib/appveyor.yml
@@ -34,6 +34,7 @@ build_script:
 - cd build
 - cmake -G "%GENERATOR%" -DCMAKE_PREFIX_PATH="%CMAKE_PATH_PREFIX%" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../INSTALL %EXTRA_CMAKE_ARGS% ..
 - cmake --build . --config Release --target install
+- cpack --verbose -G WIX
 test_script:
 - set PATH=%QTPATH%;%QTPATH%/bin;%PATH%
 - echo %PATH%
@@ -43,6 +44,7 @@ test_script:
 artifacts:
 - path: INSTALL
   name: neovim-qt
+- path: build\_CPack_Packages\win64\WIX\neovim-qt-installer.msi
 deploy:
   - provider: GitHub
     description: Automated builds (Appveyor)

--- a/contrib/wix_patch.xml
+++ b/contrib/wix_patch.xml
@@ -1,0 +1,5 @@
+<CPackWiXPatch>
+	<CPackWiXFragment Id="CM_CP_bin.nvim_qt.exe">
+		<Environment Id="Path" Action="set" Part="last" Name="PATH" Value="[INSTALL_ROOT]bin" System="yes"/>
+	</CPackWiXFragment>
+</CPackWiXPatch>

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -96,6 +96,8 @@ if(NOT APPLE)
 	install(DIRECTORY runtime
 		DESTINATION ${CMAKE_INSTALL_DATADIR}/nvim-qt/
 		PATTERN "README.md" EXCLUDE)
+	install(FILES ${PROJECT_SOURCE_DIR}/LICENSE
+		DESTINATION ${CMAKE_INSTALL_DATADIR}/nvim-qt/)
 	install(FILES nvim-qt.desktop DESTINATION ${CMAKE_INSTALL_DATADIR}/applications)
 	install(FILES ${CMAKE_SOURCE_DIR}/third-party/neovim.png
 			RENAME nvim-qt.png


### PR DESCRIPTION
Still WIP, but to make life a little easier I was trying to get Appveyor to generate .exe NSIS installers for neovim-qt.

The installer packages the same files as the zip file, plus an NSIS uninstaller.

Note: Appveyor is unable to get the neovim nightly builds (404) since today, that is why i added the second commit.