### PR TITLE
Issue 851: Fix Pull Request 856 Color Logic

### DIFF
--- a/src/gui/shellwidget/shellwidget.cpp
+++ b/src/gui/shellwidget/shellwidget.cpp
@@ -230,7 +230,6 @@ void ShellWidget::paintUnderline(
 	}
 
 	p.setPen(getSpecialPen(cell));
-
 	p.drawLine(GetUnderline(cellRect));
 }
 
@@ -275,7 +274,6 @@ void ShellWidget::paintUndercurl(
 	}
 
 	p.setPen(getSpecialPen(cell));
-
 	p.drawPath(GetUndercurlPath(cellRect));
 }
 
@@ -300,7 +298,6 @@ void ShellWidget::paintStrikeThrough(
 	}
 
 	p.setPen(getForegroundPen(cell));
-
 	p.drawLine(GetStrikeThrough(cellRect));
 }
 
@@ -378,8 +375,6 @@ QPen ShellWidget::getSpecialPen(const Cell& cell) noexcept
 	QPen pen;
 	if (cell.GetSpecialColor().isValid()) {
 		pen.setColor(cell.GetSpecialColor());
-	} else if (special().isValid()) {
-		pen.setColor(special());
 	} else if (cell.GetForegroundColor().isValid()) {
 		pen.setColor(cell.GetForegroundColor());
 	} else {


### PR DESCRIPTION
Fixes **Pull Request #856** and **Issue #851**.

My first implementation used the existing undercurl logic for underline color selection. This does not match TUI or gVim.

The Neovim TUI + gVim underline color logic is different. We will match the TUI behavior in neovim-qt.

Now... What is the behavior for TUI and gVim?

**Resulting Behavior:**
| Highlight Group | Result |
|:-|--|
| `:hi SpellBad gui=underline guisp=Red guifg=Green`| ![image](https://user-images.githubusercontent.com/11207308/120141966-74518500-c1ab-11eb-8bb4-02f339d7794c.png) |
| `:hi SpellBad gui=underline guisp=NONE guifg=Green`| ![image](https://user-images.githubusercontent.com/11207308/120142005-86332800-c1ab-11eb-9203-ecc9d477272c.png) |
| `:hi SpellBad gui=undercurl guisp=Red guifg=Green`| ![image](https://user-images.githubusercontent.com/11207308/120142046-9519da80-c1ab-11eb-8e7e-d64dcb783395.png) |
| `:hi SpellBad gui=undercurl guisp=NONE guifg=Green`| ![image](https://user-images.githubusercontent.com/11207308/120142097-abc03180-c1ab-11eb-953a-0c11769fd391.png) |
| `:hi SpellBad gui=strikethrough guisp=Red guifg=Green`| ![image](https://user-images.githubusercontent.com/11207308/120142131-c1355b80-c1ab-11eb-9c5d-828a5b38718a.png) |
| `:hi SpellBad gui=strikethrough guisp=NONE guifg=Green`| ![image](https://user-images.githubusercontent.com/11207308/120142165-d4e0c200-c1ab-11eb-9ced-b46b2c21a004.png)  |