### PR TITLE
Assume utf8 for nvim strings, remove QTextCodec

### DIFF
--- a/src/msgpackiodevice.cpp
+++ b/src/msgpackiodevice.cpp
@@ -1,5 +1,4 @@
 #include <QAbstractSocket>
-#include <QTextCodec>
 #include <QSocketNotifier>
 
 // read/write
@@ -45,7 +44,7 @@ MsgpackIODevice* MsgpackIODevice::fromStdinOut(QObject *parent)
 }
 
 MsgpackIODevice::MsgpackIODevice(QIODevice *dev, QObject *parent)
-:QObject(parent), m_reqid(0), m_dev(dev), m_encoding(0), m_reqHandler(0), m_error(NoError)
+:QObject(parent), m_reqid(0), m_dev(dev), m_reqHandler(0), m_error(NoError)
 {
 	qRegisterMetaType<MsgpackError>("MsgpackError");
 	msgpack_unpacker_init(&m_uk, MSGPACK_UNPACKER_INIT_BUFFER_SIZE);
@@ -80,31 +79,6 @@ bool MsgpackIODevice::isOpen()
 	} else {
 		return true;
 	}
-}
-
-/** The encoding used by the MsgpackIODevice::encode and MsgpackIODevice::decode methods @see setEncoding */
-QByteArray MsgpackIODevice::encoding() const
-{
-	if (m_encoding) {
-		return m_encoding->name();
-	}
-	return QByteArray();
-}
-
-/**
- * Set encoding for strings in this RPC, if it not set we
- * fall back to utf8
- *
- * \see QTextCode
- */
-bool MsgpackIODevice::setEncoding(const QByteArray& name)
-{
-	m_encoding = QTextCodec::codecForName(name);
-	if (!m_encoding) {
-		setError(UnsupportedEncoding, QString("Unsupported encoding (%1)").arg(QString::fromLatin1(name)));
-		return false;
-	}
-	return true;
 }
 
 int MsgpackIODevice::msgpack_write_to_stdout(void* data, const char* buf, unsigned long int len)
