### PR TITLE
Issue 864: Bepo Keyboard Layout

### DIFF
--- a/src/gui/input.cpp
+++ b/src/gui/input.cpp
@@ -174,6 +174,15 @@ QString convertKey(const QKeyEvent& ev) noexcept
 		return keypadKeys.value(key).arg(GetModifierPrefix(mod));
 	}
 
+	// Issue#864: Some international layouts insert accents (~^`) on Key_Space
+	if (key == Qt::Key_Space && !text.isEmpty() && text != " ") {
+		if (mod != Qt::NoModifier) {
+			return ToKeyString(GetModifierPrefix(mod), text);
+		}
+
+		return text;
+	}
+
 	const QMap<int, QString>& specialKeys { GetSpecialKeysMap() };
 
 	if (specialKeys.contains(key)) {

--- a/test/tst_input_win32.cpp
+++ b/test/tst_input_win32.cpp
@@ -13,6 +13,7 @@ private slots:
 	void CtrlCaretWellFormed() noexcept;
 	void ShiftModifierLetter() noexcept;
 	void GermanKeyboardLayout() noexcept;
+	void FrenchBepoKeyboardLayout() noexcept;
 };
 
 void TestInputWin32::LessThanModifierKeys() noexcept
@@ -94,6 +95,21 @@ void TestInputWin32::GermanKeyboardLayout() noexcept
 
 	QKeyEvent evLeftAlt8{ QEvent::KeyPress, Qt::Key_8, Qt::AltModifier, "8" };
 	QCOMPARE(NeovimQt::Input::convertKey(evLeftAlt8), QString{ "<A-8>" });
+}
+
+void TestInputWin32::FrenchBepoKeyboardLayout() noexcept
+{
+	QKeyEvent evTilde{ QEvent::KeyPress, Qt::Key_Space, Qt::NoModifier, "~" };
+	QCOMPARE(NeovimQt::Input::convertKey(evTilde), QString{ "~" });
+
+	QKeyEvent evCircum{ QEvent::KeyPress, Qt::Key_Space, Qt::NoModifier, "^" };
+	QCOMPARE(NeovimQt::Input::convertKey(evCircum), QString{ "^" });
+
+	QKeyEvent evShiftCircum{ QEvent::KeyPress, Qt::Key_Space, Qt::ShiftModifier, "^" };
+	QCOMPARE(NeovimQt::Input::convertKey(evShiftCircum), QString{ "<S-^>" });
+
+	QKeyEvent evSpace{ QEvent::KeyPress, Qt::Key_Space, Qt::NoModifier, " " };
+	QCOMPARE(NeovimQt::Input::convertKey(evSpace), QString{ "<Space>" });
 }
 
 #include "tst_input_win32.moc"


### PR DESCRIPTION
**Issue #864:** Cannot insert ~ with bepo keyboard layout

TODO

For now, this commit simply enables `QKeyEvent` debugging.