### PR TITLE
Fix clazy lint CI job

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -11,8 +11,6 @@ jobs:
     name: Clazy
     strategy:
       fail-fast: false
-    env:
-      CLAZY_VER: 1.8
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -20,22 +18,15 @@ jobs:
       - name: Install dependencies
         run: |
           sudo add-apt-repository -y ppa:neovim-ppa/unstable
-          sudo apt-get install -y libqt5svg5-dev neovim ninja-build qt5-default
+          sudo apt-get install -y libqt5svg5-dev neovim ninja-build qt5-default clazy
           sudo apt-get update -y
           mkdir build
           cd build
-          CLAZY_VER=${{ env.CLAZY_VER }}
-          CLAZY_BIN=Clazy-x86_64-${{ env.CLAZY_VER }}.AppImage
-          CLAZY_URL=https://downloads.kdab.com/clazy/${CLAZY_VER}/${CLAZY_BIN}
-          wget ${CLAZY_URL}
-          chmod +x ${CLAZY_BIN}
-          echo "CLAZY_BIN=${CLAZY_BIN}" >> $GITHUB_ENV
-          echo "CLAZY_URL=${CLAZY_URL}" >> $GITHUB_ENV
 
       - name: Configure
         run: >
           cmake -B ${{ github.workspace }}/build -GNinja -DCMAKE_BUILD_TYPE=Debug -DENABLE_CLAZY=1
-          -DCMAKE_CXX_COMPILER=${{ github.workspace }}/build/${{ env.CLAZY_BIN }}
+          -DCMAKE_CXX_COMPILER=clazy
 
       - name: Build
         run: cmake --build ${{ github.workspace }}/build


### PR DESCRIPTION
The previous recipe relied on an clazy appimage from kdab.com. This
appimage is no longer available and clazy should be available as a
package for ubuntu.

It looks like gh workflows only support ubuntu 20 which still uses clazy 1.6.