### PR TITLE
Write QSettings values for Gui features

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -61,7 +61,7 @@ jobs:
           - name: Windows_Release
             flavor: Release
             runner: windows-latest
-            generator: Visual Studio 16 2019
+            generator: Visual Studio 17 2022
             qtver: 5.15.2
             qtdir: msvc2019_64
             qtstr: windows desktop win64_msvc2019_64
@@ -98,7 +98,7 @@ jobs:
           New-Item -Path .\build -Name "build" -ItemType "directory"
           Invoke-WebRequest https://github.com/neovim/neovim/releases/download/nightly/nvim-win64.zip -OutFile nvim-win64.zip
           Expand-Archive -Path nvim-win64.zip -DestinationPath .\build\
-          Add-Content -Path $env:GITHUB_PATH -Value ${{ github.workspace }}\build\Neovim\bin\
+          Add-Content -Path $env:GITHUB_PATH -Value ${{ github.workspace }}\build\nvim-win64\bin\
           Add-Content -Path $env:GITHUB_ENV -Value "CMAKE_PREFIX_PATH=$env:QT_DIR;$env:QT_DIR\lib\cmake"
           Add-Content -Path $env:GITHUB_PATH -Value "${{ env.qt_dir }}"
           Add-Content -Path $env:GITHUB_PATH -Value "${{ env.qt_dir }}\bin"

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
     env:
-      CLANG_FORMAT_DIFF: /usr/share/clang/clang-format-12/clang-format-diff.py
+      CLANG_FORMAT_DIFF: /usr/share/clang/clang-format-14/clang-format-diff.py
       BRANCH_POINT: ${{ github.base_ref }}
     runs-on: ubuntu-latest
     steps:
@@ -26,6 +26,13 @@ jobs:
 
       - name: Setup PR Branch
         run: git branch ${{ github.base_ref }} origin/${{ github.base_ref }}
+
+      - name: Install LLVM 14
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 14 all
+          rm llvm.sh
 
       - name: Run ClangFormatDiff Script
         run: contrib/clang-format-diff.sh

--- a/contrib/clang-format.txt
+++ b/contrib/clang-format.txt
@@ -1,11 +1,11 @@
 ﻿---
 AccessModifierOffset: '-4'
-AlignAfterOpenBracket: AlwaysBreak
+AlignAfterOpenBracket: DontAlign
 AlignConsecutiveMacros: 'true'
 AlignConsecutiveAssignments: 'false'
 AlignConsecutiveDeclarations: 'false'
 AlignEscapedNewlines: DontAlign
-AlignOperands: 'false'
+AlignOperands: DontAlign
 AlignTrailingComments: 'true'
 AllowAllArgumentsOnNextLine: 'true'
 AllowAllParametersOfDeclarationOnNextLine: 'true'
@@ -46,7 +46,7 @@ CompactNamespaces: 'true'
 ConstructorInitializerAllOnOneLineOrOnePerLine: 'false'
 ConstructorInitializerIndentWidth: '4'
 ContinuationIndentWidth: '4'
-Cpp11BracedListStyle: 'true'
+Cpp11BracedListStyle: 'false'
 DerivePointerAlignment: 'false'
 FixNamespaceComments: 'true'
 IncludeBlocks: Regroup
@@ -65,8 +65,8 @@ MaxEmptyLinesToKeep: '2'
 NamespaceIndentation: None
 PointerAlignment: Left
 ReflowComments: 'true'
+SortIncludes: 'CaseInsensitive'
 SortUsingDeclarations: 'true'
-SortIncludes: CaseInsensitive
 SpaceAfterCStyleCast: 'false'
 SpaceAfterLogicalNot: 'false'
 SpaceAfterTemplateKeyword: 'false'

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -69,7 +69,6 @@ void MainWindow::init(NeovimConnector *c)
 
 	m_window = new QSplitter();
 	m_window->addWidget(m_tree);
-	m_tree->hide();
 	m_window->addWidget(shellScrollable);
 
 	const int splitterWidth{ m_window->width() };

--- a/src/gui/scrollbar.cpp
+++ b/src/gui/scrollbar.cpp
@@ -1,5 +1,7 @@
 #include "scrollbar.h"
 
