### PR TITLE
Fix Clazy Warning: clazy-overridden-signal

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,6 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR
 			"level1,"
 			"no-connect-3arg-lambda,"
 			"no-inefficient-qlist-soft,"
-			"no-overridden-signal,"
 			"no-qproperty-without-notify,"
 			"no-range-loop,"
 			)

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -96,8 +96,7 @@ Shell::Shell(NeovimConnector *nvim, QWidget *parent)
 			this, &Shell::neovimError);
 	connect(m_nvim, &NeovimConnector::processExited,
 			this, &Shell::neovimExited);
-	connect(this, &ShellWidget::fontError,
-			this, &Shell::fontError);
+	connect(this, &ShellWidget::fontError, this, &Shell::handleFontError);
 
 	m_nvim->setRequestHandler(new ShellRequestHandler(this));
 
@@ -106,7 +105,7 @@ Shell::Shell(NeovimConnector *nvim, QWidget *parent)
 	}
 }
 
-void Shell::fontError(const QString& msg)
+void Shell::handleFontError(const QString& msg)
 {
 	if (m_attached) {
 		m_nvim->api0()->vim_report_error(m_nvim->encode(msg));

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -125,7 +125,7 @@ protected slots:
 	void mouseClickReset();
 	void mouseClickIncrement(Qt::MouseButton bt);
 	void init();
-	void fontError(const QString& msg);
+	void handleFontError(const QString& msg);
 	void updateWindowId();
 	void updateClientInfo();
 	void handleGinitError(quint32 msgid, quint64 fun, const QVariant& err);


### PR DESCRIPTION
`fontError` -> `handleFontError`

We should be able to reference `Shell::fontError`, and this is not possible with the current override.