### PR TITLE
Set initial editor size properly

### DIFF
--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -129,11 +129,11 @@ void App::showUi() noexcept
 	}
 
 	if (m_parser.isSet("fullscreen")) {
-		win->delayedShow(NeovimQt::MainWindow::DelayedShow::FullScreen);
+		win->showFullScreen();
 	} else if (m_parser.isSet("maximized")) {
-		win->delayedShow(NeovimQt::MainWindow::DelayedShow::Maximized);
+		win->showMaximized();
 	} else {
-		win->delayedShow();
+		win->show();
 	}
 #endif
 }

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -31,8 +31,6 @@ public:
 	bool neovimAttached() const;
 	Shell* shell();
 	void restoreWindowGeometry();
-public slots:
-	void delayedShow(DelayedShow type=DelayedShow::Normal);
 signals:
 	void neovimAttached(bool);
 	void closing(int);
@@ -50,7 +48,6 @@ private slots:
 	void neovimExited(int status);
 	void neovimError(NeovimConnector::NeovimError);
 	void reconnectNeovim();
-	void showIfDelayed();
 	void neovimAttachmentChanged(bool);
 	void neovimIsUnsupported();
 	void neovimShowtablineSet(int);
@@ -78,7 +75,6 @@ private:
 	QSplitter* m_window{ nullptr };
 	TreeView* m_tree{ nullptr };
 	Shell* m_shell{ nullptr };
-	DelayedShow m_delayedShow{ DelayedShow::Disabled };
 	QStackedWidget m_stack;
 	QTabBar* m_tabline{ nullptr };
 	QToolBar* m_tabline_bar{ nullptr };

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -141,6 +141,7 @@ protected:
 	virtual void keyPressEvent(QKeyEvent *ev) Q_DECL_OVERRIDE;
         void paintLogo(QPainter&);
 	virtual void paintEvent(QPaintEvent *ev) Q_DECL_OVERRIDE;
+	virtual void showEvent(QShowEvent* ev) Q_DECL_OVERRIDE;
 	virtual void changeEvent(QEvent *ev) Q_DECL_OVERRIDE;
 	virtual void closeEvent(QCloseEvent *ev) Q_DECL_OVERRIDE;
 	virtual void focusInEvent(QFocusEvent *ev) Q_DECL_OVERRIDE;
@@ -198,6 +199,7 @@ private slots:
         void setAttached(bool attached=true);
 
 private:
+	bool m_init_called{ false };
 	bool m_attached{ false };
 	NeovimConnector* m_nvim{ nullptr };
 

--- a/test/tst_shell.cpp
+++ b/test/tst_shell.cpp
@@ -40,6 +40,7 @@ private slots:
 			QVERIFY(SPYWAIT(onReady));
 
 			Shell *s = new Shell(c);
+			s->show(); // To emit Shell::showEvent()
 			QSignalSpy onResize(s, SIGNAL(neovimResized(int, int)));
 			QVERIFY(onResize.isValid());
 			QVERIFY(SPYWAIT(onResize));
@@ -51,6 +52,7 @@ private slots:
 		args << "-u" << "NONE";
 		NeovimConnector *c = NeovimConnector::spawn(args);
 		Shell *s = new Shell(c);
+		s->show(); // To emit Shell::showEvent()
 		QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
 		QVERIFY(onAttached.isValid());
 		QVERIFY(SPYWAIT(onAttached));
@@ -60,13 +62,13 @@ private slots:
 
 		QPixmap p = s->grab();
 		p.save("tst_shell_start.jpg");
