### PR TITLE
Issue 922: ContextMenu incompatible with mswin.vim

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ endif
 " Right Click Context Menu (Copy-Cut-Paste)
 nnoremap <silent><RightMouse> :call GuiShowContextMenu()<CR>
 inoremap <silent><RightMouse> <Esc>:call GuiShowContextMenu()<CR>
-vnoremap <silent><RightMouse> :call GuiShowContextMenu()<CR>gv
-
+xnoremap <silent><RightMouse> :call GuiShowContextMenu()<CR>gv
+snoremap <silent><RightMouse> <C-G>:call GuiShowContextMenu()<CR>gv
 ```
 
 For more options, try `:help nvim_gui_shim` and scroll down to `Commands`.


### PR DESCRIPTION
**Issue #922:** Select mode breaks the provided context menu bindings.

The option `behave mswin` enables select-mode, and the current
GuiShowContextMenu mappings are incompatible with this mode.

The issue can be demonstrated with `gH`, right-click "Copy".

We need to map separate visual and select mode bindings.