### PR TITLE
Add Code Linter GitHub Action (ClangFormat, Clazy)

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,123 @@
+name: Linter
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  Clazy:
+    name: Clazy
+    strategy:
+      fail-fast: false
+    env:
+      CLAZY_VER: 1.8
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: |
+          sudo add-apt-repository -y ppa:neovim-ppa/unstable
+          sudo apt-get install -y libqt5svg5-dev neovim ninja-build qt5-default
+          sudo apt-get update -y
+          mkdir build
+          cd build
+          CLAZY_VER=${{ env.CLAZY_VER }}
+          CLAZY_BIN=Clazy-x86_64-${{ env.CLAZY_VER }}.AppImage
+          CLAZY_URL=https://downloads.kdab.com/clazy/${CLAZY_VER}/${CLAZY_BIN}
+          wget ${CLAZY_URL}
+          chmod +x ${CLAZY_BIN}
+          echo "CLAZY_BIN=${CLAZY_BIN}" >> $GITHUB_ENV
+          echo "CLAZY_URL=${CLAZY_URL}" >> $GITHUB_ENV
+
+      - name: Configure
+        run: >
+          cmake -B ${{ github.workspace }}/build -GNinja -DCMAKE_BUILD_TYPE=Debug -DENABLE_CLAZY=1
+          -DCMAKE_CXX_COMPILER=${{ github.workspace }}/build/${{ env.CLAZY_BIN }}
+
+      - name: Build
+        run: cmake --build ${{ github.workspace }}/build
+
+
+  ClangFormatDiff:
+    name: ClangFormat
+    if: github.event_name == 'pull_request'
+    strategy:
+      fail-fast: false
+    env:
+      CLANG_FORMAT_DIFF: /usr/share/clang/clang-format-12/clang-format-diff.py
+      BRANCH_POINT: ${{ github.base_ref }}
+    runs-on: ubuntu-latest
+    steps:
+      # https://github.com/actions/checkout/issues/416
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Setup PR Branch
+        run: git branch ${{ github.base_ref }} origin/${{ github.base_ref }}
+
+      - name: Run ClangFormatDiff Script
+        run: contrib/clang-format-diff.sh
+
+      - name: Detect ClangFormat Changes
+        run: |
+          if [ -s clang_format.patch ]; then
+            echo "changes_detected=true" >> $GITHUB_ENV
+          else
+            echo "changes_detected=false" >> $GITHUB_ENV
+          fi
+
+      - name: Upload Artifacts
+        if: fromJSON(env.changes_detected)
+        uses: actions/upload-artifact@v2
+        with:
+          name: ClangFormat Patch
+          path: clang_format.patch
+
+      - name: Auto-Commit Clone
+        if: >
+          fromJSON(env.changes_detected)
+          && contains(github.event.pull_request.labels.*.name, 'auto-commit')
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          path: auto-commit
+
+      - name: Auto-Commit Push
+        if: >
+          fromJSON(env.changes_detected)
+          && contains(github.event.pull_request.labels.*.name, 'auto-commit')
+        working-directory: auto-commit
+        run: |
+          git apply ../clang_format.patch
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git commit -am "AUTO: Apply clang-format-diff.py output"
+          git push
+
+      - name: Check Validity
+        run: |
+          if [ -s clang_format.patch ]; then
+            echo "---------------------------------------------------------------------------"
+            echo "|                          CLANG FORMAT FAILURE                           |"
+            echo "---------------------------------------------------------------------------"
+            echo "|                                                                         |"
+            echo "| Your changes are not clang-format compliant!                            |"
+            echo "|                                                                         |"
+            echo "| An Artifact 'ClangFormat Patch' was uploaded.                           |"
+            echo "|                                                                         |"
+            echo "| Consider inspecting and applying 'clang_format.patch':                  |"
+            echo "|   git apply clang_format.patch                                          |"
+            echo "|                                                                         |"
+            echo "| Alternative Options:                                                    |"
+            echo "|  - Add Pull Request Label 'auto-commit' to auto-apply the changes.      |"
+            echo "|  - Run bash script 'contrib/clang-format-diff.sh' locally.              |"
+            echo "|                                                                         |"
+            echo "---------------------------------------------------------------------------"
+            exit 1
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 build/
 src/gui/runtime/doc/tags
 third-party/msgpack*
