### PR TITLE
Use UTF8 everywhere to decode/encode

### DIFF
--- a/bindings/neovimapi.cpp
+++ b/bindings/neovimapi.cpp
@@ -73,7 +73,7 @@ void NeovimApi{{api_level}}::handleResponseError(quint32 msgid, quint64 fun, con
 	const QVariantList asList = res.toList();
 	if (asList.size() >= 2) {
 		if (asList.at(1).canConvert<QByteArray>()) {
-			errMsg = m_c->m_dev->decode(asList.at(1).toByteArray());
+            errMsg = asList.at(1).toByteArray();
 		} else {
 			errMsg = tr("Received unsupported Neovim error type");
 		}

--- a/src/auto/neovimapi0.cpp
+++ b/src/auto/neovimapi0.cpp
@@ -833,7 +833,7 @@ void NeovimApi0::handleResponseError(quint32 msgid, quint64 fun, const QVariant&
 	const QVariantList asList = res.toList();
 	if (asList.size() >= 2) {
 		if (asList.at(1).canConvert<QByteArray>()) {
-			errMsg = m_c->m_dev->decode(asList.at(1).toByteArray());
+            errMsg = asList.at(1).toByteArray();
 		} else {
 			errMsg = tr("Received unsupported Neovim error type");
 		}

--- a/src/auto/neovimapi1.cpp
+++ b/src/auto/neovimapi1.cpp
@@ -1582,7 +1582,7 @@ void NeovimApi1::handleResponseError(quint32 msgid, quint64 fun, const QVariant&
 	const QVariantList asList = res.toList();
 	if (asList.size() >= 2) {
 		if (asList.at(1).canConvert<QByteArray>()) {
-			errMsg = m_c->m_dev->decode(asList.at(1).toByteArray());
+            errMsg = asList.at(1).toByteArray();
 		} else {
 			errMsg = tr("Received unsupported Neovim error type");
 		}

--- a/src/auto/neovimapi2.cpp
+++ b/src/auto/neovimapi2.cpp
@@ -1599,7 +1599,7 @@ void NeovimApi2::handleResponseError(quint32 msgid, quint64 fun, const QVariant&
 	const QVariantList asList = res.toList();
 	if (asList.size() >= 2) {
 		if (asList.at(1).canConvert<QByteArray>()) {
-			errMsg = m_c->m_dev->decode(asList.at(1).toByteArray());
+            errMsg = asList.at(1).toByteArray();
 		} else {
 			errMsg = tr("Received unsupported Neovim error type");
 		}

--- a/src/auto/neovimapi3.cpp
+++ b/src/auto/neovimapi3.cpp
@@ -1648,7 +1648,7 @@ void NeovimApi3::handleResponseError(quint32 msgid, quint64 fun, const QVariant&
 	const QVariantList asList = res.toList();
 	if (asList.size() >= 2) {
 		if (asList.at(1).canConvert<QByteArray>()) {
-			errMsg = m_c->m_dev->decode(asList.at(1).toByteArray());
+            errMsg = asList.at(1).toByteArray();
 		} else {
 			errMsg = tr("Received unsupported Neovim error type");
 		}

--- a/src/auto/neovimapi4.cpp
+++ b/src/auto/neovimapi4.cpp
@@ -1765,7 +1765,7 @@ void NeovimApi4::handleResponseError(quint32 msgid, quint64 fun, const QVariant&
 	const QVariantList asList = res.toList();
 	if (asList.size() >= 2) {
 		if (asList.at(1).canConvert<QByteArray>()) {
-			errMsg = m_c->m_dev->decode(asList.at(1).toByteArray());
+            errMsg = asList.at(1).toByteArray();
 		} else {
 			errMsg = tr("Received unsupported Neovim error type");
 		}

--- a/src/auto/neovimapi5.cpp
+++ b/src/auto/neovimapi5.cpp
@@ -1836,7 +1836,7 @@ void NeovimApi5::handleResponseError(quint32 msgid, quint64 fun, const QVariant&
 	const QVariantList asList = res.toList();
 	if (asList.size() >= 2) {
 		if (asList.at(1).canConvert<QByteArray>()) {
-			errMsg = m_c->m_dev->decode(asList.at(1).toByteArray());
+            errMsg = asList.at(1).toByteArray();
 		} else {
 			errMsg = tr("Received unsupported Neovim error type");
 		}

--- a/src/auto/neovimapi6.cpp
+++ b/src/auto/neovimapi6.cpp
@@ -2029,7 +2029,7 @@ void NeovimApi6::handleResponseError(quint32 msgid, quint64 fun, const QVariant&
 	const QVariantList asList = res.toList();
 	if (asList.size() >= 2) {
 		if (asList.at(1).canConvert<QByteArray>()) {
-			errMsg = m_c->m_dev->decode(asList.at(1).toByteArray());
+            errMsg = asList.at(1).toByteArray();
 		} else {
 			errMsg = tr("Received unsupported Neovim error type");
 		}

--- a/src/gui/scrollbar.cpp
+++ b/src/gui/scrollbar.cpp
@@ -44,7 +44,7 @@ void ScrollBar::handleNeovimNotification(const QByteArray& name, const QVariantL
 	}
 
 	if (name == "Gui") {
-		const QString guiEvName{ m_nvim->decode(args.at(0).toByteArray()) };
+		const QString guiEvName{ args.at(0).toByteArray() };
 
 		if (guiEvName == "CursorMoved") {
 			handleCursorMoved(args);

--- a/src/gui/treeview.cpp
+++ b/src/gui/treeview.cpp
@@ -65,7 +65,7 @@ void TreeView::handleNeovimNotification(const QByteArray& name, const QVariantLi
 	}
 
 	if (name == "Gui") {
-		const QString guiEvName{ m_nvim->decode(args.at(0).toByteArray()) };
+		const QString guiEvName{ args.at(0).toByteArray() };
 
 		if (guiEvName == "TreeView") {
 			handleGuiTreeView(args);

--- a/src/msgpackiodevice.h
+++ b/src/msgpackiodevice.h
@@ -1,11 +1,10 @@
 #ifndef NEOVIM_QT_MSGPACKIODEVICE
 #define NEOVIM_QT_MSGPACKIODEVICE
 
-#include <QIODevice>
-#include <QHash>
-#include <QTextCodec>
-#include <QVariant>
 #include <msgpack.h>
+#include <QHash>
+#include <QIODevice>
+#include <QVariant>
 
 namespace NeovimQt {
 
@@ -15,7 +14,6 @@ class MsgpackIODevice: public QObject
 {
 	Q_OBJECT
 	Q_PROPERTY(MsgpackError error READ errorCause NOTIFY error)
-	Q_PROPERTY(QByteArray encoding READ encoding WRITE setEncoding NOTIFY encodingChanged)
 public:
 	enum MsgpackError {
 		NoError=0,
@@ -32,9 +30,6 @@ public:
 	bool isOpen();
 	QString errorString() const;
 	MsgpackError errorCause() const {return m_error;};
-
-	QByteArray encoding() const;
-	bool setEncoding(const QByteArray&);
 
 	quint32 msgId();
 	MsgpackRequest* startRequestUnchecked(const QString& method, quint32 argcount);
@@ -53,8 +48,6 @@ public:
 		}
 	}
 
-	QByteArray encode(const QString&);
-	QString decode(const QByteArray&);
 	bool checkVariant(const QVariant&);
 
 	bool sendResponse(uint64_t msgid, const QVariant& err, const QVariant& res);
@@ -70,8 +63,7 @@ public:
 signals:
 	void error(NeovimQt::MsgpackIODevice::MsgpackError);
 	/** A notification with the given name and arguments was received */
-	void notification(const QByteArray &name, const QVariantList& args);
-	void encodingChanged(const QByteArray& encoding);
+	void notification(const QByteArray& name, const QVariantList& args);
 
 protected:
 	void sendError(const msgpack_object& req, const QString& msg);
@@ -105,8 +97,7 @@ private:
 	static int msgpack_write_to_dev(void* data, const char* buf, unsigned long int len);
 
 	quint32 m_reqid;
-	QIODevice *m_dev;
-	QTextCodec *m_encoding;
+	QIODevice* m_dev;
 	msgpack_packer m_pk;
 	msgpack_unpacker m_uk;
 	QHash<quint32, MsgpackRequest*> m_requests;

--- a/src/neovimconnector.cpp
+++ b/src/neovimconnector.cpp
@@ -92,7 +92,7 @@ QString NeovimConnector::connectionDescription()
 		case SpawnedConnection:
 			return m_spawnExe + " " + m_spawnArgs.join(" ");
 		case HostConnection:
-			return m_connHost + ":" + m_connPort;
+			return QStringLiteral("%1:%2").arg(m_connHost).arg(m_connPort);
 		case SocketConnection:
 			return m_connSocket;
 		default:
@@ -130,23 +130,6 @@ void NeovimConnector::discoverMetadata()
 bool NeovimConnector::isReady()
 {
 	return m_ready;
-}
-
-/**
- * Decode a byte array as a string according to 'encoding'
- */
-QString NeovimConnector::decode(const QByteArray& in)
-{
-	return m_dev->decode(in);
-}
-/**
- * Encode a string into the appropriate encoding for this Neovim instance
- *
- * see :h 'encoding'
- */
-QByteArray NeovimConnector::encode(const QString& in)
-{
-	return m_dev->encode(in);
 }
 
 /**
@@ -373,7 +356,7 @@ NeovimConnector* NeovimConnector::connectToNeovim(const QString& server)
 	int colon_pos = addr.lastIndexOf(':');
 	if (colon_pos != -1 && colon_pos != 0 && addr[colon_pos-1] != ':') {
 		bool ok;
-		int port = addr.midRef(colon_pos+1).toInt(&ok);
+		int port = addr.mid(colon_pos + 1).toInt(&ok);
 		if (ok) {
 			QString host = addr.mid(0, colon_pos);
 			return connectToHost(host, port);

--- a/src/neovimconnector.h
+++ b/src/neovimconnector.h
@@ -1,11 +1,10 @@
 #ifndef NEOVIM_QT_CONNECTOR
 #define NEOVIM_QT_CONNECTOR
 
-#include <QObject>
 #include <QAbstractSocket>
+#include <QObject>
 #include <QProcess>
-#include <QTextCodec>
-#include "msgpackiodevice.h"
+
 #include "auto/neovimapi0.h"
 #include "auto/neovimapi1.h"
 #include "auto/neovimapi2.h"
@@ -13,6 +12,7 @@
 #include "auto/neovimapi4.h"
 #include "auto/neovimapi5.h"
 #include "auto/neovimapi6.h"
+#include "msgpackiodevice.h"
 
 namespace NeovimQt {
 
@@ -84,8 +84,6 @@ public:
 	NeovimApi5 * api5();
 	NeovimApi6 * api6();
 	uint64_t channel();
-	QString decode(const QByteArray&);
-	QByteArray encode(const QString&);
 	NeovimConnectionType connectionType();
 	/** Some requests for metadata and ui attachment enforce a timeout in ms */
 	void setRequestTimeout(int);

--- a/src/neovimconnectorhelper.cpp
+++ b/src/neovimconnectorhelper.cpp
@@ -56,14 +56,8 @@ void NeovimConnectorHelper::handleMetadata(quint32 msgid, quint64, const QVarian
 	m_c->m_api_supported = api_level;
 
 	if (m_c->errorCause() == NeovimConnector::NoError) {
-		// Neovim is always utf8, but this was not the case in the early days of nvim
-		// these days it should always be utf8
-		if (m_c->m_dev->setEncoding("utf8")) {
-			m_c->m_ready = true;
-			emit m_c->ready();
-		} else {
-			qWarning() << "Unable to set encoding to utf8";
-		}
+		m_c->m_ready = true;
+		emit m_c->ready();
 	} else {
 		qWarning() << "Error retrieving metadata" << m_c->errorString();
 	}

--- a/test/tst_msgpackiodevice.cpp
+++ b/test/tst_msgpackiodevice.cpp
@@ -73,27 +73,7 @@ private slots:
 		QCOMPARE(io->errorCause(), MsgpackIODevice::InvalidDevice);
 	}
 
-	void defaultValues() {
-		QVERIFY(one->encoding().isEmpty());
-		QCOMPARE(one->errorCause(), MsgpackIODevice::NoError);
-	}
-
-	void setEncoding() {
-		QCOMPARE(one->setEncoding("utf8"), true);
-		QCOMPARE(one->errorCause(), MsgpackIODevice::NoError);
-		QVERIFY(!one->encoding().isEmpty());
-	}
-
-	void setInvalidEncoding() {
-		QSignalSpy onError(one, SIGNAL(error(MsgpackError)));
-		QVERIFY(onError.isValid());
-
-		// Ignore qWarn
-		QCOMPARE(one->setEncoding("invalid-encoding"), false);
-
-		QVERIFY(SPYWAIT(onError));
-		QCOMPARE(one->errorCause(), MsgpackIODevice::UnsupportedEncoding);
-	}
+	void defaultValues() { QCOMPARE(one->errorCause(), MsgpackIODevice::NoError); }
 
 	/**
 	 * These errors are not fatal but increase coverage

--- a/test/tst_neovimconnector.cpp
+++ b/test/tst_neovimconnector.cpp
@@ -36,23 +36,6 @@ private slots:
 		QVERIFY(c->isReady());
 	}
 
-	void encodeDecode() {
-		NeovimConnector *c = NeovimConnector::spawn({"-u", "NONE"});
-
-		// This will print a warning, but should succeed
-		QString s = "ç日本語";
-		QByteArray bytes = c->encode(s);
-		QCOMPARE(c->decode(bytes), s);
-
-		QSignalSpy onReady(c, SIGNAL(ready()));
-		QVERIFY(onReady.isValid());
-		QVERIFY(SPYWAIT(onReady));
-
-		bytes = c->encode(s);
-		QCOMPARE(c->decode(bytes), s);
-
-	}
-
 	void connectToNeovimTCP() {
 		NeovimConnector *c = NeovimConnector::connectToNeovim("127.0.0.1:64999");
 		QCOMPARE(c->connectionType(), NeovimConnector::HostConnection);

--- a/test/tst_qsettings.cpp
+++ b/test/tst_qsettings.cpp
@@ -27,7 +27,7 @@ private slots:
 
 static void SendNeovimCommand(NeovimConnector& connector, const QString& command) noexcept
 {
-	QSignalSpy spyCommand{ connector.api0()->vim_command_output(connector.encode(command)),
+	QSignalSpy spyCommand{ connector.api0()->vim_command_output(command.toUtf8()),
 		&MsgpackRequest::finished };
 
 	QVERIFY(spyCommand.isValid());


### PR DESCRIPTION
A couple of reasons:
- Neovim uses only UTF8 for RPC
- QTextCodec is removed in Qt6

This is one of the points in #839