### PR TITLE
Issue 904: Titlestring incorrectly includes "Neovim"

### DIFF
--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -201,7 +201,6 @@ App::App(int &argc, char ** argv) noexcept
 :QApplication(argc, argv)
 {
 	setWindowIcon(QIcon(":/neovim.svg"));
-	setApplicationDisplayName("Neovim");
 
 	setOrganizationName("nvim-qt");
 	setApplicationName("nvim-qt");

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -8,6 +8,11 @@
 
 namespace NeovimQt {
 
+static QString DefaultWindowTitle() noexcept
+{
+	return "Neovim";
+}
+
 MainWindow::MainWindow(NeovimConnector* c, QWidget* parent)
 	: QMainWindow(parent)
 	, m_defaultFont{ font() }
@@ -18,6 +23,8 @@ MainWindow::MainWindow(NeovimConnector* c, QWidget* parent)
 	connect(m_errorWidget, &ErrorWidget::reconnectNeovim,
 			this, &MainWindow::reconnectNeovim);
 	setCentralWidget(&m_stack);
+
+	setWindowTitle(DefaultWindowTitle());
 
 	init(c);
 }
@@ -195,7 +202,12 @@ void MainWindow::neovimIsUnsupported()
 
 void MainWindow::neovimSetTitle(const QString &title)
 {
-	this->setWindowTitle(title);
+	if (title.isEmpty()) {
+		setWindowTitle(DefaultWindowTitle());
+		return;
+	}
+
+	setWindowTitle(title);
 }
 
 void MainWindow::neovimWidgetResized()

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -808,7 +808,8 @@ void Shell::handleSetTitle(const QVariantList& opargs)
 		qWarning() << "Unexpected arguments for set_title:" << opargs;
 		return;
 	}
-	QString title = m_nvim->decode(opargs.at(0).toByteArray());
+
+	const QString title{ m_nvim->decode(opargs.at(0).toByteArray()) };
 	emit neovimTitleChanged(title);
 }
 


### PR DESCRIPTION
**Issue #904:** Incorrect `titlestring` displayed

When `:set titlestring` is set, the window title displays:
"{ titlestring } -- Neovim"

This is incorrect, we should not append " -- Neovim".

However, The `:set notitle` case should display "Neovim".