### PR TITLE
Bypass showtabline if GuiTabline is set 

### DIFF
--- a/src/gui/runtime/plugin/nvim_gui_shim.vim
+++ b/src/gui/runtime/plugin/nvim_gui_shim.vim
@@ -96,14 +96,7 @@ function s:GuiLinespaceCommand(height) abort
 endfunction
 command! -nargs=? GuiLinespace call s:GuiLinespaceCommand("<args>")
 
-let s:stl=&showtabline
 function! s:GuiTabline(enable) abort
-  if a:enable
-    let s:stl=&showtabline
-    execute 'set showtabline=2'
-  else
-    execute 'set showtabline=' . s:stl
-  endif
   call rpcnotify(0, 'Gui', 'Option', 'Tabline', a:enable)
 endfunction
 command! -nargs=1 GuiTabline call s:GuiTabline(<args>)

--- a/src/gui/runtime/plugin/nvim_gui_shim.vim
+++ b/src/gui/runtime/plugin/nvim_gui_shim.vim
@@ -96,8 +96,15 @@ function s:GuiLinespaceCommand(height) abort
 endfunction
 command! -nargs=? GuiLinespace call s:GuiLinespaceCommand("<args>")
 
+let s:stl=&showtabline
 function! s:GuiTabline(enable) abort
-	call rpcnotify(0, 'Gui', 'Option', 'Tabline', a:enable)
+  if a:enable
+    let s:stl=&showtabline
+    execute 'set showtabline=2'
+  else
+    execute 'set showtabline=' . s:stl
+  endif
+  call rpcnotify(0, 'Gui', 'Option', 'Tabline', a:enable)
 endfunction
 command! -nargs=1 GuiTabline call s:GuiTabline(<args>)
 

--- a/src/gui/tabline.h
+++ b/src/gui/tabline.h
@@ -32,7 +32,6 @@ private:
 	void handleGuiOption(const QVariantList& args) noexcept;
 	void handleGuiTabline(const QVariantList& args) noexcept;
 	void handleTablineUpdate(const QVariantList& args) noexcept;
-	void handleOptionShowTabline(const QVariantList& args) noexcept;
 	void handleCloseBufferError(quint32 msgid, quint64 fun, const QVariant& err) noexcept;
 
 	void drawTablineUpdates(
@@ -52,13 +51,6 @@ private:
 	void updateTablineVisibilityLegacyMode() noexcept;
 	void updateTablinePathCallback() noexcept;
 
-	enum class OptionShowTabline : int
-	{
-		Never = 0,
-		AtLeastTwo = 1,
-		Always = 2,
-	};
-
 	NeovimConnector& m_nvim;
 	bool m_isEnabled{ cs_defaultIsTablineEnabled };
 
@@ -70,8 +62,6 @@ private:
 
 	QWidget m_spacer;
 	QAction* m_spacerAction{};
-
-	OptionShowTabline m_optionShowTabline{ OptionShowTabline::AtLeastTwo };
 };
 
 } // namespace NeovimQt


### PR DESCRIPTION
~Displaying tabs in neovim is controlled by the option showtabline:~
* ~0 -> never display~
* ~1 -> display if more than 1 tab (default)~
* ~2 -> always display~

~Ostensibly, #739 (Improved GuiTabline show buffers) changed the behavior of neovim such that buffers will be displayed in the tabline when GuiTabline is set, but showtabline's default makes GuiTabline a no-op until a second neovim tab is opened (with :tabnew, etc). The fix is to save the showtabline value and then when calling GuiTabline, if enabled set showtabline to 2, otherwise reset to the saved value.~

~This enables the (somewhat silly) configuration of setting showtabline to 0 and then toggling GuiTabline as the only means of seeing the tabline.~

Instead of settings or unsetting showtabline, assume that if GuiTabline is set, the user wants the gui tabline to be shown unconditionally.