### PR TITLE
Issue 933: Update README for HomeBrew Core

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,17 +44,15 @@ Pre-built Windows binaries are provided for all recent commits:
 
 ### MacOS
 
-You can use HomeBrew to install Neovim Qt: https://github.com/equalsraf/homebrew-neovim-qt.
+NeovimQt is available in the Homebrew package manager.
 
 To install the latest release:
 ```
-$ brew tap equalsraf/neovim-qt
 $ brew install neovim-qt
 ```
 
 To install the latest development version:
 ```
-$ brew tap equalsraf/neovim-qt
 $ brew install --HEAD neovim-qt
 ```
 


### PR DESCRIPTION
**Issue #933:** Package now available in HomeBrew core

Since the package is available in HomeBrew core, we no longer need the `brew tap equalsraf/neovim-qt` command.

We should update the README to reflect this.