### PR TITLE
Fix GitHub Actions CI Breaks

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -78,7 +78,7 @@ jobs:
         if: ${{ startsWith(matrix.runner, 'ubuntu') }}
         run: |
           sudo add-apt-repository -y ppa:neovim-ppa/stable
-          sudo apt-get install -y neovim ninja-build libqt5svg5 libqt5svg5-dev qt5-default
+          sudo apt-get install -y neovim ninja-build libqt5svg5 libqt5svg5-dev qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools
           sudo apt-get update -y
 
       - name: MacOS - Setup

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -29,7 +29,7 @@ jobs:
 
           - name: Linux_Release
             flavor: Release
-            runner: ubuntu-18.04
+            runner: ubuntu-20.04
             generator: Ninja
             cc: gcc
             cxx: g++
@@ -54,13 +54,14 @@ jobs:
           # images bundle only 11.2. For now, we must use the older image `windows-2019`.
           - name: Windows_MingGW
             flavor: Debug
-            runner: windows-2019
+            runner: windows-2022
             generator: MinGW Makefiles
             qtver: 5.15.2
             qtdir: mingw81_64
             qtstr: windows desktop win64_mingw81
             cc: gcc
             cxx: g++
+            ctest_exe_args: -tap
 
           - name: Windows_Release
             flavor: Release
@@ -69,6 +70,7 @@ jobs:
             qtver: 5.15.2
             qtdir: msvc2019_64
             qtstr: windows desktop win64_msvc2019_64
+            ctest_exe_args: -tap
             publish: true
 
     runs-on: ${{ matrix.runner }}
@@ -137,12 +139,12 @@ jobs:
           -DCMAKE_C_COMPILER=${{ matrix.cc }}
           -DCMAKE_CXX_COMPILER=${{ matrix.cxx }}
           -DENABLE_TESTS=ON
+          -DCTEST_EXE_ARGS=${{ matrix.ctest_exe_args }}
 
       - name: Build
         run: cmake --build ${{ github.workspace }}/build
 
       - name: Test
-        if: ${{ !startsWith(matrix.runner, 'windows') }}
         uses: GabrielBB/xvfb-action@v1 # Required by Linux, no X11 $DISPLAY
         with:
           working-directory: ${{ github.workspace }}/build
@@ -151,7 +153,7 @@ jobs:
       #
       # Deploy Release Binaries
       #
-      - name: Linux - Publish Release Build
+      - name: Linux - Publish
         if: ${{ matrix.publish && startsWith(matrix.runner, 'ubuntu') }}
         env:
           ARCH: x86_64
@@ -161,13 +163,13 @@ jobs:
           chmod a+x linuxdeployqt-continuous-x86_64.AppImage
           ./linuxdeployqt-continuous-x86_64.AppImage ./install/share/applications/nvim-qt.desktop -appimage
 
-      - name: MacOS - Publish Release Build
+      - name: MacOS - Publish
         if: ${{ matrix.publish && startsWith(matrix.runner, 'macos') }}
         run: |
           macdeployqt ./build/bin/nvim-qt.app -dmg
           mv ./build/bin/nvim-qt.dmg neovim-qt.dmg
 
-      - name: Windows - Publish Release Build
+      - name: Windows - Publish
         if: ${{ matrix.publish && startsWith(matrix.runner, 'windows') }}
         run: |
           cmake --build ./build --target install

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -134,6 +134,7 @@ jobs:
           -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/install
           -DCMAKE_C_COMPILER=${{ matrix.cc }}
           -DCMAKE_CXX_COMPILER=${{ matrix.cxx }}
+          -DENABLE_TESTS=ON
 
       - name: Build
         run: cmake --build ${{ github.workspace }}/build

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -15,14 +15,14 @@ jobs:
         include:
           - name: Linux_GCC
             flavor: Debug
-            runner: ubuntu-latest
+            runner: ubuntu-22.04
             generator: Ninja
             cc: gcc
             cxx: g++
 
           - name: Linux_LLVM
             flavor: Debug
-            runner: ubuntu-latest
+            runner: ubuntu-22.04
             generator: Ninja
             cc: clang
             cxx: clang++
@@ -37,14 +37,14 @@ jobs:
 
           - name: MacOS_GCC
             flavor: Debug
-            runner: macos-latest
+            runner: macos-12
             generator: Ninja
             cc: gcc-11
             cxx: g++-11
 
           - name: MacOS_Release
             flavor: Release
-            runner: macos-latest
+            runner: macos-12
             generator: Ninja
             cc: clang
             cxx: clang++
@@ -62,7 +62,7 @@ jobs:
 
           - name: Windows_Release
             flavor: Release
