### PR TITLE
Support Windows 10 Dark Mode partially

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -6,7 +6,85 @@
 #include <QStyleFactory>
 #include <QToolBar>
 
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#include <dwmapi.h>
+#pragma comment (lib, "Dwmapi.lib")
+#endif
+
 namespace NeovimQt {
+
+#ifdef Q_OS_WIN
+enum PreferredAppMode {
+	Default,
+	AllowDark,
+	ForceDark,
+	ForceLight,
+	Max
+};
+
+enum WINDOWCOMPOSITIONATTRIB {
+	WCA_UNDEFINED = 0,
+	WCA_NCRENDERING_ENABLED = 1,
+	WCA_NCRENDERING_POLICY = 2,
+	WCA_TRANSITIONS_FORCEDISABLED = 3,
+	WCA_ALLOW_NCPAINT = 4,
+	WCA_CAPTION_BUTTON_BOUNDS = 5,
+	WCA_NONCLIENT_RTL_LAYOUT = 6,
+	WCA_FORCE_ICONIC_REPRESENTATION = 7,
+	WCA_EXTENDED_FRAME_BOUNDS = 8,
+	WCA_HAS_ICONIC_BITMAP = 9,
+	WCA_THEME_ATTRIBUTES = 10,
+	WCA_NCRENDERING_EXILED = 11,
+	WCA_NCADORNMENTINFO = 12,
+	WCA_EXCLUDED_FROM_LIVEPREVIEW = 13,
+	WCA_VIDEO_OVERLAY_ACTIVE = 14,
+	WCA_FORCE_ACTIVEWINDOW_APPEARANCE = 15,
+	WCA_DISALLOW_PEEK = 16,
+	WCA_CLOAK = 17,
+	WCA_CLOAKED = 18,
+	WCA_ACCENT_POLICY = 19,
+	WCA_FREEZE_REPRESENTATION = 20,
+	WCA_EVER_UNCLOAKED = 21,
+	WCA_VISUAL_OWNER = 22,
+	WCA_HOLOGRAPHIC = 23,
+	WCA_EXCLUDED_FROM_DDA = 24,
+	WCA_PASSIVEUPDATEMODE = 25,
+	WCA_USEDARKMODECOLORS = 26,
+	WCA_LAST = 27
+};
+
+struct WINDOWCOMPOSITIONATTRIBDATA {
+	WINDOWCOMPOSITIONATTRIB Attrib;
+	PVOID pvData;
+	SIZE_T cbData;
+};
+
+using fnAllowDarkModeForWindow =  BOOL (WINAPI *)(HWND hWnd, BOOL allow);
+using fnSetPreferredAppMode = PreferredAppMode (WINAPI *)(PreferredAppMode appMode);
+using fnSetWindowCompositionAttribute =  BOOL (WINAPI *)(HWND hwnd, WINDOWCOMPOSITIONATTRIBDATA *);
+
+static void setDarkTitlebar(HWND hwnd) {
+	HMODULE hUxtheme = LoadLibraryExW(L"uxtheme.dll", NULL, LOAD_LIBRARY_SEARCH_SYSTEM32);
+	HMODULE hUser32 = GetModuleHandleW(L"user32.dll");
+	fnAllowDarkModeForWindow AllowDarkModeForWindow
+		= reinterpret_cast<fnAllowDarkModeForWindow>(GetProcAddress(hUxtheme, MAKEINTRESOURCEA(133)));
+	fnSetPreferredAppMode SetPreferredAppMode
+		= reinterpret_cast<fnSetPreferredAppMode>(GetProcAddress(hUxtheme, MAKEINTRESOURCEA(135)));
+	fnSetWindowCompositionAttribute SetWindowCompositionAttribute
+		= reinterpret_cast<fnSetWindowCompositionAttribute>(GetProcAddress(hUser32, "SetWindowCompositionAttribute"));
+
+	SetPreferredAppMode(AllowDark);
+	BOOL dark = TRUE;
+	AllowDarkModeForWindow(hwnd, dark);
+	WINDOWCOMPOSITIONATTRIBDATA data = {
+		WCA_USEDARKMODECOLORS,
+		&dark,
+		sizeof(dark)
+	};
+	SetWindowCompositionAttribute(hwnd, &data);
+}
+#endif
 
 static QString DefaultWindowTitle() noexcept
 {
@@ -28,6 +106,10 @@ MainWindow::MainWindow(NeovimConnector* c, QWidget* parent) noexcept
 	setWindowTitle(DefaultWindowTitle());
 
 	init(c);
+
+#ifdef Q_OS_WIN
+	setDarkTitlebar(reinterpret_cast<HWND>(winId()));
+#endif
 }
 
 void MainWindow::init(NeovimConnector *c)


### PR DESCRIPTION
- ~[latest build](https://ci.appveyor.com/api/buildjobs/wxca9rnbni8yc2hg/artifacts/neovim-qt.zip)~.

Uses statiolake/neovim-qt/tree/win10-darkmode.

Fixes #834.

Ongoing maintenance to be done as described in https://github.com/equalsraf/neovim-qt/issues/834#issuecomment-825160053.

