### PR TITLE
Adding support for multiple windows in the same process on macOS

### DIFF
--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -32,6 +32,17 @@ struct ConnectorInitArgs {
 
 	}
 
+	ConnectorInitArgs(QStringList nvimArgs)
+		: type{Type::Default}
+		, timeout{2000}
+		, server{""}
+		, nvim{"nvim"}
+		, positionalArgs{}
+		, neovimArgs{std::move(nvimArgs)}
+	{
+
+	}
+
 	const Type type;
 	const int timeout;
 	const QString server;
@@ -375,6 +386,14 @@ void App::showVersionInfo(QCommandLineParser& parser) noexcept
 	out << GetNeovimVersionInfo(nvimExecutable) << QT_ENDL;
 
 	PrintInfo(versionInfo);
+}
+
+void App::openNewWindow() noexcept
+{
+	auto connector = connectToRemoteNeovim(ConnectorInitArgs{getNeovimArgs()});
+	Q_ASSERT(connector);
+	NeovimQt::MainWindow *win = new NeovimQt::MainWindow(connector);
+	win->show();
 }
 
 void App::mainWindowClosing(int status) {

--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -255,8 +255,6 @@ void App::showUi() noexcept
 		win->show();
 	}
 #else
-	// FIXME: On macOS, Cmd+q kills the first window that was created.
-	// There doesn't seem to be a good order to how windows are closed.
 	auto win{createWindow(connectToRemoteNeovim(ConnectorInitArgs{ m_parser, getNeovimArgs() }))};
 
 	// delete the main window when closed to emit `destroyed()` signal to

--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -126,10 +126,11 @@ void onWindowDestroyed() {
 MainWindow* createWindow(NeovimConnector* connector)
 {
 	Q_ASSERT(connector);
-	NeovimQt::MainWindow *win = new NeovimQt::MainWindow(connector);
+
+	NeovimQt::MainWindow *win{new NeovimQt::MainWindow(connector)};
 	win->setAttribute(Qt::WA_DeleteOnClose);
 
-	App *app = qobject_cast<App *>(App::instance());
+	App *app{qobject_cast<App *>(App::instance())};
 	Q_ASSERT(app);
 
 	QObject::connect(win, &MainWindow::closing, app, onWindowClosing);
@@ -248,8 +249,7 @@ void App::showUi() noexcept
 #else
 	// FIXME: On macOS, Cmd+q kills the first window that was created.
 	// There doesn't seem to be a good order to how windows are closed.
-	auto *win = createWindow(
-			connectToRemoteNeovim(ConnectorInitArgs{m_parser, getNeovimArgs()}));
+	auto win{createWindow(connectToRemoteNeovim(ConnectorInitArgs{ m_parser, getNeovimArgs() }))};
 
 	// delete the main window when closed to emit `destroyed()` signal to
 	// support `:cq` return codes (Pull#644).
@@ -464,9 +464,9 @@ void App::openNewWindow(const QVariantList& args) noexcept
 		}
 	}
 
-	auto connector = connectToRemoteNeovim(ConnectorInitArgs{
-		type, 2000, std::move(server), std::move(nvim), getNeovimArgs()});
-	auto win = createWindow(connector);
+	NeovimConnector* connector{connectToRemoteNeovim(
+		ConnectorInitArgs{ type, 2000, std::move(server), std::move(nvim), getNeovimArgs() })};
+	MainWindow* win{createWindow(connector)};
 	win->resize(s_lastActiveWindow->size());
 	win->delayedShow();
 }

--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -29,23 +29,23 @@ struct ConnectorInitArgs {
 		Default
 	};
 
-	ConnectorInitArgs(const QCommandLineParser& parser, QStringList nvimArgs)
-		: type{getConnectorType(parser)}
-		, timeout{parser.value("timeout").toInt()}
-		, server{parser.value("server")}
-		, nvim{parser.value("nvim")}
-		, positionalArgs{parser.positionalArguments()}
-		, neovimArgs{std::move(nvimArgs)}
+	ConnectorInitArgs(const QCommandLineParser& parser, QStringList nvimArgs) noexcept
+		: type{ getConnectorType(parser) }
+		, timeout{ parser.value("timeout").toInt() }
+		, server{ parser.value("server") }
+		, nvim{ parser.value("nvim") }
+		, positionalArgs{ parser.positionalArguments() }
+		, neovimArgs{ std::move(nvimArgs) }
 	{
 
 	}
 
