### PR TITLE
Fix small issues when using as an external project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,7 @@ endif()
 
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
+set(CMAKE_INCLUDE_CURRENT_DIR_IN_INTERFACE ON)
 
 # to generate a compile_commands.json usable by ycm and other tooling
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -101,10 +101,10 @@ if(NOT APPLE)
 	install(FILES ${PROJECT_SOURCE_DIR}/LICENSE
 		DESTINATION ${CMAKE_INSTALL_DATADIR}/nvim-qt/)
 	install(FILES nvim-qt.desktop DESTINATION ${CMAKE_INSTALL_DATADIR}/applications)
-	install(FILES ${CMAKE_SOURCE_DIR}/third-party/neovim.png
+    install(FILES ${PROJECT_SOURCE_DIR}/third-party/neovim.png
 			RENAME nvim-qt.png
 			DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/192x192/apps/)
-	install(FILES ${CMAKE_SOURCE_DIR}/third-party/neovim.svg
+    install(FILES ${PROJECT_SOURCE_DIR}/third-party/neovim.svg
 			RENAME nvim-qt.svg
 			DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/scalable/apps/)
 endif()


### PR DESCRIPTION
When used as an external project, neovim-qt had some issues:
1. Main target's include directories are not propagated to the targets, that link to neovim-qt.
2. When installing, paths to neovim icons are incorrect.

This PR fixes those issues.