### PR TITLE
Issue 851: Underline should render with special

### DIFF
--- a/src/gui/shellwidget/shellwidget.cpp
+++ b/src/gui/shellwidget/shellwidget.cpp
@@ -229,7 +229,7 @@ void ShellWidget::paintUnderline(
 		return;
 	}
 
-	p.setPen(getForegroundPen(cell));
+	p.setPen(getSpecialPen(cell));
 
 	p.drawLine(GetUnderline(cellRect));
 }
@@ -274,18 +274,7 @@ void ShellWidget::paintUndercurl(
 		return;
 	}
 
-	QPen pen;
-	if (cell.GetSpecialColor().isValid()) {
-		pen.setColor(cell.GetSpecialColor());
-	} else if (special().isValid()) {
-		pen.setColor(special());
-	} else if (cell.GetForegroundColor().isValid()) {
-		pen.setColor(cell.GetForegroundColor());
-	} else {
-		pen.setColor(foreground());
-	}
-
-	p.setPen(pen);
+	p.setPen(getSpecialPen(cell));
 
 	p.drawPath(GetUndercurlPath(cellRect));
 }
@@ -373,6 +362,22 @@ QPen ShellWidget::getForegroundPen(const Cell& cell) noexcept
 {
 	QPen pen;
 	if (cell.GetForegroundColor().isValid()) {
+		pen.setColor(cell.GetForegroundColor());
+	} else {
+		pen.setColor(foreground());
+	}
+
+	return pen;
+}
+
+QPen ShellWidget::getSpecialPen(const Cell& cell) noexcept
+{
+	QPen pen;
+	if (cell.GetSpecialColor().isValid()) {
+		pen.setColor(cell.GetSpecialColor());
+	} else if (special().isValid()) {
+		pen.setColor(special());
+	} else if (cell.GetForegroundColor().isValid()) {
 		pen.setColor(cell.GetForegroundColor());
 	} else {
 		pen.setColor(foreground());

--- a/src/gui/shellwidget/shellwidget.h
+++ b/src/gui/shellwidget/shellwidget.h
@@ -181,6 +181,7 @@ private:
 
 	QFont GetCellFont(const Cell& cell) const noexcept;
 	QPen getForegroundPen(const Cell& cell) noexcept;
+	QPen getSpecialPen(const Cell& cell) noexcept;
 
 	ShellContents m_contents{ 0, 0 };
 	QSize m_cellSize;


### PR DESCRIPTION
**Issue #851:** Undercurl is rendered with the wrong color.

Currently, we render `:Highlight` with color `foreground`.

According to the Vim spec, underline should be rendered with color `special`. We will share the `QPen` color lookup logic with `paintUndercurl`.

![image](https://user-images.githubusercontent.com/11207308/118871665-c514d400-b8b5-11eb-873c-8e40dd95c7e0.png)
`:hi SpellBad ctermbg=224 gui=bold,underline guifg=#cc3e28 guisp=green`