-	ConnectorInitArgs(Type _type, int _timeout, QString _server, QString _nvim,
-					QStringList nvimArgs)
-		: type{_type}
-		, timeout{_timeout}
-		, server{std::move(_server)}
-		, nvim{std::move(_nvim)}
+	ConnectorInitArgs(
+		Type _type, int _timeout, QString _server, QString _nvim, QStringList nvimArgs) noexcept
+		: type{ _type }
+		, timeout{ _timeout }
+		, server{ std::move(_server) }
+		, nvim{ std::move(_nvim) }
 		, positionalArgs{}
 		, neovimArgs{std::move(nvimArgs)}
 	{
@@ -58,7 +58,7 @@ struct ConnectorInitArgs {
 	const QStringList positionalArgs;
 	const QStringList neovimArgs;
 
-	Type getConnectorType(const QCommandLineParser &parser)
+	Type getConnectorType(const QCommandLineParser& parser) noexcept
 	{
 		if (parser.isSet("server")) {
 			return ConnectorInitArgs::Type::Server;
@@ -76,7 +76,7 @@ struct ConnectorInitArgs {
 	}
 };
 
-NeovimConnector* connectToRemoteNeovim(const ConnectorInitArgs &args)
+NeovimConnector* connectToRemoteNeovim(const ConnectorInitArgs& args) noexcept
 {
 	NeovimConnector *connector{nullptr};
 	if (args.type == ConnectorInitArgs::Type::Embed) {
@@ -102,28 +102,30 @@ NeovimConnector* connectToRemoteNeovim(const ConnectorInitArgs &args)
 	return connector;
 }
 
-void onWindowActiveChanged(MainWindow& window)
+void onWindowActiveChanged(MainWindow& window) noexcept
 {
 	s_lastActiveWindow = &window;
 }
 
-void onFileOpenEvent(const QList<QUrl>& files)
+void onFileOpenEvent(const QList<QUrl>& files) noexcept
 {
 	Q_ASSERT(s_lastActiveWindow);
 	s_lastActiveWindow->shell()->openFiles(files);
 }
 
-void onWindowClosing(int status) {
+void onWindowClosing(int status) noexcept
+{
 	s_exitStatus = status;
 }
 
-void onWindowDestroyed() {
+void onWindowDestroyed() noexcept
+{
 	if (s_windows.empty()) {
 		qApp->exit(s_exitStatus);
 	}
 }
 
-MainWindow* createWindow(NeovimConnector* connector)
+MainWindow* createWindow(NeovimConnector* connector) noexcept
 {
 	Q_ASSERT(connector);
 

--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -17,9 +17,9 @@ namespace NeovimQt {
 
 namespace {
 
+// TODO Issue#900: Cleanup Clazy warning. Optional: remove global statics.
 MainWindow* s_lastActiveWindow;
-std::vector<MainWindow*> s_windows;
-
+std::vector<MainWindow*> s_windows; // clazy:exclude=non-pod-global-static
 int s_exitStatus{ 0 };
 
 struct ConnectorInitArgs
@@ -62,7 +62,8 @@ ConnectorInitArgs::Type getConnectorType(const QCommandLineParser& parser) noexc
 	return ConnectorInitArgs::Type::Default;
 }
 
-ConnectorInitArgs::ConnectorInitArgs(const QCommandLineParser& parser, QStringList nvimArgs) noexcept
+ConnectorInitArgs::ConnectorInitArgs(
+	const QCommandLineParser& parser, QStringList nvimArgs) noexcept
 	: type{ getConnectorType(parser) }
 	, timeout{ parser.value("timeout").toInt() }
 	, server{ parser.value("server") }
@@ -97,9 +98,9 @@ NeovimConnector& connectToRemoteNeovim(const ConnectorInitArgs& args) noexcept
 			break;
 
 		case ConnectorInitArgs::Type::Spawn:
-			if (args.positionalArgs.size() >= 2)
-			{
-				connector = NeovimConnector::spawn(args.positionalArgs.mid(1), args.positionalArgs.at(0));
+			if (args.positionalArgs.size() >= 2) {
+				connector =
+					NeovimConnector::spawn(args.positionalArgs.mid(1), args.positionalArgs.at(0));
 			}
 			break;
 
@@ -463,7 +464,6 @@ void App::openNewWindow(const QVariantList& args) noexcept
 	QString nvim{ "nvim" };
 	ConnectorInitArgs::Type type{ ConnectorInitArgs::Type::Default };
 	if (args.size() > 1 && args.at(1).type() == QVariant::Type::Map) {
-
 		const QVariantMap initMap{ args.at(1).toMap() };
 
 		if (initMap.contains("nvim")) {

--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -225,9 +225,7 @@ bool App::event(QEvent *event) noexcept
 {
 	if( event->type()  == QEvent::FileOpen) {
 		QFileOpenEvent * fileOpenEvent = static_cast<QFileOpenEvent *>(event);
-		if(fileOpenEvent) {
-			emit openFilesTriggered({fileOpenEvent->url()});
-		}
+		onFileOpenEvent({fileOpenEvent->url()});
 	}
 	else if (event->type() == QEvent::Quit) {
 		for (auto window : s_windows) {

--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -14,7 +14,7 @@
 namespace NeovimQt {
 
 struct ConnectorInitArgs {
-	enum Type {
+	enum class Type {
 		Embed,
 		Server,
 		Spawn,
@@ -29,7 +29,7 @@ struct ConnectorInitArgs {
 	const QStringList neovimArgs;
 };
 
-ConnectorInitArgs::Type getConnectorType(const QCommandLineParser &parser)
+ConnectorInitArgs::Type getConnectorType(const QCommandLineParser& parser)
 {
 	if (parser.isSet("server")) {
 		return ConnectorInitArgs::Type::Server;
@@ -46,7 +46,7 @@ ConnectorInitArgs::Type getConnectorType(const QCommandLineParser &parser)
 	return ConnectorInitArgs::Type::Default;
 }
 
-NeovimConnector *connectoToRemoteNeovim(const ConnectorInitArgs &args)
+NeovimConnector* connectToRemoteNeovim(const ConnectorInitArgs &args)
 {
 	NeovimConnector *connector{nullptr};
 	if (args.type == ConnectorInitArgs::Type::Embed) {
@@ -163,7 +163,7 @@ void App::showUi() noexcept
 		win->show();
 	}
 #else
-	auto connector = connectoToRemoteNeovim(ConnectorInitArgs{
+	auto connector = connectToRemoteNeovim(ConnectorInitArgs{
 		getConnectorType(m_parser),
 		m_parser.value("timeout").toInt(),
 		m_parser.value("server"),

--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -13,11 +13,13 @@
 
 #include <vector>
 
-namespace NeovimQt {
+namespace {
+NeovimQt::MainWindow* s_lastActiveWindow{nullptr};
+std::vector<NeovimQt::MainWindow*> s_windows;
+int s_exitStatus{0};
+} // namespace
 
-MainWindow* s_lastActiveWindow{nullptr};
-std::vector<MainWindow*> s_windows;
-int s_exitStatus{ 0 };
+namespace NeovimQt {
 
 struct ConnectorInitArgs {
 	enum class Type {

--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -69,7 +69,7 @@ NeovimConnector* connectToRemoteNeovim(const ConnectorInitArgs &args)
 	}
 
 	if (args.type == ConnectorInitArgs::Type::Spawn) {
-		assert(!args.positionalArgs.isEmpty());
+		Q_ASSERT(!args.positionalArgs.isEmpty());
 		connector = NeovimQt::NeovimConnector::spawn(args.positionalArgs.mid(1),
 				args.positionalArgs.at(0));
 	}

--- a/src/gui/app.h
+++ b/src/gui/app.h
@@ -20,7 +20,6 @@ public:
 	App(int &argc, char ** argv) noexcept;
 	bool event(QEvent *event) noexcept;
 	void showUi() noexcept;
-	void connectToRemoteNeovim() noexcept;
 	QCommandLineParser& commandLineParser() { return m_parser; }
 	static void checkArgumentsMayTerminate(QCommandLineParser&) noexcept;
 	static void processCommandlineOptions(QCommandLineParser&, QStringList) noexcept;
@@ -28,11 +27,9 @@ public:
 private:
 	static QString getRuntimePath() noexcept;
 	static QStringList getNeovimArgs() noexcept;
-	void setupRequestTimeout() noexcept;
 	static void showVersionInfo(QCommandLineParser&) noexcept;
 
 	QCommandLineParser m_parser;
-	std::shared_ptr<NeovimConnector> m_connector;
 	int m_exitStatus{ 0 };
 
 public slots:

--- a/src/gui/app.h
+++ b/src/gui/app.h
@@ -23,6 +23,7 @@ public:
 	QCommandLineParser& commandLineParser() { return m_parser; }
 	static void checkArgumentsMayTerminate(QCommandLineParser&) noexcept;
 	static void processCommandlineOptions(QCommandLineParser&, QStringList) noexcept;
+	static void openNewWindow() noexcept;
 
 private:
 	static QString getRuntimePath() noexcept;

--- a/src/gui/app.h
+++ b/src/gui/app.h
@@ -23,7 +23,7 @@ public:
 	QCommandLineParser& commandLineParser() { return m_parser; }
 	static void checkArgumentsMayTerminate(QCommandLineParser&) noexcept;
 	static void processCommandlineOptions(QCommandLineParser&, QStringList) noexcept;
-	static void openNewWindow() noexcept;
+	static void openNewWindow(const QVariantList& args) noexcept;
 
 private:
 	static QString getRuntimePath() noexcept;
@@ -31,11 +31,6 @@ private:
 	static void showVersionInfo(QCommandLineParser&) noexcept;
 
 	QCommandLineParser m_parser;
-	int m_exitStatus{ 0 };
-
-public slots:
-	void mainWindowClosing(int);
-	void exitWithStatus();
 
 signals:
 	void openFilesTriggered(const QList<QUrl>);

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -36,8 +36,6 @@ int ui_main(int argc, char **argv)
 
 	app.checkArgumentsMayTerminate(app.commandLineParser());
 
-	app.connectToRemoteNeovim();
-
 	app.showUi();
 	return app.exec();
 }

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -276,7 +276,7 @@ void MainWindow::closeEvent(QCloseEvent *ev)
 		ev->ignore();
 	}
 }
-void MainWindow::changeEvent(QEvent *ev)
+void MainWindow::changeEvent(QEvent* ev)
 {
 	if (ev->type() == QEvent::WindowStateChange && isWindow()) {
 		m_shell->updateGuiWindowState(windowState());

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -469,8 +469,7 @@ void MainWindow::restoreWindowGeometry()
 	restoreState(settings.value("window_state").toByteArray());
 }
 
-bool
-MainWindow::active() const
+bool MainWindow::active() const noexcept
 {
 	return m_isActive;
 }

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -24,7 +24,6 @@ MainWindow::MainWindow(NeovimConnector* c, QWidget* parent)
 
 void MainWindow::init(NeovimConnector *c)
 {
-	Q_ASSERT(c);
 	if (m_shell) {
 		m_shell->deleteLater();
 		m_stack.removeWidget(m_shell);
@@ -277,13 +276,13 @@ void MainWindow::closeEvent(QCloseEvent *ev)
 		ev->ignore();
 	}
 }
-void MainWindow::changeEvent( QEvent *ev)
+void MainWindow::changeEvent(QEvent *ev)
 {
 	if (ev->type() == QEvent::WindowStateChange && isWindow()) {
 		m_shell->updateGuiWindowState(windowState());
 
-		m_isActive = windowState() == Qt::WindowState::WindowActive;
-		emit activeChanged(*this, QPrivateSignal{});
+		m_isActive = (windowState() == Qt::WindowState::WindowActive);
+		emit activeChanged(*this);
 	}
 	QWidget::changeEvent(ev);
 }
@@ -467,11 +466,6 @@ void MainWindow::restoreWindowGeometry()
 	QSettings settings{ "nvim-qt", "window-geometry" };
 	restoreGeometry(settings.value("window_geometry").toByteArray());
 	restoreState(settings.value("window_state").toByteArray());
-}
-
-bool MainWindow::active() const noexcept
-{
-	return m_isActive;
 }
 
 void MainWindow::setGuiAdaptiveColorEnabled(bool isEnabled)

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -24,6 +24,7 @@ MainWindow::MainWindow(NeovimConnector* c, QWidget* parent)
 
 void MainWindow::init(NeovimConnector *c)
 {
+	Q_ASSERT(c);
 	if (m_shell) {
 		m_shell->deleteLater();
 		m_stack.removeWidget(m_shell);
@@ -280,6 +281,9 @@ void MainWindow::changeEvent( QEvent *ev)
 {
 	if (ev->type() == QEvent::WindowStateChange && isWindow()) {
 		m_shell->updateGuiWindowState(windowState());
+
+		m_isActive = windowState() == Qt::WindowState::WindowActive;
+		emit activeChanged(*this, QPrivateSignal{});
 	}
 	QWidget::changeEvent(ev);
 }
@@ -463,6 +467,12 @@ void MainWindow::restoreWindowGeometry()
 	QSettings settings{ "nvim-qt", "window-geometry" };
 	restoreGeometry(settings.value("window_geometry").toByteArray());
 	restoreState(settings.value("window_state").toByteArray());
+}
+
+bool
+MainWindow::active() const
+{
+	return m_isActive;
 }
 
 void MainWindow::setGuiAdaptiveColorEnabled(bool isEnabled)

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -24,10 +24,16 @@ MainWindow::MainWindow(NeovimConnector* c, QWidget* parent)
 
 void MainWindow::init(NeovimConnector *c)
 {
-	assert(!m_shell);
-	assert(!m_nvim);
+	if (m_shell) {
+		m_shell->deleteLater();
+		m_stack.removeWidget(m_shell);
+	}
 
-	m_shell = new Shell{c, this};
+	if (m_nvim) {
+		m_nvim->deleteLater();
+	}
+
+	m_shell = new Shell(c);
 
 	m_tabline_bar = addToolBar("tabline");
 	m_tabline_bar->setObjectName("tabline");
@@ -244,21 +250,9 @@ void MainWindow::neovimGuiCloseRequest(int status)
 
 void MainWindow::reconnectNeovim()
 {
-	assert(m_nvim);
-	assert(m_shell);
-
 	if (m_nvim->canReconnect()) {
-		m_shell->deleteLater();
-		m_stack.removeWidget(m_shell);
-		m_shell = nullptr;
-
-		auto connector = m_nvim->reconnect();
-		m_nvim->deleteLater();
-		m_nvim = nullptr;
-
-		init(connector);
+		init(m_nvim->reconnect());
 	}
-
 	m_stack.setCurrentIndex(1);
 }
 

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -39,7 +39,7 @@ public slots:
 signals:
 	void neovimAttached(bool);
 	void closing(int);
-	void activeChanged(MainWindow& window);
+	void activeChanged(NeovimQt::MainWindow& window);
 
 protected:
 	virtual void closeEvent(QCloseEvent *ev) Q_DECL_OVERRIDE;

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -32,10 +32,7 @@ public:
 	Shell* shell();
 	void restoreWindowGeometry();
 
-	bool active() const noexcept
-	{
-		return m_isActive;
-	}
+	bool active() const noexcept { return m_isActive; }
 
 public slots:
 	void delayedShow(DelayedShow type=DelayedShow::Normal);

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -31,13 +31,19 @@ public:
 	bool neovimAttached() const;
 	Shell* shell();
 	void restoreWindowGeometry();
-	bool active() const noexcept;
+
+	bool active() const noexcept
+	{
+		return m_isActive;
+	}
+
 public slots:
 	void delayedShow(DelayedShow type=DelayedShow::Normal);
 signals:
 	void neovimAttached(bool);
 	void closing(int);
-	void activeChanged(MainWindow& window, QPrivateSignal);
+	void activeChanged(MainWindow& window);
+
 protected:
 	virtual void closeEvent(QCloseEvent *ev) Q_DECL_OVERRIDE;
 	virtual void changeEvent(QEvent *ev) Q_DECL_OVERRIDE;

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -31,11 +31,13 @@ public:
 	bool neovimAttached() const;
 	Shell* shell();
 	void restoreWindowGeometry();
+	bool active() const;
 public slots:
 	void delayedShow(DelayedShow type=DelayedShow::Normal);
 signals:
 	void neovimAttached(bool);
 	void closing(int);
+	void activeChanged(MainWindow& window, QPrivateSignal);
 protected:
 	virtual void closeEvent(QCloseEvent *ev) Q_DECL_OVERRIDE;
 	virtual void changeEvent(QEvent *ev) Q_DECL_OVERRIDE;
@@ -97,6 +99,8 @@ private:
 	bool m_isAdaptiveFontEnabled{ false };
 	QFont m_defaultFont;
 	QPalette m_defaultPalette;
+
+	bool m_isActive{ false };
 
 	void updateAdaptiveColor() noexcept;
 	void updateAdaptiveFont() noexcept;

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -31,7 +31,7 @@ public:
 	bool neovimAttached() const;
 	Shell* shell();
 	void restoreWindowGeometry();
-	bool active() const;
+	bool active() const noexcept;
 public slots:
 	void delayedShow(DelayedShow type=DelayedShow::Normal);
 signals:

--- a/src/gui/runtime/doc/nvim_gui_shim.txt
+++ b/src/gui/runtime/doc/nvim_gui_shim.txt
@@ -171,6 +171,16 @@ GuiClose() notifies the GUI that it should close. The GUI may or may not
 respect this request. The shim setups an autocommand to call this function
 when the |'VimLeave'| event occurs.
 
+							*GuiNewWindow(opts)*
+|GuiNewWindow()| creates a new window with the given map of arguments.
+Supported arguments are:
+
+The following parameters desceibe the fields in {opts}.
+
+Parameters: ~
+    {server} (optional, string): Server to connect to for the new window.
+    {nvim} (optional, string): Path to nvim instance.
+
 							*GuiName()*
 Returns the name of the GUI client. If multiple GUIs are connected the last
 one is used. If no name is available an empty string is returned.

--- a/src/gui/runtime/doc/nvim_gui_shim.txt
+++ b/src/gui/runtime/doc/nvim_gui_shim.txt
@@ -178,8 +178,8 @@ Supported arguments are:
 The following parameters desceibe the fields in {opts}.
 
 Parameters: ~
-    {server} (optional, string): Server to connect to for the new window.
-    {nvim} (optional, string): Path to nvim instance.
+	{server} (optional, string): Server to connect to for the new window.
+	{nvim} (optional, string): Path to nvim instance.
 
 							*GuiName()*
 Returns the name of the GUI client. If multiple GUIs are connected the last

--- a/src/gui/runtime/plugin/nvim_gui_shim.vim
+++ b/src/gui/runtime/plugin/nvim_gui_shim.vim
@@ -21,6 +21,11 @@ function! GuiClose() abort
   call rpcnotify(0, 'Gui', 'Close', v:exiting)
 endfunction
 
+" Open new window
+function! GuiNewWindow() abort
+  call rpcnotify(0, 'Gui', 'NewWindow')
+endfunction
+
 " Notify the GUI when exiting Neovim
 augroup nvim_gui_shim
   autocmd!

--- a/src/gui/runtime/plugin/nvim_gui_shim.vim
+++ b/src/gui/runtime/plugin/nvim_gui_shim.vim
@@ -22,8 +22,11 @@ function! GuiClose() abort
 endfunction
 
 " Open new window
-function! GuiNewWindow(args) abort
-  call rpcnotify(0, 'Gui', 'NewWindow', a:args)
+function! GuiNewWindow(...) abort
+	let server = get(a:, 0, 0)
+	let nvim = get(a:, 1, 0)
+
+	call rpcnotify(0, 'Gui', 'NewWindow', server, nvim)
 endfunction
 
 " Notify the GUI when exiting Neovim

--- a/src/gui/runtime/plugin/nvim_gui_shim.vim
+++ b/src/gui/runtime/plugin/nvim_gui_shim.vim
@@ -22,11 +22,8 @@ function! GuiClose() abort
 endfunction
 
 " Open new window
-function! GuiNewWindow(...) abort
-	let server = get(a:, 0, 0)
-	let nvim = get(a:, 1, 0)
-
-	call rpcnotify(0, 'Gui', 'NewWindow', server, nvim)
+function! GuiNewWindow(args) abort
+  call rpcnotify(0, 'Gui', 'NewWindow', a:args)
 endfunction
 
 " Notify the GUI when exiting Neovim

--- a/src/gui/runtime/plugin/nvim_gui_shim.vim
+++ b/src/gui/runtime/plugin/nvim_gui_shim.vim
@@ -22,8 +22,8 @@ function! GuiClose() abort
 endfunction
 
 " Open new window
-function! GuiNewWindow() abort
-  call rpcnotify(0, 'Gui', 'NewWindow')
+function! GuiNewWindow(args) abort
+  call rpcnotify(0, 'Gui', 'NewWindow', a:args)
 endfunction
 
 " Notify the GUI when exiting Neovim

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -12,13 +12,13 @@
 #include <QPaintEvent>
 #include <QSettings>
 
+#include "app.h"
 #include "helpers.h"
 #include "input.h"
 #include "konsole_wcwidth.h"
 #include "msgpackrequest.h"
 #include "util.h"
 #include "version.h"
-#include "app.h"
 
 namespace NeovimQt {
 
@@ -825,7 +825,8 @@ void Shell::handleNeovimNotification(const QByteArray &name, const QVariantList&
 			handleCloseEvent(args);
 		} else if (guiEvName == "NewWindow") {
 			App::openNewWindow(args);
-		} else if (guiEvName == "Option" && args.size() >= 3) {
+		}
+		else if (guiEvName == "Option" && args.size() >= 3) {
 			QString option = m_nvim->decode(args.at(1).toByteArray());
 			handleExtGuiOption(option, args.at(2));
 		} else if (guiEvName == "SetClipboard" && args.size() >= 4) {

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -18,6 +18,7 @@
 #include "msgpackrequest.h"
 #include "util.h"
 #include "version.h"
+#include "app.h"
 
 namespace NeovimQt {
 
@@ -822,6 +823,8 @@ void Shell::handleNeovimNotification(const QByteArray &name, const QVariantList&
 			m_nvim->api0()->vim_set_var("GuiMousehide", val);
 		} else if (guiEvName == "Close") {
 			handleCloseEvent(args);
+		} else if (guiEvName == "NewWindow") {
+			App::openNewWindow();
 		} else if (guiEvName == "Option" && args.size() >= 3) {
 			QString option = m_nvim->decode(args.at(1).toByteArray());
 			handleExtGuiOption(option, args.at(2));

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -825,8 +825,7 @@ void Shell::handleNeovimNotification(const QByteArray &name, const QVariantList&
 			handleCloseEvent(args);
 		} else if (guiEvName == "NewWindow") {
 			App::openNewWindow(args);
-		}
-		else if (guiEvName == "Option" && args.size() >= 3) {
+		} else if (guiEvName == "Option" && args.size() >= 3) {
 			QString option = m_nvim->decode(args.at(1).toByteArray());
 			handleExtGuiOption(option, args.at(2));
 		} else if (guiEvName == "SetClipboard" && args.size() >= 4) {

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -824,7 +824,7 @@ void Shell::handleNeovimNotification(const QByteArray &name, const QVariantList&
 		} else if (guiEvName == "Close") {
 			handleCloseEvent(args);
 		} else if (guiEvName == "NewWindow") {
-			App::openNewWindow();
+			App::openNewWindow(args);
 		} else if (guiEvName == "Option" && args.size() >= 3) {
 			QString option = m_nvim->decode(args.at(1).toByteArray());
 			handleExtGuiOption(option, args.at(2));


### PR DESCRIPTION
This is my first contribution here. The end goal for me is to have the a single app contain multiple windows on macOS as an option. It makes window switching much more convenient with "Cmd+`". In order to do that, I first wanted to remove the NeovimConnector dependency from the app and have it owned by each window that might be created.

This kidn of breaks the `:cq` support when there's multiple windows, though. Before I dive much into it, I wanted to make sure I can get a proper PR in. I think I'll open an issue about the multiple window support because there are some things that has to be considered before it can be implemented.

Closes #850.