@@ -854,17 +828,11 @@ fail:
 }
 
 /**
- * Convert string to the proper encoding
- * \see MsgpackIODevice::setEncoding
+ * Convert string to the proper encoding to send to neovim (utf8)
  */
 QByteArray MsgpackIODevice::encode(const QString& str)
 {
-	if (m_encoding) {
-		return m_encoding->fromUnicode(str);
-	} else {
-		qWarning() << "Encoding String into MsgpackIODevice without an encoding (defaulting to utf8)";
-		return str.toUtf8();
-	}
+	return str.toUtf8();
 }
 
 /**
@@ -872,12 +840,7 @@ QByteArray MsgpackIODevice::encode(const QString& str)
  */
 QString MsgpackIODevice::decode(const QByteArray& data)
 {
-	if (m_encoding) {
-		return m_encoding->toUnicode(data);
-	} else {
-		qWarning() << "Decoding String from MsgpackIODevice without an encoding (defaulting to utf8)";
-		return QString::fromUtf8(data);
-	}
+	return QString::fromUtf8(data);
 }
 
 /**

--- a/src/msgpackiodevice.cpp
+++ b/src/msgpackiodevice.cpp
@@ -43,8 +43,12 @@ MsgpackIODevice* MsgpackIODevice::fromStdinOut(QObject *parent)
 	return rpc;
 }
 
-MsgpackIODevice::MsgpackIODevice(QIODevice *dev, QObject *parent)
-:QObject(parent), m_reqid(0), m_dev(dev), m_reqHandler(0), m_error(NoError)
+MsgpackIODevice::MsgpackIODevice(QIODevice* dev, QObject* parent)
+	: QObject(parent)
+	, m_reqid(0)
+	, m_dev(dev)
+	, m_reqHandler(0)
+	, m_error(NoError)
 {
 	qRegisterMetaType<MsgpackError>("MsgpackError");
 	msgpack_unpacker_init(&m_uk, MSGPACK_UNPACKER_INIT_BUFFER_SIZE);

--- a/src/msgpackiodevice.cpp
+++ b/src/msgpackiodevice.cpp
@@ -828,22 +828,6 @@ fail:
 }
 
 /**
- * Convert string to the proper encoding to send to neovim (utf8)
- */
-QByteArray MsgpackIODevice::encode(const QString& str)
-{
-	return str.toUtf8();
-}
-
-/**
- * Decode byte array as string, from Neovim's encoding
- */
-QString MsgpackIODevice::decode(const QByteArray& data)
-{
-	return QString::fromUtf8(data);
-}
-
-/**
  * QVariant can encapsulate some data types that cannot be serialised at as
  * msgpack data..
  *

--- a/src/msgpackiodevice.h
+++ b/src/msgpackiodevice.h
@@ -1,10 +1,10 @@
 #ifndef NEOVIM_QT_MSGPACKIODEVICE
 #define NEOVIM_QT_MSGPACKIODEVICE
 
-#include <QIODevice>
-#include <QHash>
-#include <QVariant>
 #include <msgpack.h>
+#include <QHash>
+#include <QIODevice>
+#include <QVariant>
 
 namespace NeovimQt {
 
@@ -51,13 +51,9 @@ public:
 	}
 
 	// Convert string to the proper encoding to send to neovim (utf8)
-	inline QByteArray encode(const QString& str) {
-		return str.toUtf8();
-	}
+	inline QByteArray encode(const QString& str) { return str.toUtf8(); }
 	// Decode byte array as string, from Neovim's encoding
-	QString decode(const QByteArray& data) {
-		return QString::fromUtf8(data);
-	}
+	QString decode(const QByteArray& data) { return QString::fromUtf8(data); }
 	bool checkVariant(const QVariant&);
 
 	bool sendResponse(uint64_t msgid, const QVariant& err, const QVariant& res);
@@ -108,7 +104,7 @@ private:
 	static int msgpack_write_to_dev(void* data, const char* buf, unsigned long int len);
 
 	quint32 m_reqid;
-	QIODevice *m_dev;
+	QIODevice* m_dev;
 	msgpack_packer m_pk;
 	msgpack_unpacker m_uk;
 	QHash<quint32, MsgpackRequest*> m_requests;

--- a/src/msgpackiodevice.h
+++ b/src/msgpackiodevice.h
@@ -3,7 +3,6 @@
 
 #include <QIODevice>
 #include <QHash>
-#include <QTextCodec>
 #include <QVariant>
 #include <msgpack.h>
 
@@ -15,7 +14,6 @@ class MsgpackIODevice: public QObject
 {
 	Q_OBJECT
 	Q_PROPERTY(MsgpackError error READ errorCause NOTIFY error)
-	Q_PROPERTY(QByteArray encoding READ encoding WRITE setEncoding NOTIFY encodingChanged)
 public:
 	enum MsgpackError {
 		NoError=0,
@@ -34,7 +32,6 @@ public:
 	MsgpackError errorCause() const {return m_error;};
 
 	QByteArray encoding() const;
-	bool setEncoding(const QByteArray&);
 
 	quint32 msgId();
 	MsgpackRequest* startRequestUnchecked(const QString& method, quint32 argcount);
@@ -106,7 +103,6 @@ private:
 
 	quint32 m_reqid;
 	QIODevice *m_dev;
-	QTextCodec *m_encoding;
 	msgpack_packer m_pk;
 	msgpack_unpacker m_uk;
 	QHash<quint32, MsgpackRequest*> m_requests;

--- a/src/msgpackiodevice.h
+++ b/src/msgpackiodevice.h
@@ -50,8 +50,14 @@ public:
 		}
 	}
 
-	QByteArray encode(const QString&);
-	QString decode(const QByteArray&);
+	// Convert string to the proper encoding to send to neovim (utf8)
+	inline QByteArray encode(const QString& str) {
+		return str.toUtf8();
+	}
+	// Decode byte array as string, from Neovim's encoding
+	QString decode(const QByteArray& data) {
+		return QString::fromUtf8(data);
+	}
 	bool checkVariant(const QVariant&);
 
 	bool sendResponse(uint64_t msgid, const QVariant& err, const QVariant& res);

--- a/src/neovimconnector.cpp
+++ b/src/neovimconnector.cpp
@@ -133,23 +133,6 @@ bool NeovimConnector::isReady()
 }
 
 /**
- * Decode a byte array as a string according to 'encoding'
- */
-QString NeovimConnector::decode(const QByteArray& in)
-{
-	return m_dev->decode(in);
-}
-/**
- * Encode a string into the appropriate encoding for this Neovim instance
- *
- * see :h 'encoding'
- */
-QByteArray NeovimConnector::encode(const QString& in)
-{
-	return m_dev->encode(in);
-}
-
-/**
  * @warning Do not call this before NeovimConnector::ready as been signaled
  * @see NeovimConnector::isReady
  */

--- a/src/neovimconnector.h
+++ b/src/neovimconnector.h
@@ -4,7 +4,6 @@
 #include <QObject>
 #include <QAbstractSocket>
 #include <QProcess>
-#include <QTextCodec>
 #include "msgpackiodevice.h"
 #include "auto/neovimapi0.h"
 #include "auto/neovimapi1.h"

--- a/src/neovimconnector.h
+++ b/src/neovimconnector.h
@@ -83,8 +83,16 @@ public:
 	NeovimApi5 * api5();
 	NeovimApi6 * api6();
 	uint64_t channel();
