### PR TITLE
QSettings use application and organization names

### DIFF
--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -56,6 +56,9 @@ App::App(int &argc, char ** argv) noexcept
 	setWindowIcon(QIcon(":/neovim.svg"));
 	setApplicationDisplayName("Neovim");
 
+	setOrganizationName("nvim-qt");
+	setApplicationName("nvim-qt");
+
 #ifdef Q_OS_MAC
 	QByteArray shellPath = qgetenv("SHELL");
 	if (!getLoginEnvironment(shellPath)) {

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -452,14 +452,14 @@ void MainWindow::changeTab(int index)
 
 void MainWindow::saveWindowGeometry()
 {
-	QSettings settings{ "nvim-qt", "window-geometry" };
+	QSettings settings{ "window-geometry" };
 	settings.setValue("window_geometry", saveGeometry());
 	settings.setValue("window_state", saveState());
 }
 
 void MainWindow::restoreWindowGeometry()
 {
-	QSettings settings{ "nvim-qt", "window-geometry" };
+	QSettings settings{ "window-geometry" };
 	restoreGeometry(settings.value("window_geometry").toByteArray());
 	restoreState(settings.value("window_state").toByteArray());
 }

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -24,7 +24,7 @@ namespace NeovimQt {
 static ShellOptions GetShellOptionsFromQSettings() noexcept
 {
 	ShellOptions opts;
-	QSettings settings{ "nvim-qt", "nvim-qt" };
+	QSettings settings;
 
 	QVariant ext_linegrid{ settings.value("ext_linegrid", opts.IsLineGridEnabled()) };
 	QVariant ext_popupmenu{ settings.value("ext_popupmenu", opts.IsPopupmenuEnabled()) };
@@ -74,7 +74,7 @@ Shell::Shell(NeovimConnector *nvim, QWidget *parent)
 	m_pum.setParent(this);
 	m_pum.hide();
 
-	QSettings settings{ "nvim-qt", "nvim-qt" };
+	QSettings settings;
 
 	// Font
 	QVariant guiFont{ settings.value("Gui/Font") };
@@ -163,7 +163,7 @@ bool Shell::setGuiFont(const QString& fdesc, bool force, bool updateOption)
 	m_nvim->api0()->vim_set_var("GuiFont", fontDesc());
 
 	// Write GuiFont to QSettings, prevent startup font flicker
-	QSettings settings{ "nvim-qt", "nvim-qt" };
+	QSettings settings;
 	settings.setValue("Gui/Font", fontDesc());
 
 	// Updating guifont when the user has already called 'set guifont=...' may cause
@@ -1014,7 +1014,7 @@ void Shell::handleGuiTabline(const QVariant& value) noexcept
 	const bool isEnabled{ value.toBool() };
 	m_nvim->api1()->nvim_ui_set_option("ext_tabline", isEnabled);
 
-	QSettings settings{ "nvim-qt", "nvim-qt" };
+	QSettings settings;
 	settings.setValue("ext_tabline", isEnabled);
 }
 
@@ -1035,7 +1035,7 @@ void Shell::handleGuiPopupmenu(const QVariant& value) noexcept
 	const bool isEnabled{ value.toBool() };
 	m_nvim->api1()->nvim_ui_set_option("ext_popupmenu", isEnabled);
 
-	QSettings settings{ "nvim-qt", "nvim-qt" };
+	QSettings settings;
 	settings.setValue("ext_popupmenu", isEnabled);
 }
 


### PR DESCRIPTION
`QSettings` will now be created based on `QCoreApplication::applicationName` and `QCoreApplication::organizaitonName`.

This modification will allow QSettings to be test-mocked.

Breaks #761.