-            runner: windows-latest
+            runner: windows-2022
             generator: Visual Studio 17 2022
             qtver: 5.15.2
             qtdir: msvc2019_64

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -37,10 +37,10 @@ jobs:
 
           - name: MacOS_GCC
             flavor: Debug
-            runner: macos-12
+            runner: macos-11
             generator: Ninja
-            cc: gcc-11
-            cxx: g++-11
+            cc: gcc-10
+            cxx: g++-10
 
           - name: MacOS_Release
             flavor: Release
@@ -59,6 +59,8 @@ jobs:
             qtver: 5.15.2
             qtdir: mingw81_64
             qtstr: windows desktop win64_mingw81
+            cc: gcc
+            cxx: g++
 
           - name: Windows_Release
             flavor: Release

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -50,9 +50,11 @@ jobs:
             cxx: clang++
             publish: true
 
+          # Qt 5.15 only supports MinGW 8.11. The `windows-latest` and `windows-2022`
+          # images bundle only 11.2. For now, we must use the older image `windows-2019`.
           - name: Windows_MingGW
             flavor: Debug
-            runner: windows-latest
+            runner: windows-2019
             generator: MinGW Makefiles
             qtver: 5.15.2
             qtdir: mingw81_64

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo add-apt-repository -y ppa:neovim-ppa/unstable
-          sudo apt-get install -y libqt5svg5-dev neovim ninja-build qt5-default clazy
+          sudo apt-get install -y libqt5svg5-dev neovim ninja-build clazy qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools
           sudo apt-get update -y
           mkdir build
           cd build

--- a/src/gui/shellwidget/test/CMakeLists.txt
+++ b/src/gui/shellwidget/test/CMakeLists.txt
@@ -11,7 +11,7 @@ add_definitions(-DTEST_SOURCE_DIR="${TEST_SOURCE_DIR}")
 function(add_xtest SOURCE_NAME)
 	add_executable(${SOURCE_NAME} ${SOURCE_NAME}.cpp)
 	target_link_libraries(${SOURCE_NAME} Qt5::Widgets Qt5::Test qshellwidget)
-	add_test(NAME ${SOURCE_NAME} COMMAND ${SOURCE_NAME})
+	add_test(NAME ${SOURCE_NAME} COMMAND ${SOURCE_NAME} ${CTEST_EXE_ARGS})
 endfunction()
 
 add_xtest(test_cell)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -28,7 +28,7 @@ function(add_xtest SOURCE_NAME)
 		${ARGV1}
 		${ARGV2})
 	target_link_libraries(${SOURCE_NAME} ${QTLIBS} ${MSGPACK_LIBRARIES} neovim-qt)
-	add_test(NAME ${SOURCE_NAME} COMMAND ${SOURCE_NAME})
+	add_test(NAME ${SOURCE_NAME} COMMAND ${SOURCE_NAME} ${CTEST_EXE_ARGS})
 	add_dependencies(check ${SOURCE_NAME})
 endfunction()
 
@@ -41,7 +41,7 @@ function(add_xtest_gui SOURCE_NAME)
 		${SOURCES_COMMON_GUI}
 		${ARGV1} ${ARGV2})
 	target_link_libraries(${SOURCE_NAME} ${QTLIBS} ${MSGPACK_LIBRARIES} neovim-qt Qt5::Widgets neovim-qt-gui)
-	add_test(NAME ${SOURCE_NAME} COMMAND ${SOURCE_NAME}
+	add_test(NAME ${SOURCE_NAME} COMMAND ${SOURCE_NAME} ${CTEST_EXE_ARGS}
 		# Run GUI tests from source dir, they depend on src files
 		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 	add_dependencies(check ${SOURCE_NAME})
@@ -50,7 +50,7 @@ endfunction()
 function(add_shared_test SOURCE_NAME)
 	add_executable(${SOURCE_NAME} ${ARGV1} ${ARGV2} ${ARGV3})
 	target_link_libraries(${SOURCE_NAME} Qt5::Network Qt5::Test Qt5::Widgets ${MSGPACK_LIBRARIES} neovim-qt)
-	add_test(NAME ${SOURCE_NAME} COMMAND ${SOURCE_NAME})
+	add_test(NAME ${SOURCE_NAME} COMMAND ${SOURCE_NAME} ${CTEST_EXE_ARGS})
 	add_dependencies(check ${SOURCE_NAME})
 endfunction()
 


### PR DESCRIPTION
With a recent VM image update, the qt5-default package was removed.

According the the following, the package naming has changed:
https://askubuntu.com/questions/1335184/qt5-default-not-in-ubuntu-21-04