### PR TITLE
Isolate and refactor GuiWidgets

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -40,6 +40,7 @@ set(RUNTIME_PATH )
 
 add_library(neovim-qt-gui
 	app.cpp
+	contextmenu.cpp
 	errorwidget.cpp
 	input.cpp
 	mainwindow.cpp

--- a/src/gui/contextmenu.cpp
+++ b/src/gui/contextmenu.cpp
@@ -1,0 +1,60 @@
+#include "contextmenu.h"
+
+namespace NeovimQt {
+
+ContextMenu::ContextMenu(NeovimConnector* nvim, QWidget* parent) noexcept
+	: QMenu(parent)
+	, m_nvim{ nvim }
+{
+	if (!m_nvim) {
+		qFatal("Fatal Error: ContextMenu must have a valid NeovimConnector!");
+	}
+
+	m_actCut.setText(QObject::tr("Cut"));
+	m_actCopy.setText(QObject::tr("Copy"));
+	m_actPaste.setText(QObject::tr("Paste"));
+	m_actSelectAll.setText(QObject::tr("Select All"));
+
+	m_actCut.setIcon(QIcon::fromTheme("edit-cut"));
+	m_actCopy.setIcon(QIcon::fromTheme("edit-copy"));
+	m_actPaste.setIcon(QIcon::fromTheme("edit-paste"));
+	m_actSelectAll.setIcon(QIcon::fromTheme("edit-select-all"));
+
+	addAction(&m_actCut);
+	addAction(&m_actCopy);
+	addAction(&m_actPaste);
+	addSeparator();
+	addAction(&m_actSelectAll);
+
+	connect(&m_actCut, &QAction::triggered, this, &ContextMenu::neovimSendCut);
+	connect(&m_actCopy, &QAction::triggered, this, &ContextMenu::neovimSendCopy);
+	connect(&m_actPaste, &QAction::triggered, this, &ContextMenu::neovimSendPaste);
+	connect(&m_actSelectAll, &QAction::triggered, this, &ContextMenu::neovimSendSelectAll);
+}
+
+void ContextMenu::neovimSendCut() noexcept
+{
+	m_nvim->api0()->vim_command_output(R"(normal! "+x)");
+}
+
+void ContextMenu::neovimSendCopy() noexcept
+{
+	m_nvim->api0()->vim_command(R"(normal! "+y)");
+}
+
+void ContextMenu::neovimSendPaste() noexcept
+{
+	m_nvim->api0()->vim_command(R"(normal! "+gP)");
+}
+
+void ContextMenu::neovimSendSelectAll() noexcept
+{
+	m_nvim->api0()->vim_command("normal! ggVG");
+}
+
+void ContextMenu::showContextMenu() noexcept
+{
+	popup(QCursor::pos());
+}
+
+} // namespace NeovimQt

--- a/src/gui/contextmenu.h
+++ b/src/gui/contextmenu.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <QMenu>
+
+#include "neovimconnector.h"
+
+namespace NeovimQt {
+
+class ContextMenu final : public QMenu
+{
+	Q_OBJECT
+
+public:
+	ContextMenu(NeovimConnector* nvim, QWidget* parent) noexcept;
+
+	void neovimSendCut() noexcept;
+	void neovimSendCopy() noexcept;
+	void neovimSendPaste() noexcept;
+	void neovimSendSelectAll() noexcept;
+
+public slots:
+	void showContextMenu() noexcept;
+
+private:
+	NeovimConnector* m_nvim;
+
+	QAction m_actCut;
+	QAction m_actCopy;
+	QAction m_actPaste;
+	QAction m_actSelectAll;
+};
+
+} // namespace NeovimQt

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -61,7 +61,7 @@ void MainWindow::init(NeovimConnector *c)
 	m_nvim = c;
 	m_nvim->setParent(this);
 
-	m_tree = new TreeView(c);
+	m_tree = new TreeView(c, this);
 
 	// GuiScrollBar
 	m_scrollbar = new ScrollBar{ m_nvim };
@@ -80,6 +80,9 @@ void MainWindow::init(NeovimConnector *c)
 	m_window->addWidget(m_tree);
 	m_tree->hide();
 	m_window->addWidget(shellScrollable);
+
+	const int splitterWidth{ m_window->width() };
+	m_window->setSizes({ splitterWidth * 25 / 100, splitterWidth * 75 / 100 });
 
 	m_stack.insertWidget(1, m_window);
 	m_stack.setCurrentIndex(1);

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -6,6 +6,7 @@
 #include <QStackedWidget>
 #include <QTabBar>
 
+#include "contextmenu.h"
 #include "errorwidget.h"
 #include "neovimconnector.h"
 #include "scrollbar.h"
@@ -59,11 +60,6 @@ private slots:
 	void showIfDelayed();
 	void handleNeovimAttachment(bool);
 	void neovimIsUnsupported();
-	void neovimShowContextMenu();
-	void neovimSendCut();
-	void neovimSendCopy();
-	void neovimSendPaste();
-	void neovimSendSelectAll();
 	void saveWindowGeometry();
 
 	// GuiAdaptive Color/Font/Style Slots
@@ -84,11 +80,7 @@ private:
 	QStackedWidget m_stack;
 
 	bool m_neovim_requested_close{ false };
-	QMenu* m_contextMenu{ nullptr };
-	QAction* m_actCut{ nullptr };
-	QAction* m_actCopy{ nullptr };
-	QAction* m_actPaste{ nullptr };
-	QAction* m_actSelectAll{ nullptr };
+	ContextMenu* m_contextMenu{ nullptr };
 	ScrollBar* m_scrollbar{ nullptr };
 	Tabline m_tabline;
 	int m_exitStatus{ 0 };

--- a/src/gui/treeview.cpp
+++ b/src/gui/treeview.cpp
@@ -6,76 +6,124 @@
 #include <QProcess>
 #include <QStandardPaths>
 
-static const int MAX_COLUMNS_ON_INIT = 10;
-
 namespace NeovimQt {
-TreeView::TreeView(NeovimConnector *nvim, QWidget *parent)
-: QTreeView(parent), m_nvim(nvim) {
-	model = new QFileSystemModel(this);
 
-	setModel(model);
+TreeView::TreeView(NeovimConnector* nvim, QWidget* parent) noexcept
+	: QTreeView(parent)
+	, m_model{ parent }
+	, m_nvim{ nvim }
+{
+	if (!m_nvim) {
+		qFatal("Fatal Error: TreeView must have a valid NeovimConnector!");
+	}
+
+	setModel(&m_model);
 
 	header()->hide();
 
-	for (int i = 1; i < MAX_COLUMNS_ON_INIT; i++) {
+	const int columnCount{ m_model.columnCount() };
+	for (int i = 1; i < columnCount; i++) {
 		hideColumn(i);
 	}
 
-	if (m_nvim->isReady()) {
-		connector_ready_cb();
-	}
-	connect(m_nvim, &NeovimConnector::ready, this, &TreeView::connector_ready_cb);
+	connect(m_nvim, &NeovimConnector::ready, this, &TreeView::neovimConnectorReady);
 }
 
-void TreeView::connector_ready_cb() {
+void TreeView::neovimConnectorReady() noexcept
+{
 	connect(this, &TreeView::doubleClicked, this, &TreeView::open);
 
-	connect(m_nvim->neovimObject(), &NeovimApi1::neovimNotification, this,
-			&TreeView::handleNeovimNotification);
+	connect(
+		m_nvim->api0(), &NeovimApi0::neovimNotification, this, &TreeView::handleNeovimNotification);
 
-	m_nvim->neovimObject()->vim_subscribe("Dir");
-	m_nvim->neovimObject()->vim_subscribe("Gui");
+	m_nvim->api0()->vim_subscribe("Dir");
+	m_nvim->api0()->vim_subscribe("Gui");
 }
 
-void TreeView::open(const QModelIndex &index) {
-	QFileInfo info = model->fileInfo(index);
-	if (info.isFile() && info.isReadable()) {
-		QVariantList args;
-		args << info.filePath();
-		m_nvim->neovimObject()->vim_call_function("GuiDrop", args);
+void TreeView::open(const QModelIndex& index) noexcept
+{
+	const QFileInfo fileInfo{ m_model.fileInfo(index) };
+	if (fileInfo.isFile() && fileInfo.isReadable()) {
+		m_nvim->api0()->vim_call_function("GuiDrop", { fileInfo.filePath() });
 	}
 	focusNextChild();
 }
 
-void TreeView::setDirectory(const QString &dir, bool notify) {
-	if (QDir(dir).exists()) {
-		QDir::setCurrent(dir);
-		model->setRootPath(dir);
-		setRootIndex(model->index(dir));
-		if (notify) {
-			m_nvim->neovimObject()->vim_change_directory(
-				QByteArray::fromStdString(dir.toStdString()));
-		}
+void TreeView::handleNeovimNotification(const QByteArray& name, const QVariantList& args) noexcept
+{
+	if (args.size() <= 0) {
+		return;
 	}
-}
 
-void TreeView::handleNeovimNotification(const QByteArray &name,
-					const QVariantList &args) {
 	if (name == "Dir" && args.size() >= 0) {
-		setDirectory(m_nvim->decode(args.at(0).toByteArray()), false);
-	} else if (name == "Gui"
-	           && args.size() > 1
-			   && m_nvim->decode(args.at(0).toByteArray()) == "TreeView") {
-		QByteArray action = args.at(1).toByteArray();
-		if (action == "Toggle") {
-			if (isVisible())
-				hide();
-			else
-				show();
-		} else if (action == "ShowHide" && args.size() == 3) {
-			args.at(2).toBool() ? show() : hide();
+		handleDirectoryChanged(args);
+		return;
+	}
+
+	if (name == "Gui") {
+		const QString guiEvName{ m_nvim->decode(args.at(0).toByteArray()) };
+
+		if (guiEvName == "TreeView") {
+			handleGuiTreeView(args);
+			return;
 		}
 	}
 }
 
-}  // namespace NeovimQt
+void TreeView::handleDirectoryChanged(const QVariantList& args) noexcept
+{
+	if (args.size() < 1 || !args.at(0).canConvert<QString>()) {
+		qWarning() << "Unexpected arguments for Dir:" << args;
+		return;
+	}
+
+	const QString dir{ args.at(0).toString() };
+
+	if (!QDir{ dir }.exists()) {
+		return;
+	}
+
+	QDir::setCurrent(dir);
+	m_model.setRootPath(dir);
+	setRootIndex(m_model.index(dir));
+}
+
+void TreeView::handleGuiTreeView(const QVariantList& args) noexcept
+{
+	if (args.size() < 2 || !args.at(1).canConvert<QString>()) {
+		qWarning() << "Unexpected arguments for Dir:" << args;
+		return;
+	}
+
+	const QString action{ args.at(1).toString() };
+	if (action == "Toggle") {
+		toggleVisibility();
+		return;
+	}
+
+	if (action == "ShowHide" && args.size() == 3) {
+		handleShowHide(args);
+	}
+}
+
+void TreeView::handleShowHide(const QVariantList& args) noexcept
+{
+	if (args.size() < 3 || !args.at(2).canConvert<bool>()) {
+		qWarning() << "Unexpected arguments for GuiTreeView ShowHide:" << args;
+	}
+
+	const bool isVisible{ args.at(2).toBool() };
+	setVisible(isVisible);
+}
+
+void TreeView::toggleVisibility() noexcept
+{
+	if (isVisible()) {
+		hide();
+	}
+	else {
+		show();
+	}
+}
+
+} // namespace NeovimQt

--- a/src/gui/treeview.h
+++ b/src/gui/treeview.h
@@ -1,29 +1,33 @@
-#ifndef TREEVIEW
-#define TREEVIEW
+#pragma once
 
 #include <QFileSystemModel>
 #include <QTreeView>
 #include <QUrl>
+
 #include "neovimconnector.h"
 
 namespace NeovimQt {
 
 class TreeView : public QTreeView {
-    Q_OBJECT
- public:
-	TreeView(NeovimConnector *, QWidget *parent = 0);
+	Q_OBJECT
 
- public slots:
-	void open(const QModelIndex &);
-	void setDirectory(const QString &, bool notify = true);
-	void handleNeovimNotification(const QByteArray &, const QVariantList &);
-	void connector_ready_cb();
+public:
+	TreeView(NeovimConnector* nvim, QWidget* parent) noexcept;
 
- protected:
-	QFileSystemModel *model;
-	NeovimConnector *m_nvim;
+public slots:
+	void open(const QModelIndex& index) noexcept;
+	void handleNeovimNotification(const QByteArray& name, const QVariantList& args) noexcept;
+	void handleDirectoryChanged(const QVariantList& args) noexcept;
+	void handleGuiTreeView(const QVariantList& args) noexcept;
+	void handleShowHide(const QVariantList& args) noexcept;
+
+	void neovimConnectorReady() noexcept;
+
+private:
+	void toggleVisibility() noexcept;
+
+	QFileSystemModel m_model;
+	NeovimConnector* m_nvim;
 };
 
-}  // namespace NeovimQt
-
-#endif  // TREEVIEW
+} // namespace NeovimQt


### PR DESCRIPTION
Moving each GuiWidget into it an isolated file and refactoring code. This work will make tracking/modifying each widget easier.

Work related to #898. For the `Shell` size to be computed on startup, we need each widget to have a known last-size on startup.