### PR TITLE
Fix Clazy Warning: clazy-fully-qualified-moc-types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,6 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR
 	if(ENABLE_CLAZY)
 		string(CONCAT CLAZY_CHECKS
 			"level0,"
-			"no-fully-qualified-moc-types,"
 			"no-overloaded-signal,"
 			"no-qenums,"
 			"level1,"

--- a/bindings/neovimapi.h
+++ b/bindings/neovimapi.h
@@ -1,13 +1,15 @@
 // Auto generated {{date}} from nvim API level:{{api_level}}
-#ifndef NEOVIM_QT_NEOVIMAPI{{api_level}}
-#define NEOVIM_QT_NEOVIMAPI{{api_level}}
-#include "msgpack.h"
+#pragma once
+
 #include <QObject>
-#include <QVariant>
 #include <QPoint>
+#include <QVariant>
+
 #include "function.h"
+#include "msgpack.h"
 
 namespace NeovimQt {
+
 class NeovimConnector;
 class MsgpackRequest;
 
@@ -43,7 +45,7 @@ public slots:
 	// DEPRECATED
 {% endif %}
 	// {{f.signature()}}
-	MsgpackRequest* {{f.name}}({{f.argstring}});
+	NeovimQt::MsgpackRequest* {{f.name}}({{f.argstring}});
 {% endfor %}
 
 signals:
@@ -53,5 +55,5 @@ signals:
 
 {% endfor %}
 };
-} // namespace
-#endif
+
+} // namespace NeovimQt

--- a/src/auto/neovimapi0.h
+++ b/src/auto/neovimapi0.h
@@ -1,13 +1,15 @@
-// Auto generated 2017-10-31 14:14:43.997573 from nvim API level:0
-#ifndef NEOVIM_QT_NEOVIMAPI0
-#define NEOVIM_QT_NEOVIMAPI0
-#include "msgpack.h"
+// Auto generated 2021-07-20 02:41:48.779803 from nvim API level:0
+#pragma once
+
 #include <QObject>
-#include <QVariant>
 #include <QPoint>
+#include <QVariant>
+
 #include "function.h"
+#include "msgpack.h"
 
 namespace NeovimQt {
+
 class NeovimConnector;
 class MsgpackRequest;
 
@@ -116,165 +118,165 @@ private:
 	NeovimConnector *m_c;
 public slots:
 	// Integer buffer_line_count(Buffer buffer, ) 
-	MsgpackRequest* buffer_line_count(int64_t buffer);
+	NeovimQt::MsgpackRequest* buffer_line_count(int64_t buffer);
 	// String buffer_get_line(Buffer buffer, Integer index, ) 
-	MsgpackRequest* buffer_get_line(int64_t buffer, int64_t index);
+	NeovimQt::MsgpackRequest* buffer_get_line(int64_t buffer, int64_t index);
 	// void buffer_set_line(Buffer buffer, Integer index, String line, ) 
-	MsgpackRequest* buffer_set_line(int64_t buffer, int64_t index, QByteArray line);
+	NeovimQt::MsgpackRequest* buffer_set_line(int64_t buffer, int64_t index, QByteArray line);
 	// void buffer_del_line(Buffer buffer, Integer index, ) 
-	MsgpackRequest* buffer_del_line(int64_t buffer, int64_t index);
+	NeovimQt::MsgpackRequest* buffer_del_line(int64_t buffer, int64_t index);
 	// ArrayOf(String) buffer_get_line_slice(Buffer buffer, Integer start, Integer end, Boolean include_start, Boolean include_end, ) 
-	MsgpackRequest* buffer_get_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end);
+	NeovimQt::MsgpackRequest* buffer_get_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end);
 	// ArrayOf(String) buffer_get_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ) 
-	MsgpackRequest* buffer_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing);
+	NeovimQt::MsgpackRequest* buffer_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing);
 	// void buffer_set_line_slice(Buffer buffer, Integer start, Integer end, Boolean include_start, Boolean include_end, ArrayOf(String) replacement, ) 
-	MsgpackRequest* buffer_set_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end, QList<QByteArray> replacement);
+	NeovimQt::MsgpackRequest* buffer_set_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end, QList<QByteArray> replacement);
 	// void buffer_set_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ArrayOf(String) replacement, ) 
-	MsgpackRequest* buffer_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement);
+	NeovimQt::MsgpackRequest* buffer_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement);
 	// Object buffer_get_var(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_get_var(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* buffer_get_var(int64_t buffer, QByteArray name);
 	// Object buffer_set_var(Buffer buffer, String name, Object value, ) 
-	MsgpackRequest* buffer_set_var(int64_t buffer, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* buffer_set_var(int64_t buffer, QByteArray name, QVariant value);
 	// Object buffer_del_var(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_del_var(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* buffer_del_var(int64_t buffer, QByteArray name);
 	// Object buffer_get_option(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_get_option(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* buffer_get_option(int64_t buffer, QByteArray name);
 	// void buffer_set_option(Buffer buffer, String name, Object value, ) 
-	MsgpackRequest* buffer_set_option(int64_t buffer, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* buffer_set_option(int64_t buffer, QByteArray name, QVariant value);
 	// Integer buffer_get_number(Buffer buffer, ) 
-	MsgpackRequest* buffer_get_number(int64_t buffer);
+	NeovimQt::MsgpackRequest* buffer_get_number(int64_t buffer);
 	// String buffer_get_name(Buffer buffer, ) 
-	MsgpackRequest* buffer_get_name(int64_t buffer);
+	NeovimQt::MsgpackRequest* buffer_get_name(int64_t buffer);
 	// void buffer_set_name(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_set_name(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* buffer_set_name(int64_t buffer, QByteArray name);
 	// Boolean buffer_is_valid(Buffer buffer, ) 
-	MsgpackRequest* buffer_is_valid(int64_t buffer);
+	NeovimQt::MsgpackRequest* buffer_is_valid(int64_t buffer);
 	// void buffer_insert(Buffer buffer, Integer lnum, ArrayOf(String) lines, ) 
-	MsgpackRequest* buffer_insert(int64_t buffer, int64_t lnum, QList<QByteArray> lines);
+	NeovimQt::MsgpackRequest* buffer_insert(int64_t buffer, int64_t lnum, QList<QByteArray> lines);
 	// ArrayOf(Integer, 2) buffer_get_mark(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_get_mark(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* buffer_get_mark(int64_t buffer, QByteArray name);
 	// Integer buffer_add_highlight(Buffer buffer, Integer src_id, String hl_group, Integer line, Integer col_start, Integer col_end, ) 
-	MsgpackRequest* buffer_add_highlight(int64_t buffer, int64_t src_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end);
+	NeovimQt::MsgpackRequest* buffer_add_highlight(int64_t buffer, int64_t src_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end);
 	// void buffer_clear_highlight(Buffer buffer, Integer src_id, Integer line_start, Integer line_end, ) 
-	MsgpackRequest* buffer_clear_highlight(int64_t buffer, int64_t src_id, int64_t line_start, int64_t line_end);
+	NeovimQt::MsgpackRequest* buffer_clear_highlight(int64_t buffer, int64_t src_id, int64_t line_start, int64_t line_end);
 	// ArrayOf(Window) tabpage_get_windows(Tabpage tabpage, ) 
-	MsgpackRequest* tabpage_get_windows(int64_t tabpage);
+	NeovimQt::MsgpackRequest* tabpage_get_windows(int64_t tabpage);
 	// Object tabpage_get_var(Tabpage tabpage, String name, ) 
-	MsgpackRequest* tabpage_get_var(int64_t tabpage, QByteArray name);
+	NeovimQt::MsgpackRequest* tabpage_get_var(int64_t tabpage, QByteArray name);
 	// Object tabpage_set_var(Tabpage tabpage, String name, Object value, ) 
-	MsgpackRequest* tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value);
 	// Object tabpage_del_var(Tabpage tabpage, String name, ) 
-	MsgpackRequest* tabpage_del_var(int64_t tabpage, QByteArray name);
+	NeovimQt::MsgpackRequest* tabpage_del_var(int64_t tabpage, QByteArray name);
 	// Window tabpage_get_window(Tabpage tabpage, ) 
-	MsgpackRequest* tabpage_get_window(int64_t tabpage);
+	NeovimQt::MsgpackRequest* tabpage_get_window(int64_t tabpage);
 	// Boolean tabpage_is_valid(Tabpage tabpage, ) 
-	MsgpackRequest* tabpage_is_valid(int64_t tabpage);
+	NeovimQt::MsgpackRequest* tabpage_is_valid(int64_t tabpage);
 	// void ui_attach(Integer width, Integer height, Boolean enable_rgb, ) 
-	MsgpackRequest* ui_attach(int64_t width, int64_t height, bool enable_rgb);
+	NeovimQt::MsgpackRequest* ui_attach(int64_t width, int64_t height, bool enable_rgb);
 	// void ui_detach() 
-	MsgpackRequest* ui_detach();
+	NeovimQt::MsgpackRequest* ui_detach();
 	// Object ui_try_resize(Integer width, Integer height, ) 
-	MsgpackRequest* ui_try_resize(int64_t width, int64_t height);
+	NeovimQt::MsgpackRequest* ui_try_resize(int64_t width, int64_t height);
 	// void vim_command(String str, ) 
-	MsgpackRequest* vim_command(QByteArray str);
+	NeovimQt::MsgpackRequest* vim_command(QByteArray str);
 	// void vim_feedkeys(String keys, String mode, Boolean escape_csi, ) 
-	MsgpackRequest* vim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi);
+	NeovimQt::MsgpackRequest* vim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi);
 	// Integer vim_input(String keys, ) 
-	MsgpackRequest* vim_input(QByteArray keys);
+	NeovimQt::MsgpackRequest* vim_input(QByteArray keys);
 	// String vim_replace_termcodes(String str, Boolean from_part, Boolean do_lt, Boolean special, ) 
-	MsgpackRequest* vim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special);
+	NeovimQt::MsgpackRequest* vim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special);
 	// String vim_command_output(String str, ) 
-	MsgpackRequest* vim_command_output(QByteArray str);
+	NeovimQt::MsgpackRequest* vim_command_output(QByteArray str);
 	// Object vim_eval(String str, ) 
-	MsgpackRequest* vim_eval(QByteArray str);
+	NeovimQt::MsgpackRequest* vim_eval(QByteArray str);
 	// Object vim_call_function(String fname, Array args, ) 
-	MsgpackRequest* vim_call_function(QByteArray fname, QVariantList args);
+	NeovimQt::MsgpackRequest* vim_call_function(QByteArray fname, QVariantList args);
 	// Integer vim_strwidth(String str, ) 
-	MsgpackRequest* vim_strwidth(QByteArray str);
+	NeovimQt::MsgpackRequest* vim_strwidth(QByteArray str);
 	// ArrayOf(String) vim_list_runtime_paths() 
-	MsgpackRequest* vim_list_runtime_paths();
+	NeovimQt::MsgpackRequest* vim_list_runtime_paths();
 	// void vim_change_directory(String dir, ) 
-	MsgpackRequest* vim_change_directory(QByteArray dir);
+	NeovimQt::MsgpackRequest* vim_change_directory(QByteArray dir);
 	// String vim_get_current_line() 
-	MsgpackRequest* vim_get_current_line();
+	NeovimQt::MsgpackRequest* vim_get_current_line();
 	// void vim_set_current_line(String line, ) 
-	MsgpackRequest* vim_set_current_line(QByteArray line);
+	NeovimQt::MsgpackRequest* vim_set_current_line(QByteArray line);
 	// void vim_del_current_line() 
-	MsgpackRequest* vim_del_current_line();
+	NeovimQt::MsgpackRequest* vim_del_current_line();
 	// Object vim_get_var(String name, ) 
-	MsgpackRequest* vim_get_var(QByteArray name);
+	NeovimQt::MsgpackRequest* vim_get_var(QByteArray name);
 	// Object vim_set_var(String name, Object value, ) 
-	MsgpackRequest* vim_set_var(QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* vim_set_var(QByteArray name, QVariant value);
 	// Object vim_del_var(String name, ) 
-	MsgpackRequest* vim_del_var(QByteArray name);
+	NeovimQt::MsgpackRequest* vim_del_var(QByteArray name);
 	// Object vim_get_vvar(String name, ) 
-	MsgpackRequest* vim_get_vvar(QByteArray name);
+	NeovimQt::MsgpackRequest* vim_get_vvar(QByteArray name);
 	// Object vim_get_option(String name, ) 
-	MsgpackRequest* vim_get_option(QByteArray name);
+	NeovimQt::MsgpackRequest* vim_get_option(QByteArray name);
 	// void vim_set_option(String name, Object value, ) 
-	MsgpackRequest* vim_set_option(QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* vim_set_option(QByteArray name, QVariant value);
 	// void vim_out_write(String str, ) 
-	MsgpackRequest* vim_out_write(QByteArray str);
+	NeovimQt::MsgpackRequest* vim_out_write(QByteArray str);
 	// void vim_err_write(String str, ) 
-	MsgpackRequest* vim_err_write(QByteArray str);
+	NeovimQt::MsgpackRequest* vim_err_write(QByteArray str);
 	// void vim_report_error(String str, ) 
-	MsgpackRequest* vim_report_error(QByteArray str);
+	NeovimQt::MsgpackRequest* vim_report_error(QByteArray str);
 	// ArrayOf(Buffer) vim_get_buffers() 
-	MsgpackRequest* vim_get_buffers();
+	NeovimQt::MsgpackRequest* vim_get_buffers();
 	// Buffer vim_get_current_buffer() 
-	MsgpackRequest* vim_get_current_buffer();
+	NeovimQt::MsgpackRequest* vim_get_current_buffer();
 	// void vim_set_current_buffer(Buffer buffer, ) 
-	MsgpackRequest* vim_set_current_buffer(int64_t buffer);
+	NeovimQt::MsgpackRequest* vim_set_current_buffer(int64_t buffer);
 	// ArrayOf(Window) vim_get_windows() 
-	MsgpackRequest* vim_get_windows();
+	NeovimQt::MsgpackRequest* vim_get_windows();
 	// Window vim_get_current_window() 
-	MsgpackRequest* vim_get_current_window();
+	NeovimQt::MsgpackRequest* vim_get_current_window();
 	// void vim_set_current_window(Window window, ) 
-	MsgpackRequest* vim_set_current_window(int64_t window);
+	NeovimQt::MsgpackRequest* vim_set_current_window(int64_t window);
 	// ArrayOf(Tabpage) vim_get_tabpages() 
-	MsgpackRequest* vim_get_tabpages();
+	NeovimQt::MsgpackRequest* vim_get_tabpages();
 	// Tabpage vim_get_current_tabpage() 
-	MsgpackRequest* vim_get_current_tabpage();
+	NeovimQt::MsgpackRequest* vim_get_current_tabpage();
 	// void vim_set_current_tabpage(Tabpage tabpage, ) 
-	MsgpackRequest* vim_set_current_tabpage(int64_t tabpage);
+	NeovimQt::MsgpackRequest* vim_set_current_tabpage(int64_t tabpage);
 	// void vim_subscribe(String event, ) 
-	MsgpackRequest* vim_subscribe(QByteArray event);
+	NeovimQt::MsgpackRequest* vim_subscribe(QByteArray event);
 	// void vim_unsubscribe(String event, ) 
-	MsgpackRequest* vim_unsubscribe(QByteArray event);
+	NeovimQt::MsgpackRequest* vim_unsubscribe(QByteArray event);
 	// Integer vim_name_to_color(String name, ) 
-	MsgpackRequest* vim_name_to_color(QByteArray name);
+	NeovimQt::MsgpackRequest* vim_name_to_color(QByteArray name);
 	// Dictionary vim_get_color_map() 
-	MsgpackRequest* vim_get_color_map();
+	NeovimQt::MsgpackRequest* vim_get_color_map();
 	// Buffer window_get_buffer(Window window, ) 
-	MsgpackRequest* window_get_buffer(int64_t window);
+	NeovimQt::MsgpackRequest* window_get_buffer(int64_t window);
 	// ArrayOf(Integer, 2) window_get_cursor(Window window, ) 
-	MsgpackRequest* window_get_cursor(int64_t window);
+	NeovimQt::MsgpackRequest* window_get_cursor(int64_t window);
 	// void window_set_cursor(Window window, ArrayOf(Integer, 2) pos, ) 
-	MsgpackRequest* window_set_cursor(int64_t window, QPoint pos);
+	NeovimQt::MsgpackRequest* window_set_cursor(int64_t window, QPoint pos);
 	// Integer window_get_height(Window window, ) 
-	MsgpackRequest* window_get_height(int64_t window);
+	NeovimQt::MsgpackRequest* window_get_height(int64_t window);
 	// void window_set_height(Window window, Integer height, ) 
-	MsgpackRequest* window_set_height(int64_t window, int64_t height);
+	NeovimQt::MsgpackRequest* window_set_height(int64_t window, int64_t height);
 	// Integer window_get_width(Window window, ) 
-	MsgpackRequest* window_get_width(int64_t window);
+	NeovimQt::MsgpackRequest* window_get_width(int64_t window);
 	// void window_set_width(Window window, Integer width, ) 
-	MsgpackRequest* window_set_width(int64_t window, int64_t width);
+	NeovimQt::MsgpackRequest* window_set_width(int64_t window, int64_t width);
 	// Object window_get_var(Window window, String name, ) 
-	MsgpackRequest* window_get_var(int64_t window, QByteArray name);
+	NeovimQt::MsgpackRequest* window_get_var(int64_t window, QByteArray name);
 	// Object window_set_var(Window window, String name, Object value, ) 
-	MsgpackRequest* window_set_var(int64_t window, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* window_set_var(int64_t window, QByteArray name, QVariant value);
 	// Object window_del_var(Window window, String name, ) 
-	MsgpackRequest* window_del_var(int64_t window, QByteArray name);
+	NeovimQt::MsgpackRequest* window_del_var(int64_t window, QByteArray name);
 	// Object window_get_option(Window window, String name, ) 
-	MsgpackRequest* window_get_option(int64_t window, QByteArray name);
+	NeovimQt::MsgpackRequest* window_get_option(int64_t window, QByteArray name);
 	// void window_set_option(Window window, String name, Object value, ) 
-	MsgpackRequest* window_set_option(int64_t window, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* window_set_option(int64_t window, QByteArray name, QVariant value);
 	// ArrayOf(Integer, 2) window_get_position(Window window, ) 
-	MsgpackRequest* window_get_position(int64_t window);
+	NeovimQt::MsgpackRequest* window_get_position(int64_t window);
 	// Tabpage window_get_tabpage(Window window, ) 
-	MsgpackRequest* window_get_tabpage(int64_t window);
+	NeovimQt::MsgpackRequest* window_get_tabpage(int64_t window);
 	// Boolean window_is_valid(Window window, ) 
-	MsgpackRequest* window_is_valid(int64_t window);
+	NeovimQt::MsgpackRequest* window_is_valid(int64_t window);
 
 signals:
 	void on_buffer_line_count(int64_t);
@@ -518,5 +520,5 @@ signals:
 	void err_window_is_valid(const QString&, const QVariant&);
 
 };
-} // namespace
-#endif
+
+} // namespace NeovimQt

--- a/src/auto/neovimapi1.h
+++ b/src/auto/neovimapi1.h
@@ -1,13 +1,15 @@
-// Auto generated 2017-10-31 14:21:01.884363 from nvim API level:1
-#ifndef NEOVIM_QT_NEOVIMAPI1
-#define NEOVIM_QT_NEOVIMAPI1
-#include "msgpack.h"
+// Auto generated 2021-07-20 02:45:08.775105 from nvim API level:1
+#pragma once
+
 #include <QObject>
-#include <QVariant>
 #include <QPoint>
+#include <QVariant>
+
 #include "function.h"
+#include "msgpack.h"
 
 namespace NeovimQt {
+
 class NeovimConnector;
 class MsgpackRequest;
 
@@ -195,403 +197,403 @@ private:
 	NeovimConnector *m_c;
 public slots:
 	// Integer nvim_buf_line_count(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_line_count(int64_t buffer);
+	NeovimQt::MsgpackRequest* nvim_buf_line_count(int64_t buffer);
 	// DEPRECATED
 	// String buffer_get_line(Buffer buffer, Integer index, ) 
-	MsgpackRequest* buffer_get_line(int64_t buffer, int64_t index);
+	NeovimQt::MsgpackRequest* buffer_get_line(int64_t buffer, int64_t index);
 	// DEPRECATED
 	// void buffer_set_line(Buffer buffer, Integer index, String line, ) 
-	MsgpackRequest* buffer_set_line(int64_t buffer, int64_t index, QByteArray line);
+	NeovimQt::MsgpackRequest* buffer_set_line(int64_t buffer, int64_t index, QByteArray line);
 	// DEPRECATED
 	// void buffer_del_line(Buffer buffer, Integer index, ) 
-	MsgpackRequest* buffer_del_line(int64_t buffer, int64_t index);
+	NeovimQt::MsgpackRequest* buffer_del_line(int64_t buffer, int64_t index);
 	// DEPRECATED
 	// ArrayOf(String) buffer_get_line_slice(Buffer buffer, Integer start, Integer end, Boolean include_start, Boolean include_end, ) 
-	MsgpackRequest* buffer_get_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end);
+	NeovimQt::MsgpackRequest* buffer_get_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end);
 	// ArrayOf(String) nvim_buf_get_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ) 
-	MsgpackRequest* nvim_buf_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing);
+	NeovimQt::MsgpackRequest* nvim_buf_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing);
 	// DEPRECATED
 	// void buffer_set_line_slice(Buffer buffer, Integer start, Integer end, Boolean include_start, Boolean include_end, ArrayOf(String) replacement, ) 
-	MsgpackRequest* buffer_set_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end, QList<QByteArray> replacement);
+	NeovimQt::MsgpackRequest* buffer_set_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end, QList<QByteArray> replacement);
 	// void nvim_buf_set_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ArrayOf(String) replacement, ) 
-	MsgpackRequest* nvim_buf_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement);
+	NeovimQt::MsgpackRequest* nvim_buf_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement);
 	// Object nvim_buf_get_var(Buffer buffer, String name, ) 