+compile_commands.json
+!.github/*

--- a/contrib/azure-pipelines.yml
+++ b/contrib/azure-pipelines.yml
@@ -20,26 +20,6 @@ jobs:
       displayName: CMake Build
 
 
-  - job: Linux_Clang_Clazy
-    pool:
-      vmImage: 'ubuntu-20.04'
-    steps:
-    - script: |
-        sudo add-apt-repository -y ppa:neovim-ppa/stable
-        sudo apt update -y
-        sudo apt install -y clazy libqt5svg5-dev neovim ninja-build qt5-default
-      displayName: Install Dependencies
-    - task: CMake@1
-      inputs:
-        workingDirectory: $(Build.BinariesDirectory)
-        cmakeArgs: -GNinja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=clazy -DENABLE_CLAZY=1 $(Build.SourcesDirectory)
-      displayName: CMake Configure
-    - task: CMake@1
-      inputs:
-        workingDirectory: $(Build.BinariesDirectory)
-        cmakeArgs: --build .
-      displayName: CMake Build
-
   - job: UbuntuBionic
     pool:
       vmImage: 'ubuntu-18.04'
@@ -59,6 +39,7 @@ jobs:
         workingDirectory: $(Build.BinariesDirectory)
         cmakeArgs: --build .
       displayName: CMake Build
+
 
   - job: Apple
     pool:

--- a/contrib/clang-format-diff.sh
+++ b/contrib/clang-format-diff.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+#
+# A script for clang-format-diff validation. Pulls a diff of the current branch
+# from git. Suggests clang-format replacements for any violations within the
+# diff. A patch is generated for the user to apply.
+#
+# ${CLANG_FORMAT_DIFF} - Path to clang-format-diff.py on your system.
+# ${DIFF_FILTER_LIST} - An optional filetype filter list.
+#
+# Path Output: clang_format.patch
+
+# Don't run this script with pending changes! It may modify your files.
+if [ -n "$(git status --porcelain)" ]; then
+	echo "ERROR: Changes reported by git, revert and retry"
+	exit 1
+fi
+
+# The tool clang-format-diff.py does not have a standard location.
+if [ -z ${CLANG_FORMAT_DIFF} ] || [ ! -x ${CLANG_FORMAT_DIFF} ]; then
+	echo "ERROR: Please set CLANG_FORMAT_DIFF and retry"
+
+	# You may find the file at one of the following locations:
+	#  - /usr/lib/llvm/11/share/clang/clang-format-diff.py
+	#  - /usr/share/clang/clang-format-12/clang-format-diff.py
+	exit 1
+fi
+
+if [ -z ${DIFF_FILTER_LIST} ]; then
+	DIFF_FILTER_LIST="*.cpp *.c *.h"
+fi
+
+if [ -z ${BRANCH_POINT} ]; then
+	BRANCH_POINT=$(git merge-base --fork-point ${BRANCH_POINT})
+fi
+
+# Copy `.clang-format`, skipping if one already exists
+cp -n contrib/clang-format.txt .clang-format
+
+# Apply all clang-format-diff changes to the working directory
+git diff -U0 --no-color ${BRANCH_POINT} -- ${DIFF_FILTER_LIST} | ${CLANG_FORMAT_DIFF} -i -p1
+
+# Create patch file of all clang-format suggested changes
+git diff > clang_format.patch
+
+# Remove patch file if empty
+[ -s clang_format.patch ] || rm clang_format.patch

--- a/contrib/clang-format.txt
+++ b/contrib/clang-format.txt
@@ -1,0 +1,83 @@
+﻿---
+AccessModifierOffset: '-4'
+AlignAfterOpenBracket: DontAlign
+AlignConsecutiveMacros: 'true'
+AlignConsecutiveAssignments: 'false'
+AlignConsecutiveDeclarations: 'false'
+AlignEscapedNewlines: DontAlign
+AlignOperands: 'false'
+AlignTrailingComments: 'true'
+AllowAllArgumentsOnNextLine: 'true'
+AllowAllParametersOfDeclarationOnNextLine: 'true'
+AllowShortBlocksOnASingleLine: 'false'
+AllowShortCaseLabelsOnASingleLine: 'false'
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLambdasOnASingleLine: Inline
+AlwaysBreakAfterReturnType: None
+AlwaysBreakTemplateDeclarations: MultiLine
+BinPackArguments: 'false'
+BinPackParameters: 'false'
+BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeBraces: Custom
+BraceWrapping:
+    AfterCaseLabel: true
+    AfterClass: true
+    AfterControlStatement: false
+    AfterEnum: true
+    AfterFunction: true
+    AfterNamespace: false
+    AfterStruct: true
+    AfterUnion: true
+    AfterExternBlock: true
+    BeforeCatch: true
+    BeforeElse: true
+    IndentBraces: false
+    SplitEmptyFunction: true
+    SplitEmptyRecord: true
+    SplitEmptyNamespace: true
+BreakBeforeTernaryOperators: 'false'
+BreakConstructorInitializers: BeforeComma
+BreakInheritanceList: BeforeComma
+BreakStringLiterals: 'true'
+ColumnLimit: '100'
+CompactNamespaces: 'true'
+ConstructorInitializerAllOnOneLineOrOnePerLine: 'false'
+ConstructorInitializerIndentWidth: '4'
+ContinuationIndentWidth: '4'
+Cpp11BracedListStyle: 'false'
+DerivePointerAlignment: 'false'
+FixNamespaceComments: 'true'
+IncludeBlocks: Regroup
+IndentCaseLabels: 'true'
+IndentPPDirectives: None
+IndentWidth: '4'
+IndentWrappedFunctionNames: 'false'
+KeepEmptyLinesAtTheStartOfBlocks: 'false'
+Language: Cpp
+MaxEmptyLinesToKeep: '2'
+NamespaceIndentation: None
+PointerAlignment: Left
+ReflowComments: 'true'
+SortIncludes: 'true'
+SortUsingDeclarations: 'true'
+SpaceAfterCStyleCast: 'false'
+SpaceAfterLogicalNot: 'false'
+SpaceAfterTemplateKeyword: 'false'
+SpaceBeforeAssignmentOperators: 'true'
+SpaceBeforeCpp11BracedList: 'false'
+SpaceBeforeCtorInitializerColon: 'true'
+SpaceBeforeInheritanceColon: 'true'
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: 'true'
+SpaceInEmptyParentheses: 'false'
+SpacesInAngles: 'false'
+SpacesInCStyleCastParentheses: 'false'
+SpacesInContainerLiterals: 'false'
+SpacesInParentheses: 'false'
+SpacesInSquareBrackets: 'false'
+Standard: Cpp11
+TabWidth: '4'
+UseTab: Always
+
+...


### PR DESCRIPTION
Moving Clazy check to GitHub Actions.

Adding a new CI rule that checks Pull Requests for clang-format
compliance. It will only apply to changed lines in Pull Requests.

The rule operates by analyzing the git diff since the PR fork-point. The
computed diff is piped into clang-format-diff.py, and the CI fails if
any clang-format differences are detected.

The PR author can apply the results:
 - Downloading a clang_format.patch Artifact
 - Adding a "auto-commit" label, commits will be auto-applied
 - Locally running contrib/clang-format-diff.sh (Linux/Mac).

This rule will only run for PRs, so we won't get noise for violations of
the existing code. We can also safely ignore clang-format, if manual
formatting is desired.