-	QString decode(const QByteArray&);
-	QByteArray encode(const QString&);
+
+	 // Decode a byte array as a string according to Neovim string encoding
+	inline QString decode(const QByteArray& in) {
+		return m_dev->decode(in);
+	}
+
+	// Encode a string into the appropriate encoding for Neovim
+	inline QByteArray encode(const QString& in) {
+		return m_dev->encode(in);
+	}
 	NeovimConnectionType connectionType();
 	/** Some requests for metadata and ui attachment enforce a timeout in ms */
 	void setRequestTimeout(int);

--- a/src/neovimconnector.h
+++ b/src/neovimconnector.h
@@ -1,10 +1,10 @@
 #ifndef NEOVIM_QT_CONNECTOR
 #define NEOVIM_QT_CONNECTOR
 
-#include <QObject>
 #include <QAbstractSocket>
+#include <QObject>
 #include <QProcess>
-#include "msgpackiodevice.h"
+
 #include "auto/neovimapi0.h"
 #include "auto/neovimapi1.h"
 #include "auto/neovimapi2.h"
@@ -12,6 +12,7 @@
 #include "auto/neovimapi4.h"
 #include "auto/neovimapi5.h"
 #include "auto/neovimapi6.h"
+#include "msgpackiodevice.h"
 
 namespace NeovimQt {
 
@@ -84,15 +85,11 @@ public:
 	NeovimApi6 * api6();
 	uint64_t channel();
 
-	 // Decode a byte array as a string according to Neovim string encoding
-	inline QString decode(const QByteArray& in) {
-		return m_dev->decode(in);
-	}
+	// Decode a byte array as a string according to Neovim string encoding
+	inline QString decode(const QByteArray& in) { return m_dev->decode(in); }
 
 	// Encode a string into the appropriate encoding for Neovim
-	inline QByteArray encode(const QString& in) {
-		return m_dev->encode(in);
-	}
+	inline QByteArray encode(const QString& in) { return m_dev->encode(in); }
 	NeovimConnectionType connectionType();
 	/** Some requests for metadata and ui attachment enforce a timeout in ms */
 	void setRequestTimeout(int);

--- a/src/neovimconnectorhelper.cpp
+++ b/src/neovimconnectorhelper.cpp
@@ -56,14 +56,8 @@ void NeovimConnectorHelper::handleMetadata(quint32 msgid, quint64, const QVarian
 	m_c->m_api_supported = api_level;
 
 	if (m_c->errorCause() == NeovimConnector::NoError) {
-		// Neovim is always utf8, but this was not the case in the early days of nvim
-		// these days it should always be utf8
-		if (m_c->m_dev->setEncoding("utf8")) {
-			m_c->m_ready = true;
-			emit m_c->ready();
-		} else {
-			qWarning() << "Unable to set encoding to utf8";
-		}
+		m_c->m_ready = true;
+		emit m_c->ready();
 	} else {
 		qWarning() << "Error retrieving metadata" << m_c->errorString();
 	}

--- a/test/tst_msgpackiodevice.cpp
+++ b/test/tst_msgpackiodevice.cpp
@@ -74,25 +74,7 @@ private slots:
 	}
 
 	void defaultValues() {
-		QVERIFY(one->encoding().isEmpty());
 		QCOMPARE(one->errorCause(), MsgpackIODevice::NoError);
-	}
-
-	void setEncoding() {
-		QCOMPARE(one->setEncoding("utf8"), true);
-		QCOMPARE(one->errorCause(), MsgpackIODevice::NoError);
-		QVERIFY(!one->encoding().isEmpty());
-	}
-
-	void setInvalidEncoding() {
-		QSignalSpy onError(one, SIGNAL(error(MsgpackError)));
-		QVERIFY(onError.isValid());
-
-		// Ignore qWarn
-		QCOMPARE(one->setEncoding("invalid-encoding"), false);
-
-		QVERIFY(SPYWAIT(onError));
-		QCOMPARE(one->errorCause(), MsgpackIODevice::UnsupportedEncoding);
 	}
 
 	/**

--- a/test/tst_msgpackiodevice.cpp
+++ b/test/tst_msgpackiodevice.cpp
@@ -73,9 +73,7 @@ private slots:
 		QCOMPARE(io->errorCause(), MsgpackIODevice::InvalidDevice);
 	}
 
-	void defaultValues() {
-		QCOMPARE(one->errorCause(), MsgpackIODevice::NoError);
-	}
+	void defaultValues() { QCOMPARE(one->errorCause(), MsgpackIODevice::NoError); }
 
 	/**
 	 * These errors are not fatal but increase coverage


### PR DESCRIPTION
In the (very) early days of neovim, it was possible to have non utf8 strings, but this was removed so we don't need to support it.

Picked from #840.

This is the same as #1035 but keeps the encode/decode methods to avoid changing the auto generated code.