### PR TITLE
Fix QSettings + QVariant error message

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -342,6 +342,10 @@ void MainWindow::saveWindowGeometry()
 
 void MainWindow::restoreWindowGeometry()
 {
+	// Workaround for error `QVariant::save: unable to save type 'QList<int>'`.
+	// This error can occur when calling the two `settings.value(...)` below.
+    qRegisterMetaTypeStreamOperators<QList<int> >("QList<int>");
+
 	QSettings settings{ "window-geometry" };
 	restoreGeometry(settings.value("window_geometry").toByteArray());
 	restoreState(settings.value("window_state").toByteArray());


### PR DESCRIPTION
I observe the following error:
```
QVariant::load: unable to load type 1029.
QVariant::save: unable to save type 'QList<int>' (type id: 1029).
```