### PR TITLE
Issue 1008: HyperKey should be ignored

### DIFF
--- a/src/gui/input.cpp
+++ b/src/gui/input.cpp
@@ -232,7 +232,9 @@ QString convertKey(const QKeyEvent& ev) noexcept
 			|| key == Qt::Key::Key_Meta
 			|| key == Qt::Key::Key_Shift
 			|| key == Qt::Key::Key_Super_L
-			|| key == Qt::Key::Key_Super_R) {
+			|| key == Qt::Key::Key_Super_R
+			|| key == Qt::Key_Hyper_L
+			|| key == Qt::Key_Hyper_R) {
 			return {};
 		}
 

--- a/test/tst_input_common.cpp
+++ b/test/tst_input_common.cpp
@@ -17,6 +17,7 @@ private slots:
 	void AltGrKeyEventWellFormed() noexcept;
 	void ShiftSpaceWellFormed() noexcept;
 	void ShiftBackSpaceWellFormed() noexcept;
+	void IgnoreHyperKey() noexcept;
 
 	// Mouse Input
 	void MouseLeftClick() noexcept;
@@ -156,6 +157,17 @@ void TestInputCommon::ShiftBackSpaceWellFormed() noexcept
 	QKeyEvent evShiftBackSpace{ QEvent::KeyPress, Qt::Key_Backspace, Qt::ShiftModifier, "\b" };
 	QCOMPARE(NeovimQt::Input::convertKey(evShiftBackSpace), QString{ "<BS>" });
 }
+
+void TestInputCommon::IgnoreHyperKey() noexcept
+{
+	// Issue#1008: Hyper key should be ignored, but instead inserts "v" instead.
+	QKeyEvent evHyperL{ QEvent::KeyPress, Qt::Key_Hyper_L, Qt::NoModifier };
+	QCOMPARE(NeovimQt::Input::convertKey(evHyperL), QString{});
+
+	QKeyEvent evHyperR{ QEvent::KeyPress, Qt::Key_Hyper_R, Qt::NoModifier };
+	QCOMPARE(NeovimQt::Input::convertKey(evHyperR), QString{});
+}
+
 
 void TestInputCommon::MouseLeftClick() noexcept
 {


### PR DESCRIPTION
**Issue #1008:** Hyper_L inserts `v`

For Hyper key events, text is inserted. This is not correct, these key events should be ignored.