### PR TITLE
Remove SIGNAL/SLOT overload neovimAttached

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,6 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR
 	if(ENABLE_CLAZY)
 		string(CONCAT CLAZY_CHECKS
 			"level0,"
-			"no-overloaded-signal,"
 			"level1,"
 			"no-connect-3arg-lambda,"
 			"no-inefficient-qlist-soft,"

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -92,8 +92,7 @@ void MainWindow::init(NeovimConnector *c)
 	m_stack.insertWidget(1, m_window);
 	m_stack.setCurrentIndex(1);
 
-	connect(m_shell, SIGNAL(neovimAttached(bool)),
-			this, SLOT(neovimAttachmentChanged(bool)));
+	connect(m_shell, &Shell::neovimAttachmentChanged, this, &MainWindow::handleNeovimAttachment);
 	connect(m_shell, SIGNAL(neovimTitleChanged(QString)),
 			this, SLOT(neovimSetTitle(QString)));
 	connect(m_shell, &Shell::neovimResized,
@@ -150,11 +149,6 @@ void MainWindow::init(NeovimConnector *c)
 	if (m_nvim->errorCause()) {
 		neovimError(m_nvim->errorCause());
 	}
-}
-
-bool MainWindow::neovimAttached() const
-{
-	return (m_shell != NULL && m_shell->neovimAttached());
 }
 
 /** The Neovim process has exited */
@@ -317,9 +311,10 @@ void MainWindow::showIfDelayed()
 	m_delayedShow = DelayedShow::Disabled;
 }
 
-void MainWindow::neovimAttachmentChanged(bool attached)
+void MainWindow::handleNeovimAttachment(bool attached)
 {
-	emit neovimAttached(attached);
+	emit neovimAttachmentChanged(attached);
+
 	if (attached) {
 		if (isWindow() && m_shell != NULL) {
 			m_shell->updateGuiWindowState(windowState());

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -28,13 +28,15 @@ public:
 	};
 
 	MainWindow(NeovimConnector *, QWidget *parent=0);
-	bool neovimAttached() const;
+
+	bool isNeovimAttached() const noexcept { return m_shell && m_shell->isNeovimAttached(); }
+
 	Shell* shell();
 	void restoreWindowGeometry();
 public slots:
 	void delayedShow(NeovimQt::MainWindow::DelayedShow type=DelayedShow::Normal);
 signals:
-	void neovimAttached(bool);
+	void neovimAttachmentChanged(bool);
 	void closing(int);
 protected:
 	virtual void closeEvent(QCloseEvent *ev) Q_DECL_OVERRIDE;
@@ -51,7 +53,7 @@ private slots:
 	void neovimError(NeovimConnector::NeovimError);
 	void reconnectNeovim();
 	void showIfDelayed();
-	void neovimAttachmentChanged(bool);
+	void handleNeovimAttachment(bool);
 	void neovimIsUnsupported();
 	void neovimShowtablineSet(int);
 	void neovimTablineUpdate(int64_t curtab, QList<NeovimQt::Tab> tabs);

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -774,7 +774,7 @@ void Shell::handleBusy(bool busy)
 	m_neovimBusy = busy;
 
 	setCursorFromBusyState();
-	emit neovimBusy(busy);
+	emit neovimBusyChanged(busy);
 }
 
 // FIXME: fix QVariant type conversions
@@ -1672,11 +1672,6 @@ QVariant Shell::inputMethodQuery(Qt::InputMethodQuery query) const
 	}
 
 	return QVariant();
-}
-
-bool Shell::neovimBusy() const
-{
-	return m_neovimBusy;
 }
 
 void Shell::dragEnterEvent(QDragEnterEvent *ev)

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -246,7 +246,7 @@ void Shell::setAttached(bool attached)
 		}
 
 	}
-	emit neovimAttached(attached);
+	emit neovimAttachmentChanged(attached);
 	update();
 }
 
@@ -278,19 +278,19 @@ void Shell::init()
 	}
 	options.insert("rgb", true);
 
-	MsgpackRequest *req;
+	MsgpackRequest* req{ nullptr };
 	if (m_nvim->api2()) {
 		req = m_nvim->api2()->nvim_ui_attach(width, height, options);
-	} else {
+	}
+	else {
 		req = m_nvim->api0()->ui_attach(width, height, true);
 	}
-	connect(req, &MsgpackRequest::timeout,
-			m_nvim, &NeovimConnector::fatalTimeout);
-	// FIXME grab timeout from connector
+
+	connect(req, &MsgpackRequest::timeout, m_nvim, &NeovimConnector::fatalTimeout);
+	// TODO Issue#880: Grab timeout from connector
 	req->setTimeout(10000);
 