-	MsgpackRequest* nvim_buf_get_var(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_buf_get_var(int64_t buffer, QByteArray name);
 	// void nvim_buf_set_var(Buffer buffer, String name, Object value, ) 
-	MsgpackRequest* nvim_buf_set_var(int64_t buffer, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* nvim_buf_set_var(int64_t buffer, QByteArray name, QVariant value);
 	// void nvim_buf_del_var(Buffer buffer, String name, ) 
-	MsgpackRequest* nvim_buf_del_var(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_buf_del_var(int64_t buffer, QByteArray name);
 	// DEPRECATED
 	// Object buffer_set_var(Buffer buffer, String name, Object value, ) 
-	MsgpackRequest* buffer_set_var(int64_t buffer, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* buffer_set_var(int64_t buffer, QByteArray name, QVariant value);
 	// DEPRECATED
 	// Object buffer_del_var(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_del_var(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* buffer_del_var(int64_t buffer, QByteArray name);
 	// Object nvim_buf_get_option(Buffer buffer, String name, ) 
-	MsgpackRequest* nvim_buf_get_option(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_buf_get_option(int64_t buffer, QByteArray name);
 	// void nvim_buf_set_option(Buffer buffer, String name, Object value, ) 
-	MsgpackRequest* nvim_buf_set_option(int64_t buffer, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* nvim_buf_set_option(int64_t buffer, QByteArray name, QVariant value);
 	// Integer nvim_buf_get_number(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_get_number(int64_t buffer);
+	NeovimQt::MsgpackRequest* nvim_buf_get_number(int64_t buffer);
 	// String nvim_buf_get_name(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_get_name(int64_t buffer);
+	NeovimQt::MsgpackRequest* nvim_buf_get_name(int64_t buffer);
 	// void nvim_buf_set_name(Buffer buffer, String name, ) 
-	MsgpackRequest* nvim_buf_set_name(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_buf_set_name(int64_t buffer, QByteArray name);
 	// Boolean nvim_buf_is_valid(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_is_valid(int64_t buffer);
+	NeovimQt::MsgpackRequest* nvim_buf_is_valid(int64_t buffer);
 	// DEPRECATED
 	// void buffer_insert(Buffer buffer, Integer lnum, ArrayOf(String) lines, ) 
-	MsgpackRequest* buffer_insert(int64_t buffer, int64_t lnum, QList<QByteArray> lines);
+	NeovimQt::MsgpackRequest* buffer_insert(int64_t buffer, int64_t lnum, QList<QByteArray> lines);
 	// ArrayOf(Integer, 2) nvim_buf_get_mark(Buffer buffer, String name, ) 
-	MsgpackRequest* nvim_buf_get_mark(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_buf_get_mark(int64_t buffer, QByteArray name);
 	// Integer nvim_buf_add_highlight(Buffer buffer, Integer src_id, String hl_group, Integer line, Integer col_start, Integer col_end, ) 
-	MsgpackRequest* nvim_buf_add_highlight(int64_t buffer, int64_t src_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end);
+	NeovimQt::MsgpackRequest* nvim_buf_add_highlight(int64_t buffer, int64_t src_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end);
 	// void nvim_buf_clear_highlight(Buffer buffer, Integer src_id, Integer line_start, Integer line_end, ) 
-	MsgpackRequest* nvim_buf_clear_highlight(int64_t buffer, int64_t src_id, int64_t line_start, int64_t line_end);
+	NeovimQt::MsgpackRequest* nvim_buf_clear_highlight(int64_t buffer, int64_t src_id, int64_t line_start, int64_t line_end);
 	// ArrayOf(Window) nvim_tabpage_list_wins(Tabpage tabpage, ) 
-	MsgpackRequest* nvim_tabpage_list_wins(int64_t tabpage);
+	NeovimQt::MsgpackRequest* nvim_tabpage_list_wins(int64_t tabpage);
 	// Object nvim_tabpage_get_var(Tabpage tabpage, String name, ) 
-	MsgpackRequest* nvim_tabpage_get_var(int64_t tabpage, QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_tabpage_get_var(int64_t tabpage, QByteArray name);
 	// void nvim_tabpage_set_var(Tabpage tabpage, String name, Object value, ) 
-	MsgpackRequest* nvim_tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* nvim_tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value);
 	// void nvim_tabpage_del_var(Tabpage tabpage, String name, ) 
-	MsgpackRequest* nvim_tabpage_del_var(int64_t tabpage, QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_tabpage_del_var(int64_t tabpage, QByteArray name);
 	// DEPRECATED
 	// Object tabpage_set_var(Tabpage tabpage, String name, Object value, ) 
-	MsgpackRequest* tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value);
 	// DEPRECATED
 	// Object tabpage_del_var(Tabpage tabpage, String name, ) 
-	MsgpackRequest* tabpage_del_var(int64_t tabpage, QByteArray name);
+	NeovimQt::MsgpackRequest* tabpage_del_var(int64_t tabpage, QByteArray name);
 	// Window nvim_tabpage_get_win(Tabpage tabpage, ) 
-	MsgpackRequest* nvim_tabpage_get_win(int64_t tabpage);
+	NeovimQt::MsgpackRequest* nvim_tabpage_get_win(int64_t tabpage);
 	// Integer nvim_tabpage_get_number(Tabpage tabpage, ) 
-	MsgpackRequest* nvim_tabpage_get_number(int64_t tabpage);
+	NeovimQt::MsgpackRequest* nvim_tabpage_get_number(int64_t tabpage);
 	// Boolean nvim_tabpage_is_valid(Tabpage tabpage, ) 
-	MsgpackRequest* nvim_tabpage_is_valid(int64_t tabpage);
+	NeovimQt::MsgpackRequest* nvim_tabpage_is_valid(int64_t tabpage);
 	// void nvim_ui_attach(Integer width, Integer height, Dictionary options, ) 
-	MsgpackRequest* nvim_ui_attach(int64_t width, int64_t height, QVariantMap options);
+	NeovimQt::MsgpackRequest* nvim_ui_attach(int64_t width, int64_t height, QVariantMap options);
 	// DEPRECATED
 	// void ui_attach(Integer width, Integer height, Boolean enable_rgb, ) 
-	MsgpackRequest* ui_attach(int64_t width, int64_t height, bool enable_rgb);
+	NeovimQt::MsgpackRequest* ui_attach(int64_t width, int64_t height, bool enable_rgb);
 	// void nvim_ui_detach() 
-	MsgpackRequest* nvim_ui_detach();
+	NeovimQt::MsgpackRequest* nvim_ui_detach();
 	// void nvim_ui_try_resize(Integer width, Integer height, ) 
-	MsgpackRequest* nvim_ui_try_resize(int64_t width, int64_t height);
+	NeovimQt::MsgpackRequest* nvim_ui_try_resize(int64_t width, int64_t height);
 	// void nvim_ui_set_option(String name, Object value, ) 
-	MsgpackRequest* nvim_ui_set_option(QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* nvim_ui_set_option(QByteArray name, QVariant value);
 	// void nvim_command(String command, ) 
-	MsgpackRequest* nvim_command(QByteArray command);
+	NeovimQt::MsgpackRequest* nvim_command(QByteArray command);
 	// void nvim_feedkeys(String keys, String mode, Boolean escape_csi, ) 
-	MsgpackRequest* nvim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi);
+	NeovimQt::MsgpackRequest* nvim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi);
 	// Integer nvim_input(String keys, ) 
-	MsgpackRequest* nvim_input(QByteArray keys);
+	NeovimQt::MsgpackRequest* nvim_input(QByteArray keys);
 	// String nvim_replace_termcodes(String str, Boolean from_part, Boolean do_lt, Boolean special, ) 
-	MsgpackRequest* nvim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special);
+	NeovimQt::MsgpackRequest* nvim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special);
 	// String nvim_command_output(String str, ) 
-	MsgpackRequest* nvim_command_output(QByteArray str);
+	NeovimQt::MsgpackRequest* nvim_command_output(QByteArray str);
 	// Object nvim_eval(String expr, ) 
-	MsgpackRequest* nvim_eval(QByteArray expr);
+	NeovimQt::MsgpackRequest* nvim_eval(QByteArray expr);
 	// Object nvim_call_function(String fname, Array args, ) 
-	MsgpackRequest* nvim_call_function(QByteArray fname, QVariantList args);
+	NeovimQt::MsgpackRequest* nvim_call_function(QByteArray fname, QVariantList args);
 	// Integer nvim_strwidth(String str, ) 
-	MsgpackRequest* nvim_strwidth(QByteArray str);
+	NeovimQt::MsgpackRequest* nvim_strwidth(QByteArray str);
 	// ArrayOf(String) nvim_list_runtime_paths() 
-	MsgpackRequest* nvim_list_runtime_paths();
+	NeovimQt::MsgpackRequest* nvim_list_runtime_paths();
 	// void nvim_set_current_dir(String dir, ) 
-	MsgpackRequest* nvim_set_current_dir(QByteArray dir);
+	NeovimQt::MsgpackRequest* nvim_set_current_dir(QByteArray dir);
 	// String nvim_get_current_line() 
-	MsgpackRequest* nvim_get_current_line();
+	NeovimQt::MsgpackRequest* nvim_get_current_line();
 	// void nvim_set_current_line(String line, ) 
-	MsgpackRequest* nvim_set_current_line(QByteArray line);
+	NeovimQt::MsgpackRequest* nvim_set_current_line(QByteArray line);
 	// void nvim_del_current_line() 
-	MsgpackRequest* nvim_del_current_line();
+	NeovimQt::MsgpackRequest* nvim_del_current_line();
 	// Object nvim_get_var(String name, ) 
-	MsgpackRequest* nvim_get_var(QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_get_var(QByteArray name);
 	// void nvim_set_var(String name, Object value, ) 
-	MsgpackRequest* nvim_set_var(QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* nvim_set_var(QByteArray name, QVariant value);
 	// void nvim_del_var(String name, ) 
-	MsgpackRequest* nvim_del_var(QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_del_var(QByteArray name);
 	// DEPRECATED
 	// Object vim_set_var(String name, Object value, ) 
-	MsgpackRequest* vim_set_var(QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* vim_set_var(QByteArray name, QVariant value);
 	// DEPRECATED
 	// Object vim_del_var(String name, ) 
-	MsgpackRequest* vim_del_var(QByteArray name);
+	NeovimQt::MsgpackRequest* vim_del_var(QByteArray name);
 	// Object nvim_get_vvar(String name, ) 
-	MsgpackRequest* nvim_get_vvar(QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_get_vvar(QByteArray name);
 	// Object nvim_get_option(String name, ) 
-	MsgpackRequest* nvim_get_option(QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_get_option(QByteArray name);
 	// void nvim_set_option(String name, Object value, ) 
-	MsgpackRequest* nvim_set_option(QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* nvim_set_option(QByteArray name, QVariant value);
 	// void nvim_out_write(String str, ) 
-	MsgpackRequest* nvim_out_write(QByteArray str);
+	NeovimQt::MsgpackRequest* nvim_out_write(QByteArray str);
 	// void nvim_err_write(String str, ) 
-	MsgpackRequest* nvim_err_write(QByteArray str);
+	NeovimQt::MsgpackRequest* nvim_err_write(QByteArray str);
 	// void nvim_err_writeln(String str, ) 
-	MsgpackRequest* nvim_err_writeln(QByteArray str);
+	NeovimQt::MsgpackRequest* nvim_err_writeln(QByteArray str);
 	// ArrayOf(Buffer) nvim_list_bufs() 
-	MsgpackRequest* nvim_list_bufs();
+	NeovimQt::MsgpackRequest* nvim_list_bufs();
 	// Buffer nvim_get_current_buf() 
-	MsgpackRequest* nvim_get_current_buf();
+	NeovimQt::MsgpackRequest* nvim_get_current_buf();
 	// void nvim_set_current_buf(Buffer buffer, ) 
-	MsgpackRequest* nvim_set_current_buf(int64_t buffer);
+	NeovimQt::MsgpackRequest* nvim_set_current_buf(int64_t buffer);
 	// ArrayOf(Window) nvim_list_wins() 
-	MsgpackRequest* nvim_list_wins();
+	NeovimQt::MsgpackRequest* nvim_list_wins();
 	// Window nvim_get_current_win() 
-	MsgpackRequest* nvim_get_current_win();
+	NeovimQt::MsgpackRequest* nvim_get_current_win();
 	// void nvim_set_current_win(Window window, ) 
-	MsgpackRequest* nvim_set_current_win(int64_t window);
+	NeovimQt::MsgpackRequest* nvim_set_current_win(int64_t window);
 	// ArrayOf(Tabpage) nvim_list_tabpages() 
-	MsgpackRequest* nvim_list_tabpages();
+	NeovimQt::MsgpackRequest* nvim_list_tabpages();
 	// Tabpage nvim_get_current_tabpage() 
-	MsgpackRequest* nvim_get_current_tabpage();
+	NeovimQt::MsgpackRequest* nvim_get_current_tabpage();
 	// void nvim_set_current_tabpage(Tabpage tabpage, ) 
-	MsgpackRequest* nvim_set_current_tabpage(int64_t tabpage);
+	NeovimQt::MsgpackRequest* nvim_set_current_tabpage(int64_t tabpage);
 	// void nvim_subscribe(String event, ) 
-	MsgpackRequest* nvim_subscribe(QByteArray event);
+	NeovimQt::MsgpackRequest* nvim_subscribe(QByteArray event);
 	// void nvim_unsubscribe(String event, ) 
-	MsgpackRequest* nvim_unsubscribe(QByteArray event);
+	NeovimQt::MsgpackRequest* nvim_unsubscribe(QByteArray event);
 	// Integer nvim_get_color_by_name(String name, ) 
-	MsgpackRequest* nvim_get_color_by_name(QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_get_color_by_name(QByteArray name);
 	// Dictionary nvim_get_color_map() 
-	MsgpackRequest* nvim_get_color_map();
+	NeovimQt::MsgpackRequest* nvim_get_color_map();
 	// Array nvim_get_api_info() 
-	MsgpackRequest* nvim_get_api_info();
+	NeovimQt::MsgpackRequest* nvim_get_api_info();
 	// Array nvim_call_atomic(Array calls, ) 
-	MsgpackRequest* nvim_call_atomic(QVariantList calls);
+	NeovimQt::MsgpackRequest* nvim_call_atomic(QVariantList calls);
 	// Buffer nvim_win_get_buf(Window window, ) 
-	MsgpackRequest* nvim_win_get_buf(int64_t window);
+	NeovimQt::MsgpackRequest* nvim_win_get_buf(int64_t window);
 	// ArrayOf(Integer, 2) nvim_win_get_cursor(Window window, ) 
-	MsgpackRequest* nvim_win_get_cursor(int64_t window);
+	NeovimQt::MsgpackRequest* nvim_win_get_cursor(int64_t window);
 	// void nvim_win_set_cursor(Window window, ArrayOf(Integer, 2) pos, ) 
-	MsgpackRequest* nvim_win_set_cursor(int64_t window, QPoint pos);
+	NeovimQt::MsgpackRequest* nvim_win_set_cursor(int64_t window, QPoint pos);
 	// Integer nvim_win_get_height(Window window, ) 
-	MsgpackRequest* nvim_win_get_height(int64_t window);
+	NeovimQt::MsgpackRequest* nvim_win_get_height(int64_t window);
 	// void nvim_win_set_height(Window window, Integer height, ) 
-	MsgpackRequest* nvim_win_set_height(int64_t window, int64_t height);
+	NeovimQt::MsgpackRequest* nvim_win_set_height(int64_t window, int64_t height);
 	// Integer nvim_win_get_width(Window window, ) 
-	MsgpackRequest* nvim_win_get_width(int64_t window);
+	NeovimQt::MsgpackRequest* nvim_win_get_width(int64_t window);
 	// void nvim_win_set_width(Window window, Integer width, ) 
-	MsgpackRequest* nvim_win_set_width(int64_t window, int64_t width);
+	NeovimQt::MsgpackRequest* nvim_win_set_width(int64_t window, int64_t width);
 	// Object nvim_win_get_var(Window window, String name, ) 
-	MsgpackRequest* nvim_win_get_var(int64_t window, QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_win_get_var(int64_t window, QByteArray name);
 	// void nvim_win_set_var(Window window, String name, Object value, ) 
-	MsgpackRequest* nvim_win_set_var(int64_t window, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* nvim_win_set_var(int64_t window, QByteArray name, QVariant value);
 	// void nvim_win_del_var(Window window, String name, ) 
-	MsgpackRequest* nvim_win_del_var(int64_t window, QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_win_del_var(int64_t window, QByteArray name);
 	// DEPRECATED
 	// Object window_set_var(Window window, String name, Object value, ) 
-	MsgpackRequest* window_set_var(int64_t window, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* window_set_var(int64_t window, QByteArray name, QVariant value);
 	// DEPRECATED
 	// Object window_del_var(Window window, String name, ) 
-	MsgpackRequest* window_del_var(int64_t window, QByteArray name);
+	NeovimQt::MsgpackRequest* window_del_var(int64_t window, QByteArray name);
 	// Object nvim_win_get_option(Window window, String name, ) 
-	MsgpackRequest* nvim_win_get_option(int64_t window, QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_win_get_option(int64_t window, QByteArray name);
 	// void nvim_win_set_option(Window window, String name, Object value, ) 
-	MsgpackRequest* nvim_win_set_option(int64_t window, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* nvim_win_set_option(int64_t window, QByteArray name, QVariant value);
 	// ArrayOf(Integer, 2) nvim_win_get_position(Window window, ) 
-	MsgpackRequest* nvim_win_get_position(int64_t window);
+	NeovimQt::MsgpackRequest* nvim_win_get_position(int64_t window);
 	// Tabpage nvim_win_get_tabpage(Window window, ) 
-	MsgpackRequest* nvim_win_get_tabpage(int64_t window);
+	NeovimQt::MsgpackRequest* nvim_win_get_tabpage(int64_t window);
 	// Integer nvim_win_get_number(Window window, ) 
-	MsgpackRequest* nvim_win_get_number(int64_t window);
+	NeovimQt::MsgpackRequest* nvim_win_get_number(int64_t window);
 	// Boolean nvim_win_is_valid(Window window, ) 
-	MsgpackRequest* nvim_win_is_valid(int64_t window);
+	NeovimQt::MsgpackRequest* nvim_win_is_valid(int64_t window);
 	// DEPRECATED
 	// Integer buffer_line_count(Buffer buffer, ) 
-	MsgpackRequest* buffer_line_count(int64_t buffer);
+	NeovimQt::MsgpackRequest* buffer_line_count(int64_t buffer);
 	// DEPRECATED
 	// ArrayOf(String) buffer_get_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ) 
-	MsgpackRequest* buffer_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing);
+	NeovimQt::MsgpackRequest* buffer_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing);
 	// DEPRECATED
 	// void buffer_set_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ArrayOf(String) replacement, ) 
-	MsgpackRequest* buffer_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement);
+	NeovimQt::MsgpackRequest* buffer_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement);
 	// DEPRECATED
 	// Object buffer_get_var(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_get_var(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* buffer_get_var(int64_t buffer, QByteArray name);
 	// DEPRECATED
 	// Object buffer_get_option(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_get_option(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* buffer_get_option(int64_t buffer, QByteArray name);
 	// DEPRECATED
 	// void buffer_set_option(Buffer buffer, String name, Object value, ) 
-	MsgpackRequest* buffer_set_option(int64_t buffer, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* buffer_set_option(int64_t buffer, QByteArray name, QVariant value);
 	// DEPRECATED
 	// Integer buffer_get_number(Buffer buffer, ) 
-	MsgpackRequest* buffer_get_number(int64_t buffer);
+	NeovimQt::MsgpackRequest* buffer_get_number(int64_t buffer);
 	// DEPRECATED
 	// String buffer_get_name(Buffer buffer, ) 
-	MsgpackRequest* buffer_get_name(int64_t buffer);
+	NeovimQt::MsgpackRequest* buffer_get_name(int64_t buffer);
 	// DEPRECATED
 	// void buffer_set_name(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_set_name(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* buffer_set_name(int64_t buffer, QByteArray name);
 	// DEPRECATED
 	// Boolean buffer_is_valid(Buffer buffer, ) 
-	MsgpackRequest* buffer_is_valid(int64_t buffer);
+	NeovimQt::MsgpackRequest* buffer_is_valid(int64_t buffer);
 	// DEPRECATED
 	// ArrayOf(Integer, 2) buffer_get_mark(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_get_mark(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* buffer_get_mark(int64_t buffer, QByteArray name);
 	// DEPRECATED
 	// Integer buffer_add_highlight(Buffer buffer, Integer src_id, String hl_group, Integer line, Integer col_start, Integer col_end, ) 
-	MsgpackRequest* buffer_add_highlight(int64_t buffer, int64_t src_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end);
+	NeovimQt::MsgpackRequest* buffer_add_highlight(int64_t buffer, int64_t src_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end);
 	// DEPRECATED
 	// void buffer_clear_highlight(Buffer buffer, Integer src_id, Integer line_start, Integer line_end, ) 
-	MsgpackRequest* buffer_clear_highlight(int64_t buffer, int64_t src_id, int64_t line_start, int64_t line_end);
+	NeovimQt::MsgpackRequest* buffer_clear_highlight(int64_t buffer, int64_t src_id, int64_t line_start, int64_t line_end);
 	// DEPRECATED
 	// ArrayOf(Window) tabpage_get_windows(Tabpage tabpage, ) 
-	MsgpackRequest* tabpage_get_windows(int64_t tabpage);
+	NeovimQt::MsgpackRequest* tabpage_get_windows(int64_t tabpage);
 	// DEPRECATED
 	// Object tabpage_get_var(Tabpage tabpage, String name, ) 
-	MsgpackRequest* tabpage_get_var(int64_t tabpage, QByteArray name);
+	NeovimQt::MsgpackRequest* tabpage_get_var(int64_t tabpage, QByteArray name);
 	// DEPRECATED
 	// Window tabpage_get_window(Tabpage tabpage, ) 
-	MsgpackRequest* tabpage_get_window(int64_t tabpage);
+	NeovimQt::MsgpackRequest* tabpage_get_window(int64_t tabpage);
 	// DEPRECATED
 	// Boolean tabpage_is_valid(Tabpage tabpage, ) 
-	MsgpackRequest* tabpage_is_valid(int64_t tabpage);
+	NeovimQt::MsgpackRequest* tabpage_is_valid(int64_t tabpage);
 	// DEPRECATED
 	// void ui_detach() 
-	MsgpackRequest* ui_detach();
+	NeovimQt::MsgpackRequest* ui_detach();
 	// DEPRECATED
 	// Object ui_try_resize(Integer width, Integer height, ) 
-	MsgpackRequest* ui_try_resize(int64_t width, int64_t height);
+	NeovimQt::MsgpackRequest* ui_try_resize(int64_t width, int64_t height);
 	// DEPRECATED
 	// void vim_command(String command, ) 
-	MsgpackRequest* vim_command(QByteArray command);
+	NeovimQt::MsgpackRequest* vim_command(QByteArray command);
 	// DEPRECATED
 	// void vim_feedkeys(String keys, String mode, Boolean escape_csi, ) 
-	MsgpackRequest* vim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi);
+	NeovimQt::MsgpackRequest* vim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi);
 	// DEPRECATED
 	// Integer vim_input(String keys, ) 
-	MsgpackRequest* vim_input(QByteArray keys);
+	NeovimQt::MsgpackRequest* vim_input(QByteArray keys);
 	// DEPRECATED
 	// String vim_replace_termcodes(String str, Boolean from_part, Boolean do_lt, Boolean special, ) 
-	MsgpackRequest* vim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special);
+	NeovimQt::MsgpackRequest* vim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special);
 	// DEPRECATED
 	// String vim_command_output(String str, ) 
-	MsgpackRequest* vim_command_output(QByteArray str);
+	NeovimQt::MsgpackRequest* vim_command_output(QByteArray str);
 	// DEPRECATED
 	// Object vim_eval(String expr, ) 
-	MsgpackRequest* vim_eval(QByteArray expr);
+	NeovimQt::MsgpackRequest* vim_eval(QByteArray expr);
 	// DEPRECATED
 	// Object vim_call_function(String fname, Array args, ) 
-	MsgpackRequest* vim_call_function(QByteArray fname, QVariantList args);
+	NeovimQt::MsgpackRequest* vim_call_function(QByteArray fname, QVariantList args);
 	// DEPRECATED
 	// Integer vim_strwidth(String str, ) 
-	MsgpackRequest* vim_strwidth(QByteArray str);
+	NeovimQt::MsgpackRequest* vim_strwidth(QByteArray str);
 	// DEPRECATED
 	// ArrayOf(String) vim_list_runtime_paths() 
-	MsgpackRequest* vim_list_runtime_paths();
+	NeovimQt::MsgpackRequest* vim_list_runtime_paths();
 	// DEPRECATED
 	// void vim_change_directory(String dir, ) 
-	MsgpackRequest* vim_change_directory(QByteArray dir);
+	NeovimQt::MsgpackRequest* vim_change_directory(QByteArray dir);
 	// DEPRECATED
 	// String vim_get_current_line() 
-	MsgpackRequest* vim_get_current_line();
+	NeovimQt::MsgpackRequest* vim_get_current_line();
 	// DEPRECATED
 	// void vim_set_current_line(String line, ) 
-	MsgpackRequest* vim_set_current_line(QByteArray line);
+	NeovimQt::MsgpackRequest* vim_set_current_line(QByteArray line);
 	// DEPRECATED
 	// void vim_del_current_line() 
-	MsgpackRequest* vim_del_current_line();
+	NeovimQt::MsgpackRequest* vim_del_current_line();
 	// DEPRECATED
 	// Object vim_get_var(String name, ) 
-	MsgpackRequest* vim_get_var(QByteArray name);
+	NeovimQt::MsgpackRequest* vim_get_var(QByteArray name);
 	// DEPRECATED
 	// Object vim_get_vvar(String name, ) 
-	MsgpackRequest* vim_get_vvar(QByteArray name);
+	NeovimQt::MsgpackRequest* vim_get_vvar(QByteArray name);
 	// DEPRECATED
 	// Object vim_get_option(String name, ) 
-	MsgpackRequest* vim_get_option(QByteArray name);
+	NeovimQt::MsgpackRequest* vim_get_option(QByteArray name);
 	// DEPRECATED
 	// void vim_set_option(String name, Object value, ) 
-	MsgpackRequest* vim_set_option(QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* vim_set_option(QByteArray name, QVariant value);
 	// DEPRECATED
 	// void vim_out_write(String str, ) 
-	MsgpackRequest* vim_out_write(QByteArray str);
+	NeovimQt::MsgpackRequest* vim_out_write(QByteArray str);
 	// DEPRECATED
 	// void vim_err_write(String str, ) 
-	MsgpackRequest* vim_err_write(QByteArray str);
+	NeovimQt::MsgpackRequest* vim_err_write(QByteArray str);
 	// DEPRECATED
 	// void vim_report_error(String str, ) 
-	MsgpackRequest* vim_report_error(QByteArray str);
+	NeovimQt::MsgpackRequest* vim_report_error(QByteArray str);
 	// DEPRECATED
 	// ArrayOf(Buffer) vim_get_buffers() 
-	MsgpackRequest* vim_get_buffers();
+	NeovimQt::MsgpackRequest* vim_get_buffers();
 	// DEPRECATED
 	// Buffer vim_get_current_buffer() 
-	MsgpackRequest* vim_get_current_buffer();
+	NeovimQt::MsgpackRequest* vim_get_current_buffer();
 	// DEPRECATED
 	// void vim_set_current_buffer(Buffer buffer, ) 
-	MsgpackRequest* vim_set_current_buffer(int64_t buffer);
+	NeovimQt::MsgpackRequest* vim_set_current_buffer(int64_t buffer);
 	// DEPRECATED
 	// ArrayOf(Window) vim_get_windows() 
-	MsgpackRequest* vim_get_windows();
+	NeovimQt::MsgpackRequest* vim_get_windows();
 	// DEPRECATED
 	// Window vim_get_current_window() 
-	MsgpackRequest* vim_get_current_window();
+	NeovimQt::MsgpackRequest* vim_get_current_window();
 	// DEPRECATED
 	// void vim_set_current_window(Window window, ) 
-	MsgpackRequest* vim_set_current_window(int64_t window);
+	NeovimQt::MsgpackRequest* vim_set_current_window(int64_t window);
 	// DEPRECATED
 	// ArrayOf(Tabpage) vim_get_tabpages() 
-	MsgpackRequest* vim_get_tabpages();
+	NeovimQt::MsgpackRequest* vim_get_tabpages();
 	// DEPRECATED
 	// Tabpage vim_get_current_tabpage() 
-	MsgpackRequest* vim_get_current_tabpage();
+	NeovimQt::MsgpackRequest* vim_get_current_tabpage();
 	// DEPRECATED
 	// void vim_set_current_tabpage(Tabpage tabpage, ) 
-	MsgpackRequest* vim_set_current_tabpage(int64_t tabpage);
+	NeovimQt::MsgpackRequest* vim_set_current_tabpage(int64_t tabpage);
 	// DEPRECATED
 	// void vim_subscribe(String event, ) 
-	MsgpackRequest* vim_subscribe(QByteArray event);
+	NeovimQt::MsgpackRequest* vim_subscribe(QByteArray event);
 	// DEPRECATED
 	// void vim_unsubscribe(String event, ) 
-	MsgpackRequest* vim_unsubscribe(QByteArray event);
+	NeovimQt::MsgpackRequest* vim_unsubscribe(QByteArray event);
 	// DEPRECATED
 	// Integer vim_name_to_color(String name, ) 
-	MsgpackRequest* vim_name_to_color(QByteArray name);
+	NeovimQt::MsgpackRequest* vim_name_to_color(QByteArray name);
 	// DEPRECATED
 	// Dictionary vim_get_color_map() 
-	MsgpackRequest* vim_get_color_map();
+	NeovimQt::MsgpackRequest* vim_get_color_map();
 	// DEPRECATED
 	// Buffer window_get_buffer(Window window, ) 
-	MsgpackRequest* window_get_buffer(int64_t window);
+	NeovimQt::MsgpackRequest* window_get_buffer(int64_t window);
 	// DEPRECATED
 	// ArrayOf(Integer, 2) window_get_cursor(Window window, ) 
-	MsgpackRequest* window_get_cursor(int64_t window);
+	NeovimQt::MsgpackRequest* window_get_cursor(int64_t window);
 	// DEPRECATED
 	// void window_set_cursor(Window window, ArrayOf(Integer, 2) pos, ) 
-	MsgpackRequest* window_set_cursor(int64_t window, QPoint pos);
+	NeovimQt::MsgpackRequest* window_set_cursor(int64_t window, QPoint pos);
 	// DEPRECATED
 	// Integer window_get_height(Window window, ) 
-	MsgpackRequest* window_get_height(int64_t window);
+	NeovimQt::MsgpackRequest* window_get_height(int64_t window);
 	// DEPRECATED
 	// void window_set_height(Window window, Integer height, ) 
-	MsgpackRequest* window_set_height(int64_t window, int64_t height);
+	NeovimQt::MsgpackRequest* window_set_height(int64_t window, int64_t height);
 	// DEPRECATED
 	// Integer window_get_width(Window window, ) 
-	MsgpackRequest* window_get_width(int64_t window);
+	NeovimQt::MsgpackRequest* window_get_width(int64_t window);
 	// DEPRECATED
 	// void window_set_width(Window window, Integer width, ) 
-	MsgpackRequest* window_set_width(int64_t window, int64_t width);
+	NeovimQt::MsgpackRequest* window_set_width(int64_t window, int64_t width);
 	// DEPRECATED
 	// Object window_get_var(Window window, String name, ) 
-	MsgpackRequest* window_get_var(int64_t window, QByteArray name);
+	NeovimQt::MsgpackRequest* window_get_var(int64_t window, QByteArray name);
 	// DEPRECATED
 	// Object window_get_option(Window window, String name, ) 
-	MsgpackRequest* window_get_option(int64_t window, QByteArray name);
+	NeovimQt::MsgpackRequest* window_get_option(int64_t window, QByteArray name);
 	// DEPRECATED
 	// void window_set_option(Window window, String name, Object value, ) 
-	MsgpackRequest* window_set_option(int64_t window, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* window_set_option(int64_t window, QByteArray name, QVariant value);
 	// DEPRECATED
 	// ArrayOf(Integer, 2) window_get_position(Window window, ) 
-	MsgpackRequest* window_get_position(int64_t window);
+	NeovimQt::MsgpackRequest* window_get_position(int64_t window);
 	// DEPRECATED
 	// Tabpage window_get_tabpage(Window window, ) 
-	MsgpackRequest* window_get_tabpage(int64_t window);
+	NeovimQt::MsgpackRequest* window_get_tabpage(int64_t window);
 	// DEPRECATED
 	// Boolean window_is_valid(Window window, ) 
-	MsgpackRequest* window_is_valid(int64_t window);
+	NeovimQt::MsgpackRequest* window_is_valid(int64_t window);
 
 signals:
 	void on_nvim_buf_line_count(int64_t);
@@ -1072,5 +1074,5 @@ signals:
 	void err_window_is_valid(const QString&, const QVariant&);
 
 };
-} // namespace
-#endif
+
+} // namespace NeovimQt

--- a/src/auto/neovimapi2.h
+++ b/src/auto/neovimapi2.h
@@ -1,13 +1,15 @@
-// Auto generated 2017-10-31 14:35:34.288640 from nvim API level:2
-#ifndef NEOVIM_QT_NEOVIMAPI2
-#define NEOVIM_QT_NEOVIMAPI2
-#include "msgpack.h"
+// Auto generated 2021-07-20 02:39:23.817220 from nvim API level:2
+#pragma once
+
 #include <QObject>
-#include <QVariant>
 #include <QPoint>
+#include <QVariant>
+
 #include "function.h"
+#include "msgpack.h"
 
 namespace NeovimQt {
+
 class NeovimConnector;
 class MsgpackRequest;
 
@@ -197,408 +199,408 @@ private:
 	NeovimConnector *m_c;
 public slots:
 	// Integer nvim_buf_line_count(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_line_count(int64_t buffer);
+	NeovimQt::MsgpackRequest* nvim_buf_line_count(int64_t buffer);
 	// DEPRECATED
 	// String buffer_get_line(Buffer buffer, Integer index, ) 
-	MsgpackRequest* buffer_get_line(int64_t buffer, int64_t index);
+	NeovimQt::MsgpackRequest* buffer_get_line(int64_t buffer, int64_t index);
 	// DEPRECATED
 	// void buffer_set_line(Buffer buffer, Integer index, String line, ) 
-	MsgpackRequest* buffer_set_line(int64_t buffer, int64_t index, QByteArray line);
+	NeovimQt::MsgpackRequest* buffer_set_line(int64_t buffer, int64_t index, QByteArray line);
 	// DEPRECATED
 	// void buffer_del_line(Buffer buffer, Integer index, ) 
-	MsgpackRequest* buffer_del_line(int64_t buffer, int64_t index);
+	NeovimQt::MsgpackRequest* buffer_del_line(int64_t buffer, int64_t index);
 	// DEPRECATED
 	// ArrayOf(String) buffer_get_line_slice(Buffer buffer, Integer start, Integer end, Boolean include_start, Boolean include_end, ) 
-	MsgpackRequest* buffer_get_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end);
+	NeovimQt::MsgpackRequest* buffer_get_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end);
 	// ArrayOf(String) nvim_buf_get_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ) 
-	MsgpackRequest* nvim_buf_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing);
+	NeovimQt::MsgpackRequest* nvim_buf_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing);
 	// DEPRECATED
 	// void buffer_set_line_slice(Buffer buffer, Integer start, Integer end, Boolean include_start, Boolean include_end, ArrayOf(String) replacement, ) 
-	MsgpackRequest* buffer_set_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end, QList<QByteArray> replacement);
+	NeovimQt::MsgpackRequest* buffer_set_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end, QList<QByteArray> replacement);
 	// void nvim_buf_set_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ArrayOf(String) replacement, ) 
-	MsgpackRequest* nvim_buf_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement);
+	NeovimQt::MsgpackRequest* nvim_buf_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement);
 	// Object nvim_buf_get_var(Buffer buffer, String name, ) 
-	MsgpackRequest* nvim_buf_get_var(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_buf_get_var(int64_t buffer, QByteArray name);
 	// Integer nvim_buf_get_changedtick(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_get_changedtick(int64_t buffer);
+	NeovimQt::MsgpackRequest* nvim_buf_get_changedtick(int64_t buffer);
 	// void nvim_buf_set_var(Buffer buffer, String name, Object value, ) 
-	MsgpackRequest* nvim_buf_set_var(int64_t buffer, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* nvim_buf_set_var(int64_t buffer, QByteArray name, QVariant value);
 	// void nvim_buf_del_var(Buffer buffer, String name, ) 
-	MsgpackRequest* nvim_buf_del_var(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_buf_del_var(int64_t buffer, QByteArray name);
 	// DEPRECATED
 	// Object buffer_set_var(Buffer buffer, String name, Object value, ) 
-	MsgpackRequest* buffer_set_var(int64_t buffer, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* buffer_set_var(int64_t buffer, QByteArray name, QVariant value);
 	// DEPRECATED
 	// Object buffer_del_var(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_del_var(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* buffer_del_var(int64_t buffer, QByteArray name);
 	// Object nvim_buf_get_option(Buffer buffer, String name, ) 
-	MsgpackRequest* nvim_buf_get_option(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_buf_get_option(int64_t buffer, QByteArray name);
 	// void nvim_buf_set_option(Buffer buffer, String name, Object value, ) 
-	MsgpackRequest* nvim_buf_set_option(int64_t buffer, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* nvim_buf_set_option(int64_t buffer, QByteArray name, QVariant value);
 	// DEPRECATED
 	// Integer nvim_buf_get_number(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_get_number(int64_t buffer);
+	NeovimQt::MsgpackRequest* nvim_buf_get_number(int64_t buffer);
 	// String nvim_buf_get_name(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_get_name(int64_t buffer);
+	NeovimQt::MsgpackRequest* nvim_buf_get_name(int64_t buffer);
 	// void nvim_buf_set_name(Buffer buffer, String name, ) 
-	MsgpackRequest* nvim_buf_set_name(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_buf_set_name(int64_t buffer, QByteArray name);
 	// Boolean nvim_buf_is_valid(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_is_valid(int64_t buffer);
+	NeovimQt::MsgpackRequest* nvim_buf_is_valid(int64_t buffer);
 	// DEPRECATED
 	// void buffer_insert(Buffer buffer, Integer lnum, ArrayOf(String) lines, ) 
-	MsgpackRequest* buffer_insert(int64_t buffer, int64_t lnum, QList<QByteArray> lines);
+	NeovimQt::MsgpackRequest* buffer_insert(int64_t buffer, int64_t lnum, QList<QByteArray> lines);
 	// ArrayOf(Integer, 2) nvim_buf_get_mark(Buffer buffer, String name, ) 
-	MsgpackRequest* nvim_buf_get_mark(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_buf_get_mark(int64_t buffer, QByteArray name);
 	// Integer nvim_buf_add_highlight(Buffer buffer, Integer src_id, String hl_group, Integer line, Integer col_start, Integer col_end, ) 
-	MsgpackRequest* nvim_buf_add_highlight(int64_t buffer, int64_t src_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end);
+	NeovimQt::MsgpackRequest* nvim_buf_add_highlight(int64_t buffer, int64_t src_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end);
 	// void nvim_buf_clear_highlight(Buffer buffer, Integer src_id, Integer line_start, Integer line_end, ) 
-	MsgpackRequest* nvim_buf_clear_highlight(int64_t buffer, int64_t src_id, int64_t line_start, int64_t line_end);
+	NeovimQt::MsgpackRequest* nvim_buf_clear_highlight(int64_t buffer, int64_t src_id, int64_t line_start, int64_t line_end);
 	// ArrayOf(Window) nvim_tabpage_list_wins(Tabpage tabpage, ) 
-	MsgpackRequest* nvim_tabpage_list_wins(int64_t tabpage);
+	NeovimQt::MsgpackRequest* nvim_tabpage_list_wins(int64_t tabpage);
 	// Object nvim_tabpage_get_var(Tabpage tabpage, String name, ) 
-	MsgpackRequest* nvim_tabpage_get_var(int64_t tabpage, QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_tabpage_get_var(int64_t tabpage, QByteArray name);
 	// void nvim_tabpage_set_var(Tabpage tabpage, String name, Object value, ) 
-	MsgpackRequest* nvim_tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* nvim_tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value);
 	// void nvim_tabpage_del_var(Tabpage tabpage, String name, ) 
-	MsgpackRequest* nvim_tabpage_del_var(int64_t tabpage, QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_tabpage_del_var(int64_t tabpage, QByteArray name);
 	// DEPRECATED
 	// Object tabpage_set_var(Tabpage tabpage, String name, Object value, ) 
-	MsgpackRequest* tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value);
 	// DEPRECATED
 	// Object tabpage_del_var(Tabpage tabpage, String name, ) 
-	MsgpackRequest* tabpage_del_var(int64_t tabpage, QByteArray name);
+	NeovimQt::MsgpackRequest* tabpage_del_var(int64_t tabpage, QByteArray name);
 	// Window nvim_tabpage_get_win(Tabpage tabpage, ) 
-	MsgpackRequest* nvim_tabpage_get_win(int64_t tabpage);
+	NeovimQt::MsgpackRequest* nvim_tabpage_get_win(int64_t tabpage);
 	// Integer nvim_tabpage_get_number(Tabpage tabpage, ) 
-	MsgpackRequest* nvim_tabpage_get_number(int64_t tabpage);
+	NeovimQt::MsgpackRequest* nvim_tabpage_get_number(int64_t tabpage);
 	// Boolean nvim_tabpage_is_valid(Tabpage tabpage, ) 
-	MsgpackRequest* nvim_tabpage_is_valid(int64_t tabpage);
+	NeovimQt::MsgpackRequest* nvim_tabpage_is_valid(int64_t tabpage);
 	// void nvim_ui_attach(Integer width, Integer height, Dictionary options, ) 
-	MsgpackRequest* nvim_ui_attach(int64_t width, int64_t height, QVariantMap options);
+	NeovimQt::MsgpackRequest* nvim_ui_attach(int64_t width, int64_t height, QVariantMap options);
 	// DEPRECATED
 	// void ui_attach(Integer width, Integer height, Boolean enable_rgb, ) 
-	MsgpackRequest* ui_attach(int64_t width, int64_t height, bool enable_rgb);
+	NeovimQt::MsgpackRequest* ui_attach(int64_t width, int64_t height, bool enable_rgb);
 	// void nvim_ui_detach() 
-	MsgpackRequest* nvim_ui_detach();
+	NeovimQt::MsgpackRequest* nvim_ui_detach();
 	// void nvim_ui_try_resize(Integer width, Integer height, ) 
-	MsgpackRequest* nvim_ui_try_resize(int64_t width, int64_t height);
+	NeovimQt::MsgpackRequest* nvim_ui_try_resize(int64_t width, int64_t height);
 	// void nvim_ui_set_option(String name, Object value, ) 
-	MsgpackRequest* nvim_ui_set_option(QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* nvim_ui_set_option(QByteArray name, QVariant value);
 	// void nvim_command(String command, ) 
-	MsgpackRequest* nvim_command(QByteArray command);
+	NeovimQt::MsgpackRequest* nvim_command(QByteArray command);
 	// void nvim_feedkeys(String keys, String mode, Boolean escape_csi, ) 
-	MsgpackRequest* nvim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi);
+	NeovimQt::MsgpackRequest* nvim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi);
 	// Integer nvim_input(String keys, ) 
-	MsgpackRequest* nvim_input(QByteArray keys);
+	NeovimQt::MsgpackRequest* nvim_input(QByteArray keys);
 	// String nvim_replace_termcodes(String str, Boolean from_part, Boolean do_lt, Boolean special, ) 
-	MsgpackRequest* nvim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special);
+	NeovimQt::MsgpackRequest* nvim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special);
 	// String nvim_command_output(String str, ) 
-	MsgpackRequest* nvim_command_output(QByteArray str);
+	NeovimQt::MsgpackRequest* nvim_command_output(QByteArray str);
 	// Object nvim_eval(String expr, ) 
-	MsgpackRequest* nvim_eval(QByteArray expr);
+	NeovimQt::MsgpackRequest* nvim_eval(QByteArray expr);
 	// Object nvim_call_function(String fname, Array args, ) 
-	MsgpackRequest* nvim_call_function(QByteArray fname, QVariantList args);
+	NeovimQt::MsgpackRequest* nvim_call_function(QByteArray fname, QVariantList args);
 	// Integer nvim_strwidth(String str, ) 
-	MsgpackRequest* nvim_strwidth(QByteArray str);
+	NeovimQt::MsgpackRequest* nvim_strwidth(QByteArray str);
 	// ArrayOf(String) nvim_list_runtime_paths() 
-	MsgpackRequest* nvim_list_runtime_paths();
+	NeovimQt::MsgpackRequest* nvim_list_runtime_paths();
 	// void nvim_set_current_dir(String dir, ) 
-	MsgpackRequest* nvim_set_current_dir(QByteArray dir);
+	NeovimQt::MsgpackRequest* nvim_set_current_dir(QByteArray dir);
 	// String nvim_get_current_line() 
-	MsgpackRequest* nvim_get_current_line();
+	NeovimQt::MsgpackRequest* nvim_get_current_line();
 	// void nvim_set_current_line(String line, ) 
-	MsgpackRequest* nvim_set_current_line(QByteArray line);
+	NeovimQt::MsgpackRequest* nvim_set_current_line(QByteArray line);
 	// void nvim_del_current_line() 
-	MsgpackRequest* nvim_del_current_line();
+	NeovimQt::MsgpackRequest* nvim_del_current_line();
 	// Object nvim_get_var(String name, ) 
-	MsgpackRequest* nvim_get_var(QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_get_var(QByteArray name);
 	// void nvim_set_var(String name, Object value, ) 
-	MsgpackRequest* nvim_set_var(QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* nvim_set_var(QByteArray name, QVariant value);
 	// void nvim_del_var(String name, ) 
-	MsgpackRequest* nvim_del_var(QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_del_var(QByteArray name);
 	// DEPRECATED
 	// Object vim_set_var(String name, Object value, ) 
-	MsgpackRequest* vim_set_var(QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* vim_set_var(QByteArray name, QVariant value);
 	// DEPRECATED
 	// Object vim_del_var(String name, ) 
-	MsgpackRequest* vim_del_var(QByteArray name);
+	NeovimQt::MsgpackRequest* vim_del_var(QByteArray name);
 	// Object nvim_get_vvar(String name, ) 
-	MsgpackRequest* nvim_get_vvar(QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_get_vvar(QByteArray name);
 	// Object nvim_get_option(String name, ) 
-	MsgpackRequest* nvim_get_option(QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_get_option(QByteArray name);
 	// void nvim_set_option(String name, Object value, ) 
-	MsgpackRequest* nvim_set_option(QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* nvim_set_option(QByteArray name, QVariant value);
 	// void nvim_out_write(String str, ) 
-	MsgpackRequest* nvim_out_write(QByteArray str);
+	NeovimQt::MsgpackRequest* nvim_out_write(QByteArray str);
 	// void nvim_err_write(String str, ) 
-	MsgpackRequest* nvim_err_write(QByteArray str);
+	NeovimQt::MsgpackRequest* nvim_err_write(QByteArray str);
 	// void nvim_err_writeln(String str, ) 
-	MsgpackRequest* nvim_err_writeln(QByteArray str);
+	NeovimQt::MsgpackRequest* nvim_err_writeln(QByteArray str);
 	// ArrayOf(Buffer) nvim_list_bufs() 
-	MsgpackRequest* nvim_list_bufs();
+	NeovimQt::MsgpackRequest* nvim_list_bufs();
 	// Buffer nvim_get_current_buf() 
-	MsgpackRequest* nvim_get_current_buf();
+	NeovimQt::MsgpackRequest* nvim_get_current_buf();
 	// void nvim_set_current_buf(Buffer buffer, ) 
-	MsgpackRequest* nvim_set_current_buf(int64_t buffer);
+	NeovimQt::MsgpackRequest* nvim_set_current_buf(int64_t buffer);
 	// ArrayOf(Window) nvim_list_wins() 
-	MsgpackRequest* nvim_list_wins();
+	NeovimQt::MsgpackRequest* nvim_list_wins();
 	// Window nvim_get_current_win() 
-	MsgpackRequest* nvim_get_current_win();
+	NeovimQt::MsgpackRequest* nvim_get_current_win();
 	// void nvim_set_current_win(Window window, ) 
-	MsgpackRequest* nvim_set_current_win(int64_t window);
+	NeovimQt::MsgpackRequest* nvim_set_current_win(int64_t window);
 	// ArrayOf(Tabpage) nvim_list_tabpages() 
-	MsgpackRequest* nvim_list_tabpages();
+	NeovimQt::MsgpackRequest* nvim_list_tabpages();
 	// Tabpage nvim_get_current_tabpage() 
-	MsgpackRequest* nvim_get_current_tabpage();
+	NeovimQt::MsgpackRequest* nvim_get_current_tabpage();
 	// void nvim_set_current_tabpage(Tabpage tabpage, ) 
-	MsgpackRequest* nvim_set_current_tabpage(int64_t tabpage);
+	NeovimQt::MsgpackRequest* nvim_set_current_tabpage(int64_t tabpage);
 	// void nvim_subscribe(String event, ) 
-	MsgpackRequest* nvim_subscribe(QByteArray event);
+	NeovimQt::MsgpackRequest* nvim_subscribe(QByteArray event);
 	// void nvim_unsubscribe(String event, ) 
-	MsgpackRequest* nvim_unsubscribe(QByteArray event);
+	NeovimQt::MsgpackRequest* nvim_unsubscribe(QByteArray event);
 	// Integer nvim_get_color_by_name(String name, ) 
-	MsgpackRequest* nvim_get_color_by_name(QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_get_color_by_name(QByteArray name);
 	// Dictionary nvim_get_color_map() 
-	MsgpackRequest* nvim_get_color_map();
+	NeovimQt::MsgpackRequest* nvim_get_color_map();
 	// Dictionary nvim_get_mode() 
-	MsgpackRequest* nvim_get_mode();
+	NeovimQt::MsgpackRequest* nvim_get_mode();
 	// Array nvim_get_api_info() 
-	MsgpackRequest* nvim_get_api_info();
+	NeovimQt::MsgpackRequest* nvim_get_api_info();
 	// Array nvim_call_atomic(Array calls, ) 
-	MsgpackRequest* nvim_call_atomic(QVariantList calls);
+	NeovimQt::MsgpackRequest* nvim_call_atomic(QVariantList calls);
 	// Buffer nvim_win_get_buf(Window window, ) 
-	MsgpackRequest* nvim_win_get_buf(int64_t window);
+	NeovimQt::MsgpackRequest* nvim_win_get_buf(int64_t window);
 	// ArrayOf(Integer, 2) nvim_win_get_cursor(Window window, ) 
-	MsgpackRequest* nvim_win_get_cursor(int64_t window);
+	NeovimQt::MsgpackRequest* nvim_win_get_cursor(int64_t window);
 	// void nvim_win_set_cursor(Window window, ArrayOf(Integer, 2) pos, ) 
-	MsgpackRequest* nvim_win_set_cursor(int64_t window, QPoint pos);
+	NeovimQt::MsgpackRequest* nvim_win_set_cursor(int64_t window, QPoint pos);
 	// Integer nvim_win_get_height(Window window, ) 
-	MsgpackRequest* nvim_win_get_height(int64_t window);
+	NeovimQt::MsgpackRequest* nvim_win_get_height(int64_t window);
 	// void nvim_win_set_height(Window window, Integer height, ) 
-	MsgpackRequest* nvim_win_set_height(int64_t window, int64_t height);
+	NeovimQt::MsgpackRequest* nvim_win_set_height(int64_t window, int64_t height);
 	// Integer nvim_win_get_width(Window window, ) 
-	MsgpackRequest* nvim_win_get_width(int64_t window);
+	NeovimQt::MsgpackRequest* nvim_win_get_width(int64_t window);
 	// void nvim_win_set_width(Window window, Integer width, ) 
-	MsgpackRequest* nvim_win_set_width(int64_t window, int64_t width);
+	NeovimQt::MsgpackRequest* nvim_win_set_width(int64_t window, int64_t width);
 	// Object nvim_win_get_var(Window window, String name, ) 
-	MsgpackRequest* nvim_win_get_var(int64_t window, QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_win_get_var(int64_t window, QByteArray name);
 	// void nvim_win_set_var(Window window, String name, Object value, ) 
-	MsgpackRequest* nvim_win_set_var(int64_t window, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* nvim_win_set_var(int64_t window, QByteArray name, QVariant value);
 	// void nvim_win_del_var(Window window, String name, ) 
-	MsgpackRequest* nvim_win_del_var(int64_t window, QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_win_del_var(int64_t window, QByteArray name);
 	// DEPRECATED
 	// Object window_set_var(Window window, String name, Object value, ) 
-	MsgpackRequest* window_set_var(int64_t window, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* window_set_var(int64_t window, QByteArray name, QVariant value);
 	// DEPRECATED
 	// Object window_del_var(Window window, String name, ) 
-	MsgpackRequest* window_del_var(int64_t window, QByteArray name);
+	NeovimQt::MsgpackRequest* window_del_var(int64_t window, QByteArray name);
 	// Object nvim_win_get_option(Window window, String name, ) 
-	MsgpackRequest* nvim_win_get_option(int64_t window, QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_win_get_option(int64_t window, QByteArray name);
 	// void nvim_win_set_option(Window window, String name, Object value, ) 
-	MsgpackRequest* nvim_win_set_option(int64_t window, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* nvim_win_set_option(int64_t window, QByteArray name, QVariant value);
 	// ArrayOf(Integer, 2) nvim_win_get_position(Window window, ) 
-	MsgpackRequest* nvim_win_get_position(int64_t window);
+	NeovimQt::MsgpackRequest* nvim_win_get_position(int64_t window);
 	// Tabpage nvim_win_get_tabpage(Window window, ) 
-	MsgpackRequest* nvim_win_get_tabpage(int64_t window);
+	NeovimQt::MsgpackRequest* nvim_win_get_tabpage(int64_t window);
 	// Integer nvim_win_get_number(Window window, ) 
-	MsgpackRequest* nvim_win_get_number(int64_t window);
+	NeovimQt::MsgpackRequest* nvim_win_get_number(int64_t window);
 	// Boolean nvim_win_is_valid(Window window, ) 
-	MsgpackRequest* nvim_win_is_valid(int64_t window);
+	NeovimQt::MsgpackRequest* nvim_win_is_valid(int64_t window);
 	// DEPRECATED
 	// Integer buffer_line_count(Buffer buffer, ) 
-	MsgpackRequest* buffer_line_count(int64_t buffer);
+	NeovimQt::MsgpackRequest* buffer_line_count(int64_t buffer);
 	// DEPRECATED
 	// ArrayOf(String) buffer_get_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ) 
-	MsgpackRequest* buffer_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing);
+	NeovimQt::MsgpackRequest* buffer_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing);
 	// DEPRECATED
 	// void buffer_set_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ArrayOf(String) replacement, ) 
-	MsgpackRequest* buffer_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement);
+	NeovimQt::MsgpackRequest* buffer_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement);
 	// DEPRECATED
 	// Object buffer_get_var(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_get_var(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* buffer_get_var(int64_t buffer, QByteArray name);
 	// DEPRECATED
 	// Object buffer_get_option(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_get_option(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* buffer_get_option(int64_t buffer, QByteArray name);
 	// DEPRECATED
 	// void buffer_set_option(Buffer buffer, String name, Object value, ) 
-	MsgpackRequest* buffer_set_option(int64_t buffer, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* buffer_set_option(int64_t buffer, QByteArray name, QVariant value);
 	// DEPRECATED
 	// Integer buffer_get_number(Buffer buffer, ) 
-	MsgpackRequest* buffer_get_number(int64_t buffer);
+	NeovimQt::MsgpackRequest* buffer_get_number(int64_t buffer);
 	// DEPRECATED
 	// String buffer_get_name(Buffer buffer, ) 
-	MsgpackRequest* buffer_get_name(int64_t buffer);
+	NeovimQt::MsgpackRequest* buffer_get_name(int64_t buffer);
 	// DEPRECATED
 	// void buffer_set_name(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_set_name(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* buffer_set_name(int64_t buffer, QByteArray name);
 	// DEPRECATED
 	// Boolean buffer_is_valid(Buffer buffer, ) 
-	MsgpackRequest* buffer_is_valid(int64_t buffer);
+	NeovimQt::MsgpackRequest* buffer_is_valid(int64_t buffer);
 	// DEPRECATED
 	// ArrayOf(Integer, 2) buffer_get_mark(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_get_mark(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* buffer_get_mark(int64_t buffer, QByteArray name);
 	// DEPRECATED
 	// Integer buffer_add_highlight(Buffer buffer, Integer src_id, String hl_group, Integer line, Integer col_start, Integer col_end, ) 
-	MsgpackRequest* buffer_add_highlight(int64_t buffer, int64_t src_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end);
+	NeovimQt::MsgpackRequest* buffer_add_highlight(int64_t buffer, int64_t src_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end);
 	// DEPRECATED
 	// void buffer_clear_highlight(Buffer buffer, Integer src_id, Integer line_start, Integer line_end, ) 
-	MsgpackRequest* buffer_clear_highlight(int64_t buffer, int64_t src_id, int64_t line_start, int64_t line_end);
+	NeovimQt::MsgpackRequest* buffer_clear_highlight(int64_t buffer, int64_t src_id, int64_t line_start, int64_t line_end);
 	// DEPRECATED
 	// ArrayOf(Window) tabpage_get_windows(Tabpage tabpage, ) 
-	MsgpackRequest* tabpage_get_windows(int64_t tabpage);
+	NeovimQt::MsgpackRequest* tabpage_get_windows(int64_t tabpage);
 	// DEPRECATED
 	// Object tabpage_get_var(Tabpage tabpage, String name, ) 
-	MsgpackRequest* tabpage_get_var(int64_t tabpage, QByteArray name);
+	NeovimQt::MsgpackRequest* tabpage_get_var(int64_t tabpage, QByteArray name);
 	// DEPRECATED
 	// Window tabpage_get_window(Tabpage tabpage, ) 
-	MsgpackRequest* tabpage_get_window(int64_t tabpage);
+	NeovimQt::MsgpackRequest* tabpage_get_window(int64_t tabpage);
 	// DEPRECATED
 	// Boolean tabpage_is_valid(Tabpage tabpage, ) 
-	MsgpackRequest* tabpage_is_valid(int64_t tabpage);
+	NeovimQt::MsgpackRequest* tabpage_is_valid(int64_t tabpage);
 	// DEPRECATED
 	// void ui_detach() 
-	MsgpackRequest* ui_detach();
+	NeovimQt::MsgpackRequest* ui_detach();
 	// DEPRECATED
 	// Object ui_try_resize(Integer width, Integer height, ) 
-	MsgpackRequest* ui_try_resize(int64_t width, int64_t height);
+	NeovimQt::MsgpackRequest* ui_try_resize(int64_t width, int64_t height);
 	// DEPRECATED
 	// void vim_command(String command, ) 
-	MsgpackRequest* vim_command(QByteArray command);
+	NeovimQt::MsgpackRequest* vim_command(QByteArray command);
 	// DEPRECATED
 	// void vim_feedkeys(String keys, String mode, Boolean escape_csi, ) 
-	MsgpackRequest* vim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi);
+	NeovimQt::MsgpackRequest* vim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi);
 	// DEPRECATED
 	// Integer vim_input(String keys, ) 
-	MsgpackRequest* vim_input(QByteArray keys);
+	NeovimQt::MsgpackRequest* vim_input(QByteArray keys);
 	// DEPRECATED
 	// String vim_replace_termcodes(String str, Boolean from_part, Boolean do_lt, Boolean special, ) 
-	MsgpackRequest* vim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special);
+	NeovimQt::MsgpackRequest* vim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special);
 	// DEPRECATED
 	// String vim_command_output(String str, ) 
-	MsgpackRequest* vim_command_output(QByteArray str);
+	NeovimQt::MsgpackRequest* vim_command_output(QByteArray str);
 	// DEPRECATED
 	// Object vim_eval(String expr, ) 
-	MsgpackRequest* vim_eval(QByteArray expr);
+	NeovimQt::MsgpackRequest* vim_eval(QByteArray expr);
 	// DEPRECATED
 	// Object vim_call_function(String fname, Array args, ) 
-	MsgpackRequest* vim_call_function(QByteArray fname, QVariantList args);
+	NeovimQt::MsgpackRequest* vim_call_function(QByteArray fname, QVariantList args);
 	// DEPRECATED
 	// Integer vim_strwidth(String str, ) 
-	MsgpackRequest* vim_strwidth(QByteArray str);
+	NeovimQt::MsgpackRequest* vim_strwidth(QByteArray str);
 	// DEPRECATED
 	// ArrayOf(String) vim_list_runtime_paths() 
-	MsgpackRequest* vim_list_runtime_paths();
+	NeovimQt::MsgpackRequest* vim_list_runtime_paths();
 	// DEPRECATED
 	// void vim_change_directory(String dir, ) 
-	MsgpackRequest* vim_change_directory(QByteArray dir);
+	NeovimQt::MsgpackRequest* vim_change_directory(QByteArray dir);
 	// DEPRECATED
 	// String vim_get_current_line() 
-	MsgpackRequest* vim_get_current_line();
+	NeovimQt::MsgpackRequest* vim_get_current_line();
 	// DEPRECATED
 	// void vim_set_current_line(String line, ) 
-	MsgpackRequest* vim_set_current_line(QByteArray line);
+	NeovimQt::MsgpackRequest* vim_set_current_line(QByteArray line);
 	// DEPRECATED
 	// void vim_del_current_line() 
-	MsgpackRequest* vim_del_current_line();
+	NeovimQt::MsgpackRequest* vim_del_current_line();
 	// DEPRECATED
 	// Object vim_get_var(String name, ) 
-	MsgpackRequest* vim_get_var(QByteArray name);
+	NeovimQt::MsgpackRequest* vim_get_var(QByteArray name);
 	// DEPRECATED
 	// Object vim_get_vvar(String name, ) 
-	MsgpackRequest* vim_get_vvar(QByteArray name);
+	NeovimQt::MsgpackRequest* vim_get_vvar(QByteArray name);
 	// DEPRECATED
 	// Object vim_get_option(String name, ) 
-	MsgpackRequest* vim_get_option(QByteArray name);
+	NeovimQt::MsgpackRequest* vim_get_option(QByteArray name);
 	// DEPRECATED
 	// void vim_set_option(String name, Object value, ) 
-	MsgpackRequest* vim_set_option(QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* vim_set_option(QByteArray name, QVariant value);
 	// DEPRECATED
 	// void vim_out_write(String str, ) 
-	MsgpackRequest* vim_out_write(QByteArray str);
+	NeovimQt::MsgpackRequest* vim_out_write(QByteArray str);
 	// DEPRECATED
 	// void vim_err_write(String str, ) 
-	MsgpackRequest* vim_err_write(QByteArray str);
+	NeovimQt::MsgpackRequest* vim_err_write(QByteArray str);
 	// DEPRECATED
 	// void vim_report_error(String str, ) 
-	MsgpackRequest* vim_report_error(QByteArray str);
+	NeovimQt::MsgpackRequest* vim_report_error(QByteArray str);
 	// DEPRECATED
 	// ArrayOf(Buffer) vim_get_buffers() 
-	MsgpackRequest* vim_get_buffers();
+	NeovimQt::MsgpackRequest* vim_get_buffers();
 	// DEPRECATED
 	// Buffer vim_get_current_buffer() 
-	MsgpackRequest* vim_get_current_buffer();
+	NeovimQt::MsgpackRequest* vim_get_current_buffer();
 	// DEPRECATED
 	// void vim_set_current_buffer(Buffer buffer, ) 
-	MsgpackRequest* vim_set_current_buffer(int64_t buffer);
+	NeovimQt::MsgpackRequest* vim_set_current_buffer(int64_t buffer);
 	// DEPRECATED
 	// ArrayOf(Window) vim_get_windows() 
-	MsgpackRequest* vim_get_windows();
+	NeovimQt::MsgpackRequest* vim_get_windows();
 	// DEPRECATED
 	// Window vim_get_current_window() 
-	MsgpackRequest* vim_get_current_window();
+	NeovimQt::MsgpackRequest* vim_get_current_window();
 	// DEPRECATED
 	// void vim_set_current_window(Window window, ) 
-	MsgpackRequest* vim_set_current_window(int64_t window);
+	NeovimQt::MsgpackRequest* vim_set_current_window(int64_t window);
 	// DEPRECATED
 	// ArrayOf(Tabpage) vim_get_tabpages() 
-	MsgpackRequest* vim_get_tabpages();
+	NeovimQt::MsgpackRequest* vim_get_tabpages();
 	// DEPRECATED
 	// Tabpage vim_get_current_tabpage() 
-	MsgpackRequest* vim_get_current_tabpage();
+	NeovimQt::MsgpackRequest* vim_get_current_tabpage();
 	// DEPRECATED
 	// void vim_set_current_tabpage(Tabpage tabpage, ) 
-	MsgpackRequest* vim_set_current_tabpage(int64_t tabpage);
+	NeovimQt::MsgpackRequest* vim_set_current_tabpage(int64_t tabpage);
 	// DEPRECATED
 	// void vim_subscribe(String event, ) 
-	MsgpackRequest* vim_subscribe(QByteArray event);
+	NeovimQt::MsgpackRequest* vim_subscribe(QByteArray event);
 	// DEPRECATED
 	// void vim_unsubscribe(String event, ) 
-	MsgpackRequest* vim_unsubscribe(QByteArray event);
+	NeovimQt::MsgpackRequest* vim_unsubscribe(QByteArray event);
 	// DEPRECATED
 	// Integer vim_name_to_color(String name, ) 
-	MsgpackRequest* vim_name_to_color(QByteArray name);
+	NeovimQt::MsgpackRequest* vim_name_to_color(QByteArray name);
 	// DEPRECATED
 	// Dictionary vim_get_color_map() 
-	MsgpackRequest* vim_get_color_map();
+	NeovimQt::MsgpackRequest* vim_get_color_map();
 	// DEPRECATED
 	// Buffer window_get_buffer(Window window, ) 
-	MsgpackRequest* window_get_buffer(int64_t window);
+	NeovimQt::MsgpackRequest* window_get_buffer(int64_t window);
 	// DEPRECATED
 	// ArrayOf(Integer, 2) window_get_cursor(Window window, ) 
-	MsgpackRequest* window_get_cursor(int64_t window);
+	NeovimQt::MsgpackRequest* window_get_cursor(int64_t window);
 	// DEPRECATED
 	// void window_set_cursor(Window window, ArrayOf(Integer, 2) pos, ) 
-	MsgpackRequest* window_set_cursor(int64_t window, QPoint pos);
+	NeovimQt::MsgpackRequest* window_set_cursor(int64_t window, QPoint pos);
 	// DEPRECATED
 	// Integer window_get_height(Window window, ) 
-	MsgpackRequest* window_get_height(int64_t window);
+	NeovimQt::MsgpackRequest* window_get_height(int64_t window);
 	// DEPRECATED
 	// void window_set_height(Window window, Integer height, ) 
-	MsgpackRequest* window_set_height(int64_t window, int64_t height);
+	NeovimQt::MsgpackRequest* window_set_height(int64_t window, int64_t height);
 	// DEPRECATED
 	// Integer window_get_width(Window window, ) 
-	MsgpackRequest* window_get_width(int64_t window);
+	NeovimQt::MsgpackRequest* window_get_width(int64_t window);
 	// DEPRECATED
 	// void window_set_width(Window window, Integer width, ) 
-	MsgpackRequest* window_set_width(int64_t window, int64_t width);
+	NeovimQt::MsgpackRequest* window_set_width(int64_t window, int64_t width);
 	// DEPRECATED
 	// Object window_get_var(Window window, String name, ) 
-	MsgpackRequest* window_get_var(int64_t window, QByteArray name);
+	NeovimQt::MsgpackRequest* window_get_var(int64_t window, QByteArray name);
 	// DEPRECATED
 	// Object window_get_option(Window window, String name, ) 
-	MsgpackRequest* window_get_option(int64_t window, QByteArray name);
+	NeovimQt::MsgpackRequest* window_get_option(int64_t window, QByteArray name);
 	// DEPRECATED
 	// void window_set_option(Window window, String name, Object value, ) 
-	MsgpackRequest* window_set_option(int64_t window, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* window_set_option(int64_t window, QByteArray name, QVariant value);
 	// DEPRECATED
 	// ArrayOf(Integer, 2) window_get_position(Window window, ) 
-	MsgpackRequest* window_get_position(int64_t window);
+	NeovimQt::MsgpackRequest* window_get_position(int64_t window);
 	// DEPRECATED
 	// Tabpage window_get_tabpage(Window window, ) 
-	MsgpackRequest* window_get_tabpage(int64_t window);
+	NeovimQt::MsgpackRequest* window_get_tabpage(int64_t window);
 	// DEPRECATED
 	// Boolean window_is_valid(Window window, ) 
-	MsgpackRequest* window_is_valid(int64_t window);
+	NeovimQt::MsgpackRequest* window_is_valid(int64_t window);
 
 signals:
 	void on_nvim_buf_line_count(int64_t);
@@ -1085,5 +1087,5 @@ signals:
 	void err_window_is_valid(const QString&, const QVariant&);
 
 };
-} // namespace
-#endif
+
+} // namespace NeovimQt

--- a/src/auto/neovimapi3.h
+++ b/src/auto/neovimapi3.h
@@ -1,13 +1,15 @@
-// Auto generated 2018-08-08 20:42:42.027594 from nvim API level:3
-#ifndef NEOVIM_QT_NEOVIMAPI3
-#define NEOVIM_QT_NEOVIMAPI3
-#include "msgpack.h"
+// Auto generated 2021-07-20 02:40:07.831991 from nvim API level:3
+#pragma once
+
 #include <QObject>
-#include <QVariant>
 #include <QPoint>
+#include <QVariant>
+
 #include "function.h"
+#include "msgpack.h"
 
 namespace NeovimQt {
+
 class NeovimConnector;
 class MsgpackRequest;
 
@@ -202,418 +204,418 @@ private:
 	NeovimConnector *m_c;
 public slots:
 	// Integer nvim_buf_line_count(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_line_count(int64_t buffer);
+	NeovimQt::MsgpackRequest* nvim_buf_line_count(int64_t buffer);
 	// DEPRECATED
 	// String buffer_get_line(Buffer buffer, Integer index, ) 
-	MsgpackRequest* buffer_get_line(int64_t buffer, int64_t index);
+	NeovimQt::MsgpackRequest* buffer_get_line(int64_t buffer, int64_t index);
 	// DEPRECATED
 	// void buffer_set_line(Buffer buffer, Integer index, String line, ) 
-	MsgpackRequest* buffer_set_line(int64_t buffer, int64_t index, QByteArray line);
+	NeovimQt::MsgpackRequest* buffer_set_line(int64_t buffer, int64_t index, QByteArray line);
 	// DEPRECATED
 	// void buffer_del_line(Buffer buffer, Integer index, ) 
-	MsgpackRequest* buffer_del_line(int64_t buffer, int64_t index);
+	NeovimQt::MsgpackRequest* buffer_del_line(int64_t buffer, int64_t index);
 	// DEPRECATED
 	// ArrayOf(String) buffer_get_line_slice(Buffer buffer, Integer start, Integer end, Boolean include_start, Boolean include_end, ) 
-	MsgpackRequest* buffer_get_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end);
+	NeovimQt::MsgpackRequest* buffer_get_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end);
 	// ArrayOf(String) nvim_buf_get_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ) 
-	MsgpackRequest* nvim_buf_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing);
+	NeovimQt::MsgpackRequest* nvim_buf_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing);
 	// DEPRECATED
 	// void buffer_set_line_slice(Buffer buffer, Integer start, Integer end, Boolean include_start, Boolean include_end, ArrayOf(String) replacement, ) 
-	MsgpackRequest* buffer_set_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end, QList<QByteArray> replacement);
+	NeovimQt::MsgpackRequest* buffer_set_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end, QList<QByteArray> replacement);
 	// void nvim_buf_set_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ArrayOf(String) replacement, ) 
-	MsgpackRequest* nvim_buf_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement);
+	NeovimQt::MsgpackRequest* nvim_buf_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement);
 	// Object nvim_buf_get_var(Buffer buffer, String name, ) 
-	MsgpackRequest* nvim_buf_get_var(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_buf_get_var(int64_t buffer, QByteArray name);
 	// Integer nvim_buf_get_changedtick(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_get_changedtick(int64_t buffer);
+	NeovimQt::MsgpackRequest* nvim_buf_get_changedtick(int64_t buffer);
 	// ArrayOf(Dictionary) nvim_buf_get_keymap(Buffer buffer, String mode, ) 
-	MsgpackRequest* nvim_buf_get_keymap(int64_t buffer, QByteArray mode);
+	NeovimQt::MsgpackRequest* nvim_buf_get_keymap(int64_t buffer, QByteArray mode);
 	// void nvim_buf_set_var(Buffer buffer, String name, Object value, ) 
-	MsgpackRequest* nvim_buf_set_var(int64_t buffer, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* nvim_buf_set_var(int64_t buffer, QByteArray name, QVariant value);
 	// void nvim_buf_del_var(Buffer buffer, String name, ) 
-	MsgpackRequest* nvim_buf_del_var(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_buf_del_var(int64_t buffer, QByteArray name);
 	// DEPRECATED
 	// Object buffer_set_var(Buffer buffer, String name, Object value, ) 
-	MsgpackRequest* buffer_set_var(int64_t buffer, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* buffer_set_var(int64_t buffer, QByteArray name, QVariant value);
 	// DEPRECATED
 	// Object buffer_del_var(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_del_var(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* buffer_del_var(int64_t buffer, QByteArray name);
 	// Object nvim_buf_get_option(Buffer buffer, String name, ) 
-	MsgpackRequest* nvim_buf_get_option(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_buf_get_option(int64_t buffer, QByteArray name);
 	// void nvim_buf_set_option(Buffer buffer, String name, Object value, ) 
-	MsgpackRequest* nvim_buf_set_option(int64_t buffer, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* nvim_buf_set_option(int64_t buffer, QByteArray name, QVariant value);
 	// DEPRECATED
 	// Integer nvim_buf_get_number(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_get_number(int64_t buffer);
+	NeovimQt::MsgpackRequest* nvim_buf_get_number(int64_t buffer);
 	// String nvim_buf_get_name(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_get_name(int64_t buffer);
+	NeovimQt::MsgpackRequest* nvim_buf_get_name(int64_t buffer);
 	// void nvim_buf_set_name(Buffer buffer, String name, ) 
-	MsgpackRequest* nvim_buf_set_name(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_buf_set_name(int64_t buffer, QByteArray name);
 	// Boolean nvim_buf_is_valid(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_is_valid(int64_t buffer);
+	NeovimQt::MsgpackRequest* nvim_buf_is_valid(int64_t buffer);
 	// DEPRECATED
 	// void buffer_insert(Buffer buffer, Integer lnum, ArrayOf(String) lines, ) 
-	MsgpackRequest* buffer_insert(int64_t buffer, int64_t lnum, QList<QByteArray> lines);
+	NeovimQt::MsgpackRequest* buffer_insert(int64_t buffer, int64_t lnum, QList<QByteArray> lines);
 	// ArrayOf(Integer, 2) nvim_buf_get_mark(Buffer buffer, String name, ) 
-	MsgpackRequest* nvim_buf_get_mark(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_buf_get_mark(int64_t buffer, QByteArray name);
 	// Integer nvim_buf_add_highlight(Buffer buffer, Integer src_id, String hl_group, Integer line, Integer col_start, Integer col_end, ) 
-	MsgpackRequest* nvim_buf_add_highlight(int64_t buffer, int64_t src_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end);
+	NeovimQt::MsgpackRequest* nvim_buf_add_highlight(int64_t buffer, int64_t src_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end);
 	// void nvim_buf_clear_highlight(Buffer buffer, Integer src_id, Integer line_start, Integer line_end, ) 
-	MsgpackRequest* nvim_buf_clear_highlight(int64_t buffer, int64_t src_id, int64_t line_start, int64_t line_end);
+	NeovimQt::MsgpackRequest* nvim_buf_clear_highlight(int64_t buffer, int64_t src_id, int64_t line_start, int64_t line_end);
 	// ArrayOf(Window) nvim_tabpage_list_wins(Tabpage tabpage, ) 
-	MsgpackRequest* nvim_tabpage_list_wins(int64_t tabpage);
+	NeovimQt::MsgpackRequest* nvim_tabpage_list_wins(int64_t tabpage);
 	// Object nvim_tabpage_get_var(Tabpage tabpage, String name, ) 
-	MsgpackRequest* nvim_tabpage_get_var(int64_t tabpage, QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_tabpage_get_var(int64_t tabpage, QByteArray name);
 	// void nvim_tabpage_set_var(Tabpage tabpage, String name, Object value, ) 
-	MsgpackRequest* nvim_tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* nvim_tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value);
 	// void nvim_tabpage_del_var(Tabpage tabpage, String name, ) 
-	MsgpackRequest* nvim_tabpage_del_var(int64_t tabpage, QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_tabpage_del_var(int64_t tabpage, QByteArray name);
 	// DEPRECATED
 	// Object tabpage_set_var(Tabpage tabpage, String name, Object value, ) 
-	MsgpackRequest* tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value);
 	// DEPRECATED
 	// Object tabpage_del_var(Tabpage tabpage, String name, ) 
-	MsgpackRequest* tabpage_del_var(int64_t tabpage, QByteArray name);
+	NeovimQt::MsgpackRequest* tabpage_del_var(int64_t tabpage, QByteArray name);
 	// Window nvim_tabpage_get_win(Tabpage tabpage, ) 
-	MsgpackRequest* nvim_tabpage_get_win(int64_t tabpage);
+	NeovimQt::MsgpackRequest* nvim_tabpage_get_win(int64_t tabpage);
 	// Integer nvim_tabpage_get_number(Tabpage tabpage, ) 
-	MsgpackRequest* nvim_tabpage_get_number(int64_t tabpage);
+	NeovimQt::MsgpackRequest* nvim_tabpage_get_number(int64_t tabpage);
 	// Boolean nvim_tabpage_is_valid(Tabpage tabpage, ) 
-	MsgpackRequest* nvim_tabpage_is_valid(int64_t tabpage);
+	NeovimQt::MsgpackRequest* nvim_tabpage_is_valid(int64_t tabpage);
 	// void nvim_ui_attach(Integer width, Integer height, Dictionary options, ) 
-	MsgpackRequest* nvim_ui_attach(int64_t width, int64_t height, QVariantMap options);
+	NeovimQt::MsgpackRequest* nvim_ui_attach(int64_t width, int64_t height, QVariantMap options);
 	// DEPRECATED
 	// void ui_attach(Integer width, Integer height, Boolean enable_rgb, ) 
-	MsgpackRequest* ui_attach(int64_t width, int64_t height, bool enable_rgb);
+	NeovimQt::MsgpackRequest* ui_attach(int64_t width, int64_t height, bool enable_rgb);
 	// void nvim_ui_detach() 
-	MsgpackRequest* nvim_ui_detach();
+	NeovimQt::MsgpackRequest* nvim_ui_detach();
 	// void nvim_ui_try_resize(Integer width, Integer height, ) 
-	MsgpackRequest* nvim_ui_try_resize(int64_t width, int64_t height);
+	NeovimQt::MsgpackRequest* nvim_ui_try_resize(int64_t width, int64_t height);
 	// void nvim_ui_set_option(String name, Object value, ) 
-	MsgpackRequest* nvim_ui_set_option(QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* nvim_ui_set_option(QByteArray name, QVariant value);
 	// void nvim_command(String command, ) 
-	MsgpackRequest* nvim_command(QByteArray command);
+	NeovimQt::MsgpackRequest* nvim_command(QByteArray command);
 	// Dictionary nvim_get_hl_by_name(String name, Boolean rgb, ) 
-	MsgpackRequest* nvim_get_hl_by_name(QByteArray name, bool rgb);
+	NeovimQt::MsgpackRequest* nvim_get_hl_by_name(QByteArray name, bool rgb);
 	// Dictionary nvim_get_hl_by_id(Integer hl_id, Boolean rgb, ) 
-	MsgpackRequest* nvim_get_hl_by_id(int64_t hl_id, bool rgb);
+	NeovimQt::MsgpackRequest* nvim_get_hl_by_id(int64_t hl_id, bool rgb);
 	// void nvim_feedkeys(String keys, String mode, Boolean escape_csi, ) 
-	MsgpackRequest* nvim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi);
+	NeovimQt::MsgpackRequest* nvim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi);
 	// Integer nvim_input(String keys, ) 
-	MsgpackRequest* nvim_input(QByteArray keys);
+	NeovimQt::MsgpackRequest* nvim_input(QByteArray keys);
 	// String nvim_replace_termcodes(String str, Boolean from_part, Boolean do_lt, Boolean special, ) 
-	MsgpackRequest* nvim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special);
+	NeovimQt::MsgpackRequest* nvim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special);
 	// String nvim_command_output(String str, ) 
-	MsgpackRequest* nvim_command_output(QByteArray str);
+	NeovimQt::MsgpackRequest* nvim_command_output(QByteArray str);
 	// Object nvim_eval(String expr, ) 
-	MsgpackRequest* nvim_eval(QByteArray expr);
+	NeovimQt::MsgpackRequest* nvim_eval(QByteArray expr);
 	// Object nvim_call_function(String fname, Array args, ) 
-	MsgpackRequest* nvim_call_function(QByteArray fname, QVariantList args);
+	NeovimQt::MsgpackRequest* nvim_call_function(QByteArray fname, QVariantList args);
 	// Object nvim_execute_lua(String code, Array args, ) 
-	MsgpackRequest* nvim_execute_lua(QByteArray code, QVariantList args);
+	NeovimQt::MsgpackRequest* nvim_execute_lua(QByteArray code, QVariantList args);
 	// Integer nvim_strwidth(String text, ) 
-	MsgpackRequest* nvim_strwidth(QByteArray text);
+	NeovimQt::MsgpackRequest* nvim_strwidth(QByteArray text);
 	// ArrayOf(String) nvim_list_runtime_paths() 
-	MsgpackRequest* nvim_list_runtime_paths();
+	NeovimQt::MsgpackRequest* nvim_list_runtime_paths();
 	// void nvim_set_current_dir(String dir, ) 
-	MsgpackRequest* nvim_set_current_dir(QByteArray dir);
+	NeovimQt::MsgpackRequest* nvim_set_current_dir(QByteArray dir);
 	// String nvim_get_current_line() 
-	MsgpackRequest* nvim_get_current_line();
+	NeovimQt::MsgpackRequest* nvim_get_current_line();
 	// void nvim_set_current_line(String line, ) 
-	MsgpackRequest* nvim_set_current_line(QByteArray line);
+	NeovimQt::MsgpackRequest* nvim_set_current_line(QByteArray line);
 	// void nvim_del_current_line() 
-	MsgpackRequest* nvim_del_current_line();
+	NeovimQt::MsgpackRequest* nvim_del_current_line();
 	// Object nvim_get_var(String name, ) 
-	MsgpackRequest* nvim_get_var(QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_get_var(QByteArray name);
 	// void nvim_set_var(String name, Object value, ) 
-	MsgpackRequest* nvim_set_var(QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* nvim_set_var(QByteArray name, QVariant value);
 	// void nvim_del_var(String name, ) 
-	MsgpackRequest* nvim_del_var(QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_del_var(QByteArray name);
 	// DEPRECATED
 	// Object vim_set_var(String name, Object value, ) 
-	MsgpackRequest* vim_set_var(QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* vim_set_var(QByteArray name, QVariant value);
 	// DEPRECATED
 	// Object vim_del_var(String name, ) 
-	MsgpackRequest* vim_del_var(QByteArray name);
+	NeovimQt::MsgpackRequest* vim_del_var(QByteArray name);
 	// Object nvim_get_vvar(String name, ) 
-	MsgpackRequest* nvim_get_vvar(QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_get_vvar(QByteArray name);
 	// Object nvim_get_option(String name, ) 
-	MsgpackRequest* nvim_get_option(QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_get_option(QByteArray name);
 	// void nvim_set_option(String name, Object value, ) 
-	MsgpackRequest* nvim_set_option(QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* nvim_set_option(QByteArray name, QVariant value);
 	// void nvim_out_write(String str, ) 
-	MsgpackRequest* nvim_out_write(QByteArray str);
+	NeovimQt::MsgpackRequest* nvim_out_write(QByteArray str);
 	// void nvim_err_write(String str, ) 
-	MsgpackRequest* nvim_err_write(QByteArray str);
+	NeovimQt::MsgpackRequest* nvim_err_write(QByteArray str);
 	// void nvim_err_writeln(String str, ) 
-	MsgpackRequest* nvim_err_writeln(QByteArray str);
+	NeovimQt::MsgpackRequest* nvim_err_writeln(QByteArray str);
 	// ArrayOf(Buffer) nvim_list_bufs() 
-	MsgpackRequest* nvim_list_bufs();
+	NeovimQt::MsgpackRequest* nvim_list_bufs();
 	// Buffer nvim_get_current_buf() 
-	MsgpackRequest* nvim_get_current_buf();
+	NeovimQt::MsgpackRequest* nvim_get_current_buf();
 	// void nvim_set_current_buf(Buffer buffer, ) 
-	MsgpackRequest* nvim_set_current_buf(int64_t buffer);
+	NeovimQt::MsgpackRequest* nvim_set_current_buf(int64_t buffer);
 	// ArrayOf(Window) nvim_list_wins() 
-	MsgpackRequest* nvim_list_wins();
+	NeovimQt::MsgpackRequest* nvim_list_wins();
 	// Window nvim_get_current_win() 
-	MsgpackRequest* nvim_get_current_win();
+	NeovimQt::MsgpackRequest* nvim_get_current_win();
 	// void nvim_set_current_win(Window window, ) 
-	MsgpackRequest* nvim_set_current_win(int64_t window);
+	NeovimQt::MsgpackRequest* nvim_set_current_win(int64_t window);
 	// ArrayOf(Tabpage) nvim_list_tabpages() 
-	MsgpackRequest* nvim_list_tabpages();
+	NeovimQt::MsgpackRequest* nvim_list_tabpages();
 	// Tabpage nvim_get_current_tabpage() 
-	MsgpackRequest* nvim_get_current_tabpage();
+	NeovimQt::MsgpackRequest* nvim_get_current_tabpage();
 	// void nvim_set_current_tabpage(Tabpage tabpage, ) 
-	MsgpackRequest* nvim_set_current_tabpage(int64_t tabpage);
+	NeovimQt::MsgpackRequest* nvim_set_current_tabpage(int64_t tabpage);
 	// void nvim_subscribe(String event, ) 
-	MsgpackRequest* nvim_subscribe(QByteArray event);
+	NeovimQt::MsgpackRequest* nvim_subscribe(QByteArray event);
 	// void nvim_unsubscribe(String event, ) 
-	MsgpackRequest* nvim_unsubscribe(QByteArray event);
+	NeovimQt::MsgpackRequest* nvim_unsubscribe(QByteArray event);
 	// Integer nvim_get_color_by_name(String name, ) 
-	MsgpackRequest* nvim_get_color_by_name(QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_get_color_by_name(QByteArray name);
 	// Dictionary nvim_get_color_map() 
-	MsgpackRequest* nvim_get_color_map();
+	NeovimQt::MsgpackRequest* nvim_get_color_map();
 	// Dictionary nvim_get_mode() 
-	MsgpackRequest* nvim_get_mode();
+	NeovimQt::MsgpackRequest* nvim_get_mode();
 	// ArrayOf(Dictionary) nvim_get_keymap(String mode, ) 
-	MsgpackRequest* nvim_get_keymap(QByteArray mode);
+	NeovimQt::MsgpackRequest* nvim_get_keymap(QByteArray mode);
 	// Array nvim_get_api_info() 
-	MsgpackRequest* nvim_get_api_info();
+	NeovimQt::MsgpackRequest* nvim_get_api_info();
 	// Array nvim_call_atomic(Array calls, ) 
-	MsgpackRequest* nvim_call_atomic(QVariantList calls);
+	NeovimQt::MsgpackRequest* nvim_call_atomic(QVariantList calls);
 	// Buffer nvim_win_get_buf(Window window, ) 
-	MsgpackRequest* nvim_win_get_buf(int64_t window);
+	NeovimQt::MsgpackRequest* nvim_win_get_buf(int64_t window);
 	// ArrayOf(Integer, 2) nvim_win_get_cursor(Window window, ) 
-	MsgpackRequest* nvim_win_get_cursor(int64_t window);
+	NeovimQt::MsgpackRequest* nvim_win_get_cursor(int64_t window);
 	// void nvim_win_set_cursor(Window window, ArrayOf(Integer, 2) pos, ) 
-	MsgpackRequest* nvim_win_set_cursor(int64_t window, QPoint pos);
+	NeovimQt::MsgpackRequest* nvim_win_set_cursor(int64_t window, QPoint pos);
 	// Integer nvim_win_get_height(Window window, ) 
-	MsgpackRequest* nvim_win_get_height(int64_t window);
+	NeovimQt::MsgpackRequest* nvim_win_get_height(int64_t window);
 	// void nvim_win_set_height(Window window, Integer height, ) 
-	MsgpackRequest* nvim_win_set_height(int64_t window, int64_t height);
+	NeovimQt::MsgpackRequest* nvim_win_set_height(int64_t window, int64_t height);
 	// Integer nvim_win_get_width(Window window, ) 
-	MsgpackRequest* nvim_win_get_width(int64_t window);
+	NeovimQt::MsgpackRequest* nvim_win_get_width(int64_t window);
 	// void nvim_win_set_width(Window window, Integer width, ) 
-	MsgpackRequest* nvim_win_set_width(int64_t window, int64_t width);
+	NeovimQt::MsgpackRequest* nvim_win_set_width(int64_t window, int64_t width);
 	// Object nvim_win_get_var(Window window, String name, ) 
-	MsgpackRequest* nvim_win_get_var(int64_t window, QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_win_get_var(int64_t window, QByteArray name);
 	// void nvim_win_set_var(Window window, String name, Object value, ) 
-	MsgpackRequest* nvim_win_set_var(int64_t window, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* nvim_win_set_var(int64_t window, QByteArray name, QVariant value);
 	// void nvim_win_del_var(Window window, String name, ) 
-	MsgpackRequest* nvim_win_del_var(int64_t window, QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_win_del_var(int64_t window, QByteArray name);
 	// DEPRECATED
 	// Object window_set_var(Window window, String name, Object value, ) 
-	MsgpackRequest* window_set_var(int64_t window, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* window_set_var(int64_t window, QByteArray name, QVariant value);
 	// DEPRECATED
 	// Object window_del_var(Window window, String name, ) 
-	MsgpackRequest* window_del_var(int64_t window, QByteArray name);
+	NeovimQt::MsgpackRequest* window_del_var(int64_t window, QByteArray name);
 	// Object nvim_win_get_option(Window window, String name, ) 
-	MsgpackRequest* nvim_win_get_option(int64_t window, QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_win_get_option(int64_t window, QByteArray name);
 	// void nvim_win_set_option(Window window, String name, Object value, ) 
-	MsgpackRequest* nvim_win_set_option(int64_t window, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* nvim_win_set_option(int64_t window, QByteArray name, QVariant value);
 	// ArrayOf(Integer, 2) nvim_win_get_position(Window window, ) 
-	MsgpackRequest* nvim_win_get_position(int64_t window);
+	NeovimQt::MsgpackRequest* nvim_win_get_position(int64_t window);
 	// Tabpage nvim_win_get_tabpage(Window window, ) 
-	MsgpackRequest* nvim_win_get_tabpage(int64_t window);
+	NeovimQt::MsgpackRequest* nvim_win_get_tabpage(int64_t window);
 	// Integer nvim_win_get_number(Window window, ) 
-	MsgpackRequest* nvim_win_get_number(int64_t window);
+	NeovimQt::MsgpackRequest* nvim_win_get_number(int64_t window);
 	// Boolean nvim_win_is_valid(Window window, ) 
-	MsgpackRequest* nvim_win_is_valid(int64_t window);
+	NeovimQt::MsgpackRequest* nvim_win_is_valid(int64_t window);
 	// DEPRECATED
 	// Integer buffer_line_count(Buffer buffer, ) 
-	MsgpackRequest* buffer_line_count(int64_t buffer);
+	NeovimQt::MsgpackRequest* buffer_line_count(int64_t buffer);
 	// DEPRECATED
 	// ArrayOf(String) buffer_get_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ) 
-	MsgpackRequest* buffer_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing);
+	NeovimQt::MsgpackRequest* buffer_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing);
 	// DEPRECATED
 	// void buffer_set_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ArrayOf(String) replacement, ) 
-	MsgpackRequest* buffer_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement);
+	NeovimQt::MsgpackRequest* buffer_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement);
 	// DEPRECATED
 	// Object buffer_get_var(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_get_var(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* buffer_get_var(int64_t buffer, QByteArray name);
 	// DEPRECATED
 	// Object buffer_get_option(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_get_option(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* buffer_get_option(int64_t buffer, QByteArray name);
 	// DEPRECATED
 	// void buffer_set_option(Buffer buffer, String name, Object value, ) 
-	MsgpackRequest* buffer_set_option(int64_t buffer, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* buffer_set_option(int64_t buffer, QByteArray name, QVariant value);
 	// DEPRECATED
 	// Integer buffer_get_number(Buffer buffer, ) 
-	MsgpackRequest* buffer_get_number(int64_t buffer);
+	NeovimQt::MsgpackRequest* buffer_get_number(int64_t buffer);
 	// DEPRECATED
 	// String buffer_get_name(Buffer buffer, ) 
-	MsgpackRequest* buffer_get_name(int64_t buffer);
+	NeovimQt::MsgpackRequest* buffer_get_name(int64_t buffer);
 	// DEPRECATED
 	// void buffer_set_name(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_set_name(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* buffer_set_name(int64_t buffer, QByteArray name);
 	// DEPRECATED
 	// Boolean buffer_is_valid(Buffer buffer, ) 
-	MsgpackRequest* buffer_is_valid(int64_t buffer);
+	NeovimQt::MsgpackRequest* buffer_is_valid(int64_t buffer);
 	// DEPRECATED
 	// ArrayOf(Integer, 2) buffer_get_mark(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_get_mark(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* buffer_get_mark(int64_t buffer, QByteArray name);
 	// DEPRECATED
 	// Integer buffer_add_highlight(Buffer buffer, Integer src_id, String hl_group, Integer line, Integer col_start, Integer col_end, ) 
-	MsgpackRequest* buffer_add_highlight(int64_t buffer, int64_t src_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end);
+	NeovimQt::MsgpackRequest* buffer_add_highlight(int64_t buffer, int64_t src_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end);
 	// DEPRECATED
 	// void buffer_clear_highlight(Buffer buffer, Integer src_id, Integer line_start, Integer line_end, ) 
-	MsgpackRequest* buffer_clear_highlight(int64_t buffer, int64_t src_id, int64_t line_start, int64_t line_end);
+	NeovimQt::MsgpackRequest* buffer_clear_highlight(int64_t buffer, int64_t src_id, int64_t line_start, int64_t line_end);
 	// DEPRECATED
 	// ArrayOf(Window) tabpage_get_windows(Tabpage tabpage, ) 
-	MsgpackRequest* tabpage_get_windows(int64_t tabpage);
+	NeovimQt::MsgpackRequest* tabpage_get_windows(int64_t tabpage);
 	// DEPRECATED
 	// Object tabpage_get_var(Tabpage tabpage, String name, ) 
-	MsgpackRequest* tabpage_get_var(int64_t tabpage, QByteArray name);
+	NeovimQt::MsgpackRequest* tabpage_get_var(int64_t tabpage, QByteArray name);
 	// DEPRECATED
 	// Window tabpage_get_window(Tabpage tabpage, ) 
-	MsgpackRequest* tabpage_get_window(int64_t tabpage);
+	NeovimQt::MsgpackRequest* tabpage_get_window(int64_t tabpage);
 	// DEPRECATED
 	// Boolean tabpage_is_valid(Tabpage tabpage, ) 
-	MsgpackRequest* tabpage_is_valid(int64_t tabpage);
+	NeovimQt::MsgpackRequest* tabpage_is_valid(int64_t tabpage);
 	// DEPRECATED
 	// void ui_detach() 
-	MsgpackRequest* ui_detach();
+	NeovimQt::MsgpackRequest* ui_detach();
 	// DEPRECATED
 	// Object ui_try_resize(Integer width, Integer height, ) 
-	MsgpackRequest* ui_try_resize(int64_t width, int64_t height);
+	NeovimQt::MsgpackRequest* ui_try_resize(int64_t width, int64_t height);
 	// DEPRECATED
 	// void vim_command(String command, ) 
-	MsgpackRequest* vim_command(QByteArray command);
+	NeovimQt::MsgpackRequest* vim_command(QByteArray command);
 	// DEPRECATED
 	// void vim_feedkeys(String keys, String mode, Boolean escape_csi, ) 
-	MsgpackRequest* vim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi);
+	NeovimQt::MsgpackRequest* vim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi);
 	// DEPRECATED
 	// Integer vim_input(String keys, ) 
-	MsgpackRequest* vim_input(QByteArray keys);
+	NeovimQt::MsgpackRequest* vim_input(QByteArray keys);
 	// DEPRECATED
 	// String vim_replace_termcodes(String str, Boolean from_part, Boolean do_lt, Boolean special, ) 
-	MsgpackRequest* vim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special);
+	NeovimQt::MsgpackRequest* vim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special);
 	// DEPRECATED
 	// String vim_command_output(String str, ) 
-	MsgpackRequest* vim_command_output(QByteArray str);
+	NeovimQt::MsgpackRequest* vim_command_output(QByteArray str);
 	// DEPRECATED
 	// Object vim_eval(String expr, ) 
-	MsgpackRequest* vim_eval(QByteArray expr);
+	NeovimQt::MsgpackRequest* vim_eval(QByteArray expr);
 	// DEPRECATED
 	// Object vim_call_function(String fname, Array args, ) 
-	MsgpackRequest* vim_call_function(QByteArray fname, QVariantList args);
+	NeovimQt::MsgpackRequest* vim_call_function(QByteArray fname, QVariantList args);
 	// DEPRECATED
 	// Integer vim_strwidth(String text, ) 
-	MsgpackRequest* vim_strwidth(QByteArray text);
+	NeovimQt::MsgpackRequest* vim_strwidth(QByteArray text);
 	// DEPRECATED
 	// ArrayOf(String) vim_list_runtime_paths() 
-	MsgpackRequest* vim_list_runtime_paths();
+	NeovimQt::MsgpackRequest* vim_list_runtime_paths();
 	// DEPRECATED
 	// void vim_change_directory(String dir, ) 
-	MsgpackRequest* vim_change_directory(QByteArray dir);
+	NeovimQt::MsgpackRequest* vim_change_directory(QByteArray dir);
 	// DEPRECATED
 	// String vim_get_current_line() 
-	MsgpackRequest* vim_get_current_line();
+	NeovimQt::MsgpackRequest* vim_get_current_line();
 	// DEPRECATED
 	// void vim_set_current_line(String line, ) 
-	MsgpackRequest* vim_set_current_line(QByteArray line);
+	NeovimQt::MsgpackRequest* vim_set_current_line(QByteArray line);
 	// DEPRECATED
 	// void vim_del_current_line() 
-	MsgpackRequest* vim_del_current_line();
+	NeovimQt::MsgpackRequest* vim_del_current_line();
 	// DEPRECATED
 	// Object vim_get_var(String name, ) 
-	MsgpackRequest* vim_get_var(QByteArray name);
+	NeovimQt::MsgpackRequest* vim_get_var(QByteArray name);
 	// DEPRECATED
 	// Object vim_get_vvar(String name, ) 
-	MsgpackRequest* vim_get_vvar(QByteArray name);
+	NeovimQt::MsgpackRequest* vim_get_vvar(QByteArray name);
 	// DEPRECATED
 	// Object vim_get_option(String name, ) 
-	MsgpackRequest* vim_get_option(QByteArray name);
+	NeovimQt::MsgpackRequest* vim_get_option(QByteArray name);
 	// DEPRECATED
 	// void vim_set_option(String name, Object value, ) 
-	MsgpackRequest* vim_set_option(QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* vim_set_option(QByteArray name, QVariant value);
 	// DEPRECATED
 	// void vim_out_write(String str, ) 
-	MsgpackRequest* vim_out_write(QByteArray str);
+	NeovimQt::MsgpackRequest* vim_out_write(QByteArray str);
 	// DEPRECATED
 	// void vim_err_write(String str, ) 
-	MsgpackRequest* vim_err_write(QByteArray str);
+	NeovimQt::MsgpackRequest* vim_err_write(QByteArray str);
 	// DEPRECATED
 	// void vim_report_error(String str, ) 
-	MsgpackRequest* vim_report_error(QByteArray str);
+	NeovimQt::MsgpackRequest* vim_report_error(QByteArray str);
 	// DEPRECATED
 	// ArrayOf(Buffer) vim_get_buffers() 
-	MsgpackRequest* vim_get_buffers();
+	NeovimQt::MsgpackRequest* vim_get_buffers();
 	// DEPRECATED
 	// Buffer vim_get_current_buffer() 
-	MsgpackRequest* vim_get_current_buffer();
+	NeovimQt::MsgpackRequest* vim_get_current_buffer();
 	// DEPRECATED
 	// void vim_set_current_buffer(Buffer buffer, ) 
-	MsgpackRequest* vim_set_current_buffer(int64_t buffer);
+	NeovimQt::MsgpackRequest* vim_set_current_buffer(int64_t buffer);
 	// DEPRECATED
 	// ArrayOf(Window) vim_get_windows() 
-	MsgpackRequest* vim_get_windows();
+	NeovimQt::MsgpackRequest* vim_get_windows();
 	// DEPRECATED
 	// Window vim_get_current_window() 
-	MsgpackRequest* vim_get_current_window();
+	NeovimQt::MsgpackRequest* vim_get_current_window();
 	// DEPRECATED
 	// void vim_set_current_window(Window window, ) 
-	MsgpackRequest* vim_set_current_window(int64_t window);
+	NeovimQt::MsgpackRequest* vim_set_current_window(int64_t window);
 	// DEPRECATED
 	// ArrayOf(Tabpage) vim_get_tabpages() 
-	MsgpackRequest* vim_get_tabpages();
+	NeovimQt::MsgpackRequest* vim_get_tabpages();
 	// DEPRECATED
 	// Tabpage vim_get_current_tabpage() 
-	MsgpackRequest* vim_get_current_tabpage();
+	NeovimQt::MsgpackRequest* vim_get_current_tabpage();
 	// DEPRECATED
 	// void vim_set_current_tabpage(Tabpage tabpage, ) 
-	MsgpackRequest* vim_set_current_tabpage(int64_t tabpage);
+	NeovimQt::MsgpackRequest* vim_set_current_tabpage(int64_t tabpage);
 	// DEPRECATED
 	// void vim_subscribe(String event, ) 
-	MsgpackRequest* vim_subscribe(QByteArray event);
+	NeovimQt::MsgpackRequest* vim_subscribe(QByteArray event);
 	// DEPRECATED
 	// void vim_unsubscribe(String event, ) 
-	MsgpackRequest* vim_unsubscribe(QByteArray event);
+	NeovimQt::MsgpackRequest* vim_unsubscribe(QByteArray event);
 	// DEPRECATED
 	// Integer vim_name_to_color(String name, ) 
-	MsgpackRequest* vim_name_to_color(QByteArray name);
+	NeovimQt::MsgpackRequest* vim_name_to_color(QByteArray name);
 	// DEPRECATED
 	// Dictionary vim_get_color_map() 
-	MsgpackRequest* vim_get_color_map();
+	NeovimQt::MsgpackRequest* vim_get_color_map();
 	// DEPRECATED
 	// Buffer window_get_buffer(Window window, ) 
-	MsgpackRequest* window_get_buffer(int64_t window);
+	NeovimQt::MsgpackRequest* window_get_buffer(int64_t window);
 	// DEPRECATED
 	// ArrayOf(Integer, 2) window_get_cursor(Window window, ) 
-	MsgpackRequest* window_get_cursor(int64_t window);
+	NeovimQt::MsgpackRequest* window_get_cursor(int64_t window);
 	// DEPRECATED
 	// void window_set_cursor(Window window, ArrayOf(Integer, 2) pos, ) 
-	MsgpackRequest* window_set_cursor(int64_t window, QPoint pos);
+	NeovimQt::MsgpackRequest* window_set_cursor(int64_t window, QPoint pos);
 	// DEPRECATED
 	// Integer window_get_height(Window window, ) 
-	MsgpackRequest* window_get_height(int64_t window);
+	NeovimQt::MsgpackRequest* window_get_height(int64_t window);
 	// DEPRECATED
 	// void window_set_height(Window window, Integer height, ) 
-	MsgpackRequest* window_set_height(int64_t window, int64_t height);
+	NeovimQt::MsgpackRequest* window_set_height(int64_t window, int64_t height);
 	// DEPRECATED
 	// Integer window_get_width(Window window, ) 
-	MsgpackRequest* window_get_width(int64_t window);
+	NeovimQt::MsgpackRequest* window_get_width(int64_t window);
 	// DEPRECATED
 	// void window_set_width(Window window, Integer width, ) 
-	MsgpackRequest* window_set_width(int64_t window, int64_t width);
+	NeovimQt::MsgpackRequest* window_set_width(int64_t window, int64_t width);
 	// DEPRECATED
 	// Object window_get_var(Window window, String name, ) 
-	MsgpackRequest* window_get_var(int64_t window, QByteArray name);
+	NeovimQt::MsgpackRequest* window_get_var(int64_t window, QByteArray name);
 	// DEPRECATED
 	// Object window_get_option(Window window, String name, ) 
-	MsgpackRequest* window_get_option(int64_t window, QByteArray name);
+	NeovimQt::MsgpackRequest* window_get_option(int64_t window, QByteArray name);
 	// DEPRECATED
 	// void window_set_option(Window window, String name, Object value, ) 
-	MsgpackRequest* window_set_option(int64_t window, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* window_set_option(int64_t window, QByteArray name, QVariant value);
 	// DEPRECATED
 	// ArrayOf(Integer, 2) window_get_position(Window window, ) 
-	MsgpackRequest* window_get_position(int64_t window);
+	NeovimQt::MsgpackRequest* window_get_position(int64_t window);
 	// DEPRECATED
 	// Tabpage window_get_tabpage(Window window, ) 
-	MsgpackRequest* window_get_tabpage(int64_t window);
+	NeovimQt::MsgpackRequest* window_get_tabpage(int64_t window);
 	// DEPRECATED
 	// Boolean window_is_valid(Window window, ) 
-	MsgpackRequest* window_is_valid(int64_t window);
+	NeovimQt::MsgpackRequest* window_is_valid(int64_t window);
 
 signals:
 	void on_nvim_buf_line_count(int64_t);
@@ -1115,5 +1117,5 @@ signals:
 	void err_window_is_valid(const QString&, const QVariant&);
 
 };
-} // namespace
-#endif
+
+} // namespace NeovimQt

--- a/src/auto/neovimapi4.h
+++ b/src/auto/neovimapi4.h
@@ -1,13 +1,15 @@
-// Auto generated 2018-09-04 09:18:09.666239 from nvim API level:4
-#ifndef NEOVIM_QT_NEOVIMAPI4
-#define NEOVIM_QT_NEOVIMAPI4
-#include "msgpack.h"
+// Auto generated 2021-07-20 02:40:56.156899 from nvim API level:4
+#pragma once
+
 #include <QObject>
-#include <QVariant>
 #include <QPoint>
+#include <QVariant>
+
 #include "function.h"
+#include "msgpack.h"
 
 namespace NeovimQt {
+
 class NeovimConnector;
 class MsgpackRequest;
 
@@ -214,442 +216,442 @@ private:
 	NeovimConnector *m_c;
 public slots:
 	// Integer nvim_buf_line_count(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_line_count(int64_t buffer);
+	NeovimQt::MsgpackRequest* nvim_buf_line_count(int64_t buffer);
 	// DEPRECATED
 	// String buffer_get_line(Buffer buffer, Integer index, ) 
-	MsgpackRequest* buffer_get_line(int64_t buffer, int64_t index);
+	NeovimQt::MsgpackRequest* buffer_get_line(int64_t buffer, int64_t index);
 	// Boolean nvim_buf_attach(Buffer buffer, Boolean send_buffer, Dictionary opts, ) 
-	MsgpackRequest* nvim_buf_attach(int64_t buffer, bool send_buffer, QVariantMap opts);
+	NeovimQt::MsgpackRequest* nvim_buf_attach(int64_t buffer, bool send_buffer, QVariantMap opts);
 	// Boolean nvim_buf_detach(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_detach(int64_t buffer);
+	NeovimQt::MsgpackRequest* nvim_buf_detach(int64_t buffer);
 	// DEPRECATED
 	// void buffer_set_line(Buffer buffer, Integer index, String line, ) 
-	MsgpackRequest* buffer_set_line(int64_t buffer, int64_t index, QByteArray line);
+	NeovimQt::MsgpackRequest* buffer_set_line(int64_t buffer, int64_t index, QByteArray line);
 	// DEPRECATED
 	// void buffer_del_line(Buffer buffer, Integer index, ) 
-	MsgpackRequest* buffer_del_line(int64_t buffer, int64_t index);
+	NeovimQt::MsgpackRequest* buffer_del_line(int64_t buffer, int64_t index);
 	// DEPRECATED
 	// ArrayOf(String) buffer_get_line_slice(Buffer buffer, Integer start, Integer end, Boolean include_start, Boolean include_end, ) 
-	MsgpackRequest* buffer_get_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end);
+	NeovimQt::MsgpackRequest* buffer_get_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end);
 	// ArrayOf(String) nvim_buf_get_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ) 
-	MsgpackRequest* nvim_buf_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing);
+	NeovimQt::MsgpackRequest* nvim_buf_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing);
 	// DEPRECATED
 	// void buffer_set_line_slice(Buffer buffer, Integer start, Integer end, Boolean include_start, Boolean include_end, ArrayOf(String) replacement, ) 
-	MsgpackRequest* buffer_set_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end, QList<QByteArray> replacement);
+	NeovimQt::MsgpackRequest* buffer_set_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end, QList<QByteArray> replacement);
 	// void nvim_buf_set_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ArrayOf(String) replacement, ) 
-	MsgpackRequest* nvim_buf_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement);
+	NeovimQt::MsgpackRequest* nvim_buf_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement);
 	// Object nvim_buf_get_var(Buffer buffer, String name, ) 
-	MsgpackRequest* nvim_buf_get_var(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_buf_get_var(int64_t buffer, QByteArray name);
 	// Integer nvim_buf_get_changedtick(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_get_changedtick(int64_t buffer);
+	NeovimQt::MsgpackRequest* nvim_buf_get_changedtick(int64_t buffer);
 	// ArrayOf(Dictionary) nvim_buf_get_keymap(Buffer buffer, String mode, ) 
-	MsgpackRequest* nvim_buf_get_keymap(int64_t buffer, QByteArray mode);
+	NeovimQt::MsgpackRequest* nvim_buf_get_keymap(int64_t buffer, QByteArray mode);
 	// Dictionary nvim_buf_get_commands(Buffer buffer, Dictionary opts, ) 
-	MsgpackRequest* nvim_buf_get_commands(int64_t buffer, QVariantMap opts);
+	NeovimQt::MsgpackRequest* nvim_buf_get_commands(int64_t buffer, QVariantMap opts);
 	// void nvim_buf_set_var(Buffer buffer, String name, Object value, ) 
-	MsgpackRequest* nvim_buf_set_var(int64_t buffer, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* nvim_buf_set_var(int64_t buffer, QByteArray name, QVariant value);
 	// void nvim_buf_del_var(Buffer buffer, String name, ) 
-	MsgpackRequest* nvim_buf_del_var(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_buf_del_var(int64_t buffer, QByteArray name);
 	// DEPRECATED
 	// Object buffer_set_var(Buffer buffer, String name, Object value, ) 
-	MsgpackRequest* buffer_set_var(int64_t buffer, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* buffer_set_var(int64_t buffer, QByteArray name, QVariant value);
 	// DEPRECATED
 	// Object buffer_del_var(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_del_var(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* buffer_del_var(int64_t buffer, QByteArray name);
 	// Object nvim_buf_get_option(Buffer buffer, String name, ) 
-	MsgpackRequest* nvim_buf_get_option(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_buf_get_option(int64_t buffer, QByteArray name);
 	// void nvim_buf_set_option(Buffer buffer, String name, Object value, ) 
-	MsgpackRequest* nvim_buf_set_option(int64_t buffer, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* nvim_buf_set_option(int64_t buffer, QByteArray name, QVariant value);
 	// DEPRECATED
 	// Integer nvim_buf_get_number(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_get_number(int64_t buffer);
+	NeovimQt::MsgpackRequest* nvim_buf_get_number(int64_t buffer);
 	// String nvim_buf_get_name(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_get_name(int64_t buffer);
+	NeovimQt::MsgpackRequest* nvim_buf_get_name(int64_t buffer);
 	// void nvim_buf_set_name(Buffer buffer, String name, ) 
-	MsgpackRequest* nvim_buf_set_name(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_buf_set_name(int64_t buffer, QByteArray name);
 	// Boolean nvim_buf_is_valid(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_is_valid(int64_t buffer);
+	NeovimQt::MsgpackRequest* nvim_buf_is_valid(int64_t buffer);
 	// DEPRECATED
 	// void buffer_insert(Buffer buffer, Integer lnum, ArrayOf(String) lines, ) 
-	MsgpackRequest* buffer_insert(int64_t buffer, int64_t lnum, QList<QByteArray> lines);
+	NeovimQt::MsgpackRequest* buffer_insert(int64_t buffer, int64_t lnum, QList<QByteArray> lines);
 	// ArrayOf(Integer, 2) nvim_buf_get_mark(Buffer buffer, String name, ) 
-	MsgpackRequest* nvim_buf_get_mark(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_buf_get_mark(int64_t buffer, QByteArray name);
 	// Integer nvim_buf_add_highlight(Buffer buffer, Integer src_id, String hl_group, Integer line, Integer col_start, Integer col_end, ) 
-	MsgpackRequest* nvim_buf_add_highlight(int64_t buffer, int64_t src_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end);
+	NeovimQt::MsgpackRequest* nvim_buf_add_highlight(int64_t buffer, int64_t src_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end);
 	// void nvim_buf_clear_highlight(Buffer buffer, Integer src_id, Integer line_start, Integer line_end, ) 
-	MsgpackRequest* nvim_buf_clear_highlight(int64_t buffer, int64_t src_id, int64_t line_start, int64_t line_end);
+	NeovimQt::MsgpackRequest* nvim_buf_clear_highlight(int64_t buffer, int64_t src_id, int64_t line_start, int64_t line_end);
 	// ArrayOf(Window) nvim_tabpage_list_wins(Tabpage tabpage, ) 
-	MsgpackRequest* nvim_tabpage_list_wins(int64_t tabpage);
+	NeovimQt::MsgpackRequest* nvim_tabpage_list_wins(int64_t tabpage);
 	// Object nvim_tabpage_get_var(Tabpage tabpage, String name, ) 
-	MsgpackRequest* nvim_tabpage_get_var(int64_t tabpage, QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_tabpage_get_var(int64_t tabpage, QByteArray name);
 	// void nvim_tabpage_set_var(Tabpage tabpage, String name, Object value, ) 
-	MsgpackRequest* nvim_tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* nvim_tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value);
 	// void nvim_tabpage_del_var(Tabpage tabpage, String name, ) 
-	MsgpackRequest* nvim_tabpage_del_var(int64_t tabpage, QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_tabpage_del_var(int64_t tabpage, QByteArray name);
 	// DEPRECATED
 	// Object tabpage_set_var(Tabpage tabpage, String name, Object value, ) 
-	MsgpackRequest* tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value);
 	// DEPRECATED
 	// Object tabpage_del_var(Tabpage tabpage, String name, ) 
-	MsgpackRequest* tabpage_del_var(int64_t tabpage, QByteArray name);
+	NeovimQt::MsgpackRequest* tabpage_del_var(int64_t tabpage, QByteArray name);
 	// Window nvim_tabpage_get_win(Tabpage tabpage, ) 
-	MsgpackRequest* nvim_tabpage_get_win(int64_t tabpage);
+	NeovimQt::MsgpackRequest* nvim_tabpage_get_win(int64_t tabpage);
 	// Integer nvim_tabpage_get_number(Tabpage tabpage, ) 
-	MsgpackRequest* nvim_tabpage_get_number(int64_t tabpage);
+	NeovimQt::MsgpackRequest* nvim_tabpage_get_number(int64_t tabpage);
 	// Boolean nvim_tabpage_is_valid(Tabpage tabpage, ) 
-	MsgpackRequest* nvim_tabpage_is_valid(int64_t tabpage);
+	NeovimQt::MsgpackRequest* nvim_tabpage_is_valid(int64_t tabpage);
 	// void nvim_ui_attach(Integer width, Integer height, Dictionary options, ) 
-	MsgpackRequest* nvim_ui_attach(int64_t width, int64_t height, QVariantMap options);
+	NeovimQt::MsgpackRequest* nvim_ui_attach(int64_t width, int64_t height, QVariantMap options);
 	// DEPRECATED
 	// void ui_attach(Integer width, Integer height, Boolean enable_rgb, ) 
-	MsgpackRequest* ui_attach(int64_t width, int64_t height, bool enable_rgb);
+	NeovimQt::MsgpackRequest* ui_attach(int64_t width, int64_t height, bool enable_rgb);
 	// void nvim_ui_detach() 
-	MsgpackRequest* nvim_ui_detach();
+	NeovimQt::MsgpackRequest* nvim_ui_detach();
 	// void nvim_ui_try_resize(Integer width, Integer height, ) 
-	MsgpackRequest* nvim_ui_try_resize(int64_t width, int64_t height);
+	NeovimQt::MsgpackRequest* nvim_ui_try_resize(int64_t width, int64_t height);
 	// void nvim_ui_set_option(String name, Object value, ) 
-	MsgpackRequest* nvim_ui_set_option(QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* nvim_ui_set_option(QByteArray name, QVariant value);
 	// void nvim_command(String command, ) 
-	MsgpackRequest* nvim_command(QByteArray command);
+	NeovimQt::MsgpackRequest* nvim_command(QByteArray command);
 	// Dictionary nvim_get_hl_by_name(String name, Boolean rgb, ) 
-	MsgpackRequest* nvim_get_hl_by_name(QByteArray name, bool rgb);
+	NeovimQt::MsgpackRequest* nvim_get_hl_by_name(QByteArray name, bool rgb);
 	// Dictionary nvim_get_hl_by_id(Integer hl_id, Boolean rgb, ) 
-	MsgpackRequest* nvim_get_hl_by_id(int64_t hl_id, bool rgb);
+	NeovimQt::MsgpackRequest* nvim_get_hl_by_id(int64_t hl_id, bool rgb);
 	// void nvim_feedkeys(String keys, String mode, Boolean escape_csi, ) 
-	MsgpackRequest* nvim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi);
+	NeovimQt::MsgpackRequest* nvim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi);
 	// Integer nvim_input(String keys, ) 
-	MsgpackRequest* nvim_input(QByteArray keys);
+	NeovimQt::MsgpackRequest* nvim_input(QByteArray keys);
 	// String nvim_replace_termcodes(String str, Boolean from_part, Boolean do_lt, Boolean special, ) 
-	MsgpackRequest* nvim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special);
+	NeovimQt::MsgpackRequest* nvim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special);
 	// String nvim_command_output(String command, ) 
-	MsgpackRequest* nvim_command_output(QByteArray command);
+	NeovimQt::MsgpackRequest* nvim_command_output(QByteArray command);
 	// Object nvim_eval(String expr, ) 
-	MsgpackRequest* nvim_eval(QByteArray expr);
+	NeovimQt::MsgpackRequest* nvim_eval(QByteArray expr);
 	// Object nvim_execute_lua(String code, Array args, ) 
-	MsgpackRequest* nvim_execute_lua(QByteArray code, QVariantList args);
+	NeovimQt::MsgpackRequest* nvim_execute_lua(QByteArray code, QVariantList args);
 	// Object nvim_call_function(String fn, Array args, ) 
-	MsgpackRequest* nvim_call_function(QByteArray fn, QVariantList args);
+	NeovimQt::MsgpackRequest* nvim_call_function(QByteArray fn, QVariantList args);
 	// Object nvim_call_dict_function(Object dict, String fn, Array args, ) 
-	MsgpackRequest* nvim_call_dict_function(QVariant dict, QByteArray fn, QVariantList args);
+	NeovimQt::MsgpackRequest* nvim_call_dict_function(QVariant dict, QByteArray fn, QVariantList args);
 	// Integer nvim_strwidth(String text, ) 
-	MsgpackRequest* nvim_strwidth(QByteArray text);
+	NeovimQt::MsgpackRequest* nvim_strwidth(QByteArray text);
 	// ArrayOf(String) nvim_list_runtime_paths() 
-	MsgpackRequest* nvim_list_runtime_paths();
+	NeovimQt::MsgpackRequest* nvim_list_runtime_paths();
 	// void nvim_set_current_dir(String dir, ) 
-	MsgpackRequest* nvim_set_current_dir(QByteArray dir);
+	NeovimQt::MsgpackRequest* nvim_set_current_dir(QByteArray dir);
 	// String nvim_get_current_line() 
-	MsgpackRequest* nvim_get_current_line();
+	NeovimQt::MsgpackRequest* nvim_get_current_line();
 	// void nvim_set_current_line(String line, ) 
-	MsgpackRequest* nvim_set_current_line(QByteArray line);
+	NeovimQt::MsgpackRequest* nvim_set_current_line(QByteArray line);
 	// void nvim_del_current_line() 
-	MsgpackRequest* nvim_del_current_line();
+	NeovimQt::MsgpackRequest* nvim_del_current_line();
 	// Object nvim_get_var(String name, ) 
-	MsgpackRequest* nvim_get_var(QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_get_var(QByteArray name);
 	// void nvim_set_var(String name, Object value, ) 
-	MsgpackRequest* nvim_set_var(QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* nvim_set_var(QByteArray name, QVariant value);
 	// void nvim_del_var(String name, ) 
-	MsgpackRequest* nvim_del_var(QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_del_var(QByteArray name);
 	// DEPRECATED
 	// Object vim_set_var(String name, Object value, ) 
-	MsgpackRequest* vim_set_var(QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* vim_set_var(QByteArray name, QVariant value);
 	// DEPRECATED
 	// Object vim_del_var(String name, ) 
-	MsgpackRequest* vim_del_var(QByteArray name);
+	NeovimQt::MsgpackRequest* vim_del_var(QByteArray name);
 	// Object nvim_get_vvar(String name, ) 
-	MsgpackRequest* nvim_get_vvar(QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_get_vvar(QByteArray name);
 	// Object nvim_get_option(String name, ) 
-	MsgpackRequest* nvim_get_option(QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_get_option(QByteArray name);
 	// void nvim_set_option(String name, Object value, ) 
-	MsgpackRequest* nvim_set_option(QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* nvim_set_option(QByteArray name, QVariant value);
 	// void nvim_out_write(String str, ) 
-	MsgpackRequest* nvim_out_write(QByteArray str);
+	NeovimQt::MsgpackRequest* nvim_out_write(QByteArray str);
 	// void nvim_err_write(String str, ) 
-	MsgpackRequest* nvim_err_write(QByteArray str);
+	NeovimQt::MsgpackRequest* nvim_err_write(QByteArray str);
 	// void nvim_err_writeln(String str, ) 
-	MsgpackRequest* nvim_err_writeln(QByteArray str);
+	NeovimQt::MsgpackRequest* nvim_err_writeln(QByteArray str);
 	// ArrayOf(Buffer) nvim_list_bufs() 
-	MsgpackRequest* nvim_list_bufs();
+	NeovimQt::MsgpackRequest* nvim_list_bufs();
 	// Buffer nvim_get_current_buf() 
-	MsgpackRequest* nvim_get_current_buf();
+	NeovimQt::MsgpackRequest* nvim_get_current_buf();
 	// void nvim_set_current_buf(Buffer buffer, ) 
-	MsgpackRequest* nvim_set_current_buf(int64_t buffer);
+	NeovimQt::MsgpackRequest* nvim_set_current_buf(int64_t buffer);
 	// ArrayOf(Window) nvim_list_wins() 
-	MsgpackRequest* nvim_list_wins();
+	NeovimQt::MsgpackRequest* nvim_list_wins();
 	// Window nvim_get_current_win() 
-	MsgpackRequest* nvim_get_current_win();
+	NeovimQt::MsgpackRequest* nvim_get_current_win();
 	// void nvim_set_current_win(Window window, ) 
-	MsgpackRequest* nvim_set_current_win(int64_t window);
+	NeovimQt::MsgpackRequest* nvim_set_current_win(int64_t window);
 	// ArrayOf(Tabpage) nvim_list_tabpages() 
-	MsgpackRequest* nvim_list_tabpages();
+	NeovimQt::MsgpackRequest* nvim_list_tabpages();
 	// Tabpage nvim_get_current_tabpage() 
-	MsgpackRequest* nvim_get_current_tabpage();
+	NeovimQt::MsgpackRequest* nvim_get_current_tabpage();
 	// void nvim_set_current_tabpage(Tabpage tabpage, ) 
-	MsgpackRequest* nvim_set_current_tabpage(int64_t tabpage);
+	NeovimQt::MsgpackRequest* nvim_set_current_tabpage(int64_t tabpage);
 	// void nvim_subscribe(String event, ) 
-	MsgpackRequest* nvim_subscribe(QByteArray event);
+	NeovimQt::MsgpackRequest* nvim_subscribe(QByteArray event);
 	// void nvim_unsubscribe(String event, ) 
-	MsgpackRequest* nvim_unsubscribe(QByteArray event);
+	NeovimQt::MsgpackRequest* nvim_unsubscribe(QByteArray event);
 	// Integer nvim_get_color_by_name(String name, ) 
-	MsgpackRequest* nvim_get_color_by_name(QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_get_color_by_name(QByteArray name);
 	// Dictionary nvim_get_color_map() 
-	MsgpackRequest* nvim_get_color_map();
+	NeovimQt::MsgpackRequest* nvim_get_color_map();
 	// Dictionary nvim_get_mode() 
-	MsgpackRequest* nvim_get_mode();
+	NeovimQt::MsgpackRequest* nvim_get_mode();
 	// ArrayOf(Dictionary) nvim_get_keymap(String mode, ) 
-	MsgpackRequest* nvim_get_keymap(QByteArray mode);
+	NeovimQt::MsgpackRequest* nvim_get_keymap(QByteArray mode);
 	// Dictionary nvim_get_commands(Dictionary opts, ) 
-	MsgpackRequest* nvim_get_commands(QVariantMap opts);
+	NeovimQt::MsgpackRequest* nvim_get_commands(QVariantMap opts);
 	// Array nvim_get_api_info() 
-	MsgpackRequest* nvim_get_api_info();
+	NeovimQt::MsgpackRequest* nvim_get_api_info();
 	// void nvim_set_client_info(String name, Dictionary version, String type, Dictionary methods, Dictionary attributes, ) 
-	MsgpackRequest* nvim_set_client_info(QByteArray name, QVariantMap version, QByteArray type, QVariantMap methods, QVariantMap attributes);
+	NeovimQt::MsgpackRequest* nvim_set_client_info(QByteArray name, QVariantMap version, QByteArray type, QVariantMap methods, QVariantMap attributes);
 	// Dictionary nvim_get_chan_info(Integer chan, ) 
-	MsgpackRequest* nvim_get_chan_info(int64_t chan);
+	NeovimQt::MsgpackRequest* nvim_get_chan_info(int64_t chan);
 	// Array nvim_list_chans() 
-	MsgpackRequest* nvim_list_chans();
+	NeovimQt::MsgpackRequest* nvim_list_chans();
 	// Array nvim_call_atomic(Array calls, ) 
-	MsgpackRequest* nvim_call_atomic(QVariantList calls);
+	NeovimQt::MsgpackRequest* nvim_call_atomic(QVariantList calls);
 	// Dictionary nvim_parse_expression(String expr, String flags, Boolean highlight, ) 
-	MsgpackRequest* nvim_parse_expression(QByteArray expr, QByteArray flags, bool highlight);
+	NeovimQt::MsgpackRequest* nvim_parse_expression(QByteArray expr, QByteArray flags, bool highlight);
 	// Array nvim_list_uis() 
-	MsgpackRequest* nvim_list_uis();
+	NeovimQt::MsgpackRequest* nvim_list_uis();
 	// Array nvim_get_proc_children(Integer pid, ) 
-	MsgpackRequest* nvim_get_proc_children(int64_t pid);
+	NeovimQt::MsgpackRequest* nvim_get_proc_children(int64_t pid);
 	// Object nvim_get_proc(Integer pid, ) 
-	MsgpackRequest* nvim_get_proc(int64_t pid);
+	NeovimQt::MsgpackRequest* nvim_get_proc(int64_t pid);
 	// Buffer nvim_win_get_buf(Window window, ) 
-	MsgpackRequest* nvim_win_get_buf(int64_t window);
+	NeovimQt::MsgpackRequest* nvim_win_get_buf(int64_t window);
 	// ArrayOf(Integer, 2) nvim_win_get_cursor(Window window, ) 
-	MsgpackRequest* nvim_win_get_cursor(int64_t window);
+	NeovimQt::MsgpackRequest* nvim_win_get_cursor(int64_t window);
 	// void nvim_win_set_cursor(Window window, ArrayOf(Integer, 2) pos, ) 
-	MsgpackRequest* nvim_win_set_cursor(int64_t window, QPoint pos);
+	NeovimQt::MsgpackRequest* nvim_win_set_cursor(int64_t window, QPoint pos);
 	// Integer nvim_win_get_height(Window window, ) 
-	MsgpackRequest* nvim_win_get_height(int64_t window);
+	NeovimQt::MsgpackRequest* nvim_win_get_height(int64_t window);
 	// void nvim_win_set_height(Window window, Integer height, ) 
-	MsgpackRequest* nvim_win_set_height(int64_t window, int64_t height);
+	NeovimQt::MsgpackRequest* nvim_win_set_height(int64_t window, int64_t height);
 	// Integer nvim_win_get_width(Window window, ) 
-	MsgpackRequest* nvim_win_get_width(int64_t window);
+	NeovimQt::MsgpackRequest* nvim_win_get_width(int64_t window);
 	// void nvim_win_set_width(Window window, Integer width, ) 
-	MsgpackRequest* nvim_win_set_width(int64_t window, int64_t width);
+	NeovimQt::MsgpackRequest* nvim_win_set_width(int64_t window, int64_t width);
 	// Object nvim_win_get_var(Window window, String name, ) 
-	MsgpackRequest* nvim_win_get_var(int64_t window, QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_win_get_var(int64_t window, QByteArray name);
 	// void nvim_win_set_var(Window window, String name, Object value, ) 
-	MsgpackRequest* nvim_win_set_var(int64_t window, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* nvim_win_set_var(int64_t window, QByteArray name, QVariant value);
 	// void nvim_win_del_var(Window window, String name, ) 
-	MsgpackRequest* nvim_win_del_var(int64_t window, QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_win_del_var(int64_t window, QByteArray name);
 	// DEPRECATED
 	// Object window_set_var(Window window, String name, Object value, ) 
-	MsgpackRequest* window_set_var(int64_t window, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* window_set_var(int64_t window, QByteArray name, QVariant value);
 	// DEPRECATED
 	// Object window_del_var(Window window, String name, ) 
-	MsgpackRequest* window_del_var(int64_t window, QByteArray name);
+	NeovimQt::MsgpackRequest* window_del_var(int64_t window, QByteArray name);
 	// Object nvim_win_get_option(Window window, String name, ) 
-	MsgpackRequest* nvim_win_get_option(int64_t window, QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_win_get_option(int64_t window, QByteArray name);
 	// void nvim_win_set_option(Window window, String name, Object value, ) 
-	MsgpackRequest* nvim_win_set_option(int64_t window, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* nvim_win_set_option(int64_t window, QByteArray name, QVariant value);
 	// ArrayOf(Integer, 2) nvim_win_get_position(Window window, ) 
-	MsgpackRequest* nvim_win_get_position(int64_t window);
+	NeovimQt::MsgpackRequest* nvim_win_get_position(int64_t window);
 	// Tabpage nvim_win_get_tabpage(Window window, ) 
-	MsgpackRequest* nvim_win_get_tabpage(int64_t window);
+	NeovimQt::MsgpackRequest* nvim_win_get_tabpage(int64_t window);
 	// Integer nvim_win_get_number(Window window, ) 
-	MsgpackRequest* nvim_win_get_number(int64_t window);
+	NeovimQt::MsgpackRequest* nvim_win_get_number(int64_t window);
 	// Boolean nvim_win_is_valid(Window window, ) 
-	MsgpackRequest* nvim_win_is_valid(int64_t window);
+	NeovimQt::MsgpackRequest* nvim_win_is_valid(int64_t window);
 	// DEPRECATED
 	// Integer buffer_line_count(Buffer buffer, ) 
-	MsgpackRequest* buffer_line_count(int64_t buffer);
+	NeovimQt::MsgpackRequest* buffer_line_count(int64_t buffer);
 	// DEPRECATED
 	// ArrayOf(String) buffer_get_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ) 
-	MsgpackRequest* buffer_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing);
+	NeovimQt::MsgpackRequest* buffer_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing);
 	// DEPRECATED
 	// void buffer_set_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ArrayOf(String) replacement, ) 
-	MsgpackRequest* buffer_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement);
+	NeovimQt::MsgpackRequest* buffer_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement);
 	// DEPRECATED
 	// Object buffer_get_var(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_get_var(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* buffer_get_var(int64_t buffer, QByteArray name);
 	// DEPRECATED
 	// Object buffer_get_option(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_get_option(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* buffer_get_option(int64_t buffer, QByteArray name);
 	// DEPRECATED
 	// void buffer_set_option(Buffer buffer, String name, Object value, ) 
-	MsgpackRequest* buffer_set_option(int64_t buffer, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* buffer_set_option(int64_t buffer, QByteArray name, QVariant value);
 	// DEPRECATED
 	// Integer buffer_get_number(Buffer buffer, ) 
-	MsgpackRequest* buffer_get_number(int64_t buffer);
+	NeovimQt::MsgpackRequest* buffer_get_number(int64_t buffer);
 	// DEPRECATED
 	// String buffer_get_name(Buffer buffer, ) 
-	MsgpackRequest* buffer_get_name(int64_t buffer);
+	NeovimQt::MsgpackRequest* buffer_get_name(int64_t buffer);
 	// DEPRECATED
 	// void buffer_set_name(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_set_name(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* buffer_set_name(int64_t buffer, QByteArray name);
 	// DEPRECATED
 	// Boolean buffer_is_valid(Buffer buffer, ) 
-	MsgpackRequest* buffer_is_valid(int64_t buffer);
+	NeovimQt::MsgpackRequest* buffer_is_valid(int64_t buffer);
 	// DEPRECATED
 	// ArrayOf(Integer, 2) buffer_get_mark(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_get_mark(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* buffer_get_mark(int64_t buffer, QByteArray name);
 	// DEPRECATED
 	// Integer buffer_add_highlight(Buffer buffer, Integer src_id, String hl_group, Integer line, Integer col_start, Integer col_end, ) 
-	MsgpackRequest* buffer_add_highlight(int64_t buffer, int64_t src_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end);
+	NeovimQt::MsgpackRequest* buffer_add_highlight(int64_t buffer, int64_t src_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end);
 	// DEPRECATED
 	// void buffer_clear_highlight(Buffer buffer, Integer src_id, Integer line_start, Integer line_end, ) 
-	MsgpackRequest* buffer_clear_highlight(int64_t buffer, int64_t src_id, int64_t line_start, int64_t line_end);
+	NeovimQt::MsgpackRequest* buffer_clear_highlight(int64_t buffer, int64_t src_id, int64_t line_start, int64_t line_end);
 	// DEPRECATED
 	// ArrayOf(Window) tabpage_get_windows(Tabpage tabpage, ) 
-	MsgpackRequest* tabpage_get_windows(int64_t tabpage);
+	NeovimQt::MsgpackRequest* tabpage_get_windows(int64_t tabpage);
 	// DEPRECATED
 	// Object tabpage_get_var(Tabpage tabpage, String name, ) 
-	MsgpackRequest* tabpage_get_var(int64_t tabpage, QByteArray name);
+	NeovimQt::MsgpackRequest* tabpage_get_var(int64_t tabpage, QByteArray name);
 	// DEPRECATED
 	// Window tabpage_get_window(Tabpage tabpage, ) 
-	MsgpackRequest* tabpage_get_window(int64_t tabpage);
+	NeovimQt::MsgpackRequest* tabpage_get_window(int64_t tabpage);
 	// DEPRECATED
 	// Boolean tabpage_is_valid(Tabpage tabpage, ) 
-	MsgpackRequest* tabpage_is_valid(int64_t tabpage);
+	NeovimQt::MsgpackRequest* tabpage_is_valid(int64_t tabpage);
 	// DEPRECATED
 	// void ui_detach() 
-	MsgpackRequest* ui_detach();
+	NeovimQt::MsgpackRequest* ui_detach();
 	// DEPRECATED
 	// Object ui_try_resize(Integer width, Integer height, ) 
-	MsgpackRequest* ui_try_resize(int64_t width, int64_t height);
+	NeovimQt::MsgpackRequest* ui_try_resize(int64_t width, int64_t height);
 	// DEPRECATED
 	// void vim_command(String command, ) 
-	MsgpackRequest* vim_command(QByteArray command);
+	NeovimQt::MsgpackRequest* vim_command(QByteArray command);
 	// DEPRECATED
 	// void vim_feedkeys(String keys, String mode, Boolean escape_csi, ) 
-	MsgpackRequest* vim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi);
+	NeovimQt::MsgpackRequest* vim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi);
 	// DEPRECATED
 	// Integer vim_input(String keys, ) 
-	MsgpackRequest* vim_input(QByteArray keys);
+	NeovimQt::MsgpackRequest* vim_input(QByteArray keys);
 	// DEPRECATED
 	// String vim_replace_termcodes(String str, Boolean from_part, Boolean do_lt, Boolean special, ) 
-	MsgpackRequest* vim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special);
+	NeovimQt::MsgpackRequest* vim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special);
 	// DEPRECATED
 	// String vim_command_output(String command, ) 
-	MsgpackRequest* vim_command_output(QByteArray command);
+	NeovimQt::MsgpackRequest* vim_command_output(QByteArray command);
 	// DEPRECATED
 	// Object vim_eval(String expr, ) 
-	MsgpackRequest* vim_eval(QByteArray expr);
+	NeovimQt::MsgpackRequest* vim_eval(QByteArray expr);
 	// DEPRECATED
 	// Object vim_call_function(String fn, Array args, ) 
-	MsgpackRequest* vim_call_function(QByteArray fn, QVariantList args);
+	NeovimQt::MsgpackRequest* vim_call_function(QByteArray fn, QVariantList args);
 	// DEPRECATED
 	// Integer vim_strwidth(String text, ) 
-	MsgpackRequest* vim_strwidth(QByteArray text);
+	NeovimQt::MsgpackRequest* vim_strwidth(QByteArray text);
 	// DEPRECATED
 	// ArrayOf(String) vim_list_runtime_paths() 
-	MsgpackRequest* vim_list_runtime_paths();
+	NeovimQt::MsgpackRequest* vim_list_runtime_paths();
 	// DEPRECATED
 	// void vim_change_directory(String dir, ) 
-	MsgpackRequest* vim_change_directory(QByteArray dir);
+	NeovimQt::MsgpackRequest* vim_change_directory(QByteArray dir);
 	// DEPRECATED
 	// String vim_get_current_line() 
-	MsgpackRequest* vim_get_current_line();
+	NeovimQt::MsgpackRequest* vim_get_current_line();
 	// DEPRECATED
 	// void vim_set_current_line(String line, ) 
-	MsgpackRequest* vim_set_current_line(QByteArray line);
+	NeovimQt::MsgpackRequest* vim_set_current_line(QByteArray line);
 	// DEPRECATED
 	// void vim_del_current_line() 
-	MsgpackRequest* vim_del_current_line();
+	NeovimQt::MsgpackRequest* vim_del_current_line();
 	// DEPRECATED
 	// Object vim_get_var(String name, ) 
-	MsgpackRequest* vim_get_var(QByteArray name);
+	NeovimQt::MsgpackRequest* vim_get_var(QByteArray name);
 	// DEPRECATED
 	// Object vim_get_vvar(String name, ) 
-	MsgpackRequest* vim_get_vvar(QByteArray name);
+	NeovimQt::MsgpackRequest* vim_get_vvar(QByteArray name);
 	// DEPRECATED
 	// Object vim_get_option(String name, ) 
-	MsgpackRequest* vim_get_option(QByteArray name);
+	NeovimQt::MsgpackRequest* vim_get_option(QByteArray name);
 	// DEPRECATED
 	// void vim_set_option(String name, Object value, ) 
-	MsgpackRequest* vim_set_option(QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* vim_set_option(QByteArray name, QVariant value);
 	// DEPRECATED
 	// void vim_out_write(String str, ) 
-	MsgpackRequest* vim_out_write(QByteArray str);
+	NeovimQt::MsgpackRequest* vim_out_write(QByteArray str);
 	// DEPRECATED
 	// void vim_err_write(String str, ) 
-	MsgpackRequest* vim_err_write(QByteArray str);
+	NeovimQt::MsgpackRequest* vim_err_write(QByteArray str);
 	// DEPRECATED
 	// void vim_report_error(String str, ) 
-	MsgpackRequest* vim_report_error(QByteArray str);
+	NeovimQt::MsgpackRequest* vim_report_error(QByteArray str);
 	// DEPRECATED
 	// ArrayOf(Buffer) vim_get_buffers() 
-	MsgpackRequest* vim_get_buffers();
+	NeovimQt::MsgpackRequest* vim_get_buffers();
 	// DEPRECATED
 	// Buffer vim_get_current_buffer() 
-	MsgpackRequest* vim_get_current_buffer();
+	NeovimQt::MsgpackRequest* vim_get_current_buffer();
 	// DEPRECATED
 	// void vim_set_current_buffer(Buffer buffer, ) 
-	MsgpackRequest* vim_set_current_buffer(int64_t buffer);
+	NeovimQt::MsgpackRequest* vim_set_current_buffer(int64_t buffer);
 	// DEPRECATED
 	// ArrayOf(Window) vim_get_windows() 
-	MsgpackRequest* vim_get_windows();
+	NeovimQt::MsgpackRequest* vim_get_windows();
 	// DEPRECATED
 	// Window vim_get_current_window() 
-	MsgpackRequest* vim_get_current_window();
+	NeovimQt::MsgpackRequest* vim_get_current_window();
 	// DEPRECATED
 	// void vim_set_current_window(Window window, ) 
-	MsgpackRequest* vim_set_current_window(int64_t window);
+	NeovimQt::MsgpackRequest* vim_set_current_window(int64_t window);
 	// DEPRECATED
 	// ArrayOf(Tabpage) vim_get_tabpages() 
-	MsgpackRequest* vim_get_tabpages();
+	NeovimQt::MsgpackRequest* vim_get_tabpages();
 	// DEPRECATED
 	// Tabpage vim_get_current_tabpage() 
-	MsgpackRequest* vim_get_current_tabpage();
+	NeovimQt::MsgpackRequest* vim_get_current_tabpage();
 	// DEPRECATED
 	// void vim_set_current_tabpage(Tabpage tabpage, ) 
-	MsgpackRequest* vim_set_current_tabpage(int64_t tabpage);
+	NeovimQt::MsgpackRequest* vim_set_current_tabpage(int64_t tabpage);
 	// DEPRECATED
 	// void vim_subscribe(String event, ) 
-	MsgpackRequest* vim_subscribe(QByteArray event);
+	NeovimQt::MsgpackRequest* vim_subscribe(QByteArray event);
 	// DEPRECATED
 	// void vim_unsubscribe(String event, ) 
-	MsgpackRequest* vim_unsubscribe(QByteArray event);
+	NeovimQt::MsgpackRequest* vim_unsubscribe(QByteArray event);
 	// DEPRECATED
 	// Integer vim_name_to_color(String name, ) 
-	MsgpackRequest* vim_name_to_color(QByteArray name);
+	NeovimQt::MsgpackRequest* vim_name_to_color(QByteArray name);
 	// DEPRECATED
 	// Dictionary vim_get_color_map() 
-	MsgpackRequest* vim_get_color_map();
+	NeovimQt::MsgpackRequest* vim_get_color_map();
 	// DEPRECATED
 	// Buffer window_get_buffer(Window window, ) 
-	MsgpackRequest* window_get_buffer(int64_t window);
+	NeovimQt::MsgpackRequest* window_get_buffer(int64_t window);
 	// DEPRECATED
 	// ArrayOf(Integer, 2) window_get_cursor(Window window, ) 
-	MsgpackRequest* window_get_cursor(int64_t window);
+	NeovimQt::MsgpackRequest* window_get_cursor(int64_t window);
 	// DEPRECATED
 	// void window_set_cursor(Window window, ArrayOf(Integer, 2) pos, ) 
-	MsgpackRequest* window_set_cursor(int64_t window, QPoint pos);
+	NeovimQt::MsgpackRequest* window_set_cursor(int64_t window, QPoint pos);
 	// DEPRECATED
 	// Integer window_get_height(Window window, ) 
-	MsgpackRequest* window_get_height(int64_t window);
+	NeovimQt::MsgpackRequest* window_get_height(int64_t window);
 	// DEPRECATED
 	// void window_set_height(Window window, Integer height, ) 
-	MsgpackRequest* window_set_height(int64_t window, int64_t height);
+	NeovimQt::MsgpackRequest* window_set_height(int64_t window, int64_t height);
 	// DEPRECATED
 	// Integer window_get_width(Window window, ) 
-	MsgpackRequest* window_get_width(int64_t window);
+	NeovimQt::MsgpackRequest* window_get_width(int64_t window);
 	// DEPRECATED
 	// void window_set_width(Window window, Integer width, ) 
-	MsgpackRequest* window_set_width(int64_t window, int64_t width);
+	NeovimQt::MsgpackRequest* window_set_width(int64_t window, int64_t width);
 	// DEPRECATED
 	// Object window_get_var(Window window, String name, ) 
-	MsgpackRequest* window_get_var(int64_t window, QByteArray name);
+	NeovimQt::MsgpackRequest* window_get_var(int64_t window, QByteArray name);
 	// DEPRECATED
 	// Object window_get_option(Window window, String name, ) 
-	MsgpackRequest* window_get_option(int64_t window, QByteArray name);
+	NeovimQt::MsgpackRequest* window_get_option(int64_t window, QByteArray name);
 	// DEPRECATED
 	// void window_set_option(Window window, String name, Object value, ) 
-	MsgpackRequest* window_set_option(int64_t window, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* window_set_option(int64_t window, QByteArray name, QVariant value);
 	// DEPRECATED
 	// ArrayOf(Integer, 2) window_get_position(Window window, ) 
-	MsgpackRequest* window_get_position(int64_t window);
+	NeovimQt::MsgpackRequest* window_get_position(int64_t window);
 	// DEPRECATED
 	// Tabpage window_get_tabpage(Window window, ) 
-	MsgpackRequest* window_get_tabpage(int64_t window);
+	NeovimQt::MsgpackRequest* window_get_tabpage(int64_t window);
 	// DEPRECATED
 	// Boolean window_is_valid(Window window, ) 
-	MsgpackRequest* window_is_valid(int64_t window);
+	NeovimQt::MsgpackRequest* window_is_valid(int64_t window);
 
 signals:
 	void on_nvim_buf_line_count(int64_t);
@@ -1187,5 +1189,5 @@ signals:
 	void err_window_is_valid(const QString&, const QVariant&);
 
 };
-} // namespace
-#endif
+
+} // namespace NeovimQt

--- a/src/auto/neovimapi5.h
+++ b/src/auto/neovimapi5.h
@@ -1,13 +1,15 @@
-// Auto generated 2019-06-08 16:53:42.519531 from nvim API level:5
-#ifndef NEOVIM_QT_NEOVIMAPI5
-#define NEOVIM_QT_NEOVIMAPI5
-#include "msgpack.h"
+// Auto generated 2021-07-20 02:41:45.923784 from nvim API level:5
+#pragma once
+
 #include <QObject>
-#include <QVariant>
 #include <QPoint>
+#include <QVariant>
+
 #include "function.h"
+#include "msgpack.h"
 
 namespace NeovimQt {
+
 class NeovimConnector;
 class MsgpackRequest;
 
@@ -221,456 +223,456 @@ private:
 	NeovimConnector *m_c;
 public slots:
 	// Integer nvim_buf_line_count(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_line_count(int64_t buffer);
+	NeovimQt::MsgpackRequest* nvim_buf_line_count(int64_t buffer);
 	// DEPRECATED
 	// String buffer_get_line(Buffer buffer, Integer index, ) 
-	MsgpackRequest* buffer_get_line(int64_t buffer, int64_t index);
+	NeovimQt::MsgpackRequest* buffer_get_line(int64_t buffer, int64_t index);
 	// Boolean nvim_buf_attach(Buffer buffer, Boolean send_buffer, Dictionary opts, ) 
-	MsgpackRequest* nvim_buf_attach(int64_t buffer, bool send_buffer, QVariantMap opts);
+	NeovimQt::MsgpackRequest* nvim_buf_attach(int64_t buffer, bool send_buffer, QVariantMap opts);
 	// Boolean nvim_buf_detach(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_detach(int64_t buffer);
+	NeovimQt::MsgpackRequest* nvim_buf_detach(int64_t buffer);
 	// DEPRECATED
 	// void buffer_set_line(Buffer buffer, Integer index, String line, ) 
-	MsgpackRequest* buffer_set_line(int64_t buffer, int64_t index, QByteArray line);
+	NeovimQt::MsgpackRequest* buffer_set_line(int64_t buffer, int64_t index, QByteArray line);
 	// DEPRECATED
 	// void buffer_del_line(Buffer buffer, Integer index, ) 
-	MsgpackRequest* buffer_del_line(int64_t buffer, int64_t index);
+	NeovimQt::MsgpackRequest* buffer_del_line(int64_t buffer, int64_t index);
 	// DEPRECATED
 	// ArrayOf(String) buffer_get_line_slice(Buffer buffer, Integer start, Integer end, Boolean include_start, Boolean include_end, ) 
-	MsgpackRequest* buffer_get_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end);
+	NeovimQt::MsgpackRequest* buffer_get_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end);
 	// ArrayOf(String) nvim_buf_get_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ) 
-	MsgpackRequest* nvim_buf_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing);
+	NeovimQt::MsgpackRequest* nvim_buf_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing);
 	// DEPRECATED
 	// void buffer_set_line_slice(Buffer buffer, Integer start, Integer end, Boolean include_start, Boolean include_end, ArrayOf(String) replacement, ) 
-	MsgpackRequest* buffer_set_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end, QList<QByteArray> replacement);
+	NeovimQt::MsgpackRequest* buffer_set_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end, QList<QByteArray> replacement);
 	// void nvim_buf_set_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ArrayOf(String) replacement, ) 
-	MsgpackRequest* nvim_buf_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement);
+	NeovimQt::MsgpackRequest* nvim_buf_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement);
 	// Integer nvim_buf_get_offset(Buffer buffer, Integer index, ) 
-	MsgpackRequest* nvim_buf_get_offset(int64_t buffer, int64_t index);
+	NeovimQt::MsgpackRequest* nvim_buf_get_offset(int64_t buffer, int64_t index);
 	// Object nvim_buf_get_var(Buffer buffer, String name, ) 
-	MsgpackRequest* nvim_buf_get_var(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_buf_get_var(int64_t buffer, QByteArray name);
 	// Integer nvim_buf_get_changedtick(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_get_changedtick(int64_t buffer);
+	NeovimQt::MsgpackRequest* nvim_buf_get_changedtick(int64_t buffer);
 	// ArrayOf(Dictionary) nvim_buf_get_keymap(Buffer buffer, String mode, ) 
-	MsgpackRequest* nvim_buf_get_keymap(int64_t buffer, QByteArray mode);
+	NeovimQt::MsgpackRequest* nvim_buf_get_keymap(int64_t buffer, QByteArray mode);
 	// Dictionary nvim_buf_get_commands(Buffer buffer, Dictionary opts, ) 
-	MsgpackRequest* nvim_buf_get_commands(int64_t buffer, QVariantMap opts);
+	NeovimQt::MsgpackRequest* nvim_buf_get_commands(int64_t buffer, QVariantMap opts);
 	// void nvim_buf_set_var(Buffer buffer, String name, Object value, ) 
-	MsgpackRequest* nvim_buf_set_var(int64_t buffer, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* nvim_buf_set_var(int64_t buffer, QByteArray name, QVariant value);
 	// void nvim_buf_del_var(Buffer buffer, String name, ) 
-	MsgpackRequest* nvim_buf_del_var(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_buf_del_var(int64_t buffer, QByteArray name);
 	// DEPRECATED
 	// Object buffer_set_var(Buffer buffer, String name, Object value, ) 
-	MsgpackRequest* buffer_set_var(int64_t buffer, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* buffer_set_var(int64_t buffer, QByteArray name, QVariant value);
 	// DEPRECATED
 	// Object buffer_del_var(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_del_var(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* buffer_del_var(int64_t buffer, QByteArray name);
 	// Object nvim_buf_get_option(Buffer buffer, String name, ) 
-	MsgpackRequest* nvim_buf_get_option(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_buf_get_option(int64_t buffer, QByteArray name);
 	// void nvim_buf_set_option(Buffer buffer, String name, Object value, ) 
-	MsgpackRequest* nvim_buf_set_option(int64_t buffer, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* nvim_buf_set_option(int64_t buffer, QByteArray name, QVariant value);
 	// DEPRECATED
 	// Integer nvim_buf_get_number(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_get_number(int64_t buffer);
+	NeovimQt::MsgpackRequest* nvim_buf_get_number(int64_t buffer);
 	// String nvim_buf_get_name(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_get_name(int64_t buffer);
+	NeovimQt::MsgpackRequest* nvim_buf_get_name(int64_t buffer);
 	// void nvim_buf_set_name(Buffer buffer, String name, ) 
-	MsgpackRequest* nvim_buf_set_name(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_buf_set_name(int64_t buffer, QByteArray name);
 	// Boolean nvim_buf_is_loaded(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_is_loaded(int64_t buffer);
+	NeovimQt::MsgpackRequest* nvim_buf_is_loaded(int64_t buffer);
 	// Boolean nvim_buf_is_valid(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_is_valid(int64_t buffer);
+	NeovimQt::MsgpackRequest* nvim_buf_is_valid(int64_t buffer);
 	// DEPRECATED
 	// void buffer_insert(Buffer buffer, Integer lnum, ArrayOf(String) lines, ) 
-	MsgpackRequest* buffer_insert(int64_t buffer, int64_t lnum, QList<QByteArray> lines);
+	NeovimQt::MsgpackRequest* buffer_insert(int64_t buffer, int64_t lnum, QList<QByteArray> lines);
 	// ArrayOf(Integer, 2) nvim_buf_get_mark(Buffer buffer, String name, ) 
-	MsgpackRequest* nvim_buf_get_mark(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_buf_get_mark(int64_t buffer, QByteArray name);
 	// Integer nvim_buf_add_highlight(Buffer buffer, Integer ns_id, String hl_group, Integer line, Integer col_start, Integer col_end, ) 
-	MsgpackRequest* nvim_buf_add_highlight(int64_t buffer, int64_t ns_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end);
+	NeovimQt::MsgpackRequest* nvim_buf_add_highlight(int64_t buffer, int64_t ns_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end);
 	// void nvim_buf_clear_namespace(Buffer buffer, Integer ns_id, Integer line_start, Integer line_end, ) 
-	MsgpackRequest* nvim_buf_clear_namespace(int64_t buffer, int64_t ns_id, int64_t line_start, int64_t line_end);
+	NeovimQt::MsgpackRequest* nvim_buf_clear_namespace(int64_t buffer, int64_t ns_id, int64_t line_start, int64_t line_end);
 	// void nvim_buf_clear_highlight(Buffer buffer, Integer ns_id, Integer line_start, Integer line_end, ) 
-	MsgpackRequest* nvim_buf_clear_highlight(int64_t buffer, int64_t ns_id, int64_t line_start, int64_t line_end);
+	NeovimQt::MsgpackRequest* nvim_buf_clear_highlight(int64_t buffer, int64_t ns_id, int64_t line_start, int64_t line_end);
 	// Integer nvim_buf_set_virtual_text(Buffer buffer, Integer ns_id, Integer line, Array chunks, Dictionary opts, ) 
-	MsgpackRequest* nvim_buf_set_virtual_text(int64_t buffer, int64_t ns_id, int64_t line, QVariantList chunks, QVariantMap opts);
+	NeovimQt::MsgpackRequest* nvim_buf_set_virtual_text(int64_t buffer, int64_t ns_id, int64_t line, QVariantList chunks, QVariantMap opts);
 	// ArrayOf(Window) nvim_tabpage_list_wins(Tabpage tabpage, ) 
-	MsgpackRequest* nvim_tabpage_list_wins(int64_t tabpage);
+	NeovimQt::MsgpackRequest* nvim_tabpage_list_wins(int64_t tabpage);
 	// Object nvim_tabpage_get_var(Tabpage tabpage, String name, ) 
-	MsgpackRequest* nvim_tabpage_get_var(int64_t tabpage, QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_tabpage_get_var(int64_t tabpage, QByteArray name);
 	// void nvim_tabpage_set_var(Tabpage tabpage, String name, Object value, ) 
-	MsgpackRequest* nvim_tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* nvim_tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value);
 	// void nvim_tabpage_del_var(Tabpage tabpage, String name, ) 
-	MsgpackRequest* nvim_tabpage_del_var(int64_t tabpage, QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_tabpage_del_var(int64_t tabpage, QByteArray name);
 	// DEPRECATED
 	// Object tabpage_set_var(Tabpage tabpage, String name, Object value, ) 
-	MsgpackRequest* tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value);
 	// DEPRECATED
 	// Object tabpage_del_var(Tabpage tabpage, String name, ) 
-	MsgpackRequest* tabpage_del_var(int64_t tabpage, QByteArray name);
+	NeovimQt::MsgpackRequest* tabpage_del_var(int64_t tabpage, QByteArray name);
 	// Window nvim_tabpage_get_win(Tabpage tabpage, ) 
-	MsgpackRequest* nvim_tabpage_get_win(int64_t tabpage);
+	NeovimQt::MsgpackRequest* nvim_tabpage_get_win(int64_t tabpage);
 	// Integer nvim_tabpage_get_number(Tabpage tabpage, ) 
-	MsgpackRequest* nvim_tabpage_get_number(int64_t tabpage);
+	NeovimQt::MsgpackRequest* nvim_tabpage_get_number(int64_t tabpage);
 	// Boolean nvim_tabpage_is_valid(Tabpage tabpage, ) 
-	MsgpackRequest* nvim_tabpage_is_valid(int64_t tabpage);
+	NeovimQt::MsgpackRequest* nvim_tabpage_is_valid(int64_t tabpage);
 	// void nvim_ui_attach(Integer width, Integer height, Dictionary options, ) 
-	MsgpackRequest* nvim_ui_attach(int64_t width, int64_t height, QVariantMap options);
+	NeovimQt::MsgpackRequest* nvim_ui_attach(int64_t width, int64_t height, QVariantMap options);
 	// DEPRECATED
 	// void ui_attach(Integer width, Integer height, Boolean enable_rgb, ) 
-	MsgpackRequest* ui_attach(int64_t width, int64_t height, bool enable_rgb);
+	NeovimQt::MsgpackRequest* ui_attach(int64_t width, int64_t height, bool enable_rgb);
 	// void nvim_ui_detach() 
-	MsgpackRequest* nvim_ui_detach();
+	NeovimQt::MsgpackRequest* nvim_ui_detach();
 	// void nvim_ui_try_resize(Integer width, Integer height, ) 
-	MsgpackRequest* nvim_ui_try_resize(int64_t width, int64_t height);
+	NeovimQt::MsgpackRequest* nvim_ui_try_resize(int64_t width, int64_t height);
 	// void nvim_ui_set_option(String name, Object value, ) 
-	MsgpackRequest* nvim_ui_set_option(QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* nvim_ui_set_option(QByteArray name, QVariant value);
 	// void nvim_command(String command, ) 
-	MsgpackRequest* nvim_command(QByteArray command);
+	NeovimQt::MsgpackRequest* nvim_command(QByteArray command);
 	// Dictionary nvim_get_hl_by_name(String name, Boolean rgb, ) 
-	MsgpackRequest* nvim_get_hl_by_name(QByteArray name, bool rgb);
+	NeovimQt::MsgpackRequest* nvim_get_hl_by_name(QByteArray name, bool rgb);
 	// Dictionary nvim_get_hl_by_id(Integer hl_id, Boolean rgb, ) 
-	MsgpackRequest* nvim_get_hl_by_id(int64_t hl_id, bool rgb);
+	NeovimQt::MsgpackRequest* nvim_get_hl_by_id(int64_t hl_id, bool rgb);
 	// void nvim_feedkeys(String keys, String mode, Boolean escape_csi, ) 
-	MsgpackRequest* nvim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi);
+	NeovimQt::MsgpackRequest* nvim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi);
 	// Integer nvim_input(String keys, ) 
-	MsgpackRequest* nvim_input(QByteArray keys);
+	NeovimQt::MsgpackRequest* nvim_input(QByteArray keys);
 	// String nvim_replace_termcodes(String str, Boolean from_part, Boolean do_lt, Boolean special, ) 
-	MsgpackRequest* nvim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special);
+	NeovimQt::MsgpackRequest* nvim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special);
 	// String nvim_command_output(String command, ) 
-	MsgpackRequest* nvim_command_output(QByteArray command);
+	NeovimQt::MsgpackRequest* nvim_command_output(QByteArray command);
 	// Object nvim_eval(String expr, ) 
-	MsgpackRequest* nvim_eval(QByteArray expr);
+	NeovimQt::MsgpackRequest* nvim_eval(QByteArray expr);
 	// Object nvim_execute_lua(String code, Array args, ) 
-	MsgpackRequest* nvim_execute_lua(QByteArray code, QVariantList args);
+	NeovimQt::MsgpackRequest* nvim_execute_lua(QByteArray code, QVariantList args);
 	// Object nvim_call_function(String fn, Array args, ) 
-	MsgpackRequest* nvim_call_function(QByteArray fn, QVariantList args);
+	NeovimQt::MsgpackRequest* nvim_call_function(QByteArray fn, QVariantList args);
 	// Object nvim_call_dict_function(Object dict, String fn, Array args, ) 
-	MsgpackRequest* nvim_call_dict_function(QVariant dict, QByteArray fn, QVariantList args);
+	NeovimQt::MsgpackRequest* nvim_call_dict_function(QVariant dict, QByteArray fn, QVariantList args);
 	// Integer nvim_strwidth(String text, ) 
-	MsgpackRequest* nvim_strwidth(QByteArray text);
+	NeovimQt::MsgpackRequest* nvim_strwidth(QByteArray text);
 	// ArrayOf(String) nvim_list_runtime_paths() 
-	MsgpackRequest* nvim_list_runtime_paths();
+	NeovimQt::MsgpackRequest* nvim_list_runtime_paths();
 	// void nvim_set_current_dir(String dir, ) 
-	MsgpackRequest* nvim_set_current_dir(QByteArray dir);
+	NeovimQt::MsgpackRequest* nvim_set_current_dir(QByteArray dir);
 	// String nvim_get_current_line() 
-	MsgpackRequest* nvim_get_current_line();
+	NeovimQt::MsgpackRequest* nvim_get_current_line();
 	// void nvim_set_current_line(String line, ) 
-	MsgpackRequest* nvim_set_current_line(QByteArray line);
+	NeovimQt::MsgpackRequest* nvim_set_current_line(QByteArray line);
 	// void nvim_del_current_line() 
-	MsgpackRequest* nvim_del_current_line();
+	NeovimQt::MsgpackRequest* nvim_del_current_line();
 	// Object nvim_get_var(String name, ) 
-	MsgpackRequest* nvim_get_var(QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_get_var(QByteArray name);
 	// void nvim_set_var(String name, Object value, ) 
-	MsgpackRequest* nvim_set_var(QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* nvim_set_var(QByteArray name, QVariant value);
 	// void nvim_del_var(String name, ) 
-	MsgpackRequest* nvim_del_var(QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_del_var(QByteArray name);
 	// DEPRECATED
 	// Object vim_set_var(String name, Object value, ) 
-	MsgpackRequest* vim_set_var(QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* vim_set_var(QByteArray name, QVariant value);
 	// DEPRECATED
 	// Object vim_del_var(String name, ) 
-	MsgpackRequest* vim_del_var(QByteArray name);
+	NeovimQt::MsgpackRequest* vim_del_var(QByteArray name);
 	// Object nvim_get_vvar(String name, ) 
-	MsgpackRequest* nvim_get_vvar(QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_get_vvar(QByteArray name);
 	// Object nvim_get_option(String name, ) 
-	MsgpackRequest* nvim_get_option(QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_get_option(QByteArray name);
 	// void nvim_set_option(String name, Object value, ) 
-	MsgpackRequest* nvim_set_option(QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* nvim_set_option(QByteArray name, QVariant value);
 	// void nvim_out_write(String str, ) 
-	MsgpackRequest* nvim_out_write(QByteArray str);
+	NeovimQt::MsgpackRequest* nvim_out_write(QByteArray str);
 	// void nvim_err_write(String str, ) 
-	MsgpackRequest* nvim_err_write(QByteArray str);
+	NeovimQt::MsgpackRequest* nvim_err_write(QByteArray str);
 	// void nvim_err_writeln(String str, ) 
-	MsgpackRequest* nvim_err_writeln(QByteArray str);
+	NeovimQt::MsgpackRequest* nvim_err_writeln(QByteArray str);
 	// ArrayOf(Buffer) nvim_list_bufs() 
-	MsgpackRequest* nvim_list_bufs();
+	NeovimQt::MsgpackRequest* nvim_list_bufs();
 	// Buffer nvim_get_current_buf() 
-	MsgpackRequest* nvim_get_current_buf();
+	NeovimQt::MsgpackRequest* nvim_get_current_buf();
 	// void nvim_set_current_buf(Buffer buffer, ) 
-	MsgpackRequest* nvim_set_current_buf(int64_t buffer);
+	NeovimQt::MsgpackRequest* nvim_set_current_buf(int64_t buffer);
 	// ArrayOf(Window) nvim_list_wins() 
-	MsgpackRequest* nvim_list_wins();
+	NeovimQt::MsgpackRequest* nvim_list_wins();
 	// Window nvim_get_current_win() 
-	MsgpackRequest* nvim_get_current_win();
+	NeovimQt::MsgpackRequest* nvim_get_current_win();
 	// void nvim_set_current_win(Window window, ) 
-	MsgpackRequest* nvim_set_current_win(int64_t window);
+	NeovimQt::MsgpackRequest* nvim_set_current_win(int64_t window);
 	// ArrayOf(Tabpage) nvim_list_tabpages() 
-	MsgpackRequest* nvim_list_tabpages();
+	NeovimQt::MsgpackRequest* nvim_list_tabpages();
 	// Tabpage nvim_get_current_tabpage() 
-	MsgpackRequest* nvim_get_current_tabpage();
+	NeovimQt::MsgpackRequest* nvim_get_current_tabpage();
 	// void nvim_set_current_tabpage(Tabpage tabpage, ) 
-	MsgpackRequest* nvim_set_current_tabpage(int64_t tabpage);
+	NeovimQt::MsgpackRequest* nvim_set_current_tabpage(int64_t tabpage);
 	// Integer nvim_create_namespace(String name, ) 
-	MsgpackRequest* nvim_create_namespace(QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_create_namespace(QByteArray name);
 	// Dictionary nvim_get_namespaces() 
-	MsgpackRequest* nvim_get_namespaces();
+	NeovimQt::MsgpackRequest* nvim_get_namespaces();
 	// void nvim_subscribe(String event, ) 
-	MsgpackRequest* nvim_subscribe(QByteArray event);
+	NeovimQt::MsgpackRequest* nvim_subscribe(QByteArray event);
 	// void nvim_unsubscribe(String event, ) 
-	MsgpackRequest* nvim_unsubscribe(QByteArray event);
+	NeovimQt::MsgpackRequest* nvim_unsubscribe(QByteArray event);
 	// Integer nvim_get_color_by_name(String name, ) 
-	MsgpackRequest* nvim_get_color_by_name(QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_get_color_by_name(QByteArray name);
 	// Dictionary nvim_get_color_map() 
-	MsgpackRequest* nvim_get_color_map();
+	NeovimQt::MsgpackRequest* nvim_get_color_map();
 	// Dictionary nvim_get_mode() 
-	MsgpackRequest* nvim_get_mode();
+	NeovimQt::MsgpackRequest* nvim_get_mode();
 	// ArrayOf(Dictionary) nvim_get_keymap(String mode, ) 
-	MsgpackRequest* nvim_get_keymap(QByteArray mode);
+	NeovimQt::MsgpackRequest* nvim_get_keymap(QByteArray mode);
 	// Dictionary nvim_get_commands(Dictionary opts, ) 
-	MsgpackRequest* nvim_get_commands(QVariantMap opts);
+	NeovimQt::MsgpackRequest* nvim_get_commands(QVariantMap opts);
 	// Array nvim_get_api_info() 
-	MsgpackRequest* nvim_get_api_info();
+	NeovimQt::MsgpackRequest* nvim_get_api_info();
 	// void nvim_set_client_info(String name, Dictionary version, String type, Dictionary methods, Dictionary attributes, ) 
-	MsgpackRequest* nvim_set_client_info(QByteArray name, QVariantMap version, QByteArray type, QVariantMap methods, QVariantMap attributes);
+	NeovimQt::MsgpackRequest* nvim_set_client_info(QByteArray name, QVariantMap version, QByteArray type, QVariantMap methods, QVariantMap attributes);
 	// Dictionary nvim_get_chan_info(Integer chan, ) 
-	MsgpackRequest* nvim_get_chan_info(int64_t chan);
+	NeovimQt::MsgpackRequest* nvim_get_chan_info(int64_t chan);
 	// Array nvim_list_chans() 
-	MsgpackRequest* nvim_list_chans();
+	NeovimQt::MsgpackRequest* nvim_list_chans();
 	// Array nvim_call_atomic(Array calls, ) 
-	MsgpackRequest* nvim_call_atomic(QVariantList calls);
+	NeovimQt::MsgpackRequest* nvim_call_atomic(QVariantList calls);
 	// Dictionary nvim_parse_expression(String expr, String flags, Boolean highlight, ) 
-	MsgpackRequest* nvim_parse_expression(QByteArray expr, QByteArray flags, bool highlight);
+	NeovimQt::MsgpackRequest* nvim_parse_expression(QByteArray expr, QByteArray flags, bool highlight);
 	// Array nvim_list_uis() 
-	MsgpackRequest* nvim_list_uis();
+	NeovimQt::MsgpackRequest* nvim_list_uis();
 	// Array nvim_get_proc_children(Integer pid, ) 
-	MsgpackRequest* nvim_get_proc_children(int64_t pid);
+	NeovimQt::MsgpackRequest* nvim_get_proc_children(int64_t pid);
 	// Object nvim_get_proc(Integer pid, ) 
-	MsgpackRequest* nvim_get_proc(int64_t pid);
+	NeovimQt::MsgpackRequest* nvim_get_proc(int64_t pid);
 	// Buffer nvim_win_get_buf(Window window, ) 
-	MsgpackRequest* nvim_win_get_buf(int64_t window);
+	NeovimQt::MsgpackRequest* nvim_win_get_buf(int64_t window);
 	// void nvim_win_set_buf(Window window, Buffer buffer, ) 
-	MsgpackRequest* nvim_win_set_buf(int64_t window, int64_t buffer);
+	NeovimQt::MsgpackRequest* nvim_win_set_buf(int64_t window, int64_t buffer);
 	// ArrayOf(Integer, 2) nvim_win_get_cursor(Window window, ) 
-	MsgpackRequest* nvim_win_get_cursor(int64_t window);
+	NeovimQt::MsgpackRequest* nvim_win_get_cursor(int64_t window);
 	// void nvim_win_set_cursor(Window window, ArrayOf(Integer, 2) pos, ) 
-	MsgpackRequest* nvim_win_set_cursor(int64_t window, QPoint pos);
+	NeovimQt::MsgpackRequest* nvim_win_set_cursor(int64_t window, QPoint pos);
 	// Integer nvim_win_get_height(Window window, ) 
-	MsgpackRequest* nvim_win_get_height(int64_t window);
+	NeovimQt::MsgpackRequest* nvim_win_get_height(int64_t window);
 	// void nvim_win_set_height(Window window, Integer height, ) 
-	MsgpackRequest* nvim_win_set_height(int64_t window, int64_t height);
+	NeovimQt::MsgpackRequest* nvim_win_set_height(int64_t window, int64_t height);
 	// Integer nvim_win_get_width(Window window, ) 
-	MsgpackRequest* nvim_win_get_width(int64_t window);
+	NeovimQt::MsgpackRequest* nvim_win_get_width(int64_t window);
 	// void nvim_win_set_width(Window window, Integer width, ) 
-	MsgpackRequest* nvim_win_set_width(int64_t window, int64_t width);
+	NeovimQt::MsgpackRequest* nvim_win_set_width(int64_t window, int64_t width);
 	// Object nvim_win_get_var(Window window, String name, ) 
-	MsgpackRequest* nvim_win_get_var(int64_t window, QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_win_get_var(int64_t window, QByteArray name);
 	// void nvim_win_set_var(Window window, String name, Object value, ) 
-	MsgpackRequest* nvim_win_set_var(int64_t window, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* nvim_win_set_var(int64_t window, QByteArray name, QVariant value);
 	// void nvim_win_del_var(Window window, String name, ) 
-	MsgpackRequest* nvim_win_del_var(int64_t window, QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_win_del_var(int64_t window, QByteArray name);
 	// DEPRECATED
 	// Object window_set_var(Window window, String name, Object value, ) 
-	MsgpackRequest* window_set_var(int64_t window, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* window_set_var(int64_t window, QByteArray name, QVariant value);
 	// DEPRECATED
 	// Object window_del_var(Window window, String name, ) 
-	MsgpackRequest* window_del_var(int64_t window, QByteArray name);
+	NeovimQt::MsgpackRequest* window_del_var(int64_t window, QByteArray name);
 	// Object nvim_win_get_option(Window window, String name, ) 
-	MsgpackRequest* nvim_win_get_option(int64_t window, QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_win_get_option(int64_t window, QByteArray name);
 	// void nvim_win_set_option(Window window, String name, Object value, ) 
-	MsgpackRequest* nvim_win_set_option(int64_t window, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* nvim_win_set_option(int64_t window, QByteArray name, QVariant value);
 	// ArrayOf(Integer, 2) nvim_win_get_position(Window window, ) 
-	MsgpackRequest* nvim_win_get_position(int64_t window);
+	NeovimQt::MsgpackRequest* nvim_win_get_position(int64_t window);
 	// Tabpage nvim_win_get_tabpage(Window window, ) 
-	MsgpackRequest* nvim_win_get_tabpage(int64_t window);
+	NeovimQt::MsgpackRequest* nvim_win_get_tabpage(int64_t window);
 	// Integer nvim_win_get_number(Window window, ) 
-	MsgpackRequest* nvim_win_get_number(int64_t window);
+	NeovimQt::MsgpackRequest* nvim_win_get_number(int64_t window);
 	// Boolean nvim_win_is_valid(Window window, ) 
-	MsgpackRequest* nvim_win_is_valid(int64_t window);
+	NeovimQt::MsgpackRequest* nvim_win_is_valid(int64_t window);
 	// DEPRECATED
 	// Integer buffer_line_count(Buffer buffer, ) 
-	MsgpackRequest* buffer_line_count(int64_t buffer);
+	NeovimQt::MsgpackRequest* buffer_line_count(int64_t buffer);
 	// DEPRECATED
 	// ArrayOf(String) buffer_get_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ) 
-	MsgpackRequest* buffer_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing);
+	NeovimQt::MsgpackRequest* buffer_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing);
 	// DEPRECATED
 	// void buffer_set_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ArrayOf(String) replacement, ) 
-	MsgpackRequest* buffer_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement);
+	NeovimQt::MsgpackRequest* buffer_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement);
 	// DEPRECATED
 	// Object buffer_get_var(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_get_var(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* buffer_get_var(int64_t buffer, QByteArray name);
 	// DEPRECATED
 	// Object buffer_get_option(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_get_option(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* buffer_get_option(int64_t buffer, QByteArray name);
 	// DEPRECATED
 	// void buffer_set_option(Buffer buffer, String name, Object value, ) 
-	MsgpackRequest* buffer_set_option(int64_t buffer, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* buffer_set_option(int64_t buffer, QByteArray name, QVariant value);
 	// DEPRECATED
 	// Integer buffer_get_number(Buffer buffer, ) 
-	MsgpackRequest* buffer_get_number(int64_t buffer);
+	NeovimQt::MsgpackRequest* buffer_get_number(int64_t buffer);
 	// DEPRECATED
 	// String buffer_get_name(Buffer buffer, ) 
-	MsgpackRequest* buffer_get_name(int64_t buffer);
+	NeovimQt::MsgpackRequest* buffer_get_name(int64_t buffer);
 	// DEPRECATED
 	// void buffer_set_name(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_set_name(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* buffer_set_name(int64_t buffer, QByteArray name);
 	// DEPRECATED
 	// Boolean buffer_is_valid(Buffer buffer, ) 
-	MsgpackRequest* buffer_is_valid(int64_t buffer);
+	NeovimQt::MsgpackRequest* buffer_is_valid(int64_t buffer);
 	// DEPRECATED
 	// ArrayOf(Integer, 2) buffer_get_mark(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_get_mark(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* buffer_get_mark(int64_t buffer, QByteArray name);
 	// DEPRECATED
 	// Integer buffer_add_highlight(Buffer buffer, Integer ns_id, String hl_group, Integer line, Integer col_start, Integer col_end, ) 
-	MsgpackRequest* buffer_add_highlight(int64_t buffer, int64_t ns_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end);
+	NeovimQt::MsgpackRequest* buffer_add_highlight(int64_t buffer, int64_t ns_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end);
 	// DEPRECATED
 	// void buffer_clear_highlight(Buffer buffer, Integer ns_id, Integer line_start, Integer line_end, ) 
-	MsgpackRequest* buffer_clear_highlight(int64_t buffer, int64_t ns_id, int64_t line_start, int64_t line_end);
+	NeovimQt::MsgpackRequest* buffer_clear_highlight(int64_t buffer, int64_t ns_id, int64_t line_start, int64_t line_end);
 	// DEPRECATED
 	// ArrayOf(Window) tabpage_get_windows(Tabpage tabpage, ) 
-	MsgpackRequest* tabpage_get_windows(int64_t tabpage);
+	NeovimQt::MsgpackRequest* tabpage_get_windows(int64_t tabpage);
 	// DEPRECATED
 	// Object tabpage_get_var(Tabpage tabpage, String name, ) 
-	MsgpackRequest* tabpage_get_var(int64_t tabpage, QByteArray name);
+	NeovimQt::MsgpackRequest* tabpage_get_var(int64_t tabpage, QByteArray name);
 	// DEPRECATED
 	// Window tabpage_get_window(Tabpage tabpage, ) 
-	MsgpackRequest* tabpage_get_window(int64_t tabpage);
+	NeovimQt::MsgpackRequest* tabpage_get_window(int64_t tabpage);
 	// DEPRECATED
 	// Boolean tabpage_is_valid(Tabpage tabpage, ) 
-	MsgpackRequest* tabpage_is_valid(int64_t tabpage);
+	NeovimQt::MsgpackRequest* tabpage_is_valid(int64_t tabpage);
 	// DEPRECATED
 	// void ui_detach() 
-	MsgpackRequest* ui_detach();
+	NeovimQt::MsgpackRequest* ui_detach();
 	// DEPRECATED
 	// Object ui_try_resize(Integer width, Integer height, ) 
-	MsgpackRequest* ui_try_resize(int64_t width, int64_t height);
+	NeovimQt::MsgpackRequest* ui_try_resize(int64_t width, int64_t height);
 	// DEPRECATED
 	// void vim_command(String command, ) 
-	MsgpackRequest* vim_command(QByteArray command);
+	NeovimQt::MsgpackRequest* vim_command(QByteArray command);
 	// DEPRECATED
 	// void vim_feedkeys(String keys, String mode, Boolean escape_csi, ) 
-	MsgpackRequest* vim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi);
+	NeovimQt::MsgpackRequest* vim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi);
 	// DEPRECATED
 	// Integer vim_input(String keys, ) 
-	MsgpackRequest* vim_input(QByteArray keys);
+	NeovimQt::MsgpackRequest* vim_input(QByteArray keys);
 	// DEPRECATED
 	// String vim_replace_termcodes(String str, Boolean from_part, Boolean do_lt, Boolean special, ) 
-	MsgpackRequest* vim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special);
+	NeovimQt::MsgpackRequest* vim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special);
 	// DEPRECATED
 	// String vim_command_output(String command, ) 
-	MsgpackRequest* vim_command_output(QByteArray command);
+	NeovimQt::MsgpackRequest* vim_command_output(QByteArray command);
 	// DEPRECATED
 	// Object vim_eval(String expr, ) 
-	MsgpackRequest* vim_eval(QByteArray expr);
+	NeovimQt::MsgpackRequest* vim_eval(QByteArray expr);
 	// DEPRECATED
 	// Object vim_call_function(String fn, Array args, ) 
-	MsgpackRequest* vim_call_function(QByteArray fn, QVariantList args);
+	NeovimQt::MsgpackRequest* vim_call_function(QByteArray fn, QVariantList args);
 	// DEPRECATED
 	// Integer vim_strwidth(String text, ) 
-	MsgpackRequest* vim_strwidth(QByteArray text);
+	NeovimQt::MsgpackRequest* vim_strwidth(QByteArray text);
 	// DEPRECATED
 	// ArrayOf(String) vim_list_runtime_paths() 
-	MsgpackRequest* vim_list_runtime_paths();
+	NeovimQt::MsgpackRequest* vim_list_runtime_paths();
 	// DEPRECATED
 	// void vim_change_directory(String dir, ) 
-	MsgpackRequest* vim_change_directory(QByteArray dir);
+	NeovimQt::MsgpackRequest* vim_change_directory(QByteArray dir);
 	// DEPRECATED
 	// String vim_get_current_line() 
-	MsgpackRequest* vim_get_current_line();
+	NeovimQt::MsgpackRequest* vim_get_current_line();
 	// DEPRECATED
 	// void vim_set_current_line(String line, ) 
-	MsgpackRequest* vim_set_current_line(QByteArray line);
+	NeovimQt::MsgpackRequest* vim_set_current_line(QByteArray line);
 	// DEPRECATED
 	// void vim_del_current_line() 
-	MsgpackRequest* vim_del_current_line();
+	NeovimQt::MsgpackRequest* vim_del_current_line();
 	// DEPRECATED
 	// Object vim_get_var(String name, ) 
-	MsgpackRequest* vim_get_var(QByteArray name);
+	NeovimQt::MsgpackRequest* vim_get_var(QByteArray name);
 	// DEPRECATED
 	// Object vim_get_vvar(String name, ) 
-	MsgpackRequest* vim_get_vvar(QByteArray name);
+	NeovimQt::MsgpackRequest* vim_get_vvar(QByteArray name);
 	// DEPRECATED
 	// Object vim_get_option(String name, ) 
-	MsgpackRequest* vim_get_option(QByteArray name);
+	NeovimQt::MsgpackRequest* vim_get_option(QByteArray name);
 	// DEPRECATED
 	// void vim_set_option(String name, Object value, ) 
-	MsgpackRequest* vim_set_option(QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* vim_set_option(QByteArray name, QVariant value);
 	// DEPRECATED
 	// void vim_out_write(String str, ) 
-	MsgpackRequest* vim_out_write(QByteArray str);
+	NeovimQt::MsgpackRequest* vim_out_write(QByteArray str);
 	// DEPRECATED
 	// void vim_err_write(String str, ) 
-	MsgpackRequest* vim_err_write(QByteArray str);
+	NeovimQt::MsgpackRequest* vim_err_write(QByteArray str);
 	// DEPRECATED
 	// void vim_report_error(String str, ) 
-	MsgpackRequest* vim_report_error(QByteArray str);
+	NeovimQt::MsgpackRequest* vim_report_error(QByteArray str);
 	// DEPRECATED
 	// ArrayOf(Buffer) vim_get_buffers() 
-	MsgpackRequest* vim_get_buffers();
+	NeovimQt::MsgpackRequest* vim_get_buffers();
 	// DEPRECATED
 	// Buffer vim_get_current_buffer() 
-	MsgpackRequest* vim_get_current_buffer();
+	NeovimQt::MsgpackRequest* vim_get_current_buffer();
 	// DEPRECATED
 	// void vim_set_current_buffer(Buffer buffer, ) 
-	MsgpackRequest* vim_set_current_buffer(int64_t buffer);
+	NeovimQt::MsgpackRequest* vim_set_current_buffer(int64_t buffer);
 	// DEPRECATED
 	// ArrayOf(Window) vim_get_windows() 
-	MsgpackRequest* vim_get_windows();
+	NeovimQt::MsgpackRequest* vim_get_windows();
 	// DEPRECATED
 	// Window vim_get_current_window() 
-	MsgpackRequest* vim_get_current_window();
+	NeovimQt::MsgpackRequest* vim_get_current_window();
 	// DEPRECATED
 	// void vim_set_current_window(Window window, ) 
-	MsgpackRequest* vim_set_current_window(int64_t window);
+	NeovimQt::MsgpackRequest* vim_set_current_window(int64_t window);
 	// DEPRECATED
 	// ArrayOf(Tabpage) vim_get_tabpages() 
-	MsgpackRequest* vim_get_tabpages();
+	NeovimQt::MsgpackRequest* vim_get_tabpages();
 	// DEPRECATED
 	// Tabpage vim_get_current_tabpage() 
-	MsgpackRequest* vim_get_current_tabpage();
+	NeovimQt::MsgpackRequest* vim_get_current_tabpage();
 	// DEPRECATED
 	// void vim_set_current_tabpage(Tabpage tabpage, ) 
-	MsgpackRequest* vim_set_current_tabpage(int64_t tabpage);
+	NeovimQt::MsgpackRequest* vim_set_current_tabpage(int64_t tabpage);
 	// DEPRECATED
 	// void vim_subscribe(String event, ) 
-	MsgpackRequest* vim_subscribe(QByteArray event);
+	NeovimQt::MsgpackRequest* vim_subscribe(QByteArray event);
 	// DEPRECATED
 	// void vim_unsubscribe(String event, ) 
-	MsgpackRequest* vim_unsubscribe(QByteArray event);
+	NeovimQt::MsgpackRequest* vim_unsubscribe(QByteArray event);
 	// DEPRECATED
 	// Integer vim_name_to_color(String name, ) 
-	MsgpackRequest* vim_name_to_color(QByteArray name);
+	NeovimQt::MsgpackRequest* vim_name_to_color(QByteArray name);
 	// DEPRECATED
 	// Dictionary vim_get_color_map() 
-	MsgpackRequest* vim_get_color_map();
+	NeovimQt::MsgpackRequest* vim_get_color_map();
 	// DEPRECATED
 	// Buffer window_get_buffer(Window window, ) 
-	MsgpackRequest* window_get_buffer(int64_t window);
+	NeovimQt::MsgpackRequest* window_get_buffer(int64_t window);
 	// DEPRECATED
 	// ArrayOf(Integer, 2) window_get_cursor(Window window, ) 
-	MsgpackRequest* window_get_cursor(int64_t window);
+	NeovimQt::MsgpackRequest* window_get_cursor(int64_t window);
 	// DEPRECATED
 	// void window_set_cursor(Window window, ArrayOf(Integer, 2) pos, ) 
-	MsgpackRequest* window_set_cursor(int64_t window, QPoint pos);
+	NeovimQt::MsgpackRequest* window_set_cursor(int64_t window, QPoint pos);
 	// DEPRECATED
 	// Integer window_get_height(Window window, ) 
-	MsgpackRequest* window_get_height(int64_t window);
+	NeovimQt::MsgpackRequest* window_get_height(int64_t window);
 	// DEPRECATED
 	// void window_set_height(Window window, Integer height, ) 
-	MsgpackRequest* window_set_height(int64_t window, int64_t height);
+	NeovimQt::MsgpackRequest* window_set_height(int64_t window, int64_t height);
 	// DEPRECATED
 	// Integer window_get_width(Window window, ) 
-	MsgpackRequest* window_get_width(int64_t window);
+	NeovimQt::MsgpackRequest* window_get_width(int64_t window);
 	// DEPRECATED
 	// void window_set_width(Window window, Integer width, ) 
-	MsgpackRequest* window_set_width(int64_t window, int64_t width);
+	NeovimQt::MsgpackRequest* window_set_width(int64_t window, int64_t width);
 	// DEPRECATED
 	// Object window_get_var(Window window, String name, ) 
-	MsgpackRequest* window_get_var(int64_t window, QByteArray name);
+	NeovimQt::MsgpackRequest* window_get_var(int64_t window, QByteArray name);
 	// DEPRECATED
 	// Object window_get_option(Window window, String name, ) 
-	MsgpackRequest* window_get_option(int64_t window, QByteArray name);
+	NeovimQt::MsgpackRequest* window_get_option(int64_t window, QByteArray name);
 	// DEPRECATED
 	// void window_set_option(Window window, String name, Object value, ) 
-	MsgpackRequest* window_set_option(int64_t window, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* window_set_option(int64_t window, QByteArray name, QVariant value);
 	// DEPRECATED
 	// ArrayOf(Integer, 2) window_get_position(Window window, ) 
-	MsgpackRequest* window_get_position(int64_t window);
+	NeovimQt::MsgpackRequest* window_get_position(int64_t window);
 	// DEPRECATED
 	// Tabpage window_get_tabpage(Window window, ) 
-	MsgpackRequest* window_get_tabpage(int64_t window);
+	NeovimQt::MsgpackRequest* window_get_tabpage(int64_t window);
 	// DEPRECATED
 	// Boolean window_is_valid(Window window, ) 
-	MsgpackRequest* window_is_valid(int64_t window);
+	NeovimQt::MsgpackRequest* window_is_valid(int64_t window);
 
 signals:
 	void on_nvim_buf_line_count(int64_t);
@@ -1229,5 +1231,5 @@ signals:
 	void err_window_is_valid(const QString&, const QVariant&);
 
 };
-} // namespace
-#endif
+
+} // namespace NeovimQt

--- a/src/auto/neovimapi6.cpp
+++ b/src/auto/neovimapi6.cpp
@@ -1,4 +1,4 @@
-// Auto generated 2019-01-13 02:04:50.926393 from nvim API level:6
+// Auto generated 2021-07-20 02:42:32.035419 from nvim API level:6
 #include "auto/neovimapi6.h"
 #include "neovimconnector.h"
 #include "msgpackrequest.h"
@@ -198,6 +198,30 @@ MsgpackRequest* NeovimApi6::nvim_buf_get_keymap(int64_t buffer, QByteArray mode)
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
 	m_c->m_dev->send(buffer);
 	m_c->m_dev->send(mode);
+	return r;
+}
+MsgpackRequest* NeovimApi6::nvim_buf_set_keymap(int64_t buffer, QByteArray mode, QByteArray lhs, QByteArray rhs, QVariantMap opts)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_set_keymap", 5);
+	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_BUF_SET_KEYMAP);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
+	m_c->m_dev->send(buffer);
+	m_c->m_dev->send(mode);
+	m_c->m_dev->send(lhs);
+	m_c->m_dev->send(rhs);
+	m_c->m_dev->send(opts);
+	return r;
+}
+MsgpackRequest* NeovimApi6::nvim_buf_del_keymap(int64_t buffer, QByteArray mode, QByteArray lhs)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_buf_del_keymap", 3);
+	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_BUF_DEL_KEYMAP);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
+	m_c->m_dev->send(buffer);
+	m_c->m_dev->send(mode);
+	m_c->m_dev->send(lhs);
 	return r;
 }
 MsgpackRequest* NeovimApi6::nvim_buf_get_commands(int64_t buffer, QVariantMap opts)
@@ -540,6 +564,15 @@ MsgpackRequest* NeovimApi6::nvim_ui_try_resize_grid(int64_t grid, int64_t width,
 	m_c->m_dev->send(height);
 	return r;
 }
+MsgpackRequest* NeovimApi6::nvim_ui_pum_set_height(int64_t height)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_ui_pum_set_height", 1);
+	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_UI_PUM_SET_HEIGHT);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
+	m_c->m_dev->send(height);
+	return r;
+}
 MsgpackRequest* NeovimApi6::nvim_command(QByteArray command)
 {
 	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_command", 1);
@@ -587,6 +620,20 @@ MsgpackRequest* NeovimApi6::nvim_input(QByteArray keys)
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
 	m_c->m_dev->send(keys);
+	return r;
+}
+MsgpackRequest* NeovimApi6::nvim_input_mouse(QByteArray button, QByteArray action, QByteArray modifier, int64_t grid, int64_t row, int64_t col)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_input_mouse", 6);
+	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_INPUT_MOUSE);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
+	m_c->m_dev->send(button);
+	m_c->m_dev->send(action);
+	m_c->m_dev->send(modifier);
+	m_c->m_dev->send(grid);
+	m_c->m_dev->send(row);
+	m_c->m_dev->send(col);
 	return r;
 }
 MsgpackRequest* NeovimApi6::nvim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special)
@@ -757,6 +804,16 @@ MsgpackRequest* NeovimApi6::nvim_get_vvar(QByteArray name)
 	m_c->m_dev->send(name);
 	return r;
 }
+MsgpackRequest* NeovimApi6::nvim_set_vvar(QByteArray name, QVariant value)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_set_vvar", 2);
+	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_SET_VVAR);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
+	m_c->m_dev->send(name);
+	m_c->m_dev->send(value);
+	return r;
+}
 MsgpackRequest* NeovimApi6::nvim_get_option(QByteArray name)
 {
 	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_option", 1);
@@ -853,6 +910,27 @@ MsgpackRequest* NeovimApi6::nvim_set_current_win(int64_t window)
 	m_c->m_dev->send(window);
 	return r;
 }
+MsgpackRequest* NeovimApi6::nvim_create_buf(bool listed, bool scratch)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_create_buf", 2);
+	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_CREATE_BUF);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
+	m_c->m_dev->send(listed);
+	m_c->m_dev->send(scratch);
+	return r;
+}
+MsgpackRequest* NeovimApi6::nvim_open_win(int64_t buffer, bool enter, QVariantMap config)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_open_win", 3);
+	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_OPEN_WIN);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
+	m_c->m_dev->send(buffer);
+	m_c->m_dev->send(enter);
+	m_c->m_dev->send(config);
+	return r;
+}
 MsgpackRequest* NeovimApi6::nvim_list_tabpages()
 {
 	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_list_tabpages", 0);
@@ -895,6 +973,29 @@ MsgpackRequest* NeovimApi6::nvim_get_namespaces()
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
 	return r;
 }
+MsgpackRequest* NeovimApi6::nvim_paste(QByteArray data, bool crlf, int64_t phase)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_paste", 3);
+	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_PASTE);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
+	m_c->m_dev->send(data);
+	m_c->m_dev->send(crlf);
+	m_c->m_dev->send(phase);
+	return r;
+}
+MsgpackRequest* NeovimApi6::nvim_put(QList<QByteArray> lines, QByteArray type, bool after, bool follow)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_put", 4);
+	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_PUT);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
+	m_c->m_dev->sendArrayOf(lines);
+	m_c->m_dev->send(type);
+	m_c->m_dev->send(after);
+	m_c->m_dev->send(follow);
+	return r;
+}
 MsgpackRequest* NeovimApi6::nvim_subscribe(QByteArray event)
 {
 	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_subscribe", 1);
@@ -930,6 +1031,24 @@ MsgpackRequest* NeovimApi6::nvim_get_color_map()
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
 	return r;
 }
+MsgpackRequest* NeovimApi6::nvim_get_context(QVariantMap opts)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_context", 1);
+	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_GET_CONTEXT);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
+	m_c->m_dev->send(opts);
+	return r;
+}
+MsgpackRequest* NeovimApi6::nvim_load_context(QVariantMap dict)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_load_context", 1);
+	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_LOAD_CONTEXT);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
+	m_c->m_dev->send(dict);
+	return r;
+}
 MsgpackRequest* NeovimApi6::nvim_get_mode()
 {
 	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_get_mode", 0);
@@ -945,6 +1064,28 @@ MsgpackRequest* NeovimApi6::nvim_get_keymap(QByteArray mode)
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
 	m_c->m_dev->send(mode);
+	return r;
+}
+MsgpackRequest* NeovimApi6::nvim_set_keymap(QByteArray mode, QByteArray lhs, QByteArray rhs, QVariantMap opts)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_set_keymap", 4);
+	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_SET_KEYMAP);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
+	m_c->m_dev->send(mode);
+	m_c->m_dev->send(lhs);
+	m_c->m_dev->send(rhs);
+	m_c->m_dev->send(opts);
+	return r;
+}
+MsgpackRequest* NeovimApi6::nvim_del_keymap(QByteArray mode, QByteArray lhs)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_del_keymap", 2);
+	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_DEL_KEYMAP);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
+	m_c->m_dev->send(mode);
+	m_c->m_dev->send(lhs);
 	return r;
 }
 MsgpackRequest* NeovimApi6::nvim_get_commands(QVariantMap opts)
