### PR TITLE
Fix tst_shell missing icon

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -29,7 +29,8 @@ function(add_xtest SOURCE_NAME)
 endfunction()
 
 function(add_xtest_gui SOURCE_NAME)
-	add_executable(${SOURCE_NAME} ${SOURCE_NAME}.cpp ${ARGV1} ${ARGV2})
+	qt5_add_resources(RCC_SOURCES data.qrc)
+	add_executable(${SOURCE_NAME} ${RCC_SOURCES} ${SOURCE_NAME}.cpp ${ARGV1} ${ARGV2})
 	target_link_libraries(${SOURCE_NAME} ${QTLIBS} ${MSGPACK_LIBRARIES} neovim-qt Qt5::Widgets neovim-qt-gui)
 	add_test(NAME ${SOURCE_NAME} COMMAND ${SOURCE_NAME}
 		# Run GUI tests from source dir, they depend on src files

--- a/test/data.qrc
+++ b/test/data.qrc
@@ -1,0 +1,5 @@
+<!DOCTYPE RCC><RCC VERSION="1.0">
+<qresource>
+  <file alias="neovim.svg">../third-party/neovim.svg</file>
+</qresource>
+</RCC>


### PR DESCRIPTION
This error occurs due to a missing *.qrc file.
    
Test error:
`qt.svg: Cannot open file ':/neovim.svg', because: No such file or directory`