### PR TITLE
Add some more modern syntax in CMake files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ src/gui/runtime/doc/tags
 third-party/msgpack*
 compile_commands.json
 !.github
+
+# Qt Creator project files
+CMakeLists.txt.user

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,14 +129,9 @@ include(MacOSXPaths)
 
 # Qt
 set(CMAKE_AUTOMOC ON)
-find_package(Qt5Core REQUIRED)
-find_package(Qt5Network REQUIRED)
-find_package(Qt5Svg REQUIRED)
-find_package(Qt5Widgets REQUIRED)
+set(CMAKE_AUTORCC ON)
 
-if(Qt5Core_VERSION VERSION_LESS 5.8)
-	message(FATAL_ERROR "Minimum supported Qt5 version is 5.8!")
-endif()
+find_package(Qt5 5.8 REQUIRED COMPONENTS Core Network Svg Widgets)
 
 # msgpack
 option(USE_SYSTEM_MSGPACK "Use system msgpack libraries " OFF)
@@ -147,7 +142,7 @@ else()
 endif()
 
 if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
-    add_definitions(-DQT_NO_DEBUG_OUTPUT)
+    add_compile_definitions(-DQT_NO_DEBUG_OUTPUT)
 endif()
 
 # Place targets in bin/ or lib/ for all build configurations
@@ -163,7 +158,7 @@ endforeach()
 
 if(MSVC)
   # Allow use of deprecated function names in MSVC (read/write)
-  add_definitions(-D_CRT_NONSTDC_NO_DEPRECATE)
+  add_compile_definitions(-D_CRT_NONSTDC_NO_DEPRECATE)
 endif()
 
 add_subdirectory(src)
@@ -171,7 +166,7 @@ add_subdirectory(doc)
 
 option(ENABLE_TESTS "Build tests" OFF)
 if(ENABLE_TESTS)
-	find_package(Qt5Test REQUIRED)
+    find_package(Qt5 REQUIRED COMPONENTS Test)
 	enable_testing()
 	add_subdirectory(test)
 	add_subdirectory(src/gui/shellwidget/test)
@@ -182,14 +177,15 @@ find_package(PythonInterp)
 if (PYTHONINTERP_FOUND)
 	set(NVIM "nvim" CACHE STRING "Path to nvim executable")
 	add_custom_target(bindings
-		COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/bindings/generate_bindings.py ${NVIM} ${CMAKE_SOURCE_DIR}/src/auto
-		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/bindings/generate_bindings.py
+          ${NVIM} ${PROJECT_SOURCE_DIR}/src/auto
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
 		COMMENT "Generating bindings"
-		)
+    )
 
 	add_custom_target(bindings-preview
-		COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/bindings/generate_bindings.py ${NVIM}
-		)
+        COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/bindings/generate_bindings.py ${NVIM}
+    )
 endif()
 
 include(CPackOptions)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,27 +1,33 @@
-
 configure_file(version.h.in ${CMAKE_CURRENT_BINARY_DIR}/version.h)
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
-set(NEOVIM_QT_SOURCES
-  auto/neovimapi0.cpp
-  auto/neovimapi1.cpp
-  auto/neovimapi2.cpp
-  auto/neovimapi3.cpp
-  auto/neovimapi4.cpp
-  auto/neovimapi5.cpp
-  auto/neovimapi6.cpp
-  function.cpp
-  msgpackiodevice.cpp
-  msgpackrequest.cpp
-  neovimconnector.cpp
-  neovimconnectorhelper.cpp
-  util.cpp)
+add_library(neovim-qt STATIC)
+
+target_sources(neovim-qt
+  PRIVATE
+    function.cpp
+    function.h
+    msgpackiodevice.cpp
+    msgpackiodevice.h
+    msgpackrequest.cpp
+    msgpackrequest.h
+    neovimconnector.cpp
+    neovimconnector.h
+    neovimconnectorhelper.cpp
+    neovimconnectorhelper.h
+    util.cpp
+    util.h
+)
 
 if(WIN32)
-  list(APPEND NEOVIM_QT_SOURCES stdinreader.cpp)
+    target_sources(neovim-qt
+      PRIVATE
+        stdinreader.cpp
+        stdinreader.h
+    )
 endif()
 