@@ -1235,6 +1376,35 @@ MsgpackRequest* NeovimApi6::nvim_win_is_valid(int64_t window)
 	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
 	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
 	m_c->m_dev->send(window);
+	return r;
+}
+MsgpackRequest* NeovimApi6::nvim_win_set_config(int64_t window, QVariantMap config)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_set_config", 2);
+	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_WIN_SET_CONFIG);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
+	m_c->m_dev->send(window);
+	m_c->m_dev->send(config);
+	return r;
+}
+MsgpackRequest* NeovimApi6::nvim_win_get_config(int64_t window)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_get_config", 1);
+	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_WIN_GET_CONFIG);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
+	m_c->m_dev->send(window);
+	return r;
+}
+MsgpackRequest* NeovimApi6::nvim_win_close(int64_t window, bool force)
+{
+	MsgpackRequest *r = m_c->m_dev->startRequestUnchecked("nvim_win_close", 2);
+	r->setFunction(NeovimApi6::NEOVIM_FN_NVIM_WIN_CLOSE);
+	connect(r, &MsgpackRequest::finished, this, &NeovimApi6::handleResponse);
+	connect(r, &MsgpackRequest::error, this, &NeovimApi6::handleResponseError);
+	m_c->m_dev->send(window);
+	m_c->m_dev->send(force);
 	return r;
 }
 MsgpackRequest* NeovimApi6::buffer_line_count(int64_t buffer)
