### PR TITLE
Refactor tst_shell

### DIFF
--- a/test/common.h
+++ b/test/common.h
@@ -1,5 +1,6 @@
-#ifndef NEOVIM_QT_TEST_COMMON
-#define NEOVIM_QT_TEST_COMMON
+#pragma once
+
+#include <QSignalSpy>
 
 // This is just a fix for QSignalSpy::wait
 // http://stackoverflow.com/questions/22390208/google-test-mock-with-qt-signals
@@ -7,5 +8,3 @@ bool SPYWAIT(QSignalSpy &spy, int timeout=30000)
 {
 	return spy.count()>0||spy.wait(timeout);
 }
-
-#endif

--- a/test/tst_shell.h
+++ b/test/tst_shell.h
@@ -1,13 +1,17 @@
 #pragma once
 
+#include <QClipboard>
+#include <QString>
 #include <QStringList>
 
 namespace NeovimQt {
 
+QClipboard::Mode GetClipboardMode(char reg) noexcept;
+
+QString GetPlatformTestFont() noexcept;
+
 QStringList BinaryAndArgumentsNoForkWithCommand(const QString& command) noexcept;
 
 void AddPlatformSpecificExitCodeCases() noexcept;
-
-class Test;
 
 } // Namespace NeovimQt

--- a/test/tst_shell_mac.cpp
+++ b/test/tst_shell_mac.cpp
@@ -1,9 +1,18 @@
 #include "tst_shell.h"
 
-#include <QStringList>
 #include <QTest>
 
 namespace NeovimQt {
+
+QClipboard::Mode GetClipboardMode(char /*reg*/) noexcept
+{
+	return QClipboard::Clipboard;
+}
+
+QString GetPlatformTestFont() noexcept
+{
+	return QStringLiteral("Monaco");
+}
 
 QStringList BinaryAndArgumentsNoForkWithCommand(const QString& command) noexcept
 {

--- a/test/tst_shell_unix.cpp
+++ b/test/tst_shell_unix.cpp
@@ -1,9 +1,22 @@
 #include "tst_shell.h"
 
-#include <QStringList>
 #include <QTest>
 
 namespace NeovimQt {
+
+QClipboard::Mode GetClipboardMode(char reg) noexcept
+{
+	if (reg != '+') {
+		return QClipboard::Selection;
+	}
+
+	return QClipboard::Clipboard;
+}
+
+QString GetPlatformTestFont() noexcept
+{
+	return QStringLiteral("DejaVu Sans Mono");
+}
 
 QStringList BinaryAndArgumentsNoForkWithCommand(const QString& command) noexcept
 {

--- a/test/tst_shell_win32.cpp
+++ b/test/tst_shell_win32.cpp
@@ -1,9 +1,18 @@
 #include "tst_shell.h"
 
-#include <QStringList>
 #include <QTest>
 
 namespace NeovimQt {
+
+QClipboard::Mode GetClipboardMode(char /*reg*/) noexcept
+{
+	return QClipboard::Clipboard;
+}
+
+QString GetPlatformTestFont() noexcept
+{
+	return QStringLiteral("DejaVu Sans Mono");
+}
 
 QStringList BinaryAndArgumentsNoForkWithCommand(const QString& command) noexcept
 {


### PR DESCRIPTION
Refactoring the `tst_shell` code:
 - Reduce code duplication
 - Remove #ifdef-s
 - Add QSettings Coverage
 - Split tests into smaller isolated scenarios