-add_library(neovim-qt STATIC ${NEOVIM_QT_SOURCES})
-target_link_libraries(neovim-qt Qt5::Network msgpackc-static)
+target_link_libraries(neovim-qt PUBLIC Qt5::Network msgpackc-static)
 
+add_subdirectory(auto)
 add_subdirectory(gui)

--- a/src/auto/CMakeLists.txt
+++ b/src/auto/CMakeLists.txt
@@ -1,0 +1,17 @@
+target_sources(neovim-qt
+  PRIVATE
+    neovimapi0.cpp
+    neovimapi0.h
+    neovimapi1.cpp
+    neovimapi1.h
+    neovimapi2.cpp
+    neovimapi2.h
+    neovimapi3.cpp
+    neovimapi3.h
+    neovimapi4.cpp
+    neovimapi4.h
+    neovimapi5.cpp
+    neovimapi5.h
+    neovimapi6.cpp
+    neovimapi6.h
+)

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -1,44 +1,31 @@
 set(QTLIBS Qt5::Network Qt5::Svg Qt5::Widgets)
 
 include_directories(.. shellwidget)
-qt5_add_resources(NEOVIM_RCC_SOURCES data.qrc)
+
 if(WIN32)
-	set(SRCS_PLATFORM
-		arguments_qwindowgeometry.cpp
-		input_win32.cpp
-		printinfo_msgbox.cpp
-		)
 	if (USE_STATIC_QT)
 		add_definitions(-DUSE_STATIC_QT)
 		link_directories(${CMAKE_PREFIX_PATH}/share/qt5/plugins/platforms)
-		set(QTLIBS ${QTLIBS} Qt5PlatformCompositorSupport qwindows)
+        list(APPEND QTLIBS Qt5PlatformCompositorSupport qwindows)
 	endif()
 	set(RES_FILE "data.rc")
 	enable_language(RC)
 elseif(APPLE)
-	set(SRCS_PLATFORM
-		arguments_qwindowgeometry.cpp
-		input_mac.cpp
-		printinfo_stdout.cpp
-		)
 	set(ICON_PATH ${PROJECT_SOURCE_DIR}/third-party/neovim.icns)
 	set_source_files_properties(${ICON_PATH} PROPERTIES MACOSX_PACKAGE_LOCATION "Resources")
 
 	set(MACOSX_BUNDLE_INFO_PLIST ${PROJECT_SOURCE_DIR}/cmake/MacOSXBundleInfo.plist.in)
-else()
-	set(SRCS_PLATFORM
-		arguments_geometry.cpp
-		input_unix.cpp
-		printinfo_stdout.cpp
-		)
 endif()
 
 add_subdirectory(shellwidget)
 
 include(GNUInstallDirs)
-set(RUNTIME_PATH )
+set(RUNTIME_PATH)
 