@@ -1908,6 +2078,12 @@ void NeovimApi6::handleResponseError(quint32 msgid, quint64 fun, const QVariant&
 	case NeovimApi6::NEOVIM_FN_NVIM_BUF_GET_KEYMAP:
 		emit err_nvim_buf_get_keymap(errMsg, res);
 		break;
+	case NeovimApi6::NEOVIM_FN_NVIM_BUF_SET_KEYMAP:
+		emit err_nvim_buf_set_keymap(errMsg, res);
+		break;
+	case NeovimApi6::NEOVIM_FN_NVIM_BUF_DEL_KEYMAP:
+		emit err_nvim_buf_del_keymap(errMsg, res);
+		break;
 	case NeovimApi6::NEOVIM_FN_NVIM_BUF_GET_COMMANDS:
 		emit err_nvim_buf_get_commands(errMsg, res);
 		break;
@@ -2007,6 +2183,9 @@ void NeovimApi6::handleResponseError(quint32 msgid, quint64 fun, const QVariant&
 	case NeovimApi6::NEOVIM_FN_NVIM_UI_TRY_RESIZE_GRID:
 		emit err_nvim_ui_try_resize_grid(errMsg, res);
 		break;
+	case NeovimApi6::NEOVIM_FN_NVIM_UI_PUM_SET_HEIGHT:
+		emit err_nvim_ui_pum_set_height(errMsg, res);
+		break;
 	case NeovimApi6::NEOVIM_FN_NVIM_COMMAND:
 		emit err_nvim_command(errMsg, res);
 		break;
@@ -2021,6 +2200,9 @@ void NeovimApi6::handleResponseError(quint32 msgid, quint64 fun, const QVariant&
 		break;
 	case NeovimApi6::NEOVIM_FN_NVIM_INPUT:
 		emit err_nvim_input(errMsg, res);
+		break;
+	case NeovimApi6::NEOVIM_FN_NVIM_INPUT_MOUSE:
+		emit err_nvim_input_mouse(errMsg, res);
 		break;
 	case NeovimApi6::NEOVIM_FN_NVIM_REPLACE_TERMCODES:
 		emit err_nvim_replace_termcodes(errMsg, res);
@@ -2076,6 +2258,9 @@ void NeovimApi6::handleResponseError(quint32 msgid, quint64 fun, const QVariant&
 	case NeovimApi6::NEOVIM_FN_NVIM_GET_VVAR:
 		emit err_nvim_get_vvar(errMsg, res);
 		break;
+	case NeovimApi6::NEOVIM_FN_NVIM_SET_VVAR:
+		emit err_nvim_set_vvar(errMsg, res);
+		break;
 	case NeovimApi6::NEOVIM_FN_NVIM_GET_OPTION:
 		emit err_nvim_get_option(errMsg, res);
 		break;
@@ -2109,6 +2294,12 @@ void NeovimApi6::handleResponseError(quint32 msgid, quint64 fun, const QVariant&
 	case NeovimApi6::NEOVIM_FN_NVIM_SET_CURRENT_WIN:
 		emit err_nvim_set_current_win(errMsg, res);
 		break;
+	case NeovimApi6::NEOVIM_FN_NVIM_CREATE_BUF:
+		emit err_nvim_create_buf(errMsg, res);
+		break;
+	case NeovimApi6::NEOVIM_FN_NVIM_OPEN_WIN:
+		emit err_nvim_open_win(errMsg, res);
+		break;
 	case NeovimApi6::NEOVIM_FN_NVIM_LIST_TABPAGES:
 		emit err_nvim_list_tabpages(errMsg, res);
 		break;
@@ -2124,6 +2315,12 @@ void NeovimApi6::handleResponseError(quint32 msgid, quint64 fun, const QVariant&
 	case NeovimApi6::NEOVIM_FN_NVIM_GET_NAMESPACES:
 		emit err_nvim_get_namespaces(errMsg, res);
 		break;
+	case NeovimApi6::NEOVIM_FN_NVIM_PASTE:
+		emit err_nvim_paste(errMsg, res);
+		break;
+	case NeovimApi6::NEOVIM_FN_NVIM_PUT:
+		emit err_nvim_put(errMsg, res);
+		break;
 	case NeovimApi6::NEOVIM_FN_NVIM_SUBSCRIBE:
 		emit err_nvim_subscribe(errMsg, res);
 		break;
@@ -2136,11 +2333,23 @@ void NeovimApi6::handleResponseError(quint32 msgid, quint64 fun, const QVariant&
 	case NeovimApi6::NEOVIM_FN_NVIM_GET_COLOR_MAP:
 		emit err_nvim_get_color_map(errMsg, res);
 		break;
+	case NeovimApi6::NEOVIM_FN_NVIM_GET_CONTEXT:
+		emit err_nvim_get_context(errMsg, res);
+		break;
+	case NeovimApi6::NEOVIM_FN_NVIM_LOAD_CONTEXT:
+		emit err_nvim_load_context(errMsg, res);
+		break;
 	case NeovimApi6::NEOVIM_FN_NVIM_GET_MODE:
 		emit err_nvim_get_mode(errMsg, res);
 		break;
 	case NeovimApi6::NEOVIM_FN_NVIM_GET_KEYMAP:
 		emit err_nvim_get_keymap(errMsg, res);
+		break;
+	case NeovimApi6::NEOVIM_FN_NVIM_SET_KEYMAP:
+		emit err_nvim_set_keymap(errMsg, res);
+		break;
+	case NeovimApi6::NEOVIM_FN_NVIM_DEL_KEYMAP:
+		emit err_nvim_del_keymap(errMsg, res);
 		break;
 	case NeovimApi6::NEOVIM_FN_NVIM_GET_COMMANDS:
 		emit err_nvim_get_commands(errMsg, res);
@@ -2231,6 +2440,15 @@ void NeovimApi6::handleResponseError(quint32 msgid, quint64 fun, const QVariant&
 		break;
 	case NeovimApi6::NEOVIM_FN_NVIM_WIN_IS_VALID:
 		emit err_nvim_win_is_valid(errMsg, res);
+		break;
+	case NeovimApi6::NEOVIM_FN_NVIM_WIN_SET_CONFIG:
+		emit err_nvim_win_set_config(errMsg, res);
+		break;
+	case NeovimApi6::NEOVIM_FN_NVIM_WIN_GET_CONFIG:
+		emit err_nvim_win_get_config(errMsg, res);
+		break;
+	case NeovimApi6::NEOVIM_FN_NVIM_WIN_CLOSE:
+		emit err_nvim_win_close(errMsg, res);
 		break;
 	case NeovimApi6::NEOVIM_FN_BUFFER_LINE_COUNT:
 		emit err_buffer_line_count(errMsg, res);
@@ -2579,6 +2797,18 @@ void NeovimApi6::handleResponse(quint32 msgid, quint64 fun, const QVariant& res)
 
 		}
 		break;
+	case NeovimApi6::NEOVIM_FN_NVIM_BUF_SET_KEYMAP:
+		{
+			emit on_nvim_buf_set_keymap();
+
+		}
+		break;
+	case NeovimApi6::NEOVIM_FN_NVIM_BUF_DEL_KEYMAP:
+		{
+			emit on_nvim_buf_del_keymap();
+
+		}
+		break;
 	case NeovimApi6::NEOVIM_FN_NVIM_BUF_GET_COMMANDS:
 		{
 			QVariantMap data;
@@ -2885,6 +3115,12 @@ void NeovimApi6::handleResponse(quint32 msgid, quint64 fun, const QVariant& res)
 
 		}
 		break;
+	case NeovimApi6::NEOVIM_FN_NVIM_UI_PUM_SET_HEIGHT:
+		{
+			emit on_nvim_ui_pum_set_height();
+
+		}
+		break;
 	case NeovimApi6::NEOVIM_FN_NVIM_COMMAND:
 		{
 			emit on_nvim_command();
@@ -2930,6 +3166,12 @@ void NeovimApi6::handleResponse(quint32 msgid, quint64 fun, const QVariant& res)
 			} else {
 				emit on_nvim_input(data);
 			}
+
+		}
+		break;
+	case NeovimApi6::NEOVIM_FN_NVIM_INPUT_MOUSE:
+		{
+			emit on_nvim_input_mouse();
 
 		}
 		break;
@@ -3119,6 +3361,12 @@ void NeovimApi6::handleResponse(quint32 msgid, quint64 fun, const QVariant& res)
 
 		}
 		break;
+	case NeovimApi6::NEOVIM_FN_NVIM_SET_VVAR:
+		{
+			emit on_nvim_set_vvar();
+
+		}
+		break;
 	case NeovimApi6::NEOVIM_FN_NVIM_GET_OPTION:
 		{
 			QVariant data;
@@ -3215,6 +3463,30 @@ void NeovimApi6::handleResponse(quint32 msgid, quint64 fun, const QVariant& res)
 
 		}
 		break;
+	case NeovimApi6::NEOVIM_FN_NVIM_CREATE_BUF:
+		{
+			int64_t data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_create_buf");
+				return;
+			} else {
+				emit on_nvim_create_buf(data);
+			}
+
+		}
+		break;
+	case NeovimApi6::NEOVIM_FN_NVIM_OPEN_WIN:
+		{
+			int64_t data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_open_win");
+				return;
+			} else {
+				emit on_nvim_open_win(data);
+			}
+
+		}
+		break;
 	case NeovimApi6::NEOVIM_FN_NVIM_LIST_TABPAGES:
 		{
 			QList<int64_t> data;
@@ -3269,6 +3541,24 @@ void NeovimApi6::handleResponse(quint32 msgid, quint64 fun, const QVariant& res)
 
 		}
 		break;
+	case NeovimApi6::NEOVIM_FN_NVIM_PASTE:
+		{
+			bool data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_paste");
+				return;
+			} else {
+				emit on_nvim_paste(data);
+			}
+
+		}
+		break;
+	case NeovimApi6::NEOVIM_FN_NVIM_PUT:
+		{
+			emit on_nvim_put();
+
+		}
+		break;
 	case NeovimApi6::NEOVIM_FN_NVIM_SUBSCRIBE:
 		{
 			emit on_nvim_subscribe();
@@ -3305,6 +3595,30 @@ void NeovimApi6::handleResponse(quint32 msgid, quint64 fun, const QVariant& res)
 
 		}
 		break;
+	case NeovimApi6::NEOVIM_FN_NVIM_GET_CONTEXT:
+		{
+			QVariantMap data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_get_context");
+				return;
+			} else {
+				emit on_nvim_get_context(data);
+			}
+
+		}
+		break;
+	case NeovimApi6::NEOVIM_FN_NVIM_LOAD_CONTEXT:
+		{
+			QVariant data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_load_context");
+				return;
+			} else {
+				emit on_nvim_load_context(data);
+			}
+
+		}
+		break;
 	case NeovimApi6::NEOVIM_FN_NVIM_GET_MODE:
 		{
 			QVariantMap data;
@@ -3326,6 +3640,18 @@ void NeovimApi6::handleResponse(quint32 msgid, quint64 fun, const QVariant& res)
 			} else {
 				emit on_nvim_get_keymap(data);
 			}