+#include <QSettings>
+
 #include "shell.h"
 
 namespace NeovimQt {
@@ -15,7 +17,9 @@ ScrollBar::ScrollBar(NeovimConnector* nvim, QWidget* parent) noexcept
 	connect(m_nvim, &NeovimConnector::ready, this, &ScrollBar::neovimConnectorReady);
 	connect(this, &QScrollBar::valueChanged, this, &ScrollBar::handleValueChanged);
 
-	setVisible(false);
+	QSettings settings;
+	setVisible(settings.value("Gui/ScrollBar", false).toBool());
+
 	setMinimum(1);
 }
 
@@ -196,6 +200,9 @@ void ScrollBar::handleSetScrollBarVisible(const QVariantList& args) noexcept
 
 	const bool isVisible{ args.at(1).toBool() };
 	setVisible(isVisible);
+
+	QSettings settings;
+	settings.setValue("Gui/ScrollBar", isVisible);
 }
 
 void ScrollBar::handleValueChanged(int value)

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -1016,8 +1016,6 @@ void Shell::handleWindowFrameless(const QVariant& value) noexcept {
 
 void Shell::handleCloseEvent(const QVariantList& args) noexcept
 {
-	qDebug() << "Neovim requested a GUI close";
-
 	if (args.size() >= 2 && !args.at(1).canConvert<int>()) {
 		qWarning() << "Unexpected exit status for close:" << args.at(1);
 		return;
@@ -1831,7 +1829,6 @@ void ShellRequestHandler::handleRequest(MsgpackIODevice* dev, quint32 msgid, con
 
 			auto clipboard_data = QGuiApplication::clipboard()->mimeData(mode);
 			auto data = clipboard_data->text();
-			qDebug() << data << "<<<<< clipboard text";
 			// The register data is either a string with a single line,
 			// or a list of strings for multiple lines.
 			if (data.contains("\n")) {
@@ -1850,7 +1847,6 @@ void ShellRequestHandler::handleRequest(MsgpackIODevice* dev, quint32 msgid, con
 				result.append("");
 			}
 
-			qDebug() << "Neovim requested clipboard contents" << args << mode << "->" << result;
 			dev->sendResponse(msgid, QVariant(), result);
 			return;
 		}

--- a/src/gui/treeview.cpp
+++ b/src/gui/treeview.cpp
@@ -4,6 +4,7 @@
 #include <QHeaderView>
 #include <QKeyEvent>
 #include <QProcess>
+#include <QSettings>
 #include <QStandardPaths>
 
 namespace NeovimQt {
@@ -25,6 +26,9 @@ TreeView::TreeView(NeovimConnector* nvim, QWidget* parent) noexcept
 	for (int i = 1; i < columnCount; i++) {
 		hideColumn(i);
 	}
+
+	QSettings settings;
+	setVisible(settings.value("Gui/TreeView", false).toBool());
 
 	connect(m_nvim, &NeovimConnector::ready, this, &TreeView::neovimConnectorReady);
 }
@@ -97,7 +101,7 @@ void TreeView::handleGuiTreeView(const QVariantList& args) noexcept
 
 	const QString action{ args.at(1).toString() };
 	if (action == "Toggle") {
-		toggleVisibility();
+		updateVisibility(!isVisible());
 		return;
 	}
 
@@ -113,17 +117,15 @@ void TreeView::handleShowHide(const QVariantList& args) noexcept
 	}
 
 	const bool isVisible{ args.at(2).toBool() };
-	setVisible(isVisible);
+
+	updateVisibility(isVisible);
 }
 
-void TreeView::toggleVisibility() noexcept
+void TreeView::updateVisibility(bool isVisible) noexcept
 {
-	if (isVisible()) {
-		hide();
-	}
-	else {
-		show();
-	}
+	QSettings settings;
+	settings.setValue("Gui/TreeView", isVisible);
+	setVisible(isVisible);
 }
 
 } // namespace NeovimQt

--- a/src/gui/treeview.h
+++ b/src/gui/treeview.h
@@ -24,7 +24,7 @@ public slots:
 	void neovimConnectorReady() noexcept;
 
 private:
-	void toggleVisibility() noexcept;
+	void updateVisibility(bool isVisible) noexcept;
 
 	QFileSystemModel m_model;
 	NeovimConnector* m_nvim;

--- a/src/neovimconnectorhelper.cpp
+++ b/src/neovimconnectorhelper.cpp
@@ -50,27 +50,10 @@ void NeovimConnectorHelper::handleMetadata(quint32 msgid, quint64, const QVarian
 
 	const int api_compat = metadata.value("version").toMap().value("api_compatible").toUInt();
 	const int api_level = metadata.value("version").toMap().value("api_level").toUInt();
-	qDebug() << "Neovim API version compatible with" << api_compat << "supported" << api_level;
+	// qDebug() << "Neovim API version compatible with" << api_compat << "supported" << api_level;
 	m_c->m_uiOptions = metadata.value("ui_options").toList();
 	m_c->m_api_compat = api_compat;
 	m_c->m_api_supported = api_level;
-
-#if 0
-	QMapIterator<QString,QVariant> it(metadata);
-	while (it.hasNext()) {
-		it.next();
-		if (it.key() == "functions") {
-			auto api1 = m_c->api1();
-			if (api1 ) {
-				NeovimApi1::checkFunctions(it.value().toList());
-			}
-			auto api2 = m_c->api1();
-			if (api2 ) {
-				NeovimApi2::checkFunctions(it.value().toList());
-			}
-		}
-	}
-#endif
 
 	if (m_c->errorCause() == NeovimConnector::NoError) {
 		// Neovim is always utf8, but this was not the case in the early days of nvim

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,17 +12,21 @@ add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND})
 # Place all platform-specific test definitions here
 if(WIN32)
 	set(SRC_SHELL_PLATFORM tst_shell_win32.cpp)
-	set(SRC_INPUT_PLATFORM ${CMAKE_SOURCE_DIR}/src/gui/input_win32.cpp)
 elseif(APPLE)
 	set(SRC_SHELL_PLATFORM tst_shell_mac.cpp)
-	set(SRC_INPUT_PLATFORM ${CMAKE_SOURCE_DIR}/src/gui/input_mac.cpp)
 else()
 	set(SRC_SHELL_PLATFORM tst_shell_unix.cpp)
-	set(SRC_INPUT_PLATFORM ${CMAKE_SOURCE_DIR}/src/gui/input_unix.cpp)
 endif()
 
+set(SOURCES_COMMON common.cpp)
+set(SOURCES_COMMON_GUI common_gui.cpp)
+
 function(add_xtest SOURCE_NAME)
-	add_executable(${SOURCE_NAME} ${SOURCE_NAME}.cpp ${ARGV1} ${ARGV2})
+	add_executable(${SOURCE_NAME}
+		${SOURCE_NAME}.cpp
+		${SOURCES_COMMON}
+		${ARGV1}
+		${ARGV2})
 	target_link_libraries(${SOURCE_NAME} ${QTLIBS} ${MSGPACK_LIBRARIES} neovim-qt)
 	add_test(NAME ${SOURCE_NAME} COMMAND ${SOURCE_NAME})
 	add_dependencies(check ${SOURCE_NAME})
@@ -30,7 +34,12 @@ endfunction()
 
 function(add_xtest_gui SOURCE_NAME)
 	qt5_add_resources(RCC_SOURCES data.qrc)
-	add_executable(${SOURCE_NAME} ${RCC_SOURCES} ${SOURCE_NAME}.cpp ${ARGV1} ${ARGV2})
+	add_executable(${SOURCE_NAME}
+		${RCC_SOURCES}
+		${SOURCE_NAME}.cpp
+		${SOURCES_COMMON}
+		${SOURCES_COMMON_GUI}
+		${ARGV1} ${ARGV2})
 	target_link_libraries(${SOURCE_NAME} ${QTLIBS} ${MSGPACK_LIBRARIES} neovim-qt Qt5::Widgets neovim-qt-gui)
 	add_test(NAME ${SOURCE_NAME} COMMAND ${SOURCE_NAME}
 		# Run GUI tests from source dir, they depend on src files
@@ -52,6 +61,9 @@ add_xtest(tst_encoding)
 add_xtest(tst_msgpackiodevice)
 add_xtest_gui(tst_shell ${SRC_SHELL_PLATFORM})
 add_xtest_gui(tst_main)
+add_xtest_gui(tst_qsettings
+	${SRC_SHELL_PLATFORM}
+	mock_qsettings.cpp)
 
 # Platform Specific Input Tests
 add_xtest(tst_input_mac
@@ -68,12 +80,12 @@ add_xtest(tst_input_win32
 add_shared_test(tst_input_common_mac
 	tst_input_common.cpp
 	${CMAKE_SOURCE_DIR}/src/gui/input.cpp
-	${SRC_INPUT_PLATFORM})
+	${CMAKE_SOURCE_DIR}/src/gui/input_mac.cpp)
 add_shared_test(tst_input_common_unix
 	tst_input_common.cpp
 	${CMAKE_SOURCE_DIR}/src/gui/input.cpp
-	${SRC_INPUT_PLATFORM})
+	${CMAKE_SOURCE_DIR}/src/gui/input_unix.cpp)
 add_shared_test(tst_input_common_win32
 	tst_input_common.cpp
 	${CMAKE_SOURCE_DIR}/src/gui/input.cpp
-	${SRC_INPUT_PLATFORM})
+	${CMAKE_SOURCE_DIR}/src/gui/input_win32.cpp)

--- a/test/common.cpp
+++ b/test/common.cpp
@@ -1,0 +1,22 @@
+#include "common.h"
+
+#include <QFileInfo>
+
+bool SPYWAIT(QSignalSpy& spy, int timeout) noexcept
+{
+	// For more details, see:
+	// http://stackoverflow.com/questions/22390208/google-test-mock-with-qt-signals
+	return spy.count() > 0 || spy.wait(timeout);
+}
+
+QString GetRuntimeAbsolutePath() noexcept
+{
+	static const QFileInfo cs_runtime{ QStringLiteral(CMAKE_SOURCE_DIR)
+		+ QStringLiteral("/src/gui/runtime") };
+
+	if (!cs_runtime.exists()) {
+		qFatal("Unable to find GUI runtime!");
+	}
+
+	return cs_runtime.absoluteFilePath();
+}

--- a/test/common.h
+++ b/test/common.h
@@ -1,10 +1,11 @@
 #pragma once
 
 #include <QSignalSpy>
+#include <QString>
 
-// This is just a fix for QSignalSpy::wait
-// http://stackoverflow.com/questions/22390208/google-test-mock-with-qt-signals
-bool SPYWAIT(QSignalSpy& spy, int timeout = 30000)
-{
-	return spy.count() > 0 || spy.wait(timeout);
-}
+/// Waits for the signal with timeout (default 30s). Works even for signals
+/// that have already been fired. Returns false on timeout.
+bool SPYWAIT(QSignalSpy& spy, int timeout = 30000) noexcept;
+
+/// Returns the filesystem path to the neovim-qt runtime plugin.
+QString GetRuntimeAbsolutePath() noexcept;

--- a/test/common_gui.cpp
+++ b/test/common_gui.cpp
@@ -1,0 +1,60 @@
+#include "common_gui.h"
+
+#include <gui/mainwindow.h>
+
+#include "common.h"
+
+namespace NeovimQt {
+
+static const QStringList cs_argsNone{ "-u", "NONE" }; // clazy:exclude=non-pod-global-static
+
+template<class T> static void ValidateNeovimConnection(T* obj) noexcept
+{
+	QSignalSpy onAttached{ obj, &T::neovimAttachmentChanged };
+
+	Q_ASSERT(onAttached.isValid());
+
+	const bool signalEmitted{ onAttached.wait() };
+	Q_ASSERT(signalEmitted);
+
+	const int signalCount{ onAttached.count() };
+	Q_ASSERT(signalCount == 1);
+
+	Q_ASSERT(obj->isNeovimAttached());
+}
+
+std::pair<NeovimConnector*, Shell*> CreateShellWidget() noexcept
+{
+	NeovimConnector* c{ NeovimConnector::spawn(cs_argsNone) };
+	Shell* s{ new Shell{ c } };
+
+	ValidateNeovimConnection(s);
+
+	return { c, s };
+}
+
+std::pair<NeovimConnector*, MainWindow*> CreateMainWindow() noexcept
+{
+	NeovimConnector* c{ NeovimConnector::spawn(cs_argsNone) };
+	MainWindow* w{ new MainWindow{ c } };
+
+	ValidateNeovimConnection(w);
+
+	return { c, w };
+}
+
+std::pair<NeovimConnector*, MainWindow*> CreateMainWindowWithRuntime() noexcept
+{
+	static const QStringList cs_argsNoneRuntime{
+		"-u", "NONE", "--cmd", "set rtp+=" + GetRuntimeAbsolutePath()
+	};
+
+	NeovimConnector* c{ NeovimConnector::spawn(cs_argsNoneRuntime) };
+	MainWindow* w{ new MainWindow{ c } };
+
+	ValidateNeovimConnection(w);
+
+	return { c, w };
+}
+
+} // namespace NeovimQt

--- a/test/common_gui.h
+++ b/test/common_gui.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <gui/mainwindow.h>
+#include <gui/shell.h>
+#include <neovimconnector.h>
+#include <utility>
+
+namespace NeovimQt {
+
+std::pair<NeovimConnector*, Shell*> CreateShellWidget() noexcept;
+
+std::pair<NeovimConnector*, MainWindow*> CreateMainWindow() noexcept;
+
+std::pair<NeovimConnector*, MainWindow*> CreateMainWindowWithRuntime() noexcept;
+
+} // namespace NeovimQt

--- a/test/mock_qsettings.cpp
+++ b/test/mock_qsettings.cpp
@@ -1,0 +1,41 @@
+#include "mock_qsettings.h"
+
+#include <QIODevice>
+
+namespace NeovimQt { namespace MockQSettings {
+
+static QSettings::SettingsMap s_mockSettingsMap; // clazy:exclude=non-pod-global-static
+
+static bool read(QIODevice& /*device*/, QSettings::SettingsMap& map) noexcept
+{
+	map = s_mockSettingsMap;
+	return true;
+}
+
+static bool write(QIODevice& device, const QSettings::SettingsMap& map) noexcept
+{
+	// QSettings will not call readMockQSettings without content in `device`.
+	// https://stackoverflow.com/questions/41495765/cannot-get-qsettings-to-read-from-custom-storage-format
+	device.write("X", 1);
+
+	s_mockSettingsMap = map;
+	return true;
+}
+
+void EnableByDefault() noexcept
+{
+	static const QSettings::Format s_mockFormat{ QSettings::registerFormat("mock", read, write) };
+	QSettings::setDefaultFormat(s_mockFormat);
+}
+
+void ClearAllContents() noexcept
+{
+	s_mockSettingsMap = {};
+}
+
+void OverwriteContents(QSettings::SettingsMap newValue) noexcept
+{
+	s_mockSettingsMap = std::move(newValue);
+}
+
+}} // namespace NeovimQt::MockQSettings

--- a/test/mock_qsettings.h
+++ b/test/mock_qsettings.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <QSettings>
+
+namespace NeovimQt { namespace MockQSettings {
+
+/// Overrides QSettings to use the mock format by default
+void EnableByDefault() noexcept;
+
+/// Clears all contents store in MockQSettings
+void ClearAllContents() noexcept;
+
+/// Overwrites call contents stored in MockQSettings with newValue
+void OverwriteContents(QSettings::SettingsMap newValue) noexcept;
+
+}} // namespace NeovimQt::MockQSettings

--- a/test/tst_callallmethods.cpp
+++ b/test/tst_callallmethods.cpp
@@ -97,20 +97,18 @@ void TestCallAllMethods::call_metaobject_slots(QObject *obj)
 			continue;
 		}
 