-	connect(req, &MsgpackRequest::finished,
-			this, &Shell::setAttached);
+	connect(req, &MsgpackRequest::finished, this, &Shell::setAttached);
 
 	// Subscribe to GUI events
 	m_nvim->api0()->vim_subscribe("Gui");
@@ -1677,11 +1677,6 @@ QVariant Shell::inputMethodQuery(Qt::InputMethodQuery query) const
 bool Shell::neovimBusy() const
 {
 	return m_neovimBusy;
-}
-
-bool Shell::neovimAttached() const
-{
-	return m_attached;
 }
 
 void Shell::dragEnterEvent(QDragEnterEvent *ev)

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -36,14 +36,15 @@ public:
 class Shell: public ShellWidget
 {
 	Q_OBJECT
-	Q_PROPERTY(bool neovimBusy READ neovimBusy() NOTIFY neovimBusy())
+	Q_PROPERTY(bool isNeovimBusy READ isNeovimBusy() NOTIFY neovimBusyChanged(bool))
 	Q_PROPERTY(bool isNeovimAttached READ isNeovimAttached() NOTIFY neovimAttachmentChanged(bool))
 public:
 	Shell(NeovimConnector *nvim, QWidget *parent=0);
 	~Shell();
 	QSize sizeIncrement() const;
 	virtual QVariant inputMethodQuery(Qt::InputMethodQuery) const Q_DECL_OVERRIDE;
-	bool neovimBusy() const;
+
+	bool isNeovimBusy() const noexcept { return m_neovimBusy; }
 
 	bool isNeovimAttached() const noexcept { return m_attached; }
 
@@ -83,7 +84,7 @@ public:
 
 signals:
 	void neovimTitleChanged(const QString &title);
-	void neovimBusy(bool);
+	void neovimBusyChanged(bool);
 	void neovimResized(int rows, int cols);
 	void neovimAttachmentChanged(bool);
 	void neovimMaximized(bool);

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -37,14 +37,15 @@ class Shell: public ShellWidget
 {
 	Q_OBJECT
 	Q_PROPERTY(bool neovimBusy READ neovimBusy() NOTIFY neovimBusy())
-	Q_PROPERTY(bool neovimAttached READ neovimAttached() NOTIFY neovimAttached())
+	Q_PROPERTY(bool isNeovimAttached READ isNeovimAttached() NOTIFY neovimAttachmentChanged(bool))
 public:
 	Shell(NeovimConnector *nvim, QWidget *parent=0);
 	~Shell();
 	QSize sizeIncrement() const;
 	virtual QVariant inputMethodQuery(Qt::InputMethodQuery) const Q_DECL_OVERRIDE;
 	bool neovimBusy() const;
-	bool neovimAttached() const;
+
+	bool isNeovimAttached() const noexcept { return m_attached; }
 
 	PopupMenu& getPopupMenu() noexcept
 	{
@@ -84,7 +85,7 @@ signals:
 	void neovimTitleChanged(const QString &title);
 	void neovimBusy(bool);
 	void neovimResized(int rows, int cols);
-	void neovimAttached(bool);
+	void neovimAttachmentChanged(bool);
 	void neovimMaximized(bool);
 	void neovimForeground();
 	void neovimOpacity(double);
@@ -194,7 +195,7 @@ protected:
 	QString neovimErrorToString(const QVariant& err);
 
 private slots:
-        void setAttached(bool attached=true);
+	void setAttached(bool attached);
 
 private:
 	bool m_attached{ false };

--- a/test/tst_shell.cpp
+++ b/test/tst_shell.cpp
@@ -51,10 +51,10 @@ private slots:
 		args << "-u" << "NONE";
 		NeovimConnector *c = NeovimConnector::spawn(args);
 		Shell *s = new Shell(c);
-		QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
+		QSignalSpy onAttached(s, SIGNAL(neovimAttachmentChanged(bool)));
 		QVERIFY(onAttached.isValid());
 		QVERIFY(SPYWAIT(onAttached));
-		QVERIFY(s->neovimAttached());
+		QVERIFY(s->isNeovimAttached());
 
 		s->repaint();
 
@@ -67,10 +67,10 @@ private slots:
 		QStringList args = {"-u", "NONE"};
 		NeovimConnector *c = NeovimConnector::spawn(args);
 		Shell *s = new Shell(c);
-		QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
+		QSignalSpy onAttached(s, SIGNAL(neovimAttachmentChanged(bool)));
 		QVERIFY(onAttached.isValid());
 		QVERIFY(SPYWAIT(onAttached));
-		QVERIFY(s->neovimAttached());
+		QVERIFY(s->isNeovimAttached());
 		checkStartVars(c);
 	}
 
@@ -79,10 +79,10 @@ private slots:
 		NeovimConnector *c = NeovimConnector::spawn(args);
 		MainWindow *s = new MainWindow(c);
 		s->show();
-		QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
+		QSignalSpy onAttached(s, SIGNAL(neovimAttachmentChanged(bool)));
 		QVERIFY(onAttached.isValid());
 		QVERIFY(SPYWAIT(onAttached));
-		QVERIFY(s->neovimAttached());
+		QVERIFY(s->isNeovimAttached());
 		checkStartVars(c);
 	}
 
@@ -103,10 +103,10 @@ private slots:
 		NeovimConnector *c = NeovimConnector::spawn(args);
 		Shell *s = new Shell(c);
 
-		QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
+		QSignalSpy onAttached(s, SIGNAL(neovimAttachmentChanged(bool)));
 		QVERIFY(onAttached.isValid());
 		QVERIFY(SPYWAIT(onAttached));
-		QVERIFY(s->neovimAttached());
+		QVERIFY(s->isNeovimAttached());
 
 		auto req = c->api0()->vim_command_output(c->encode("echo g:test_gviminit"));
 		QSignalSpy cmd(req, SIGNAL(finished(quint32, quint64, QVariant)));
@@ -128,10 +128,10 @@ private slots:
 			"--cmd", "set rtp+=" + fi.absoluteFilePath()};
 		NeovimConnector *c = NeovimConnector::spawn(args);
 		MainWindow *s = new MainWindow(c);