+
+		}
+		break;
+	case NeovimApi6::NEOVIM_FN_NVIM_SET_KEYMAP:
+		{
+			emit on_nvim_set_keymap();
+
+		}
+		break;
+	case NeovimApi6::NEOVIM_FN_NVIM_DEL_KEYMAP:
+		{
+			emit on_nvim_del_keymap();
 
 		}
 		break;
@@ -3632,6 +3958,30 @@ void NeovimApi6::handleResponse(quint32 msgid, quint64 fun, const QVariant& res)
 			} else {
 				emit on_nvim_win_is_valid(data);
 			}
+
+		}
+		break;
+	case NeovimApi6::NEOVIM_FN_NVIM_WIN_SET_CONFIG:
+		{
+			emit on_nvim_win_set_config();
+
+		}
+		break;
+	case NeovimApi6::NEOVIM_FN_NVIM_WIN_GET_CONFIG:
+		{
+			QVariantMap data;
+			if (decode(res, data)) {
+				m_c->setError(NeovimConnector::RuntimeMsgpackError, "Error unpacking return type for nvim_win_get_config");
+				return;
+			} else {
+				emit on_nvim_win_get_config(data);
+			}
+
+		}
+		break;
+	case NeovimApi6::NEOVIM_FN_NVIM_WIN_CLOSE:
+		{
+			emit on_nvim_win_close();
 
 		}
 		break;