-		if ( meth.parameterNames().size() == 0 && meth.name() != "deleteLater") {
-			qDebug() << "Calling" << meth.name();
+		if (meth.parameterNames().size() == 0 && meth.name() != "deleteLater") {
 			meth.invoke(obj);
-		} else if ( meth.parameterNames().size() == 1 ) {
+		}
+		else if (meth.parameterNames().size() == 1) {
 			if ( meth.parameterTypes().at(0) == "Window" ) {
 				meth.invoke(obj, Q_ARG(int64_t, 1));
 			}
-		} else {
-			qDebug() << "Skipping" << meth.methodSignature();
 		}
 	}
 
 	// Test Performance: timeout expected, set value carefully.
-	QVERIFY2(!SPYWAIT(neovimErrors, 2500 /*msec*/), "Fatal errors");
+	QVERIFY2(!SPYWAIT(neovimErrors, 250 /*msec*/), "Fatal errors");
 }
 
 /// vim_call_functions() was the first API function

--- a/test/tst_qsettings.cpp
+++ b/test/tst_qsettings.cpp
@@ -1,0 +1,140 @@
+#include <gui/mainwindow.h>
+#include <msgpackrequest.h>
+#include <QtTest/QtTest>
+
+#include "common.h"
+#include "common_gui.h"
+#include "mock_qsettings.h"
+#include "tst_shell.h"
+
+namespace NeovimQt {
+
+class TestQSettings : public QObject
+{
+	Q_OBJECT
+
+private slots:
+	void initTestCase() noexcept;
+	void cleanup() noexcept;
+
+	void OptionLineGrid() noexcept;
+	void OptionPopupMenu() noexcept;
+	void OptionTabline() noexcept;
+	void GuiFont() noexcept;
+	void GuiScrollBar() noexcept;
+	void GuiTreeView() noexcept;
+};
+
+static void SendNeovimCommand(NeovimConnector& connector, const QString& command) noexcept
+{
+	QSignalSpy spyCommand{ connector.api0()->vim_command_output(connector.encode(command)),
+		&MsgpackRequest::finished };
+
+	QVERIFY(spyCommand.isValid());
+	QVERIFY(SPYWAIT(spyCommand));
+}
+
+void TestQSettings::initTestCase() noexcept
+{
+	NeovimQt::MockQSettings::EnableByDefault();
+}
+
+void TestQSettings::cleanup() noexcept
+{
+	NeovimQt::MockQSettings::ClearAllContents();
+}
+
+void TestQSettings::OptionLineGrid() noexcept
+{
+	QSettings settings;
+
+	settings.setValue("ext_linegrid", true);
+	auto csWithLineGrid{ CreateShellWidget() };
+	Shell* sWithLineGrid{ csWithLineGrid.second };
+	ShellOptions shellOptionsWithLineGrid{ sWithLineGrid->GetShellOptions() };
+
+	QCOMPARE(shellOptionsWithLineGrid.IsLineGridEnabled(), true);
+
+	settings.setValue("ext_linegrid", false);
+	auto csLegacy{ CreateShellWidget() };
+	Shell* sLegacy{ csLegacy.second };
+	ShellOptions shellOptionsLegacy{ sLegacy->GetShellOptions() };
+
+	QCOMPARE(shellOptionsLegacy.IsLineGridEnabled(), false);
+}
+
+void TestQSettings::OptionPopupMenu() noexcept
+{
+	auto cw{ CreateMainWindowWithRuntime() };
+	NeovimConnector& connector{ *cw.first };
+
+	QSettings settings;
+
+	SendNeovimCommand(connector, "GuiPopupmenu 1");
+	QCOMPARE(settings.value("ext_popupmenu").toBool(), true);
+
+	SendNeovimCommand(connector, "GuiPopupmenu 0");
+	QCOMPARE(settings.value("ext_popupmenu").toBool(), false);
+}
+
+void TestQSettings::OptionTabline() noexcept
+{
+	auto cw{ CreateMainWindowWithRuntime() };
+	NeovimConnector& connector{ *cw.first };
+
+	QSettings settings;
+
+	SendNeovimCommand(connector, "GuiTabline 1");
+	QCOMPARE(settings.value("ext_tabline").toBool(), true);
+
+	SendNeovimCommand(connector, "GuiTabline 0");
+	QCOMPARE(settings.value("ext_tabline").toBool(), false);
+}
+
+void TestQSettings::GuiFont() noexcept
+{
+	auto cw{ CreateMainWindowWithRuntime() };
+	NeovimConnector& connector{ *cw.first };
+	MainWindow& window{ *cw.second };
+
+	QSettings settings;
+
+	const QString fontDesc{ QStringLiteral("%1:h20").arg(GetPlatformTestFont()) };
+	const QString fontCommand{ QStringLiteral("GuiFont! %1").arg(fontDesc) };
+
+	SendNeovimCommand(connector, fontCommand);
+	QCOMPARE(window.shell()->fontDesc(), fontDesc);
+	QCOMPARE(settings.value("Gui/Font").toString(), fontDesc);
+}
+
+void TestQSettings::GuiScrollBar() noexcept
+{
+	auto cw{ CreateMainWindowWithRuntime() };
+	NeovimConnector& connector{ *cw.first };
+
+	QSettings settings;
+
+	SendNeovimCommand(connector, "GuiScrollBar 1");
+	QCOMPARE(settings.value("Gui/ScrollBar").toBool(), true);
+
+	SendNeovimCommand(connector, "GuiScrollBar 0");
+	QCOMPARE(settings.value("Gui/ScrollBar").toBool(), false);
+}
+void TestQSettings::GuiTreeView() noexcept
+{
+	auto cw{ CreateMainWindowWithRuntime() };
+	NeovimConnector& connector{ *cw.first };
+
+	QSettings settings;
+
+	SendNeovimCommand(connector, "GuiTreeviewShow");
+	QCOMPARE(settings.value("Gui/TreeView").toBool(), true);
+
+	SendNeovimCommand(connector, "GuiTreeviewHide");
+	QCOMPARE(settings.value("Gui/TreeView").toBool(), false);
+}
+
+} // Namespace NeovimQt
+
+QTEST_MAIN(NeovimQt::TestQSettings)
+#include "tst_qsettings.moc"

