### PR TITLE
Convert socket paths to absolute for QLocalSocket

### DIFF
--- a/src/neovimconnector.cpp
+++ b/src/neovimconnector.cpp
@@ -86,6 +86,20 @@ QString NeovimConnector::errorString()
 	return m_errorString;
 }
 
+QString NeovimConnector::connectionDescription()
+{
+	switch (m_ctype) {
+		case SpawnedConnection:
+			return m_spawnExe + " " + m_spawnArgs.join(" ");
+		case HostConnection:
+			return m_connHost + ":" + m_connPort;
+		case SocketConnection:
+			return m_connSocket;
+		default:
+			return "";
+	}
+}
+
 /**
  * Returns the channel id used by Neovim to identify this connection
  */

--- a/src/neovimconnector.h
+++ b/src/neovimconnector.h
@@ -95,6 +95,7 @@ public:
 	quint64 apiCompatibility();
 	quint64 apiLevel();
 	bool hasUIOption(const QByteArray& option);
+	QString connectionDescription();
 
 signals:
 	/** Emitted when Neovim is ready @see ready */


### PR DESCRIPTION

    
Attempting to connect to a local socket in UNIX systems using a relative
    path - this happens because Qt considers relative socket paths as being
    relative to the system temporary folder
    
https://bugreports.qt.io/browse/QTBUG-50877
    
Fixes #936

- [x] i still need to skip that test in other systems
- [x] not sure if Q_OS_UNIX is set for Mac OS
