### PR TITLE
Fix Clazy Warning: clazy-qproperty-without-notify

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,6 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR
 			"level0,"
 			"level1,"
 			"no-inefficient-qlist-soft,"
-			"no-qproperty-without-notify,"
 			)
 
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Xclang -plugin-arg-clazy -Xclang ${CLAZY_CHECKS} -Wno-deprecated-declarations -Werror")

--- a/src/gui/shellwidget/shellwidget.h
+++ b/src/gui/shellwidget/shellwidget.h
@@ -1,5 +1,4 @@
-#ifndef QSHELLWIDGET2_SHELLWIDGET
-#define QSHELLWIDGET2_SHELLWIDGET
+#pragma once
 
 #include <QWidget>
 
@@ -9,12 +8,13 @@
 class ShellWidget: public QWidget
 {
 	Q_OBJECT
-	Q_PROPERTY(QColor background READ background WRITE setBackground)
-	Q_PROPERTY(QColor foreground READ foreground WRITE setForeground)
-	Q_PROPERTY(int rows READ rows)
-	Q_PROPERTY(int columns READ columns)
-	Q_PROPERTY(QSize cellSize READ cellSize)
-	Q_PROPERTY(bool ligatureMode MEMBER m_isLigatureModeEnabled READ isLigatureModeEnabled WRITE setLigatureMode)
+	Q_PROPERTY(QColor background READ background WRITE setBackground NOTIFY backgroundChanged)
+	Q_PROPERTY(QColor foreground READ foreground WRITE setForeground NOTIFY foregroundChanged)
+	Q_PROPERTY(int rows READ rows NOTIFY rowsChanged)
+	Q_PROPERTY(int columns READ columns NOTIFY columnsChanged)
+	Q_PROPERTY(QSize cellSize READ cellSize NOTIFY cellSizeChanged)
+	Q_PROPERTY(bool ligatureMode MEMBER m_isLigatureModeEnabled READ isLigatureModeEnabled WRITE setLigatureMode NOTIFY ligatureModeChanged)
+
 public:
 	ShellWidget(QWidget *parent=0);
 
@@ -84,6 +84,13 @@ public:
 signals:
 	void shellFontChanged();
 	void fontError(const QString& msg);
+	void backgroundChanged(QColor bgColor);
+	void foregroundChanged(QColor fgColor);
+	void rowsChanged(int rows);
+	void columnsChanged(int cols);
+	void cellSizeChanged(QSize size);
+	void ligatureModeChanged(bool isEnabled);
+
 public slots:
 	void resizeShell(int rows, int columns);
 	void setSpecial(const QColor& color);
@@ -194,5 +201,3 @@ private:
 
 	Background m_background{ Background::Dark };
 };
-
-#endif

--- a/src/msgpackiodevice.h
+++ b/src/msgpackiodevice.h
@@ -15,7 +15,7 @@ class MsgpackIODevice: public QObject
 {
 	Q_OBJECT
 	Q_PROPERTY(MsgpackError error READ errorCause NOTIFY error)
-	Q_PROPERTY(QByteArray encoding READ encoding WRITE setEncoding)
+	Q_PROPERTY(QByteArray encoding READ encoding WRITE setEncoding NOTIFY encodingChanged)
 public:
 	enum MsgpackError {
 		NoError=0,
@@ -71,6 +71,7 @@ signals:
 	void error(NeovimQt::MsgpackIODevice::MsgpackError);
 	/** A notification with the given name and arguments was received */
 	void notification(const QByteArray &name, const QVariantList& args);
+	void encodingChanged(const QByteArray& encoding);
 
 protected:
 	void sendError(const msgpack_object& req, const QString& msg);


### PR DESCRIPTION
Add `NOTIFY` signals to several `Q_PROPERTY` fields.