### PR TITLE
Issue 917: Cannot map <C-Space> on Linux

### DIFF
--- a/src/gui/input.cpp
+++ b/src/gui/input.cpp
@@ -174,6 +174,11 @@ QString convertKey(const QKeyEvent& ev) noexcept
 		return keypadKeys.value(key).arg(GetModifierPrefix(mod));
 	}
 
+	// Issue#917: On Linux, Control + Space sends text as "\u0000"
+	if (key == Qt::Key_Space && text.size() > 0 && !text.at(0).isPrint()) {
+		text = " ";
+	}
+
 	// Issue#864: Some international layouts insert accents (~^`) on Key_Space
 	if (key == Qt::Key_Space && !text.isEmpty() && text != " ") {
 		if (mod != Qt::NoModifier) {

--- a/test/tst_input_unix.cpp
+++ b/test/tst_input_unix.cpp
@@ -13,6 +13,7 @@ private slots:
 	void CtrlCaretWellFormed() noexcept;
 	void ShiftModifierLetter() noexcept;
 	void GermanKeyboardLayout() noexcept;
+	void ControlSpace() noexcept;
 };
 
 void TestInputUnix::LessThanModifierKeys() noexcept
@@ -95,6 +96,13 @@ void TestInputUnix::GermanKeyboardLayout() noexcept
 
 	QKeyEvent evOptionPlus{ QEvent::KeyPress, Qt::Key_AsciiTilde, Qt::GroupSwitchModifier, "~" };
 	QCOMPARE(NeovimQt::Input::convertKey(evOptionPlus), QString{ "~" });
+}
+
+void TestInputUnix::ControlSpace() noexcept
+{
+	// Intentionally written with QStringLiteral, other alternatives do not create the same QKeyEvent
+	QKeyEvent evControlSpace{ QEvent::KeyPress, Qt::Key_Space, Qt::ControlModifier, QStringLiteral( "\u0000" ) };
+	QCOMPARE(NeovimQt::Input::convertKey(evControlSpace), QString{ "<C-Space>" });
 }
 
 #include "tst_input_unix.moc"


### PR DESCRIPTION
**Issue #917:** Cannot map `<C-Space>` on Linux

Linux sends `text` as `"\u0000"` in this scenario.

This unexpected value breaks our detection logic for Issue#864.

Add cleanup logic to set text as `" "`.