-		QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
+		QSignalSpy onAttached(s, SIGNAL(neovimAttachmentChanged(bool)));
 		QVERIFY(onAttached.isValid());
 		QVERIFY(SPYWAIT(onAttached));
-		QVERIFY(s->neovimAttached());
+		QVERIFY(s->isNeovimAttached());
 
 		QObject::connect(c->neovimObject(), &NeovimApi1::err_vim_command_output, [](QString msg, const QVariant& err) {
 				qDebug() << msg << err;
@@ -227,10 +227,10 @@ private slots:
 		NeovimConnector* c{ NeovimConnector::spawn(args) };
 		MainWindow* s{ new MainWindow(c) };
 		s->show();
-		QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
+		QSignalSpy onAttached(s, SIGNAL(neovimAttachmentChanged(bool)));
 		QVERIFY(onAttached.isValid());
 		QVERIFY(SPYWAIT(onAttached));
-		QVERIFY(s->neovimAttached());
+		QVERIFY(s->isNeovimAttached());
 
 		// GUI shim Close event
 		QSignalSpy onClose(s->shell(), &Shell::neovimGuiCloseRequest);
@@ -294,10 +294,10 @@ private slots:
 			"--cmd", "set rtp+=" + fi.absoluteFilePath()};
 		NeovimConnector *c = NeovimConnector::spawn(args);
 		MainWindow *s = new MainWindow(c);
-		QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
+		QSignalSpy onAttached(s, SIGNAL(neovimAttachmentChanged(bool)));
 		QVERIFY(onAttached.isValid());
 		QVERIFY(SPYWAIT(onAttached));
-		QVERIFY(s->neovimAttached());
+		QVERIFY(s->isNeovimAttached());
 
 		QObject::connect(c->neovimObject(), &NeovimApi1::err_vim_command_output, [](QString msg, const QVariant& err) {
 				qDebug() << msg << err;
@@ -355,10 +355,10 @@ private slots:
 			"--cmd", "set rtp+=" + fi.absoluteFilePath()};
 		NeovimConnector *c = NeovimConnector::spawn(args);
 		MainWindow *s = new MainWindow(c);
-		QSignalSpy onAttached(s, SIGNAL(neovimAttached(bool)));
+		QSignalSpy onAttached(s, SIGNAL(neovimAttachmentChanged(bool)));
 		QVERIFY(onAttached.isValid());
 		QVERIFY(SPYWAIT(onAttached));
-		QVERIFY(s->neovimAttached());
+		QVERIFY(s->isNeovimAttached());
 
 		QObject::connect(c->neovimObject(), &NeovimApi1::err_vim_command_output, [](QString msg, const QVariant& err) {
 				qDebug() << msg << err;


### PR DESCRIPTION
The function is overloaded in Shell and MainWindow:
```
    void neovimAttached()
    void neovimAttached(bool)
```
Split this function into two parts:
```
    (SIGNAL) void neovimAttachmentChanged(bool);
    (QPROP) void isNeovimAttached();
```