### PR TITLE
Issue 854: Bold + Italic font weight not applied correctly

### DIFF
--- a/src/gui/shellwidget/shellwidget.cpp
+++ b/src/gui/shellwidget/shellwidget.cpp
@@ -353,8 +353,11 @@ QFont ShellWidget::GetCellFont(const Cell& cell) const noexcept
 		}
 	}
 
-	if (cell.IsBold() || cell.IsItalic()) {
+	if (cell.IsBold()) {
 		cellFont.setBold(cell.IsBold());
+	}
+
+	if (cell.IsItalic()) {
 		cellFont.setItalic(cell.IsItalic());
 	}
 


### PR DESCRIPTION
**Issue #854:** Bold + Italic font weight not applied correctly

We need to separate the italic/bold checks. Otherwise, the Neovim provided values for `cellFont` can override the user-provided values of `GuiFont`.

The existing logic was invalid for this case.