### PR TITLE
ShellWidget emits shellFontChanged on startup

### DIFF
--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -95,8 +95,6 @@ Shell::Shell(NeovimConnector *nvim, QWidget *parent)
 			this, &Shell::neovimError);
 	connect(m_nvim, &NeovimConnector::processExited,
 			this, &Shell::neovimExited);
-	connect(this, &ShellWidget::shellFontChanged,
-			this, &Shell::fontChanged);
 	connect(this, &ShellWidget::fontError,
 			this, &Shell::fontError);
 

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -99,7 +99,6 @@ signals:
 	void neovimTablineUpdate(int64_t curtab, QList<NeovimQt::Tab> tabs);
 	void neovimShowtablineSet(int);
 	void neovimShowContextMenu();
-	void fontChanged();
 	void colorsChanged();
 
 	// GuiAdaptive Color/Font Signals

--- a/src/gui/shellwidget/shellwidget.cpp
+++ b/src/gui/shellwidget/shellwidget.cpp
@@ -35,7 +35,8 @@ ShellWidget* ShellWidget::fromFile(const QString& path)
 void ShellWidget::setDefaultFont()
 {
 	static const QFont font{ getDefaultFontFamily(), 11 /*pointSize*/, -1 /*weight*/, false /*italic*/ };
-	setShellFont(font, true /*force*/);
+	setFont(font);
+	setCellSize();
 }
 
 /*static*/ QString ShellWidget::getDefaultFontFamily() noexcept
@@ -61,13 +62,13 @@ bool ShellWidget::setShellFont(const QFont& font, bool force) noexcept
 	QFontInfo fi(font);
 	if (fi.family().compare(font.family(), Qt::CaseInsensitive) != 0 &&
 			font.family().compare("Monospace", Qt::CaseInsensitive) != 0) {
-		emit fontError(QString("Unknown font: %1").arg(font.family()));
+		emit fontError(QStringLiteral("Unknown font: %1").arg(font.family()));
 		return false;
 	}
 
 	if (!force) {
 		if (!fi.fixedPitch()) {
-			emit fontError(QString("%1 is not a fixed pitch font").arg(font.family()));
+			emit fontError(QStringLiteral("%1 is not a fixed pitch font").arg(font.family()));
 			return false;
 		}
 

--- a/test/tst_shell.cpp
+++ b/test/tst_shell.cpp
@@ -154,7 +154,7 @@ private slots:
 		QVERIFY(cmd_gf.isValid());
 		QVERIFY(SPYWAIT(cmd_gf));
 
-		QSignalSpy spy_fontchange(s->shell(), &Shell::fontChanged);
+		QSignalSpy spy_fontchange(s->shell(), &ShellWidget::shellFontChanged);
 
 		// Test Performance: timeout occurs often, set value carefully.
 		SPYWAIT(spy_fontchange, 2500 /*msec*/);
@@ -174,7 +174,7 @@ private slots:
 		QVERIFY(cmd_gf2.isValid());
 		QVERIFY(SPYWAIT(cmd_gf2));
 
-		QSignalSpy spy_fontchange2(s->shell(), &Shell::fontChanged);
+		QSignalSpy spy_fontchange2(s->shell(), &ShellWidget::shellFontChanged);
 
 		// Test Performance: timeout occurs often, set value carefully.
 		SPYWAIT(spy_fontchange2, 2500 /*msec*/);


### PR DESCRIPTION
ShellWidget incorrectly emits this signal. The default font is not really a font change.

This bug is responsible for the double-signals that can be seen on startup.

Causes poor tst_shell performance.