-add_library(neovim-qt-gui
+add_library(neovim-qt-gui STATIC)
+
+target_sources(neovim-qt-gui
+  PRIVATE
 	app.cpp
 	contextmenu.cpp
 	errorwidget.cpp
@@ -51,8 +38,39 @@ add_library(neovim-qt-gui
 	tabline.cpp
 	treeview.cpp
 	${SRCS_PLATFORM}
-	${NEOVIM_RCC_SOURCES})
-target_link_libraries(neovim-qt-gui ${QTLIBS} qshellwidget neovim-qt)
+    data.qrc
+)
+
+if(WIN32)
+    target_sources(neovim-qt-gui
+      PRIVATE
+        arguments_qwindowgeometry.cpp
+        input_win32.cpp
+        printinfo_msgbox.cpp
+    )
+elseif(APPLE)
+    target_sources(neovim-qt-gui
+      PRIVATE
+        arguments_qwindowgeometry.cpp
+        input_mac.cpp
+        printinfo_stdout.cpp
+    )
+else()
+    target_sources(neovim-qt-gui
+      PRIVATE
+        arguments_geometry.cpp
+        input_unix.cpp
+        printinfo_stdout.cpp
+    )
+endif()
+
+
+target_link_libraries(neovim-qt-gui
+  PUBLIC
+    ${QTLIBS}
+    qshellwidget
+    neovim-qt
+)
 
 if(APPLE)
 	set_property(SOURCE app.cpp PROPERTY COMPILE_DEFINITIONS
@@ -62,12 +80,18 @@ else()
 		NVIM_QT_RELATIVE_RUNTIME_PATH="../share/nvim-qt/runtime")
 endif()
 
-add_executable(nvim-qt WIN32 MACOSX_BUNDLE main.cpp
-	${NEOVIM_RCC_SOURCES}
-	${RES_FILE}
-	${ICON_PATH})
 
-target_link_libraries(nvim-qt ${QTLIBS} neovim-qt-gui)
+add_executable(nvim-qt WIN32 MACOSX_BUNDLE)
+
+target_sources(nvim-qt
+  PRIVATE
+    main.cpp
+    data.qrc
+	${RES_FILE}
+    ${ICON_PATH}
+)
+
+target_link_libraries(nvim-qt PRIVATE neovim-qt-gui)
 
 if(APPLE)
 	add_custom_command(TARGET nvim-qt COMMAND ${CMAKE_COMMAND} -E copy_directory
@@ -112,8 +136,10 @@ endif()
 if(WIN32 AND NOT CMAKE_CROSSCOMPILING AND NOT DEFINED USE_STATIC_QT)
 	include(WinDeployQt)
 	WinDeployQt(TARGET nvim-qt COMPILER_RUNTIME INCLUDE_MODULES ${QTLIBS} EXCLUDE_MODULES webkit webkit2)
-	install(DIRECTORY ${PROJECT_BINARY_DIR}/windeployqt/
-		DESTINATION ${CMAKE_INSTALL_BINDIR})
+    install(
+        DIRECTORY ${PROJECT_BINARY_DIR}/windeployqt/
+        DESTINATION ${CMAKE_INSTALL_BINDIR}
+    )
 endif()
 
 # Generate help tags

--- a/src/gui/shellwidget/CMakeLists.txt
+++ b/src/gui/shellwidget/CMakeLists.txt
@@ -7,33 +7,46 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 # Qt
 set(CMAKE_AUTOMOC ON)
-find_package(Qt5Widgets REQUIRED)
+
+find_package(Qt5 REQUIRED COMPONENTS Widgets)
 if(ENABLE_TESTS)
-	find_package(Qt5Test REQUIRED)
+    find_package(Qt5 REQUIRED COMPONENTS Test)
 endif()
 
 if (WIN32 AND USE_STATIC_QT)
-	add_definitions(-DUSE_STATIC_QT)
+    add_compile_definitions(-DUSE_STATIC_QT)
 endif ()
 
-set(SOURCES
-  cell.cpp
-  cursor.cpp
-  highlight.cpp
-  helpers.cpp
-  konsole_wcwidth.cpp
-  shellcontents.cpp
-  shellwidget.cpp)
+add_library(qshellwidget STATIC)
 
-add_library(qshellwidget STATIC ${SOURCES})
-target_link_libraries(qshellwidget Qt5::Widgets)
+target_sources(qshellwidget
+  PRIVATE
+    cell.cpp
+    cell.h
+    cursor.cpp
+    cursor.h
+    helpers.cpp
+    helpers.h
+    highlight.cpp
+    highlight.h
+    konsole_wcwidth.cpp
+    konsole_wcwidth.h
+    shellcontents.cpp
+    shellcontents.h
+    shellwidget.cpp
+    shellwidget.h
+)
+
+target_link_libraries(qshellwidget PUBLIC Qt5::Widgets)
 
 add_executable(example EXCLUDE_FROM_ALL example.cpp)
-target_link_libraries(example qshellwidget )
+target_link_libraries(example PRIVATE qshellwidget)
+
 add_executable(example2 EXCLUDE_FROM_ALL example2.cpp)
-target_link_libraries(example2 qshellwidget )
+target_link_libraries(example2 PRIVATE qshellwidget)
+
 add_executable(example3 EXCLUDE_FROM_ALL example3.cpp)
-target_link_libraries(example3 qshellwidget )
+target_link_libraries(example3 PRIVATE qshellwidget)
 
 add_executable(fontinfo EXCLUDE_FROM_ALL fontinfo.cpp)
-target_link_libraries(fontinfo Qt5::Widgets )
+target_link_libraries(fontinfo PRIVATE Qt5::Widgets)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,7 +4,7 @@ include_directories(${CMAKE_SOURCE_DIR}/src)
 add_definitions(-DCMAKE_SOURCE_DIR=\"${CMAKE_SOURCE_DIR}\")
 add_definitions(-DNVIM_QT_BINARY=\"$<TARGET_FILE:nvim-qt>\")
 if (WIN32 AND USE_STATIC_QT)
-	add_definitions(-DUSE_STATIC_QT)
+    add_compile_definitions(-DUSE_STATIC_QT)
 endif ()
 
 add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND})
@@ -33,9 +33,8 @@ function(add_xtest SOURCE_NAME)
 endfunction()
 
 function(add_xtest_gui SOURCE_NAME)
-	qt5_add_resources(RCC_SOURCES data.qrc)
 	add_executable(${SOURCE_NAME}
-		${RCC_SOURCES}
+        data.qrc
 		${SOURCE_NAME}.cpp
 		${SOURCES_COMMON}
 		${SOURCES_COMMON_GUI}
@@ -67,25 +66,25 @@ add_xtest_gui(tst_qsettings
 
 # Platform Specific Input Tests
 add_xtest(tst_input_mac
-	${CMAKE_SOURCE_DIR}/src/gui/input.cpp
-	${CMAKE_SOURCE_DIR}/src/gui/input_mac.cpp)
+    ${PROJECT_SOURCE_DIR}/src/gui/input.cpp
+    ${PROJECT_SOURCE_DIR}/src/gui/input_mac.cpp)
 add_xtest(tst_input_unix
-	${CMAKE_SOURCE_DIR}/src/gui/input.cpp
-	${CMAKE_SOURCE_DIR}/src/gui/input_unix.cpp)
+    ${PROJECT_SOURCE_DIR}/src/gui/input.cpp
+    ${PROJECT_SOURCE_DIR}/src/gui/input_unix.cpp)
 add_xtest(tst_input_win32
-	${CMAKE_SOURCE_DIR}/src/gui/input.cpp
-	${CMAKE_SOURCE_DIR}/src/gui/input_win32.cpp)
+    ${PROJECT_SOURCE_DIR}/src/gui/input.cpp
+    ${PROJECT_SOURCE_DIR}/src/gui/input_win32.cpp)
 
 # Platform Agnostic Input Tests
 add_shared_test(tst_input_common_mac
 	tst_input_common.cpp
-	${CMAKE_SOURCE_DIR}/src/gui/input.cpp
-	${CMAKE_SOURCE_DIR}/src/gui/input_mac.cpp)
+    ${PROJECT_SOURCE_DIR}/src/gui/input.cpp
+    ${PROJECT_SOURCE_DIR}/src/gui/input_mac.cpp)
 add_shared_test(tst_input_common_unix
 	tst_input_common.cpp
-	${CMAKE_SOURCE_DIR}/src/gui/input.cpp
-	${CMAKE_SOURCE_DIR}/src/gui/input_unix.cpp)
+    ${PROJECT_SOURCE_DIR}/src/gui/input.cpp
+    ${PROJECT_SOURCE_DIR}/src/gui/input_unix.cpp)
 add_shared_test(tst_input_common_win32
 	tst_input_common.cpp
-	${CMAKE_SOURCE_DIR}/src/gui/input.cpp
-	${CMAKE_SOURCE_DIR}/src/gui/input_win32.cpp)
+    ${PROJECT_SOURCE_DIR}/src/gui/input.cpp
+    ${PROJECT_SOURCE_DIR}/src/gui/input_win32.cpp)


### PR DESCRIPTION
Here:
- Config mode syntax for find_package. This syntax is recommended by CMake and official Qt 6 documentation (works for Qt 5 too).
- CMAKE_AUTORCC variable for less verbosity
- add_compile_definitions is recommended by CMake, as it superseeds the add_difinitions.
- Use target_sources instead of variables (more reliable and flexible) for source additions
- Add headers to sources, so that some IDE could pick up them (like Qt Creator).
- Some other small fixes