### PR TITLE
Issue 1011: Underline color with ext_linegrid off

### DIFF
--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -403,7 +403,7 @@ void Shell::handleHighlightSet(const QVariantMap& attrs)
 	if (attrs.contains(("special"))) {
 		m_hg_special = QColor{ attrs.value("special").toUInt() };
 	} else {
-		m_hg_special = special();
+		m_hg_special = QColor::Invalid;
 	}
 
 	if (attrs.contains("reverse")) {

--- a/src/gui/shelloptions.h
+++ b/src/gui/shelloptions.h
@@ -4,7 +4,7 @@ namespace NeovimQt {
 
 constexpr bool cs_defaultIsTablineEnabled{ false };
 constexpr bool cs_defaultIsPopupmenuEnabled{ false };
-constexpr bool cs_defaultIsLineGridEnabled{ false };
+constexpr bool cs_defaultIsLineGridEnabled{ true };
 
 class ShellOptions final {
 public:


### PR DESCRIPTION
**Issue #1011:** Reevaluate underline color logic
**Issue #929:** Underline is always red by default

The special color selection logic is incorrect for the old UI rendering protocol (ext_linegrid = false).

Only sets special when one is explicitly provided and enables ext_linegrid by default.