@@ -4376,6 +4726,20 @@ bool NeovimApi6::checkFunctions(const QVariantList& ftable)
 						<< QString("Buffer")
 						<< QString("String")
 						, false)
+		<< Function("void", "nvim_buf_set_keymap",
+			QList<QString>()
+						<< QString("Buffer")
+						<< QString("String")
+						<< QString("String")
+						<< QString("String")
+						<< QString("Dictionary")
+						, false)
+		<< Function("void", "nvim_buf_del_keymap",
+			QList<QString>()
+						<< QString("Buffer")
+						<< QString("String")
+						<< QString("String")
+						, false)
 		<< Function("Dictionary", "nvim_buf_get_commands",
 			QList<QString>()
 						<< QString("Buffer")
@@ -4551,6 +4915,10 @@ bool NeovimApi6::checkFunctions(const QVariantList& ftable)
 						<< QString("Integer")
 						<< QString("Integer")
 						, false)
+		<< Function("void", "nvim_ui_pum_set_height",
+			QList<QString>()
+						<< QString("Integer")
+						, false)
 		<< Function("void", "nvim_command",
 			QList<QString>()
 						<< QString("String")
@@ -4574,6 +4942,15 @@ bool NeovimApi6::checkFunctions(const QVariantList& ftable)
 		<< Function("Integer", "nvim_input",
 			QList<QString>()
 						<< QString("String")
+						, false)
+		<< Function("void", "nvim_input_mouse",
+			QList<QString>()
+						<< QString("String")
+						<< QString("String")
+						<< QString("String")
+						<< QString("Integer")
+						<< QString("Integer")
+						<< QString("Integer")
 						, false)
 		<< Function("String", "nvim_replace_termcodes",
 			QList<QString>()
@@ -4653,6 +5030,11 @@ bool NeovimApi6::checkFunctions(const QVariantList& ftable)
 			QList<QString>()
 						<< QString("String")
 						, false)
+		<< Function("void", "nvim_set_vvar",
+			QList<QString>()
+						<< QString("String")
+						<< QString("Object")
+						, false)
 		<< Function("Object", "nvim_get_option",
 			QList<QString>()
 						<< QString("String")
@@ -4694,6 +5076,17 @@ bool NeovimApi6::checkFunctions(const QVariantList& ftable)
 			QList<QString>()
 						<< QString("Window")
 						, false)
+		<< Function("Buffer", "nvim_create_buf",
+			QList<QString>()
+						<< QString("Boolean")
+						<< QString("Boolean")
+						, false)
+		<< Function("Window", "nvim_open_win",
+			QList<QString>()
+						<< QString("Buffer")
+						<< QString("Boolean")
+						<< QString("Dictionary")
+						, false)
 		<< Function("ArrayOf(Tabpage)", "nvim_list_tabpages",
 			QList<QString>()
 						, false)
@@ -4711,6 +5104,19 @@ bool NeovimApi6::checkFunctions(const QVariantList& ftable)
 		<< Function("Dictionary", "nvim_get_namespaces",
 			QList<QString>()
 						, false)
+		<< Function("Boolean", "nvim_paste",
+			QList<QString>()
+						<< QString("String")
+						<< QString("Boolean")
+						<< QString("Integer")
+						, false)
+		<< Function("void", "nvim_put",
+			QList<QString>()
+						<< QString("ArrayOf(String)")
+						<< QString("String")
+						<< QString("Boolean")
+						<< QString("Boolean")
+						, false)
 		<< Function("void", "nvim_subscribe",
 			QList<QString>()
 						<< QString("String")
@@ -4726,11 +5132,31 @@ bool NeovimApi6::checkFunctions(const QVariantList& ftable)
 		<< Function("Dictionary", "nvim_get_color_map",
 			QList<QString>()
 						, false)
+		<< Function("Dictionary", "nvim_get_context",
+			QList<QString>()
+						<< QString("Dictionary")
+						, false)
+		<< Function("Object", "nvim_load_context",
+			QList<QString>()
+						<< QString("Dictionary")
+						, false)
 		<< Function("Dictionary", "nvim_get_mode",
 			QList<QString>()
 						, false)
 		<< Function("ArrayOf(Dictionary)", "nvim_get_keymap",
 			QList<QString>()
+						<< QString("String")
+						, false)
+		<< Function("void", "nvim_set_keymap",
+			QList<QString>()
+						<< QString("String")
+						<< QString("String")
+						<< QString("String")
+						<< QString("Dictionary")
+						, false)
+		<< Function("void", "nvim_del_keymap",
+			QList<QString>()
+						<< QString("String")
 						<< QString("String")
 						, false)
 		<< Function("Dictionary", "nvim_get_commands",
@@ -4872,6 +5298,20 @@ bool NeovimApi6::checkFunctions(const QVariantList& ftable)
 		<< Function("Boolean", "nvim_win_is_valid",
 			QList<QString>()
 						<< QString("Window")
+						, false)
+		<< Function("void", "nvim_win_set_config",
+			QList<QString>()
+						<< QString("Window")
+						<< QString("Dictionary")
+						, false)
+		<< Function("Dictionary", "nvim_win_get_config",
+			QList<QString>()
+						<< QString("Window")
+						, false)
+		<< Function("void", "nvim_win_close",
+			QList<QString>()
+						<< QString("Window")
+						<< QString("Boolean")
 						, false)
 		<< Function("Integer", "buffer_line_count",
 			QList<QString>()

--- a/src/auto/neovimapi6.h
+++ b/src/auto/neovimapi6.h
@@ -1,13 +1,15 @@
-// Auto generated 2019-01-13 02:04:50.898803 from nvim API level:6
-#ifndef NEOVIM_QT_NEOVIMAPI6
-#define NEOVIM_QT_NEOVIMAPI6
-#include "msgpack.h"
+// Auto generated 2021-07-20 02:42:32.076419 from nvim API level:6
+#pragma once
+
 #include <QObject>
-#include <QVariant>
 #include <QPoint>
+#include <QVariant>
+
 #include "function.h"
+#include "msgpack.h"
 
 namespace NeovimQt {
+
 class NeovimConnector;
 class MsgpackRequest;
 
@@ -34,6 +36,8 @@ public:
 				NEOVIM_FN_NVIM_BUF_GET_VAR,
 				NEOVIM_FN_NVIM_BUF_GET_CHANGEDTICK,
 				NEOVIM_FN_NVIM_BUF_GET_KEYMAP,
+				NEOVIM_FN_NVIM_BUF_SET_KEYMAP,
+				NEOVIM_FN_NVIM_BUF_DEL_KEYMAP,
 				NEOVIM_FN_NVIM_BUF_GET_COMMANDS,
 				NEOVIM_FN_NVIM_BUF_SET_VAR,
 				NEOVIM_FN_NVIM_BUF_DEL_VAR,
@@ -67,11 +71,13 @@ public:
 				NEOVIM_FN_NVIM_UI_TRY_RESIZE,
 				NEOVIM_FN_NVIM_UI_SET_OPTION,
 				NEOVIM_FN_NVIM_UI_TRY_RESIZE_GRID,
+				NEOVIM_FN_NVIM_UI_PUM_SET_HEIGHT,
 				NEOVIM_FN_NVIM_COMMAND,
 				NEOVIM_FN_NVIM_GET_HL_BY_NAME,
 				NEOVIM_FN_NVIM_GET_HL_BY_ID,
 				NEOVIM_FN_NVIM_FEEDKEYS,
 				NEOVIM_FN_NVIM_INPUT,
+				NEOVIM_FN_NVIM_INPUT_MOUSE,
 				NEOVIM_FN_NVIM_REPLACE_TERMCODES,
 				NEOVIM_FN_NVIM_COMMAND_OUTPUT,
 				NEOVIM_FN_NVIM_EVAL,
@@ -90,6 +96,7 @@ public:
 				NEOVIM_FN_VIM_SET_VAR,
 				NEOVIM_FN_VIM_DEL_VAR,
 				NEOVIM_FN_NVIM_GET_VVAR,
+				NEOVIM_FN_NVIM_SET_VVAR,
 				NEOVIM_FN_NVIM_GET_OPTION,
 				NEOVIM_FN_NVIM_SET_OPTION,
 				NEOVIM_FN_NVIM_OUT_WRITE,
@@ -101,17 +108,25 @@ public:
 				NEOVIM_FN_NVIM_LIST_WINS,
 				NEOVIM_FN_NVIM_GET_CURRENT_WIN,
 				NEOVIM_FN_NVIM_SET_CURRENT_WIN,
+				NEOVIM_FN_NVIM_CREATE_BUF,
+				NEOVIM_FN_NVIM_OPEN_WIN,
 				NEOVIM_FN_NVIM_LIST_TABPAGES,
 				NEOVIM_FN_NVIM_GET_CURRENT_TABPAGE,
 				NEOVIM_FN_NVIM_SET_CURRENT_TABPAGE,
 				NEOVIM_FN_NVIM_CREATE_NAMESPACE,
 				NEOVIM_FN_NVIM_GET_NAMESPACES,
+				NEOVIM_FN_NVIM_PASTE,
+				NEOVIM_FN_NVIM_PUT,
 				NEOVIM_FN_NVIM_SUBSCRIBE,
 				NEOVIM_FN_NVIM_UNSUBSCRIBE,
 				NEOVIM_FN_NVIM_GET_COLOR_BY_NAME,
 				NEOVIM_FN_NVIM_GET_COLOR_MAP,
+				NEOVIM_FN_NVIM_GET_CONTEXT,
+				NEOVIM_FN_NVIM_LOAD_CONTEXT,
 				NEOVIM_FN_NVIM_GET_MODE,
 				NEOVIM_FN_NVIM_GET_KEYMAP,
+				NEOVIM_FN_NVIM_SET_KEYMAP,
+				NEOVIM_FN_NVIM_DEL_KEYMAP,
 				NEOVIM_FN_NVIM_GET_COMMANDS,
 				NEOVIM_FN_NVIM_GET_API_INFO,
 				NEOVIM_FN_NVIM_SET_CLIENT_INFO,
@@ -142,6 +157,9 @@ public:
 				NEOVIM_FN_NVIM_WIN_GET_TABPAGE,
 				NEOVIM_FN_NVIM_WIN_GET_NUMBER,
 				NEOVIM_FN_NVIM_WIN_IS_VALID,
+				NEOVIM_FN_NVIM_WIN_SET_CONFIG,
+				NEOVIM_FN_NVIM_WIN_GET_CONFIG,
+				NEOVIM_FN_NVIM_WIN_CLOSE,
 				NEOVIM_FN_BUFFER_LINE_COUNT,
 				NEOVIM_FN_BUFFER_GET_LINES,
 				NEOVIM_FN_BUFFER_SET_LINES,
@@ -223,460 +241,492 @@ private:
 	NeovimConnector *m_c;
 public slots:
 	// Integer nvim_buf_line_count(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_line_count(int64_t buffer);
+	NeovimQt::MsgpackRequest* nvim_buf_line_count(int64_t buffer);
 	// DEPRECATED
 	// String buffer_get_line(Buffer buffer, Integer index, ) 
-	MsgpackRequest* buffer_get_line(int64_t buffer, int64_t index);
+	NeovimQt::MsgpackRequest* buffer_get_line(int64_t buffer, int64_t index);
 	// Boolean nvim_buf_attach(Buffer buffer, Boolean send_buffer, Dictionary opts, ) 
-	MsgpackRequest* nvim_buf_attach(int64_t buffer, bool send_buffer, QVariantMap opts);
+	NeovimQt::MsgpackRequest* nvim_buf_attach(int64_t buffer, bool send_buffer, QVariantMap opts);
 	// Boolean nvim_buf_detach(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_detach(int64_t buffer);
+	NeovimQt::MsgpackRequest* nvim_buf_detach(int64_t buffer);
 	// DEPRECATED
 	// void buffer_set_line(Buffer buffer, Integer index, String line, ) 
-	MsgpackRequest* buffer_set_line(int64_t buffer, int64_t index, QByteArray line);
+	NeovimQt::MsgpackRequest* buffer_set_line(int64_t buffer, int64_t index, QByteArray line);
 	// DEPRECATED
 	// void buffer_del_line(Buffer buffer, Integer index, ) 
-	MsgpackRequest* buffer_del_line(int64_t buffer, int64_t index);
+	NeovimQt::MsgpackRequest* buffer_del_line(int64_t buffer, int64_t index);
 	// DEPRECATED
 	// ArrayOf(String) buffer_get_line_slice(Buffer buffer, Integer start, Integer end, Boolean include_start, Boolean include_end, ) 
-	MsgpackRequest* buffer_get_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end);
+	NeovimQt::MsgpackRequest* buffer_get_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end);
 	// ArrayOf(String) nvim_buf_get_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ) 
-	MsgpackRequest* nvim_buf_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing);
+	NeovimQt::MsgpackRequest* nvim_buf_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing);
 	// DEPRECATED
 	// void buffer_set_line_slice(Buffer buffer, Integer start, Integer end, Boolean include_start, Boolean include_end, ArrayOf(String) replacement, ) 
-	MsgpackRequest* buffer_set_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end, QList<QByteArray> replacement);
+	NeovimQt::MsgpackRequest* buffer_set_line_slice(int64_t buffer, int64_t start, int64_t end, bool include_start, bool include_end, QList<QByteArray> replacement);
 	// void nvim_buf_set_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ArrayOf(String) replacement, ) 
