### PR TITLE
Debug messages should only work in 'Debug' builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,7 +151,7 @@ else()
 endif()
 include_directories(${MSGPACK_INCLUDE_DIRS})
 
-if(CMAKE_BUILD_TYPE STREQUAL "Release")
+if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
     add_definitions(-DQT_NO_DEBUG_OUTPUT)
 endif()
 


### PR DESCRIPTION
closes #945

As a side note, in my system (cmake 3.21 in Linux) the default build type is  RelWithDebInfo and even if I force CMAKE_BUILD_TYPE=Release the build is still RelWithDebInfo.