--- a/test/tst_shell.cpp
+++ b/test/tst_shell.cpp
@@ -296,7 +296,6 @@ void TestShell::checkStartVars(NeovimQt::NeovimConnector* conn) noexcept
 
 	const QStringList vars{ "GuiWindowId", "GuiWindowMaximized", "GuiWindowFullScreen", "GuiFont", "GuiWindowFrameless" };
 	for (const auto& var : vars) {
-		qDebug() << "Checking Neovim for Gui var" << var;
 		QSignalSpy onVar(nvim, SIGNAL(on_vim_get_var(QVariant)));
 		QVERIFY(onVar.isValid());
 		nvim->vim_get_var(conn->encode(var));

--- a/test/tst_shell.cpp
+++ b/test/tst_shell.cpp
@@ -9,6 +9,7 @@
 #include <QtTest/QtTest>
 
 #include "common.h"
+#include "common_gui.h"
 
 #if defined(Q_OS_WIN) && defined(USE_STATIC_QT)
 #include <QtPlugin>
@@ -43,69 +44,6 @@ protected:
 static void SignalPrintError(QString msg, const QVariant& err) noexcept
 {
 	qDebug() << msg << err;
-}
-
-static const QStringList cs_argsNone{ "-u", "NONE" }; // clazy:exclude=non-pod-global-static
-
-template<class T> static void ValidateNeovimConnection(T* obj) noexcept
-{
-	QSignalSpy onAttached{ obj, &T::neovimAttachmentChanged };
-
-	Q_ASSERT(onAttached.isValid());
-
-	const bool signalEmitted{ onAttached.wait() };
-	Q_ASSERT(signalEmitted);
-
-	const int signalCount{ onAttached.count() };
-	Q_ASSERT(signalCount == 1);
-
-	Q_ASSERT(obj->isNeovimAttached());
-}
-
-static std::pair<NeovimConnector*, Shell*> CreateShellWidget() noexcept
-{
-	NeovimConnector* c{ NeovimConnector::spawn(cs_argsNone) };
-	Shell* s{ new Shell{ c } };
-
-	ValidateNeovimConnection(s);
-
-	return { c, s };
-}
-
-static std::pair<NeovimConnector*, MainWindow*> CreateMainWindow() noexcept
-{
-	NeovimConnector* c{ NeovimConnector::spawn(cs_argsNone) };
-	MainWindow* w{ new MainWindow{ c } };
-
-	ValidateNeovimConnection(w);
-
-	return { c, w };
-}
-
-static QString GetRuntimeAbsolutePath() noexcept
-{
-	static const QFileInfo cs_runtime{
-		QStringLiteral(CMAKE_SOURCE_DIR) + QStringLiteral("/src/gui/runtime") };
-
-	if (!cs_runtime.exists()) {
-		qFatal("Unable to find GUI runtime!");
-	}
-
-	return cs_runtime.absoluteFilePath();
-}
-
-static std::pair<NeovimConnector*, MainWindow*> CreateMainWindowWithRuntime() noexcept
-{
-	static const QStringList cs_argsNoneRuntime{
-		"-u", "NONE", "--cmd", "set rtp+=" + GetRuntimeAbsolutePath()
-	};
-
-	NeovimConnector* c{ NeovimConnector::spawn(cs_argsNoneRuntime) };
-	MainWindow* w{ new MainWindow{ c } };
-
-	ValidateNeovimConnection(w);
-
-	return { c, w };
 }
 
 void TestShell::initTestCase() noexcept


### PR DESCRIPTION
Several `Gui...` features impact startup `ShellWidget` size.

We should store the last known size for all of these options. This will allow us to set the correct `Shell` size on starup, without calling for successive resize events.

This is necessary to properly size splits, and prevent startup flicker.

Adds test coverage for these `QSettings` values.

Related: #866 #898 #927