### PR TITLE
Issue 982: Ability to disable GuiTabline buffers

### DIFF
--- a/src/gui/runtime/plugin/nvim_gui_shim.vim
+++ b/src/gui/runtime/plugin/nvim_gui_shim.vim
@@ -101,6 +101,11 @@ function! s:GuiTabline(enable) abort
 endfunction
 command! -nargs=1 GuiTabline call s:GuiTabline(<args>)
 
+function! s:GuiTablineBuffers(enable) abort
+	call rpcnotify(0, 'Gui', 'Option', 'TablineBuffers', a:enable)
+endfunction
+command! -nargs=1 GuiTablineBuffers call s:GuiTablineBuffers(<args>)
+
 function! s:GuiPopupmenu(enable) abort
 	call rpcnotify(0, 'Gui', 'Option', 'Popupmenu', a:enable)
 endfunction

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -921,9 +921,7 @@ void Shell::handleNeovimNotification(const QByteArray &name, const QVariantList&
 
 void Shell::handleExtGuiOption(const QString& name, const QVariant& value)
 {
-	if (name == "Tabline") {
-		handleGuiTabline(value);
-	} else if (name == "Popupmenu") {
+	if (name == "Popupmenu") {
 		handleGuiPopupmenu(value);
 	} else if (name == "RenderLigatures"){
 		setLigatureMode(value.toBool());
@@ -1037,27 +1035,6 @@ void Shell::handleCloseEvent(const QVariantList& args) noexcept
 	}
 
 	emit neovimGuiCloseRequest(status);
-}
-
-void Shell::handleGuiTabline(const QVariant& value) noexcept
-{
-	if (!m_nvim->api1())
-	{
-		qDebug() << "GuiTabline not supported by Neovim API!";
-		return;
-	}
-
-	if (!value.canConvert<bool>())
-	{
-		qDebug() << "GuiTabline value not recognized!";
-		return;
-	}
-
-	const bool isEnabled{ value.toBool() };
-	m_nvim->api1()->nvim_ui_set_option("ext_tabline", isEnabled);
-
-	QSettings settings;
-	settings.setValue("ext_tabline", isEnabled);
 }
 
 void Shell::handleGuiPopupmenu(const QVariant& value) noexcept

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -154,7 +154,6 @@ protected:
 	virtual void handleLineSpace(const QVariant& value) noexcept;
 	virtual void handleWindowFrameless(const QVariant& value) noexcept;
 	virtual void handleCloseEvent(const QVariantList &args) noexcept;
-	virtual void handleGuiTabline(const QVariant& value) noexcept;
 	virtual void handleGuiPopupmenu(const QVariant& value) noexcept;
 
 	// Modern 'ext_linegrid' Grid UI Events

--- a/src/gui/tabline.cpp
+++ b/src/gui/tabline.cpp
@@ -12,6 +12,9 @@
 
 #include "msgpackrequest.h"
 
+static constexpr auto cs_showBuffersOptionName { "Tabline/OptionShowBuffers" };
+static constexpr auto cs_showTablineOptionName { "ext_tabline" };
+
 namespace NeovimQt {
 
 Tabline::Tabline(NeovimConnector& nvim, QWidget* parent) noexcept
@@ -55,7 +58,8 @@ Tabline::Tabline(NeovimConnector& nvim, QWidget* parent) noexcept
 	connect(&m_bufferline, &QTabBar::tabCloseRequested, this, &Tabline::closeRequestedBufline);
 
 	QSettings settings;
-	m_isEnabled = settings.value("ext_tabline", cs_defaultIsTablineEnabled).toBool();
+	m_isEnabled = settings.value(cs_showTablineOptionName, cs_defaultIsTablineEnabled).toBool();
+	m_isBufferlineEnabled = settings.value(cs_showBuffersOptionName, true).toBool();
 	updateTablineVisibility();
 }
 
@@ -107,6 +111,11 @@ void Tabline::handleGuiOption(const QVariantList& args) noexcept
 
 	if (option == "Tabline") {
 		handleGuiTabline(args);
+		return;
+	}
+	if (option == "TablineBuffers") {
+		handleGuiTablineBuffers(args);
+		return;
 	}
 }
 
@@ -118,7 +127,34 @@ void Tabline::handleGuiTabline(const QVariantList& args) noexcept
 	}
 
 	const bool isEnabled{ args.at(2).toBool() };
+
 	m_isEnabled = isEnabled;
+
+	QSettings settings;
+	settings.setValue(cs_showTablineOptionName, isEnabled);
+
+	if (m_nvim.api1()) {
+		m_nvim.api1()->nvim_ui_set_option(cs_showTablineOptionName, isEnabled);
+	}
+
+	updateTablineVisibility();
+}
+
+
+void Tabline::handleGuiTablineBuffers(const QVariantList& args) noexcept
+{
+	if (args.size() < 3 || !args.at(2).canConvert<bool>()) {
+		qWarning() << "Unexpected format for GuiTablineBuffers:" << args;
+		return;
+	}
+
+	const bool isEnabled{ args.at(2).toBool() };
+
+	m_isBufferlineEnabled = isEnabled;
+
+	QSettings settings;
+	settings.setValue(cs_showBuffersOptionName, isEnabled);
+
 	updateTablineVisibility();
 }
 
@@ -355,7 +391,7 @@ void Tabline::updateTablineVisibility() noexcept
 
 	// Legacy Mode: Neovim does not provide buffer info to GuiTabline
 	// Support for tabs + buffers was added in Neovim API 8
-	const bool isLegacyMode{ m_bufferline.count() == 0 };
+	const bool isLegacyMode{ !m_isBufferlineEnabled || m_bufferline.count() == 0 };
 
 	const bool isAtLeastTwoTabs{ m_tabline.count() >= 2 };
 	const bool isAtLeastTwoBuffers{ m_bufferline.count() >= 2 };

--- a/src/gui/tabline.h
+++ b/src/gui/tabline.h
@@ -31,6 +31,7 @@ private:
 
 	void handleGuiOption(const QVariantList& args) noexcept;
 	void handleGuiTabline(const QVariantList& args) noexcept;
+	void handleGuiTablineBuffers(const QVariantList& args) noexcept;
 	void handleTablineUpdate(const QVariantList& args) noexcept;
 	void handleOptionShowTabline(const QVariantList& args) noexcept;
 	void handleCloseBufferError(quint32 msgid, quint64 fun, const QVariant& err) noexcept;
@@ -61,6 +62,7 @@ private:
 
 	NeovimConnector& m_nvim;
 	bool m_isEnabled{ cs_defaultIsTablineEnabled };
+	bool m_isBufferlineEnabled{ true };
 
 	QTabBar m_tabline;
 	QAction* m_tablineAction{};


### PR DESCRIPTION
**Issue #982:** Ability to dsiable GuiTabline buffers

Users have requested the ability to disable buffers in the :GuiTabline display. Adds a command `:GuiTablineBuffers` which controls the display of buffers when "ext_tabline" is enabled.

Also moves some "ext_tabline" code from shell.cpp to tabline.cpp.