### PR TITLE
Add azure CI build for ubuntu 18.04

### DIFF
--- a/contrib/azure-pipelines.yml
+++ b/contrib/azure-pipelines.yml
@@ -40,6 +40,25 @@ jobs:
         cmakeArgs: --build .
       displayName: CMake Build
 
+  - job: UbuntuBionic
+    pool:
+      vmImage: 'ubuntu-18.04'
+    steps:
+    - script: |
+        sudo add-apt-repository -y ppa:neovim-ppa/stable
+        sudo apt update -y
+        sudo apt install -y libqt5svg5-dev neovim ninja-build qt5-default
+      displayName: Install Dependencies
+    - task: CMake@1
+      inputs:
+        workingDirectory: $(Build.BinariesDirectory)
+        cmakeArgs: -GNinja -DCMAKE_BUILD_TYPE=Debug $(Build.SourcesDirectory)
+      displayName: CMake Configure
+    - task: CMake@1
+      inputs:
+        workingDirectory: $(Build.BinariesDirectory)
+        cmakeArgs: --build .
+      displayName: CMake Build
 
   - job: Apple
     pool:

--- a/src/gui/shellwidget/shellwidget.cpp
+++ b/src/gui/shellwidget/shellwidget.cpp
@@ -543,7 +543,7 @@ void ShellWidget::paintForegroundTextBlock(
 
 		// When the cursor IS within the glyph run, decompose individual characters under the cursor.
 		const int cursorGlyphRunPos { cursorPos - glyphsRendered };
-		const QString textGlyphRun{ QStringView{text}.mid(glyphsRendered, sizeGlyphRun).toString() };
+		const QString textGlyphRun{ QStringRef{ &text, glyphsRendered, sizeGlyphRun }.toString() };
 
 		// Compares a glyph run with and without ligatures. Ligature glyphs are detected as differences
 		// in these two lists. A non-empty newCursorGlyphList indicates glyph substitution is required.
@@ -1007,9 +1007,7 @@ QVariant ShellWidget::TryGetQFontFromDescription(const QString& fdesc) const noe
 	for (const auto& attr : attrs) {
 		if (attr.size() >= 2 && attr[0] == 'h') {
 			bool ok{ false };
-			// TODO: the additional toString() call is needed to be compatible with
-			// both Qt5/6. Remove when the minimum Qt version is 5.15 or above
-			qreal height = QStringView{attr}.mid(1).toString().toFloat(&ok);
+			qreal height = attr.midRef(1).toFloat(&ok);
 			if (!ok || height < 0) {
 				return QStringLiteral("Invalid font height");
 			}
@@ -1021,9 +1019,7 @@ QVariant ShellWidget::TryGetQFontFromDescription(const QString& fdesc) const noe
 		} else if (attr == "sb") {
 			weight = QFont::DemiBold;
 		} else if (attr.length() > 0 && attr.at(0) == 'w') {
-			// TODO: the additional toString() call is needed to be compatible
-			// both Qt5/6. Remove when the minimum Qt version is 5.15 or above
-			weight = (QStringView{attr}.right(attr.length()-1)).toString().toInt();
+			weight = (attr.rightRef(attr.length()-1)).toInt();
 			if (weight < 0 || weight > 99) {
 				return QStringLiteral("Invalid font weight");
 			}

--- a/src/gui/shellwidget/shellwidget.cpp
+++ b/src/gui/shellwidget/shellwidget.cpp
@@ -517,7 +517,7 @@ void ShellWidget::paintForegroundTextBlock(
 	int glyphsRendered{ 0 };
 	for (auto& glyphRun : textLayout.glyphRuns()) {
 		auto glyphPositionList{ glyphRun.positions() };
-		qsizetype sizeGlyphRun{ glyphPositionList.size() };
+		auto sizeGlyphRun{ glyphPositionList.size() };
 
 		const int cellWidth{ (cell.IsDoubleWidth()) ?
 			m_cellSize.width() * 2 : m_cellSize.width() };

--- a/src/neovimconnector.cpp
+++ b/src/neovimconnector.cpp
@@ -353,9 +353,7 @@ NeovimConnector* NeovimConnector::connectToNeovim(const QString& server)
 	int colon_pos = addr.lastIndexOf(':');
 	if (colon_pos != -1 && colon_pos != 0 && addr[colon_pos-1] != ':') {
 		bool ok;
-		// TODO: the additional toString() call is needed to be compatible with
-		// both Qt5/6. Remove when the minimum Qt version is 5.15 or above
-		int port = QStringView{addr}.mid(colon_pos+1).toString().toInt(&ok);
+		int port = addr.midRef(colon_pos+1).toInt(&ok);
 		if (ok) {
 			QString host = addr.mid(0, colon_pos);
 			return connectToHost(host, port);


### PR DESCRIPTION
Recently I introduced a change that breaks builds in older versions
of Qt (<5.10) - this was not spotted in CI builds since none of the
builders uses a version under 5.10. This enables a Ubuntu 18.04 build
that should use an older Qt version.