-
 	}
 
 	void startVarsShellWidget() {
 		QStringList args = {"-u", "NONE"};
 		NeovimConnector *c = NeovimConnector::spawn(args);
 		Shell *s = new Shell(c);
+		s->show(); // To emit Shell::showEvent()
 		QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
 		QVERIFY(onAttached.isValid());
 		QVERIFY(SPYWAIT(onAttached));
@@ -91,6 +93,7 @@ private slots:
 		args << "-u" << "NONE";
 		NeovimConnector *c = NeovimConnector::spawn(args);
 		Shell *s = new Shell(c);
+		s->show(); // To emit Shell::showEvent()
 		QSignalSpy onOptionSet(s, &Shell::neovimExtTablineSet);
 		QVERIFY(onOptionSet.isValid());
 		QVERIFY(SPYWAIT(onOptionSet));
@@ -102,6 +105,7 @@ private slots:
 		args << "-u" << "NONE";
 		NeovimConnector *c = NeovimConnector::spawn(args);
 		Shell *s = new Shell(c);
+		s->show(); // To emit Shell::showEvent()
 
 		QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
 		QVERIFY(onAttached.isValid());
@@ -128,6 +132,16 @@ private slots:
 			"--cmd", "set rtp+=" + fi.absoluteFilePath()};
 		NeovimConnector *c = NeovimConnector::spawn(args);
 		MainWindow *s = new MainWindow(c);
+
+		// Show the window in order to emit Shell::showEvent(). It should be
+		// maximized to avoid hit-enter-prompt as much as possible.
+		// `:GuiFont` shows warning message "Warning: Font {fontname} reports
+		// bad fixed pitch metrics" (only on Windows?). If the shown window is
+		// too small (and it's often the case, the default window size is too
+		// small), this message causes hit-enter-prompt and make the test
+		// fail.
+		s->showMaximized();
+
 		QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
 		QVERIFY(onAttached.isValid());
 		QVERIFY(SPYWAIT(onAttached));
@@ -226,7 +240,7 @@ private slots:
 
 		NeovimConnector* c{ NeovimConnector::spawn(args) };
 		MainWindow* s{ new MainWindow(c) };
-		s->show();
+		s->show(); // To emit Shell::showEvent()
 		QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
 		QVERIFY(onAttached.isValid());
 		QVERIFY(SPYWAIT(onAttached));
@@ -294,6 +308,7 @@ private slots:
 			"--cmd", "set rtp+=" + fi.absoluteFilePath()};
 		NeovimConnector *c = NeovimConnector::spawn(args);
 		MainWindow *s = new MainWindow(c);
+		s->show(); // To emit Shell::showEvent()
 		QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
 		QVERIFY(onAttached.isValid());
 		QVERIFY(SPYWAIT(onAttached));
@@ -355,6 +370,7 @@ private slots:
 			"--cmd", "set rtp+=" + fi.absoluteFilePath()};
 		NeovimConnector *c = NeovimConnector::spawn(args);
 		MainWindow *s = new MainWindow(c);
+		s->show(); // To emit Shell::showEvent()
 		QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
 		QVERIFY(onAttached.isValid());
 		QVERIFY(SPYWAIT(onAttached));


### PR DESCRIPTION
When you run `nvim-qt -- -O a b` in your console, you'll see inequally divided two editor pains in the opened Neovim-Qt. This is because the initial editor size (lines and columns) is not based on the actual window size.

To resolve this issue, we need to know the window size and cell size before initializing Neovim. However it's impossible with the current implementation, because the window is shown only after Neovim initialization (delayed show mechanism first introduced in #70). I tried to see if I could get Qt to calculate the layout before the window is shown, but I couldn't find a way.

Therefore this commit tweaks three things:

- Show window (and shell widget) first and attach to neovim after the main window is shown.
- Use actual window size to calculate initial attaching size instead of the hard-coded value (the current code is assuming 60% of display size as a initial height and width, regardless of the actual window size).
- Remove delayed show mechanism entirely.

In addition to those, prevent init() from being called multiple times. This is because init() is now called from showEvent() but showEvent() is emitted not only when the window is newly created but also minimized window is restored.

Note that this PR entirely removes delaying mechanism. Even though I don't think the original issue #70 will appear again because Neovim-qt now restores the previous geometry on startup, I think we should check this fix doesn't make startup issues (not only #70 but also others like #198) before merging (but how?). Personally I *sometimes* do notice a flicker on startup but it's acceptable (considering that setting up colorscheme can also cause the similar flicker).

Fix #799.