-	MsgpackRequest* nvim_buf_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement);
+	NeovimQt::MsgpackRequest* nvim_buf_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement);
 	// Integer nvim_buf_get_offset(Buffer buffer, Integer index, ) 
-	MsgpackRequest* nvim_buf_get_offset(int64_t buffer, int64_t index);
+	NeovimQt::MsgpackRequest* nvim_buf_get_offset(int64_t buffer, int64_t index);
 	// Object nvim_buf_get_var(Buffer buffer, String name, ) 
-	MsgpackRequest* nvim_buf_get_var(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_buf_get_var(int64_t buffer, QByteArray name);
 	// Integer nvim_buf_get_changedtick(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_get_changedtick(int64_t buffer);
+	NeovimQt::MsgpackRequest* nvim_buf_get_changedtick(int64_t buffer);
 	// ArrayOf(Dictionary) nvim_buf_get_keymap(Buffer buffer, String mode, ) 
-	MsgpackRequest* nvim_buf_get_keymap(int64_t buffer, QByteArray mode);
+	NeovimQt::MsgpackRequest* nvim_buf_get_keymap(int64_t buffer, QByteArray mode);
+	// void nvim_buf_set_keymap(Buffer buffer, String mode, String lhs, String rhs, Dictionary opts, ) 
+	NeovimQt::MsgpackRequest* nvim_buf_set_keymap(int64_t buffer, QByteArray mode, QByteArray lhs, QByteArray rhs, QVariantMap opts);
+	// void nvim_buf_del_keymap(Buffer buffer, String mode, String lhs, ) 
+	NeovimQt::MsgpackRequest* nvim_buf_del_keymap(int64_t buffer, QByteArray mode, QByteArray lhs);
 	// Dictionary nvim_buf_get_commands(Buffer buffer, Dictionary opts, ) 
-	MsgpackRequest* nvim_buf_get_commands(int64_t buffer, QVariantMap opts);
+	NeovimQt::MsgpackRequest* nvim_buf_get_commands(int64_t buffer, QVariantMap opts);
 	// void nvim_buf_set_var(Buffer buffer, String name, Object value, ) 
-	MsgpackRequest* nvim_buf_set_var(int64_t buffer, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* nvim_buf_set_var(int64_t buffer, QByteArray name, QVariant value);
 	// void nvim_buf_del_var(Buffer buffer, String name, ) 
-	MsgpackRequest* nvim_buf_del_var(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_buf_del_var(int64_t buffer, QByteArray name);
 	// DEPRECATED
 	// Object buffer_set_var(Buffer buffer, String name, Object value, ) 
-	MsgpackRequest* buffer_set_var(int64_t buffer, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* buffer_set_var(int64_t buffer, QByteArray name, QVariant value);
 	// DEPRECATED
 	// Object buffer_del_var(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_del_var(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* buffer_del_var(int64_t buffer, QByteArray name);
 	// Object nvim_buf_get_option(Buffer buffer, String name, ) 
-	MsgpackRequest* nvim_buf_get_option(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_buf_get_option(int64_t buffer, QByteArray name);
 	// void nvim_buf_set_option(Buffer buffer, String name, Object value, ) 
-	MsgpackRequest* nvim_buf_set_option(int64_t buffer, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* nvim_buf_set_option(int64_t buffer, QByteArray name, QVariant value);
 	// DEPRECATED
 	// Integer nvim_buf_get_number(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_get_number(int64_t buffer);
+	NeovimQt::MsgpackRequest* nvim_buf_get_number(int64_t buffer);
 	// String nvim_buf_get_name(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_get_name(int64_t buffer);
+	NeovimQt::MsgpackRequest* nvim_buf_get_name(int64_t buffer);
 	// void nvim_buf_set_name(Buffer buffer, String name, ) 
-	MsgpackRequest* nvim_buf_set_name(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_buf_set_name(int64_t buffer, QByteArray name);
 	// Boolean nvim_buf_is_loaded(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_is_loaded(int64_t buffer);
+	NeovimQt::MsgpackRequest* nvim_buf_is_loaded(int64_t buffer);
 	// Boolean nvim_buf_is_valid(Buffer buffer, ) 
-	MsgpackRequest* nvim_buf_is_valid(int64_t buffer);
+	NeovimQt::MsgpackRequest* nvim_buf_is_valid(int64_t buffer);
 	// DEPRECATED
 	// void buffer_insert(Buffer buffer, Integer lnum, ArrayOf(String) lines, ) 
-	MsgpackRequest* buffer_insert(int64_t buffer, int64_t lnum, QList<QByteArray> lines);
+	NeovimQt::MsgpackRequest* buffer_insert(int64_t buffer, int64_t lnum, QList<QByteArray> lines);
 	// ArrayOf(Integer, 2) nvim_buf_get_mark(Buffer buffer, String name, ) 
-	MsgpackRequest* nvim_buf_get_mark(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_buf_get_mark(int64_t buffer, QByteArray name);
 	// Integer nvim_buf_add_highlight(Buffer buffer, Integer ns_id, String hl_group, Integer line, Integer col_start, Integer col_end, ) 
-	MsgpackRequest* nvim_buf_add_highlight(int64_t buffer, int64_t ns_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end);
+	NeovimQt::MsgpackRequest* nvim_buf_add_highlight(int64_t buffer, int64_t ns_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end);
 	// void nvim_buf_clear_namespace(Buffer buffer, Integer ns_id, Integer line_start, Integer line_end, ) 
-	MsgpackRequest* nvim_buf_clear_namespace(int64_t buffer, int64_t ns_id, int64_t line_start, int64_t line_end);
+	NeovimQt::MsgpackRequest* nvim_buf_clear_namespace(int64_t buffer, int64_t ns_id, int64_t line_start, int64_t line_end);
 	// void nvim_buf_clear_highlight(Buffer buffer, Integer ns_id, Integer line_start, Integer line_end, ) 
-	MsgpackRequest* nvim_buf_clear_highlight(int64_t buffer, int64_t ns_id, int64_t line_start, int64_t line_end);
+	NeovimQt::MsgpackRequest* nvim_buf_clear_highlight(int64_t buffer, int64_t ns_id, int64_t line_start, int64_t line_end);
 	// Integer nvim_buf_set_virtual_text(Buffer buffer, Integer ns_id, Integer line, Array chunks, Dictionary opts, ) 
-	MsgpackRequest* nvim_buf_set_virtual_text(int64_t buffer, int64_t ns_id, int64_t line, QVariantList chunks, QVariantMap opts);
+	NeovimQt::MsgpackRequest* nvim_buf_set_virtual_text(int64_t buffer, int64_t ns_id, int64_t line, QVariantList chunks, QVariantMap opts);
 	// ArrayOf(Window) nvim_tabpage_list_wins(Tabpage tabpage, ) 
-	MsgpackRequest* nvim_tabpage_list_wins(int64_t tabpage);
+	NeovimQt::MsgpackRequest* nvim_tabpage_list_wins(int64_t tabpage);
 	// Object nvim_tabpage_get_var(Tabpage tabpage, String name, ) 
-	MsgpackRequest* nvim_tabpage_get_var(int64_t tabpage, QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_tabpage_get_var(int64_t tabpage, QByteArray name);
 	// void nvim_tabpage_set_var(Tabpage tabpage, String name, Object value, ) 
-	MsgpackRequest* nvim_tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* nvim_tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value);
 	// void nvim_tabpage_del_var(Tabpage tabpage, String name, ) 
-	MsgpackRequest* nvim_tabpage_del_var(int64_t tabpage, QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_tabpage_del_var(int64_t tabpage, QByteArray name);
 	// DEPRECATED
 	// Object tabpage_set_var(Tabpage tabpage, String name, Object value, ) 
-	MsgpackRequest* tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* tabpage_set_var(int64_t tabpage, QByteArray name, QVariant value);
 	// DEPRECATED
 	// Object tabpage_del_var(Tabpage tabpage, String name, ) 
-	MsgpackRequest* tabpage_del_var(int64_t tabpage, QByteArray name);
+	NeovimQt::MsgpackRequest* tabpage_del_var(int64_t tabpage, QByteArray name);
 	// Window nvim_tabpage_get_win(Tabpage tabpage, ) 
-	MsgpackRequest* nvim_tabpage_get_win(int64_t tabpage);
+	NeovimQt::MsgpackRequest* nvim_tabpage_get_win(int64_t tabpage);
 	// Integer nvim_tabpage_get_number(Tabpage tabpage, ) 
-	MsgpackRequest* nvim_tabpage_get_number(int64_t tabpage);
+	NeovimQt::MsgpackRequest* nvim_tabpage_get_number(int64_t tabpage);
 	// Boolean nvim_tabpage_is_valid(Tabpage tabpage, ) 
-	MsgpackRequest* nvim_tabpage_is_valid(int64_t tabpage);
+	NeovimQt::MsgpackRequest* nvim_tabpage_is_valid(int64_t tabpage);
 	// void nvim_ui_attach(Integer width, Integer height, Dictionary options, ) 
-	MsgpackRequest* nvim_ui_attach(int64_t width, int64_t height, QVariantMap options);
+	NeovimQt::MsgpackRequest* nvim_ui_attach(int64_t width, int64_t height, QVariantMap options);
 	// DEPRECATED
 	// void ui_attach(Integer width, Integer height, Boolean enable_rgb, ) 
-	MsgpackRequest* ui_attach(int64_t width, int64_t height, bool enable_rgb);
+	NeovimQt::MsgpackRequest* ui_attach(int64_t width, int64_t height, bool enable_rgb);
 	// void nvim_ui_detach() 
-	MsgpackRequest* nvim_ui_detach();
+	NeovimQt::MsgpackRequest* nvim_ui_detach();
 	// void nvim_ui_try_resize(Integer width, Integer height, ) 
-	MsgpackRequest* nvim_ui_try_resize(int64_t width, int64_t height);
+	NeovimQt::MsgpackRequest* nvim_ui_try_resize(int64_t width, int64_t height);
 	// void nvim_ui_set_option(String name, Object value, ) 
-	MsgpackRequest* nvim_ui_set_option(QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* nvim_ui_set_option(QByteArray name, QVariant value);
 	// void nvim_ui_try_resize_grid(Integer grid, Integer width, Integer height, ) 
-	MsgpackRequest* nvim_ui_try_resize_grid(int64_t grid, int64_t width, int64_t height);
+	NeovimQt::MsgpackRequest* nvim_ui_try_resize_grid(int64_t grid, int64_t width, int64_t height);
+	// void nvim_ui_pum_set_height(Integer height, ) 
+	NeovimQt::MsgpackRequest* nvim_ui_pum_set_height(int64_t height);
 	// void nvim_command(String command, ) 
-	MsgpackRequest* nvim_command(QByteArray command);
+	NeovimQt::MsgpackRequest* nvim_command(QByteArray command);
 	// Dictionary nvim_get_hl_by_name(String name, Boolean rgb, ) 
-	MsgpackRequest* nvim_get_hl_by_name(QByteArray name, bool rgb);
+	NeovimQt::MsgpackRequest* nvim_get_hl_by_name(QByteArray name, bool rgb);
 	// Dictionary nvim_get_hl_by_id(Integer hl_id, Boolean rgb, ) 
-	MsgpackRequest* nvim_get_hl_by_id(int64_t hl_id, bool rgb);
+	NeovimQt::MsgpackRequest* nvim_get_hl_by_id(int64_t hl_id, bool rgb);
 	// void nvim_feedkeys(String keys, String mode, Boolean escape_csi, ) 
-	MsgpackRequest* nvim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi);
+	NeovimQt::MsgpackRequest* nvim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi);
 	// Integer nvim_input(String keys, ) 
-	MsgpackRequest* nvim_input(QByteArray keys);
+	NeovimQt::MsgpackRequest* nvim_input(QByteArray keys);
+	// void nvim_input_mouse(String button, String action, String modifier, Integer grid, Integer row, Integer col, ) 
+	NeovimQt::MsgpackRequest* nvim_input_mouse(QByteArray button, QByteArray action, QByteArray modifier, int64_t grid, int64_t row, int64_t col);
 	// String nvim_replace_termcodes(String str, Boolean from_part, Boolean do_lt, Boolean special, ) 
-	MsgpackRequest* nvim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special);
+	NeovimQt::MsgpackRequest* nvim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special);
 	// String nvim_command_output(String command, ) 
-	MsgpackRequest* nvim_command_output(QByteArray command);
+	NeovimQt::MsgpackRequest* nvim_command_output(QByteArray command);
 	// Object nvim_eval(String expr, ) 
-	MsgpackRequest* nvim_eval(QByteArray expr);
+	NeovimQt::MsgpackRequest* nvim_eval(QByteArray expr);
 	// Object nvim_execute_lua(String code, Array args, ) 
-	MsgpackRequest* nvim_execute_lua(QByteArray code, QVariantList args);
+	NeovimQt::MsgpackRequest* nvim_execute_lua(QByteArray code, QVariantList args);
 	// Object nvim_call_function(String fn, Array args, ) 
-	MsgpackRequest* nvim_call_function(QByteArray fn, QVariantList args);
+	NeovimQt::MsgpackRequest* nvim_call_function(QByteArray fn, QVariantList args);
 	// Object nvim_call_dict_function(Object dict, String fn, Array args, ) 
-	MsgpackRequest* nvim_call_dict_function(QVariant dict, QByteArray fn, QVariantList args);
+	NeovimQt::MsgpackRequest* nvim_call_dict_function(QVariant dict, QByteArray fn, QVariantList args);
 	// Integer nvim_strwidth(String text, ) 
-	MsgpackRequest* nvim_strwidth(QByteArray text);
+	NeovimQt::MsgpackRequest* nvim_strwidth(QByteArray text);
 	// ArrayOf(String) nvim_list_runtime_paths() 
-	MsgpackRequest* nvim_list_runtime_paths();
+	NeovimQt::MsgpackRequest* nvim_list_runtime_paths();
 	// void nvim_set_current_dir(String dir, ) 
-	MsgpackRequest* nvim_set_current_dir(QByteArray dir);
+	NeovimQt::MsgpackRequest* nvim_set_current_dir(QByteArray dir);
 	// String nvim_get_current_line() 
-	MsgpackRequest* nvim_get_current_line();
+	NeovimQt::MsgpackRequest* nvim_get_current_line();
 	// void nvim_set_current_line(String line, ) 
-	MsgpackRequest* nvim_set_current_line(QByteArray line);
+	NeovimQt::MsgpackRequest* nvim_set_current_line(QByteArray line);
 	// void nvim_del_current_line() 
-	MsgpackRequest* nvim_del_current_line();
+	NeovimQt::MsgpackRequest* nvim_del_current_line();
 	// Object nvim_get_var(String name, ) 
-	MsgpackRequest* nvim_get_var(QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_get_var(QByteArray name);
 	// void nvim_set_var(String name, Object value, ) 
-	MsgpackRequest* nvim_set_var(QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* nvim_set_var(QByteArray name, QVariant value);
 	// void nvim_del_var(String name, ) 
-	MsgpackRequest* nvim_del_var(QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_del_var(QByteArray name);
 	// DEPRECATED
 	// Object vim_set_var(String name, Object value, ) 
-	MsgpackRequest* vim_set_var(QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* vim_set_var(QByteArray name, QVariant value);
 	// DEPRECATED
 	// Object vim_del_var(String name, ) 
-	MsgpackRequest* vim_del_var(QByteArray name);
+	NeovimQt::MsgpackRequest* vim_del_var(QByteArray name);
 	// Object nvim_get_vvar(String name, ) 
-	MsgpackRequest* nvim_get_vvar(QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_get_vvar(QByteArray name);
+	// void nvim_set_vvar(String name, Object value, ) 
+	NeovimQt::MsgpackRequest* nvim_set_vvar(QByteArray name, QVariant value);
 	// Object nvim_get_option(String name, ) 
-	MsgpackRequest* nvim_get_option(QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_get_option(QByteArray name);
 	// void nvim_set_option(String name, Object value, ) 
-	MsgpackRequest* nvim_set_option(QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* nvim_set_option(QByteArray name, QVariant value);
 	// void nvim_out_write(String str, ) 
-	MsgpackRequest* nvim_out_write(QByteArray str);
+	NeovimQt::MsgpackRequest* nvim_out_write(QByteArray str);
 	// void nvim_err_write(String str, ) 
-	MsgpackRequest* nvim_err_write(QByteArray str);
+	NeovimQt::MsgpackRequest* nvim_err_write(QByteArray str);
 	// void nvim_err_writeln(String str, ) 
-	MsgpackRequest* nvim_err_writeln(QByteArray str);
+	NeovimQt::MsgpackRequest* nvim_err_writeln(QByteArray str);
 	// ArrayOf(Buffer) nvim_list_bufs() 
-	MsgpackRequest* nvim_list_bufs();
+	NeovimQt::MsgpackRequest* nvim_list_bufs();
 	// Buffer nvim_get_current_buf() 
-	MsgpackRequest* nvim_get_current_buf();
+	NeovimQt::MsgpackRequest* nvim_get_current_buf();
 	// void nvim_set_current_buf(Buffer buffer, ) 
-	MsgpackRequest* nvim_set_current_buf(int64_t buffer);
+	NeovimQt::MsgpackRequest* nvim_set_current_buf(int64_t buffer);
 	// ArrayOf(Window) nvim_list_wins() 
-	MsgpackRequest* nvim_list_wins();
+	NeovimQt::MsgpackRequest* nvim_list_wins();
 	// Window nvim_get_current_win() 
-	MsgpackRequest* nvim_get_current_win();
+	NeovimQt::MsgpackRequest* nvim_get_current_win();
 	// void nvim_set_current_win(Window window, ) 
-	MsgpackRequest* nvim_set_current_win(int64_t window);
+	NeovimQt::MsgpackRequest* nvim_set_current_win(int64_t window);
+	// Buffer nvim_create_buf(Boolean listed, Boolean scratch, ) 
+	NeovimQt::MsgpackRequest* nvim_create_buf(bool listed, bool scratch);
+	// Window nvim_open_win(Buffer buffer, Boolean enter, Dictionary config, ) 
+	NeovimQt::MsgpackRequest* nvim_open_win(int64_t buffer, bool enter, QVariantMap config);
 	// ArrayOf(Tabpage) nvim_list_tabpages() 
-	MsgpackRequest* nvim_list_tabpages();
+	NeovimQt::MsgpackRequest* nvim_list_tabpages();
 	// Tabpage nvim_get_current_tabpage() 
-	MsgpackRequest* nvim_get_current_tabpage();
+	NeovimQt::MsgpackRequest* nvim_get_current_tabpage();
 	// void nvim_set_current_tabpage(Tabpage tabpage, ) 
-	MsgpackRequest* nvim_set_current_tabpage(int64_t tabpage);
+	NeovimQt::MsgpackRequest* nvim_set_current_tabpage(int64_t tabpage);
 	// Integer nvim_create_namespace(String name, ) 
-	MsgpackRequest* nvim_create_namespace(QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_create_namespace(QByteArray name);
 	// Dictionary nvim_get_namespaces() 
-	MsgpackRequest* nvim_get_namespaces();
+	NeovimQt::MsgpackRequest* nvim_get_namespaces();
+	// Boolean nvim_paste(String data, Boolean crlf, Integer phase, ) 
+	NeovimQt::MsgpackRequest* nvim_paste(QByteArray data, bool crlf, int64_t phase);
+	// void nvim_put(ArrayOf(String) lines, String type, Boolean after, Boolean follow, ) 
+	NeovimQt::MsgpackRequest* nvim_put(QList<QByteArray> lines, QByteArray type, bool after, bool follow);
 	// void nvim_subscribe(String event, ) 
-	MsgpackRequest* nvim_subscribe(QByteArray event);
+	NeovimQt::MsgpackRequest* nvim_subscribe(QByteArray event);
 	// void nvim_unsubscribe(String event, ) 
-	MsgpackRequest* nvim_unsubscribe(QByteArray event);
+	NeovimQt::MsgpackRequest* nvim_unsubscribe(QByteArray event);
 	// Integer nvim_get_color_by_name(String name, ) 
-	MsgpackRequest* nvim_get_color_by_name(QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_get_color_by_name(QByteArray name);
 	// Dictionary nvim_get_color_map() 
-	MsgpackRequest* nvim_get_color_map();
+	NeovimQt::MsgpackRequest* nvim_get_color_map();
+	// Dictionary nvim_get_context(Dictionary opts, ) 
+	NeovimQt::MsgpackRequest* nvim_get_context(QVariantMap opts);
+	// Object nvim_load_context(Dictionary dict, ) 
+	NeovimQt::MsgpackRequest* nvim_load_context(QVariantMap dict);
 	// Dictionary nvim_get_mode() 
-	MsgpackRequest* nvim_get_mode();
+	NeovimQt::MsgpackRequest* nvim_get_mode();
 	// ArrayOf(Dictionary) nvim_get_keymap(String mode, ) 
-	MsgpackRequest* nvim_get_keymap(QByteArray mode);
+	NeovimQt::MsgpackRequest* nvim_get_keymap(QByteArray mode);
+	// void nvim_set_keymap(String mode, String lhs, String rhs, Dictionary opts, ) 
+	NeovimQt::MsgpackRequest* nvim_set_keymap(QByteArray mode, QByteArray lhs, QByteArray rhs, QVariantMap opts);
+	// void nvim_del_keymap(String mode, String lhs, ) 
+	NeovimQt::MsgpackRequest* nvim_del_keymap(QByteArray mode, QByteArray lhs);
 	// Dictionary nvim_get_commands(Dictionary opts, ) 
-	MsgpackRequest* nvim_get_commands(QVariantMap opts);
+	NeovimQt::MsgpackRequest* nvim_get_commands(QVariantMap opts);
 	// Array nvim_get_api_info() 
-	MsgpackRequest* nvim_get_api_info();
+	NeovimQt::MsgpackRequest* nvim_get_api_info();
 	// void nvim_set_client_info(String name, Dictionary version, String type, Dictionary methods, Dictionary attributes, ) 
-	MsgpackRequest* nvim_set_client_info(QByteArray name, QVariantMap version, QByteArray type, QVariantMap methods, QVariantMap attributes);
+	NeovimQt::MsgpackRequest* nvim_set_client_info(QByteArray name, QVariantMap version, QByteArray type, QVariantMap methods, QVariantMap attributes);
 	// Dictionary nvim_get_chan_info(Integer chan, ) 
-	MsgpackRequest* nvim_get_chan_info(int64_t chan);
+	NeovimQt::MsgpackRequest* nvim_get_chan_info(int64_t chan);
 	// Array nvim_list_chans() 
-	MsgpackRequest* nvim_list_chans();
+	NeovimQt::MsgpackRequest* nvim_list_chans();
 	// Array nvim_call_atomic(Array calls, ) 
-	MsgpackRequest* nvim_call_atomic(QVariantList calls);
+	NeovimQt::MsgpackRequest* nvim_call_atomic(QVariantList calls);
 	// Dictionary nvim_parse_expression(String expr, String flags, Boolean highlight, ) 
-	MsgpackRequest* nvim_parse_expression(QByteArray expr, QByteArray flags, bool highlight);
+	NeovimQt::MsgpackRequest* nvim_parse_expression(QByteArray expr, QByteArray flags, bool highlight);
 	// Array nvim_list_uis() 
-	MsgpackRequest* nvim_list_uis();
+	NeovimQt::MsgpackRequest* nvim_list_uis();
 	// Array nvim_get_proc_children(Integer pid, ) 
-	MsgpackRequest* nvim_get_proc_children(int64_t pid);
+	NeovimQt::MsgpackRequest* nvim_get_proc_children(int64_t pid);
 	// Object nvim_get_proc(Integer pid, ) 
-	MsgpackRequest* nvim_get_proc(int64_t pid);
+	NeovimQt::MsgpackRequest* nvim_get_proc(int64_t pid);
 	// void nvim_select_popupmenu_item(Integer item, Boolean insert, Boolean finish, Dictionary opts, ) 
-	MsgpackRequest* nvim_select_popupmenu_item(int64_t item, bool insert, bool finish, QVariantMap opts);
+	NeovimQt::MsgpackRequest* nvim_select_popupmenu_item(int64_t item, bool insert, bool finish, QVariantMap opts);
 	// Buffer nvim_win_get_buf(Window window, ) 
-	MsgpackRequest* nvim_win_get_buf(int64_t window);
+	NeovimQt::MsgpackRequest* nvim_win_get_buf(int64_t window);
 	// void nvim_win_set_buf(Window window, Buffer buffer, ) 
-	MsgpackRequest* nvim_win_set_buf(int64_t window, int64_t buffer);
+	NeovimQt::MsgpackRequest* nvim_win_set_buf(int64_t window, int64_t buffer);
 	// ArrayOf(Integer, 2) nvim_win_get_cursor(Window window, ) 
-	MsgpackRequest* nvim_win_get_cursor(int64_t window);
+	NeovimQt::MsgpackRequest* nvim_win_get_cursor(int64_t window);
 	// void nvim_win_set_cursor(Window window, ArrayOf(Integer, 2) pos, ) 
-	MsgpackRequest* nvim_win_set_cursor(int64_t window, QPoint pos);
+	NeovimQt::MsgpackRequest* nvim_win_set_cursor(int64_t window, QPoint pos);
 	// Integer nvim_win_get_height(Window window, ) 
-	MsgpackRequest* nvim_win_get_height(int64_t window);
+	NeovimQt::MsgpackRequest* nvim_win_get_height(int64_t window);
 	// void nvim_win_set_height(Window window, Integer height, ) 
-	MsgpackRequest* nvim_win_set_height(int64_t window, int64_t height);
+	NeovimQt::MsgpackRequest* nvim_win_set_height(int64_t window, int64_t height);
 	// Integer nvim_win_get_width(Window window, ) 
-	MsgpackRequest* nvim_win_get_width(int64_t window);
+	NeovimQt::MsgpackRequest* nvim_win_get_width(int64_t window);
 	// void nvim_win_set_width(Window window, Integer width, ) 
-	MsgpackRequest* nvim_win_set_width(int64_t window, int64_t width);
+	NeovimQt::MsgpackRequest* nvim_win_set_width(int64_t window, int64_t width);
 	// Object nvim_win_get_var(Window window, String name, ) 
-	MsgpackRequest* nvim_win_get_var(int64_t window, QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_win_get_var(int64_t window, QByteArray name);
 	// void nvim_win_set_var(Window window, String name, Object value, ) 
-	MsgpackRequest* nvim_win_set_var(int64_t window, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* nvim_win_set_var(int64_t window, QByteArray name, QVariant value);
 	// void nvim_win_del_var(Window window, String name, ) 
-	MsgpackRequest* nvim_win_del_var(int64_t window, QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_win_del_var(int64_t window, QByteArray name);
 	// DEPRECATED
 	// Object window_set_var(Window window, String name, Object value, ) 
-	MsgpackRequest* window_set_var(int64_t window, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* window_set_var(int64_t window, QByteArray name, QVariant value);
 	// DEPRECATED
 	// Object window_del_var(Window window, String name, ) 
-	MsgpackRequest* window_del_var(int64_t window, QByteArray name);
+	NeovimQt::MsgpackRequest* window_del_var(int64_t window, QByteArray name);
 	// Object nvim_win_get_option(Window window, String name, ) 
-	MsgpackRequest* nvim_win_get_option(int64_t window, QByteArray name);
+	NeovimQt::MsgpackRequest* nvim_win_get_option(int64_t window, QByteArray name);
 	// void nvim_win_set_option(Window window, String name, Object value, ) 
-	MsgpackRequest* nvim_win_set_option(int64_t window, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* nvim_win_set_option(int64_t window, QByteArray name, QVariant value);
 	// ArrayOf(Integer, 2) nvim_win_get_position(Window window, ) 
-	MsgpackRequest* nvim_win_get_position(int64_t window);
+	NeovimQt::MsgpackRequest* nvim_win_get_position(int64_t window);
 	// Tabpage nvim_win_get_tabpage(Window window, ) 
-	MsgpackRequest* nvim_win_get_tabpage(int64_t window);
+	NeovimQt::MsgpackRequest* nvim_win_get_tabpage(int64_t window);
 	// Integer nvim_win_get_number(Window window, ) 
-	MsgpackRequest* nvim_win_get_number(int64_t window);
+	NeovimQt::MsgpackRequest* nvim_win_get_number(int64_t window);
 	// Boolean nvim_win_is_valid(Window window, ) 
-	MsgpackRequest* nvim_win_is_valid(int64_t window);
+	NeovimQt::MsgpackRequest* nvim_win_is_valid(int64_t window);
+	// void nvim_win_set_config(Window window, Dictionary config, ) 
+	NeovimQt::MsgpackRequest* nvim_win_set_config(int64_t window, QVariantMap config);
+	// Dictionary nvim_win_get_config(Window window, ) 
+	NeovimQt::MsgpackRequest* nvim_win_get_config(int64_t window);
+	// void nvim_win_close(Window window, Boolean force, ) 
+	NeovimQt::MsgpackRequest* nvim_win_close(int64_t window, bool force);
 	// DEPRECATED
 	// Integer buffer_line_count(Buffer buffer, ) 
-	MsgpackRequest* buffer_line_count(int64_t buffer);
+	NeovimQt::MsgpackRequest* buffer_line_count(int64_t buffer);
 	// DEPRECATED
 	// ArrayOf(String) buffer_get_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ) 
-	MsgpackRequest* buffer_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing);
+	NeovimQt::MsgpackRequest* buffer_get_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing);
 	// DEPRECATED
 	// void buffer_set_lines(Buffer buffer, Integer start, Integer end, Boolean strict_indexing, ArrayOf(String) replacement, ) 
-	MsgpackRequest* buffer_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement);
+	NeovimQt::MsgpackRequest* buffer_set_lines(int64_t buffer, int64_t start, int64_t end, bool strict_indexing, QList<QByteArray> replacement);
 	// DEPRECATED
 	// Object buffer_get_var(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_get_var(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* buffer_get_var(int64_t buffer, QByteArray name);
 	// DEPRECATED
 	// Object buffer_get_option(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_get_option(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* buffer_get_option(int64_t buffer, QByteArray name);
 	// DEPRECATED
 	// void buffer_set_option(Buffer buffer, String name, Object value, ) 
-	MsgpackRequest* buffer_set_option(int64_t buffer, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* buffer_set_option(int64_t buffer, QByteArray name, QVariant value);
 	// DEPRECATED
 	// Integer buffer_get_number(Buffer buffer, ) 
-	MsgpackRequest* buffer_get_number(int64_t buffer);
+	NeovimQt::MsgpackRequest* buffer_get_number(int64_t buffer);
 	// DEPRECATED
 	// String buffer_get_name(Buffer buffer, ) 
-	MsgpackRequest* buffer_get_name(int64_t buffer);
+	NeovimQt::MsgpackRequest* buffer_get_name(int64_t buffer);
 	// DEPRECATED
 	// void buffer_set_name(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_set_name(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* buffer_set_name(int64_t buffer, QByteArray name);
 	// DEPRECATED
 	// Boolean buffer_is_valid(Buffer buffer, ) 
-	MsgpackRequest* buffer_is_valid(int64_t buffer);
+	NeovimQt::MsgpackRequest* buffer_is_valid(int64_t buffer);
 	// DEPRECATED
 	// ArrayOf(Integer, 2) buffer_get_mark(Buffer buffer, String name, ) 
-	MsgpackRequest* buffer_get_mark(int64_t buffer, QByteArray name);
+	NeovimQt::MsgpackRequest* buffer_get_mark(int64_t buffer, QByteArray name);
 	// DEPRECATED
 	// Integer buffer_add_highlight(Buffer buffer, Integer ns_id, String hl_group, Integer line, Integer col_start, Integer col_end, ) 
-	MsgpackRequest* buffer_add_highlight(int64_t buffer, int64_t ns_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end);
+	NeovimQt::MsgpackRequest* buffer_add_highlight(int64_t buffer, int64_t ns_id, QByteArray hl_group, int64_t line, int64_t col_start, int64_t col_end);
 	// DEPRECATED
 	// void buffer_clear_highlight(Buffer buffer, Integer ns_id, Integer line_start, Integer line_end, ) 
-	MsgpackRequest* buffer_clear_highlight(int64_t buffer, int64_t ns_id, int64_t line_start, int64_t line_end);
+	NeovimQt::MsgpackRequest* buffer_clear_highlight(int64_t buffer, int64_t ns_id, int64_t line_start, int64_t line_end);
 	// DEPRECATED
 	// ArrayOf(Window) tabpage_get_windows(Tabpage tabpage, ) 
-	MsgpackRequest* tabpage_get_windows(int64_t tabpage);
+	NeovimQt::MsgpackRequest* tabpage_get_windows(int64_t tabpage);
 	// DEPRECATED
 	// Object tabpage_get_var(Tabpage tabpage, String name, ) 
-	MsgpackRequest* tabpage_get_var(int64_t tabpage, QByteArray name);
+	NeovimQt::MsgpackRequest* tabpage_get_var(int64_t tabpage, QByteArray name);
 	// DEPRECATED
 	// Window tabpage_get_window(Tabpage tabpage, ) 
-	MsgpackRequest* tabpage_get_window(int64_t tabpage);
+	NeovimQt::MsgpackRequest* tabpage_get_window(int64_t tabpage);
 	// DEPRECATED
 	// Boolean tabpage_is_valid(Tabpage tabpage, ) 
-	MsgpackRequest* tabpage_is_valid(int64_t tabpage);
+	NeovimQt::MsgpackRequest* tabpage_is_valid(int64_t tabpage);
 	// DEPRECATED
 	// void ui_detach() 
-	MsgpackRequest* ui_detach();
+	NeovimQt::MsgpackRequest* ui_detach();
 	// DEPRECATED
 	// Object ui_try_resize(Integer width, Integer height, ) 
-	MsgpackRequest* ui_try_resize(int64_t width, int64_t height);
+	NeovimQt::MsgpackRequest* ui_try_resize(int64_t width, int64_t height);
 	// DEPRECATED
 	// void vim_command(String command, ) 
-	MsgpackRequest* vim_command(QByteArray command);
+	NeovimQt::MsgpackRequest* vim_command(QByteArray command);
 	// DEPRECATED
 	// void vim_feedkeys(String keys, String mode, Boolean escape_csi, ) 
-	MsgpackRequest* vim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi);
+	NeovimQt::MsgpackRequest* vim_feedkeys(QByteArray keys, QByteArray mode, bool escape_csi);
 	// DEPRECATED
 	// Integer vim_input(String keys, ) 
-	MsgpackRequest* vim_input(QByteArray keys);
+	NeovimQt::MsgpackRequest* vim_input(QByteArray keys);
 	// DEPRECATED
 	// String vim_replace_termcodes(String str, Boolean from_part, Boolean do_lt, Boolean special, ) 
-	MsgpackRequest* vim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special);
+	NeovimQt::MsgpackRequest* vim_replace_termcodes(QByteArray str, bool from_part, bool do_lt, bool special);
 	// DEPRECATED
 	// String vim_command_output(String command, ) 
-	MsgpackRequest* vim_command_output(QByteArray command);
+	NeovimQt::MsgpackRequest* vim_command_output(QByteArray command);
 	// DEPRECATED
 	// Object vim_eval(String expr, ) 
-	MsgpackRequest* vim_eval(QByteArray expr);
+	NeovimQt::MsgpackRequest* vim_eval(QByteArray expr);
 	// DEPRECATED
 	// Object vim_call_function(String fn, Array args, ) 
-	MsgpackRequest* vim_call_function(QByteArray fn, QVariantList args);
+	NeovimQt::MsgpackRequest* vim_call_function(QByteArray fn, QVariantList args);
 	// DEPRECATED
 	// Integer vim_strwidth(String text, ) 
-	MsgpackRequest* vim_strwidth(QByteArray text);
+	NeovimQt::MsgpackRequest* vim_strwidth(QByteArray text);
 	// DEPRECATED
 	// ArrayOf(String) vim_list_runtime_paths() 
-	MsgpackRequest* vim_list_runtime_paths();
+	NeovimQt::MsgpackRequest* vim_list_runtime_paths();
 	// DEPRECATED
 	// void vim_change_directory(String dir, ) 
-	MsgpackRequest* vim_change_directory(QByteArray dir);
+	NeovimQt::MsgpackRequest* vim_change_directory(QByteArray dir);
 	// DEPRECATED
 	// String vim_get_current_line() 
-	MsgpackRequest* vim_get_current_line();
+	NeovimQt::MsgpackRequest* vim_get_current_line();
 	// DEPRECATED
 	// void vim_set_current_line(String line, ) 
-	MsgpackRequest* vim_set_current_line(QByteArray line);
+	NeovimQt::MsgpackRequest* vim_set_current_line(QByteArray line);
 	// DEPRECATED
 	// void vim_del_current_line() 
-	MsgpackRequest* vim_del_current_line();
+	NeovimQt::MsgpackRequest* vim_del_current_line();
 	// DEPRECATED
 	// Object vim_get_var(String name, ) 
-	MsgpackRequest* vim_get_var(QByteArray name);
+	NeovimQt::MsgpackRequest* vim_get_var(QByteArray name);
 	// DEPRECATED
 	// Object vim_get_vvar(String name, ) 
-	MsgpackRequest* vim_get_vvar(QByteArray name);
+	NeovimQt::MsgpackRequest* vim_get_vvar(QByteArray name);
 	// DEPRECATED
 	// Object vim_get_option(String name, ) 
-	MsgpackRequest* vim_get_option(QByteArray name);
+	NeovimQt::MsgpackRequest* vim_get_option(QByteArray name);
 	// DEPRECATED
 	// void vim_set_option(String name, Object value, ) 
-	MsgpackRequest* vim_set_option(QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* vim_set_option(QByteArray name, QVariant value);
 	// DEPRECATED
 	// void vim_out_write(String str, ) 
-	MsgpackRequest* vim_out_write(QByteArray str);
+	NeovimQt::MsgpackRequest* vim_out_write(QByteArray str);
 	// DEPRECATED
 	// void vim_err_write(String str, ) 
-	MsgpackRequest* vim_err_write(QByteArray str);
+	NeovimQt::MsgpackRequest* vim_err_write(QByteArray str);
 	// DEPRECATED
 	// void vim_report_error(String str, ) 
-	MsgpackRequest* vim_report_error(QByteArray str);
+	NeovimQt::MsgpackRequest* vim_report_error(QByteArray str);
 	// DEPRECATED
 	// ArrayOf(Buffer) vim_get_buffers() 
-	MsgpackRequest* vim_get_buffers();
+	NeovimQt::MsgpackRequest* vim_get_buffers();
 	// DEPRECATED
 	// Buffer vim_get_current_buffer() 
-	MsgpackRequest* vim_get_current_buffer();
+	NeovimQt::MsgpackRequest* vim_get_current_buffer();
 	// DEPRECATED
 	// void vim_set_current_buffer(Buffer buffer, ) 
-	MsgpackRequest* vim_set_current_buffer(int64_t buffer);
+	NeovimQt::MsgpackRequest* vim_set_current_buffer(int64_t buffer);
 	// DEPRECATED
 	// ArrayOf(Window) vim_get_windows() 
-	MsgpackRequest* vim_get_windows();
+	NeovimQt::MsgpackRequest* vim_get_windows();
 	// DEPRECATED
 	// Window vim_get_current_window() 
-	MsgpackRequest* vim_get_current_window();
+	NeovimQt::MsgpackRequest* vim_get_current_window();
 	// DEPRECATED
 	// void vim_set_current_window(Window window, ) 
-	MsgpackRequest* vim_set_current_window(int64_t window);
+	NeovimQt::MsgpackRequest* vim_set_current_window(int64_t window);
 	// DEPRECATED
 	// ArrayOf(Tabpage) vim_get_tabpages() 
-	MsgpackRequest* vim_get_tabpages();
+	NeovimQt::MsgpackRequest* vim_get_tabpages();
 	// DEPRECATED
 	// Tabpage vim_get_current_tabpage() 
-	MsgpackRequest* vim_get_current_tabpage();
+	NeovimQt::MsgpackRequest* vim_get_current_tabpage();
 	// DEPRECATED
 	// void vim_set_current_tabpage(Tabpage tabpage, ) 
-	MsgpackRequest* vim_set_current_tabpage(int64_t tabpage);
+	NeovimQt::MsgpackRequest* vim_set_current_tabpage(int64_t tabpage);
 	// DEPRECATED
 	// void vim_subscribe(String event, ) 
-	MsgpackRequest* vim_subscribe(QByteArray event);
+	NeovimQt::MsgpackRequest* vim_subscribe(QByteArray event);
 	// DEPRECATED
 	// void vim_unsubscribe(String event, ) 
-	MsgpackRequest* vim_unsubscribe(QByteArray event);
+	NeovimQt::MsgpackRequest* vim_unsubscribe(QByteArray event);
 	// DEPRECATED
 	// Integer vim_name_to_color(String name, ) 
-	MsgpackRequest* vim_name_to_color(QByteArray name);
+	NeovimQt::MsgpackRequest* vim_name_to_color(QByteArray name);
 	// DEPRECATED
 	// Dictionary vim_get_color_map() 
-	MsgpackRequest* vim_get_color_map();
+	NeovimQt::MsgpackRequest* vim_get_color_map();
 	// DEPRECATED
 	// Buffer window_get_buffer(Window window, ) 
-	MsgpackRequest* window_get_buffer(int64_t window);
+	NeovimQt::MsgpackRequest* window_get_buffer(int64_t window);
 	// DEPRECATED
 	// ArrayOf(Integer, 2) window_get_cursor(Window window, ) 
-	MsgpackRequest* window_get_cursor(int64_t window);
+	NeovimQt::MsgpackRequest* window_get_cursor(int64_t window);
 	// DEPRECATED
 	// void window_set_cursor(Window window, ArrayOf(Integer, 2) pos, ) 
-	MsgpackRequest* window_set_cursor(int64_t window, QPoint pos);
+	NeovimQt::MsgpackRequest* window_set_cursor(int64_t window, QPoint pos);
 	// DEPRECATED
 	// Integer window_get_height(Window window, ) 
-	MsgpackRequest* window_get_height(int64_t window);
+	NeovimQt::MsgpackRequest* window_get_height(int64_t window);
 	// DEPRECATED
 	// void window_set_height(Window window, Integer height, ) 
-	MsgpackRequest* window_set_height(int64_t window, int64_t height);
+	NeovimQt::MsgpackRequest* window_set_height(int64_t window, int64_t height);
 	// DEPRECATED
 	// Integer window_get_width(Window window, ) 
-	MsgpackRequest* window_get_width(int64_t window);
+	NeovimQt::MsgpackRequest* window_get_width(int64_t window);
 	// DEPRECATED
 	// void window_set_width(Window window, Integer width, ) 
-	MsgpackRequest* window_set_width(int64_t window, int64_t width);
+	NeovimQt::MsgpackRequest* window_set_width(int64_t window, int64_t width);
 	// DEPRECATED
 	// Object window_get_var(Window window, String name, ) 
-	MsgpackRequest* window_get_var(int64_t window, QByteArray name);
+	NeovimQt::MsgpackRequest* window_get_var(int64_t window, QByteArray name);
 	// DEPRECATED
 	// Object window_get_option(Window window, String name, ) 
-	MsgpackRequest* window_get_option(int64_t window, QByteArray name);
+	NeovimQt::MsgpackRequest* window_get_option(int64_t window, QByteArray name);
 	// DEPRECATED
 	// void window_set_option(Window window, String name, Object value, ) 
-	MsgpackRequest* window_set_option(int64_t window, QByteArray name, QVariant value);
+	NeovimQt::MsgpackRequest* window_set_option(int64_t window, QByteArray name, QVariant value);
 	// DEPRECATED
 	// ArrayOf(Integer, 2) window_get_position(Window window, ) 
-	MsgpackRequest* window_get_position(int64_t window);
+	NeovimQt::MsgpackRequest* window_get_position(int64_t window);
 	// DEPRECATED
 	// Tabpage window_get_tabpage(Window window, ) 
-	MsgpackRequest* window_get_tabpage(int64_t window);
+	NeovimQt::MsgpackRequest* window_get_tabpage(int64_t window);
 	// DEPRECATED
 	// Boolean window_is_valid(Window window, ) 
-	MsgpackRequest* window_is_valid(int64_t window);
+	NeovimQt::MsgpackRequest* window_is_valid(int64_t window);
 
 signals:
 	void on_nvim_buf_line_count(int64_t);
@@ -720,6 +770,12 @@ signals:
 
 	void on_nvim_buf_get_keymap(QList<QVariantMap>);
 	void err_nvim_buf_get_keymap(const QString&, const QVariant&);
+
+	void on_nvim_buf_set_keymap(void);
+	void err_nvim_buf_set_keymap(const QString&, const QVariant&);
+
+	void on_nvim_buf_del_keymap(void);
+	void err_nvim_buf_del_keymap(const QString&, const QVariant&);
 
 	void on_nvim_buf_get_commands(QVariantMap);
 	void err_nvim_buf_get_commands(const QString&, const QVariant&);
@@ -820,6 +876,9 @@ signals:
 	void on_nvim_ui_try_resize_grid(void);
 	void err_nvim_ui_try_resize_grid(const QString&, const QVariant&);
 
+	void on_nvim_ui_pum_set_height(void);
+	void err_nvim_ui_pum_set_height(const QString&, const QVariant&);
+
 	void on_nvim_command(void);
 	void err_nvim_command(const QString&, const QVariant&);
 
@@ -834,6 +893,9 @@ signals:
 
 	void on_nvim_input(int64_t);
 	void err_nvim_input(const QString&, const QVariant&);
+
+	void on_nvim_input_mouse(void);
+	void err_nvim_input_mouse(const QString&, const QVariant&);
 
 	void on_nvim_replace_termcodes(QByteArray);
 	void err_nvim_replace_termcodes(const QString&, const QVariant&);
@@ -889,6 +951,9 @@ signals:
 	void on_nvim_get_vvar(QVariant);
 	void err_nvim_get_vvar(const QString&, const QVariant&);
 
+	void on_nvim_set_vvar(void);
+	void err_nvim_set_vvar(const QString&, const QVariant&);
+
 	void on_nvim_get_option(QVariant);
 	void err_nvim_get_option(const QString&, const QVariant&);
 
@@ -922,6 +987,12 @@ signals:
 	void on_nvim_set_current_win(void);
 	void err_nvim_set_current_win(const QString&, const QVariant&);
 
+	void on_nvim_create_buf(int64_t);
+	void err_nvim_create_buf(const QString&, const QVariant&);
+
+	void on_nvim_open_win(int64_t);
+	void err_nvim_open_win(const QString&, const QVariant&);
+
 	void on_nvim_list_tabpages(QList<int64_t>);
 	void err_nvim_list_tabpages(const QString&, const QVariant&);
 
@@ -937,6 +1008,12 @@ signals:
 	void on_nvim_get_namespaces(QVariantMap);
 	void err_nvim_get_namespaces(const QString&, const QVariant&);
 
+	void on_nvim_paste(bool);
+	void err_nvim_paste(const QString&, const QVariant&);
+
+	void on_nvim_put(void);
+	void err_nvim_put(const QString&, const QVariant&);
+
 	void on_nvim_subscribe(void);
 	void err_nvim_subscribe(const QString&, const QVariant&);
 
@@ -949,11 +1026,23 @@ signals:
 	void on_nvim_get_color_map(QVariantMap);
 	void err_nvim_get_color_map(const QString&, const QVariant&);
 
+	void on_nvim_get_context(QVariantMap);
+	void err_nvim_get_context(const QString&, const QVariant&);
+
+	void on_nvim_load_context(QVariant);
+	void err_nvim_load_context(const QString&, const QVariant&);
+
 	void on_nvim_get_mode(QVariantMap);
 	void err_nvim_get_mode(const QString&, const QVariant&);
 
 	void on_nvim_get_keymap(QList<QVariantMap>);
 	void err_nvim_get_keymap(const QString&, const QVariant&);
+
+	void on_nvim_set_keymap(void);
+	void err_nvim_set_keymap(const QString&, const QVariant&);
+
+	void on_nvim_del_keymap(void);
+	void err_nvim_del_keymap(const QString&, const QVariant&);
 
 	void on_nvim_get_commands(QVariantMap);
 	void err_nvim_get_commands(const QString&, const QVariant&);
@@ -1044,6 +1133,15 @@ signals:
 
 	void on_nvim_win_is_valid(bool);
 	void err_nvim_win_is_valid(const QString&, const QVariant&);
+
+	void on_nvim_win_set_config(void);
+	void err_nvim_win_set_config(const QString&, const QVariant&);
+
+	void on_nvim_win_get_config(QVariantMap);
+	void err_nvim_win_get_config(const QString&, const QVariant&);
+
+	void on_nvim_win_close(void);
+	void err_nvim_win_close(const QString&, const QVariant&);
 
 	void on_buffer_line_count(int64_t);
 	void err_buffer_line_count(const QString&, const QVariant&);
@@ -1241,5 +1339,5 @@ signals:
 	void err_window_is_valid(const QString&, const QVariant&);
 
 };
-} // namespace
-#endif
+
+} // namespace NeovimQt

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -32,7 +32,7 @@ public:
 	Shell* shell();
 	void restoreWindowGeometry();
 public slots:
-	void delayedShow(DelayedShow type=DelayedShow::Normal);
+	void delayedShow(NeovimQt::MainWindow::DelayedShow type=DelayedShow::Normal);
 signals:
 	void neovimAttached(bool);
 	void closing(int);
@@ -54,7 +54,7 @@ private slots:
 	void neovimAttachmentChanged(bool);
 	void neovimIsUnsupported();
 	void neovimShowtablineSet(int);
-	void neovimTablineUpdate(int64_t curtab, QList<Tab> tabs);
+	void neovimTablineUpdate(int64_t curtab, QList<NeovimQt::Tab> tabs);
 	void neovimShowContextMenu();
 	void neovimSendCut();
 	void neovimSendCopy();

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -96,7 +96,7 @@ signals:
 	void neovimExtTablineSet(bool);
 	/// The tabline needs updating. curtab is the handle of the current tab (not its index)
 	/// as seen in Tab::tab.
-	void neovimTablineUpdate(int64_t curtab, QList<Tab> tabs);
+	void neovimTablineUpdate(int64_t curtab, QList<NeovimQt::Tab> tabs);
 	void neovimShowtablineSet(int);
 	void neovimShowContextMenu();
 	void fontChanged();

--- a/src/msgpackiodevice.h
+++ b/src/msgpackiodevice.h
@@ -71,7 +71,7 @@ public:
 
 	QList<quint32> pendingRequests() const;
 signals:
-	void error(MsgpackError);
+	void error(NeovimQt::MsgpackIODevice::MsgpackError);
 	/** A notification with the given name and arguments was received */
 	void notification(const QByteArray &name, const QVariantList& args);
 
@@ -94,7 +94,7 @@ protected:
 	bool decodeMsgpack(const msgpack_object& in, QPoint& out);
 
 protected slots:
-	void setError(MsgpackError err, const QString& msg);
+	void setError(NeovimQt::MsgpackIODevice::MsgpackError err, const QString& msg);
 
 	void dataAvailable();
 	void dataAvailableStdin(const QByteArray&);

--- a/src/neovimconnector.h
+++ b/src/neovimconnector.h
@@ -103,7 +103,7 @@ public:
 signals:
 	/** Emitted when Neovim is ready @see ready */
 	void ready();
-	void error(NeovimError);
+	void error(NeovimQt::NeovimConnector::NeovimError);
 	void processExited(int exitCode);
 
 public slots:


### PR DESCRIPTION
Add `NeovimQt::` to some types.

Requires Neovim API modifications, using this to test #867 and 3eb6f51918ebd7eb1f3d97af84cc2a599b5988c7.