### PR TITLE
Fix Clazy Warning: clazy-qenums

### DIFF
--- a/.github/workflows/neovim-api.yml
+++ b/.github/workflows/neovim-api.yml
@@ -20,8 +20,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Download Neovim Source
         run: |
@@ -111,8 +109,6 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Install Neovim
         env:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,6 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR
 		string(CONCAT CLAZY_CHECKS
 			"level0,"
 			"no-overloaded-signal,"
-			"no-qenums,"
 			"level1,"
 			"no-connect-3arg-lambda,"
 			"no-inefficient-qlist-soft,"

--- a/bindings/neovimapi.h
+++ b/bindings/neovimapi.h
@@ -16,7 +16,6 @@ class MsgpackRequest;
 class NeovimApi{{api_level}}: public QObject
 {
 	Q_OBJECT
-	Q_ENUMS(FunctionId)
 
 public:
 
@@ -26,6 +25,7 @@ public:
 		NEOVIM_FN_{{ f.name.upper() }},
 		{% endfor %}
 	};
+	Q_ENUM(FunctionId)
 
 	static bool checkFunctions(const QVariantList& ftable);
 	static FunctionId functionId(const Function& f);

--- a/src/auto/neovimapi0.h
+++ b/src/auto/neovimapi0.h
@@ -1,4 +1,4 @@
-// Auto generated 2021-07-20 02:41:48.779803 from nvim API level:0
+// Auto generated 2021-07-21 04:43:14.350986 from nvim API level:0
 #pragma once
 
 #include <QObject>
@@ -16,7 +16,6 @@ class MsgpackRequest;
 class NeovimApi0: public QObject
 {
 	Q_OBJECT
-	Q_ENUMS(FunctionId)
 
 public:
 
@@ -103,6 +102,7 @@ public:
 				NEOVIM_FN_WINDOW_GET_TABPAGE,
 				NEOVIM_FN_WINDOW_IS_VALID,
 			};
+	Q_ENUM(FunctionId)
 
 	static bool checkFunctions(const QVariantList& ftable);
 	static FunctionId functionId(const Function& f);

--- a/src/auto/neovimapi1.h
+++ b/src/auto/neovimapi1.h
@@ -1,4 +1,4 @@
-// Auto generated 2021-07-20 02:45:08.775105 from nvim API level:1
+// Auto generated 2021-07-21 04:46:51.484084 from nvim API level:1
 #pragma once
 
 #include <QObject>
@@ -16,7 +16,6 @@ class MsgpackRequest;
 class NeovimApi1: public QObject
 {
 	Q_OBJECT
-	Q_ENUMS(FunctionId)
 
 public:
 
@@ -182,6 +181,7 @@ public:
 				NEOVIM_FN_WINDOW_GET_TABPAGE,
 				NEOVIM_FN_WINDOW_IS_VALID,
 			};
+	Q_ENUM(FunctionId)
 
 	static bool checkFunctions(const QVariantList& ftable);
 	static FunctionId functionId(const Function& f);

--- a/src/auto/neovimapi2.h
+++ b/src/auto/neovimapi2.h
@@ -1,4 +1,4 @@
-// Auto generated 2021-07-20 02:39:23.817220 from nvim API level:2
+// Auto generated 2021-07-21 04:41:06.709368 from nvim API level:2
 #pragma once
 
 #include <QObject>
@@ -16,7 +16,6 @@ class MsgpackRequest;
 class NeovimApi2: public QObject
 {
 	Q_OBJECT
-	Q_ENUMS(FunctionId)
 
 public:
 
@@ -184,6 +183,7 @@ public:
 				NEOVIM_FN_WINDOW_GET_TABPAGE,
 				NEOVIM_FN_WINDOW_IS_VALID,
 			};
+	Q_ENUM(FunctionId)
 
 	static bool checkFunctions(const QVariantList& ftable);
 	static FunctionId functionId(const Function& f);

--- a/src/auto/neovimapi3.h
+++ b/src/auto/neovimapi3.h
@@ -1,4 +1,4 @@
-// Auto generated 2021-07-20 02:40:07.831991 from nvim API level:3
+// Auto generated 2021-07-21 04:41:45.838828 from nvim API level:3
 #pragma once
 
 #include <QObject>
@@ -16,7 +16,6 @@ class MsgpackRequest;
 class NeovimApi3: public QObject
 {
 	Q_OBJECT
-	Q_ENUMS(FunctionId)
 
 public:
 
@@ -189,6 +188,7 @@ public:
 				NEOVIM_FN_WINDOW_GET_TABPAGE,
 				NEOVIM_FN_WINDOW_IS_VALID,
 			};
+	Q_ENUM(FunctionId)
 
 	static bool checkFunctions(const QVariantList& ftable);
 	static FunctionId functionId(const Function& f);

--- a/src/auto/neovimapi4.h
+++ b/src/auto/neovimapi4.h
@@ -1,4 +1,4 @@
-// Auto generated 2021-07-20 02:40:56.156899 from nvim API level:4
+// Auto generated 2021-07-21 04:42:27.746319 from nvim API level:4
 #pragma once
 
 #include <QObject>
@@ -16,7 +16,6 @@ class MsgpackRequest;
 class NeovimApi4: public QObject
 {
 	Q_OBJECT
-	Q_ENUMS(FunctionId)
 
 public:
 
@@ -201,6 +200,7 @@ public:
 				NEOVIM_FN_WINDOW_GET_TABPAGE,
 				NEOVIM_FN_WINDOW_IS_VALID,
 			};
+	Q_ENUM(FunctionId)
 
 	static bool checkFunctions(const QVariantList& ftable);
 	static FunctionId functionId(const Function& f);

--- a/src/auto/neovimapi5.h
+++ b/src/auto/neovimapi5.h
@@ -1,4 +1,4 @@
-// Auto generated 2021-07-20 02:41:45.923784 from nvim API level:5
+// Auto generated 2021-07-21 04:43:08.681084 from nvim API level:5
 #pragma once
 
 #include <QObject>
@@ -16,7 +16,6 @@ class MsgpackRequest;
 class NeovimApi5: public QObject
 {
 	Q_OBJECT
-	Q_ENUMS(FunctionId)
 
 public:
 
@@ -208,6 +207,7 @@ public:
 				NEOVIM_FN_WINDOW_GET_TABPAGE,
 				NEOVIM_FN_WINDOW_IS_VALID,
 			};
+	Q_ENUM(FunctionId)
 
 	static bool checkFunctions(const QVariantList& ftable);
 	static FunctionId functionId(const Function& f);

--- a/src/auto/neovimapi6.h
+++ b/src/auto/neovimapi6.h
@@ -1,4 +1,4 @@
-// Auto generated 2021-07-20 02:42:32.076419 from nvim API level:6
+// Auto generated 2021-07-21 04:43:51.959832 from nvim API level:6
 #pragma once
 
 #include <QObject>
@@ -16,7 +16,6 @@ class MsgpackRequest;
 class NeovimApi6: public QObject
 {
 	Q_OBJECT
-	Q_ENUMS(FunctionId)
 
 public:
 
@@ -226,6 +225,7 @@ public:
 				NEOVIM_FN_WINDOW_GET_TABPAGE,
 				NEOVIM_FN_WINDOW_IS_VALID,
 			};
+	Q_ENUM(FunctionId)
 
 	static bool checkFunctions(const QVariantList& ftable);
 	static FunctionId functionId(const Function& f);

--- a/src/function.h
+++ b/src/function.h
@@ -12,7 +12,6 @@
 namespace NeovimQt {
 
 class Function {
-	Q_ENUMS(FunctionId)
 public:
 
 	Function();

--- a/src/msgpackiodevice.h
+++ b/src/msgpackiodevice.h
@@ -23,11 +23,8 @@ public:
 		InvalidMsgpack,
 		UnsupportedEncoding,
 	};
-#ifdef Q_ENUM
 	Q_ENUM(MsgpackError)
-#else
-	Q_ENUMS(MsgpackError)
-#endif
+
 	MsgpackIODevice(QIODevice *, QObject *parent=0);
 	~MsgpackIODevice();
         static MsgpackIODevice* fromStdinOut(QObject *parent=0);

--- a/src/neovimconnector.h
+++ b/src/neovimconnector.h
@@ -49,11 +49,7 @@ public:
 		MsgpackError,
 		RuntimeMsgpackError,
 	};
-#ifdef Q_ENUM
 	Q_ENUM(NeovimError)
-#else
-	Q_ENUMS(NeovimError)
-#endif
 
 	/** Underlying connection used to read Neovim */
         enum NeovimConnectionType {


### PR DESCRIPTION
The Q_ENUMS macro is deprecated, use Q_ENUM instead.

Requires modification to auto-generated code.