### PR TITLE
GitHub Actions Windows No Test Output

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -20,35 +20,35 @@ jobs:
             cc: gcc
             cxx: g++
 
-          - name: Linux_LLVM
-            flavor: Debug
-            runner: ubuntu-latest
-            generator: Ninja
-            cc: clang
-            cxx: clang++
-
-          - name: Linux_Release
-            flavor: Release
-            runner: ubuntu-18.04
-            generator: Ninja
-            cc: gcc
-            cxx: g++
-            publish: true
-
-          - name: MacOS_GCC
-            flavor: Debug
-            runner: macos-latest
-            generator: Ninja
-            cc: gcc-11
-            cxx: g++-11
-
-          - name: MacOS_Release
-            flavor: Release
-            runner: macos-latest
-            generator: Ninja
-            cc: clang
-            cxx: clang++
-            publish: true
+            #          - name: Linux_LLVM
+            #            flavor: Debug
+            #            runner: ubuntu-latest
+            #            generator: Ninja
+            #            cc: clang
+            #            cxx: clang++
+            #
+            #          - name: Linux_Release
+            #            flavor: Release
+            #            runner: ubuntu-18.04
+            #            generator: Ninja
+            #            cc: gcc
+            #            cxx: g++
+            #            publish: true
+            #
+            #          - name: MacOS_GCC
+            #            flavor: Debug
+            #            runner: macos-latest
+            #            generator: Ninja
+            #            cc: gcc-11
+            #            cxx: g++-11
+            #
+            #          - name: MacOS_Release
+            #            flavor: Release
+            #            runner: macos-latest
+            #            generator: Ninja
+            #            cc: clang
+            #            cxx: clang++
+            #            publish: true
 
           - name: Windows_MingGW
             flavor: Debug
@@ -182,3 +182,5 @@ jobs:
             neovim-qt.dmg
             neovim-qt-installer.msi
             neovim-qt.zip
+            build/test_*
+            build/tst_*

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -136,6 +136,30 @@ jobs:
       - name: Build
         run: cmake --build ${{ github.workspace }}/build
 
+      - name: Windows - Publish Release Build
+        if: ${{ matrix.publish && startsWith(matrix.runner, 'windows') }}
+        run: |
+          cmake --build ./build --target install
+          Push-Location ${{ github.workspace }}/build
+          cpack --verbose -G WIX
+          Pop-Location
+          Compress-Archive -Path ./install -DestinationPath neovim-qt.zip
+          Move-Item -Path ./build/neovim-qt-installer.msi -Destination neovim-qt-installer.msi
+
+      - name: Upload Artifacts
+        if: ${{ matrix.publish }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.name }}
+          if-no-files-found: ignore
+          path: |
+            Neovim-Qt-*-x86_64.AppImage
+            neovim-qt.dmg
+            neovim-qt-installer.msi
+            neovim-qt.zip
+            build/test_*
+            build/tst_*
+
       - name: Test
         uses: GabrielBB/xvfb-action@v1 # Required by Linux, no X11 $DISPLAY
         with:
@@ -161,26 +185,3 @@ jobs:
           macdeployqt ./build/bin/nvim-qt.app -dmg
           mv ./build/bin/nvim-qt.dmg neovim-qt.dmg
 
-      - name: Windows - Publish Release Build
-        if: ${{ matrix.publish && startsWith(matrix.runner, 'windows') }}
-        run: |
-          cmake --build ./build --target install
-          Push-Location ${{ github.workspace }}/build
-          cpack --verbose -G WIX
-          Pop-Location
-          Compress-Archive -Path ./install -DestinationPath neovim-qt.zip
-          Move-Item -Path ./build/neovim-qt-installer.msi -Destination neovim-qt-installer.msi
-
-      - name: Upload Artifacts
-        if: ${{ matrix.publish }}
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ matrix.name }}
-          if-no-files-found: ignore
-          path: |
-            Neovim-Qt-*-x86_64.AppImage
-            neovim-qt.dmg
-            neovim-qt-installer.msi
-            neovim-qt.zip
-            build/test_*
-            build/tst_*

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -137,7 +137,6 @@ jobs:
         run: cmake --build ${{ github.workspace }}/build
 
       - name: Test
-        if: ${{ !startsWith(matrix.runner, 'windows') }}
         uses: GabrielBB/xvfb-action@v1 # Required by Linux, no X11 $DISPLAY
         with:
           working-directory: ${{ github.workspace }}/build

--- a/test/tst_encoding.cpp
+++ b/test/tst_encoding.cpp
@@ -53,6 +53,7 @@ void TestEncoding::map()
 			});
 	QVERIFY(SPYWAIT(onVimGetVar));
 	disconnect(conn);
+	QVERIFY(false); // FIXME Intentional Test Failure Added!
 }
 
 // A reminder that Strings in the Neovim API are binary data

--- a/test/tst_input_common.cpp
+++ b/test/tst_input_common.cpp
@@ -29,6 +29,7 @@ void TestInputCommon::LessThanKey() noexcept
 	// Issue#607: Shift is implied with "<", send "<lt>" instead.
 	QKeyEvent evIssue607{ QEvent::KeyPress, Qt::Key::Key_Less, Qt::KeyboardModifier::ShiftModifier, "<" };
 	QCOMPARE(NeovimQt::Input::convertKey(evIssue607), QString{ "<lt>" });
+	QVERIFY(false); // FIXME Intentional Test Failure Added!
 }
 
 void TestInputCommon::ModifierOnlyKeyEventsIgnored() noexcept


### PR DESCRIPTION
**Issue #884:** GitHub Actions No Windows Test Output

Provided as an example of this issue. The Windows runners do not display any test output.

GitHub Actions is dropping `ctest` output. Blocks usage of GitHub Actions.