### PR TITLE
Fix Clazy Warning: clazy-range-loop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,6 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR
 			"no-inefficient-qlist-soft,"
 			"no-overridden-signal,"
 			"no-qproperty-without-notify,"
-			"no-range-loop,"
 			)
 
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Xclang -plugin-arg-clazy -Xclang ${CLAZY_CHECKS} -Wno-deprecated-declarations -Werror")

--- a/src/gui/shellwidget/shellwidget.cpp
+++ b/src/gui/shellwidget/shellwidget.cpp
@@ -1009,7 +1009,7 @@ QVariant ShellWidget::TryGetQFontFromDescription(const QString& fdesc) const noe
 	qreal pointSizeF = curFont.pointSizeF();
 	int weight = -1;
 	bool italic = false;
-	for (const auto& attr : attrs) {
+	for (const auto& attr : qAsConst(attrs)) {
 		if (attr.size() >= 2 && attr[0] == 'h') {
 			bool ok{ false };
 			qreal height = attr.midRef(1).toFloat(&ok);


### PR DESCRIPTION
Use `aAsConst(...)` to prevent the container from detaching.