### PR TITLE
Only set tooltip and icon if buffer has path

### DIFF
--- a/src/gui/tabline.cpp
+++ b/src/gui/tabline.cpp
@@ -273,6 +273,10 @@ static void SetTabIconAndTooltipCallback(
 
 	const QString bufferPath{ resp.toString() };
 
+	if (bufferPath.isEmpty()) {
+		return;
+	}
+	
 	bufferline->setTabToolTip(bufIndex, bufferPath);
 	bufferline->setTabIcon(bufIndex, GetIconFromFilePath(bufferPath));
 }


### PR DESCRIPTION
There's a really obnoxious bug on OSX where opening a new file (opening `nvim-qt` without specifying a file, or typing `:enew`) fills the console with [AppKit](https://developer.apple.com/documentation/appkit/nsworkspace/1528158-iconforfile) error spam:

```
noah@Noahs-MacBook-Pro ~/personal/neovim-qt  [master ≡]
$ build/bin/nvim-qt.app/Contents/MacOS/nvim-qt
2022-10-03 22:46:07.735 nvim-qt[22744:7208827] Path  given to -[NSWorkspace iconForFile:] is not a full path.
2022-10-03 22:46:07.739 nvim-qt[22744:7208827] Path  given to -[NSWorkspace iconForFile:] is not a full path.
```

Seems that AppKit doesn't like it if Qt gives it a blank path, and we're giving Qt the blank path. Oops.

I don't know almost anything about c++ and certainly don't know anything about c++ development, lol, so let me know if there's some way I can write an automated test for this and then run it.