### PR TITLE
Make Unit Tests off-by-default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,7 +173,7 @@ endif()
 add_subdirectory(src)
 add_subdirectory(doc)
 
-option(ENABLE_TESTS "Build tests" ON)
+option(ENABLE_TESTS "Build tests" OFF)
 if(ENABLE_TESTS)
 	find_package(Qt5Test REQUIRED)
 	enable_testing()


### PR DESCRIPTION
**Issue #1016:** Unit Tests should be off-by-default

Most users don't need the test code build/run, we can disable them by default to decrease build times and the likelihood of error.