### PR TITLE
Cleanup Shell event handler

### DIFF
--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -510,15 +510,12 @@ void Shell::handleRedraw(const QByteArray& name, const QVariantList& opargs)
 		handleMouse(false);
 	} else if (name == "mode_change"){
 		handleModeChange(opargs);
-	} else if (name == "cursor_on"){
 	} else if (name == "set_title"){
 		handleSetTitle(opargs);
-	} else if (name == "cursor_off"){
 	} else if (name == "busy_start"){
 		handleBusy(true);
 	} else if (name == "busy_stop"){
 		handleBusy(false);
-	} else if (name == "set_icon") {
 	} else if (name == "tabline_update") {
 		if (opargs.size() < 2 || !opargs.at(0).canConvert<int64_t>()) {
 			qWarning() << "Unexpected argument for tabline_update:" << opargs;
@@ -577,11 +574,10 @@ void Shell::handleRedraw(const QByteArray& name, const QVariantList& opargs)
 		handleGridScroll(opargs);
 	} else if (name == "hl_group_set") {
 		handleHighlightGroupSet(opargs);
-	} else if (name == "win_viewport") {
 	} else {
-		qDebug() << "Received unknown redraw notification" << name << opargs;
+		// Uncomment for writing new event handling code.
+		// qDebug() << "Received unknown redraw notification" << name << opargs;
 	}
-
 }
 
 void Shell::handlePopupMenuShow(const QVariantList& opargs)
@@ -889,12 +885,11 @@ void Shell::handleExtGuiOption(const QString& name, const QVariant& value)
 		handleGuiTabline(value);
 	} else if (name == "Popupmenu") {
 		handleGuiPopupmenu(value);
-	} else if (name == "Cmdline") {
-	} else if (name == "Wildmenu") {
 	} else if (name == "RenderLigatures"){
 		setLigatureMode(value.toBool());
 	} else {
-		qDebug() << "Unknown GUI Option" << name << value;
+		// Uncomment for writing new event handling code.
+		// qDebug() << "Unknown GUI Option" << name << value;
 	}
 }
 
@@ -902,7 +897,6 @@ void Shell::handleSetOption(const QString& name, const QVariant& value)
 {
 	if (name == "guifont") {
 		setGuiFont(value.toString(), false /*force*/, false /*setOption*/);
-	} else if (name == "guifontset") {
 	} else if (name == "guifontwide") {
 		handleGuiFontWide(value);
 	} else if (name == "linespace") {
@@ -911,17 +905,9 @@ void Shell::handleSetOption(const QString& name, const QVariant& value)
 		emit neovimShowtablineSet(value.toString().toInt());
 	} else if (name == "ext_tabline") {
 		emit neovimExtTablineSet(value.toBool());
-	} else if (name == "ext_popupmenu") {
-	// TODO
-	} else if (name == "arabicshape") {
-	} else if (name == "ambiwidth") {
-	} else if (name == "emoji") {
-	} else if (name == "termguicolors") {
-	} else if (name == "ext_cmdline") {
-	} else if (name == "ext_wildmenu") {
-	} else if (name == "ext_linegrid") {
 	} else {
-		qDebug() << "Received unknown option" << name << value;
+		// Uncomment for writing new event handling code.
+		// qDebug() << "Received unknown option" << name << value;
 	}
 }
 


### PR DESCRIPTION
Removes unused if blocks in the event handler.

Comments out `qDebug()` messages for unrecognized events. These messages are too verbose in many cases (Debug Builds, tst_shell).

With the new `Shell::DispatchRedrawNotifications` from # #677, these messages are less useful. Today, event handling can be done from objects other than `Shell`.