### PR TITLE
Save test output in files files

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -148,6 +148,9 @@ jobs:
           run: ctest -VV --output-on-failure -C ${{ matrix.flavor }}
       - name: Show windows logs
         if: ${{ failure() && startsWith(matrix.runner, 'windows') }}
+        run: Get-EventLog -List
+      - name: Show windows logs
+        if: ${{ failure() && startsWith(matrix.runner, 'windows') }}
         run: Get-EventLog -LogName Application -ET ERROR
       - uses: actions/upload-artifact@v3
         name: Publish test results

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -145,9 +145,9 @@ jobs:
         uses: GabrielBB/xvfb-action@v1 # Required by Linux, no X11 $DISPLAY
         with:
           working-directory: ${{ github.workspace }}/build
-          run: ctest --output-on-failure -C ${{ matrix.flavor }}
+          run: ctest -VV --output-on-failure -C ${{ matrix.flavor }}
       - uses: actions/upload-artifact@v3
-        if: failure()
+        name: Publish test results
         with:
           name: test-results
           path: ./**/*.tests.txt

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -147,7 +147,7 @@ jobs:
           working-directory: ${{ github.workspace }}/build
           run: ctest -VV --output-on-failure -C ${{ matrix.flavor }}
       - name: Show windows logs
-        if: ${{ matrix.publish && startsWith(matrix.runner, 'windows') }}
+        if: ${{ failed() && startsWith(matrix.runner, 'windows') }}
         run: Get-EventLog -LogName Application -ET ERROR
       - uses: actions/upload-artifact@v3
         name: Publish test results

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -147,7 +147,7 @@ jobs:
           working-directory: ${{ github.workspace }}/build
           run: ctest -VV --output-on-failure -C ${{ matrix.flavor }}
       - name: Show windows logs
-        if: ${{ failed() && startsWith(matrix.runner, 'windows') }}
+        if: ${{ failure() && startsWith(matrix.runner, 'windows') }}
         run: Get-EventLog -LogName Application -ET ERROR
       - uses: actions/upload-artifact@v3
         name: Publish test results

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -148,6 +148,7 @@ jobs:
           run: ctest -VV --output-on-failure -C ${{ matrix.flavor }}
       - uses: actions/upload-artifact@v3
         name: Publish test results
+        if: always()
         with:
           name: test-results
           path: ./**/*.tests.txt

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -61,7 +61,6 @@ jobs:
             qtstr: windows desktop win64_mingw81
             cc: gcc
             cxx: g++
-            ctest_exe_args: -tap
 
           - name: Windows_Release
             flavor: Release
@@ -70,7 +69,6 @@ jobs:
             qtver: 5.15.2
             qtdir: msvc2019_64
             qtstr: windows desktop win64_msvc2019_64
-            ctest_exe_args: -tap
             publish: true
 
     runs-on: ${{ matrix.runner }}
@@ -139,7 +137,6 @@ jobs:
           -DCMAKE_C_COMPILER=${{ matrix.cc }}
           -DCMAKE_CXX_COMPILER=${{ matrix.cxx }}
           -DENABLE_TESTS=ON
-          -DCTEST_EXE_ARGS=${{ matrix.ctest_exe_args }}
 
       - name: Build
         run: cmake --build ${{ github.workspace }}/build
@@ -149,6 +146,11 @@ jobs:
         with:
           working-directory: ${{ github.workspace }}/build
           run: ctest --output-on-failure -C ${{ matrix.flavor }}
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: test-results
+          path: ./**/*.tests.txt
 
       #
       # Deploy Release Binaries

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -146,6 +146,9 @@ jobs:
         with:
           working-directory: ${{ github.workspace }}/build
           run: ctest -VV --output-on-failure -C ${{ matrix.flavor }}
+      - name: Show windows logs
+        if: ${{ matrix.publish && startsWith(matrix.runner, 'windows') }}
+        run: Get-EventLog -LogName Application -ET ERROR
       - uses: actions/upload-artifact@v3
         name: Publish test results
         if: always()

--- a/src/gui/shellwidget/test/CMakeLists.txt
+++ b/src/gui/shellwidget/test/CMakeLists.txt
@@ -11,7 +11,7 @@ add_definitions(-DTEST_SOURCE_DIR="${TEST_SOURCE_DIR}")
 function(add_xtest SOURCE_NAME)
 	add_executable(${SOURCE_NAME} ${SOURCE_NAME}.cpp)
 	target_link_libraries(${SOURCE_NAME} Qt5::Widgets Qt5::Test qshellwidget)
-	add_test(NAME ${SOURCE_NAME} COMMAND ${SOURCE_NAME} ${CTEST_EXE_ARGS})
+	add_test(NAME ${SOURCE_NAME} COMMAND ${SOURCE_NAME} -o -,txt -o ${SOURCE_NAME}.tests.txt,txt)
 endfunction()
 
 add_xtest(test_cell)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -28,7 +28,7 @@ function(add_xtest SOURCE_NAME)
 		${ARGV1}
 		${ARGV2})
 	target_link_libraries(${SOURCE_NAME} ${QTLIBS} ${MSGPACK_LIBRARIES} neovim-qt)
-	add_test(NAME ${SOURCE_NAME} COMMAND ${SOURCE_NAME} ${CTEST_EXE_ARGS})
+	add_test(NAME ${SOURCE_NAME} COMMAND ${SOURCE_NAME} -o -,txt -o ${SOURCE_NAME}.tests.txt,txt)
 	add_dependencies(check ${SOURCE_NAME})
 endfunction()
 
@@ -41,7 +41,7 @@ function(add_xtest_gui SOURCE_NAME)
 		${SOURCES_COMMON_GUI}
 		${ARGV1} ${ARGV2})
 	target_link_libraries(${SOURCE_NAME} ${QTLIBS} ${MSGPACK_LIBRARIES} neovim-qt Qt5::Widgets neovim-qt-gui)
-	add_test(NAME ${SOURCE_NAME} COMMAND ${SOURCE_NAME} ${CTEST_EXE_ARGS}
+	add_test(NAME ${SOURCE_NAME} COMMAND ${SOURCE_NAME} -o -,txt -o ${SOURCE_NAME}.tests.txt,txt
 		# Run GUI tests from source dir, they depend on src files
 		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 	add_dependencies(check ${SOURCE_NAME})
@@ -50,7 +50,7 @@ endfunction()
 function(add_shared_test SOURCE_NAME)
 	add_executable(${SOURCE_NAME} ${ARGV1} ${ARGV2} ${ARGV3})
 	target_link_libraries(${SOURCE_NAME} Qt5::Network Qt5::Test Qt5::Widgets ${MSGPACK_LIBRARIES} neovim-qt)
-	add_test(NAME ${SOURCE_NAME} COMMAND ${SOURCE_NAME} ${CTEST_EXE_ARGS})
+	add_test(NAME ${SOURCE_NAME} COMMAND ${SOURCE_NAME} -o -,txt -o ${SOURCE_NAME}.tests.txt,txt)
 	add_dependencies(check ${SOURCE_NAME})
 endfunction()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -28,7 +28,7 @@ function(add_xtest SOURCE_NAME)
 		${ARGV1}
 		${ARGV2})
 	target_link_libraries(${SOURCE_NAME} ${QTLIBS} ${MSGPACK_LIBRARIES} neovim-qt)
-	add_test(NAME ${SOURCE_NAME} COMMAND ${SOURCE_NAME} -o -,txt -o ${SOURCE_NAME}.tests.txt,txt)
+	add_test(NAME ${SOURCE_NAME} COMMAND ${SOURCE_NAME} -vs -v2 -nocrashhandler -o -,txt -o ${SOURCE_NAME}.tests.txt,txt)
 	add_dependencies(check ${SOURCE_NAME})
 endfunction()
 
@@ -41,7 +41,7 @@ function(add_xtest_gui SOURCE_NAME)
 		${SOURCES_COMMON_GUI}
 		${ARGV1} ${ARGV2})
 	target_link_libraries(${SOURCE_NAME} ${QTLIBS} ${MSGPACK_LIBRARIES} neovim-qt Qt5::Widgets neovim-qt-gui)
-	add_test(NAME ${SOURCE_NAME} COMMAND ${SOURCE_NAME} -o -,txt -o ${SOURCE_NAME}.tests.txt,txt
+	add_test(NAME ${SOURCE_NAME} COMMAND ${SOURCE_NAME} -vs -v2 -nocrashhandler -o -,txt -o ${SOURCE_NAME}.tests.txt,txt
 		# Run GUI tests from source dir, they depend on src files
 		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 	add_dependencies(check ${SOURCE_NAME})
@@ -50,7 +50,7 @@ endfunction()
 function(add_shared_test SOURCE_NAME)
 	add_executable(${SOURCE_NAME} ${ARGV1} ${ARGV2} ${ARGV3})
 	target_link_libraries(${SOURCE_NAME} Qt5::Network Qt5::Test Qt5::Widgets ${MSGPACK_LIBRARIES} neovim-qt)
-	add_test(NAME ${SOURCE_NAME} COMMAND ${SOURCE_NAME} -o -,txt -o ${SOURCE_NAME}.tests.txt,txt)
+	add_test(NAME ${SOURCE_NAME} COMMAND ${SOURCE_NAME} -vs -v2 -nocrashhandler -o -,txt -o ${SOURCE_NAME}.tests.txt,txt)
 	add_dependencies(check ${SOURCE_NAME})
 endfunction()
 


### PR DESCRIPTION
Remove the CTEST_EXE_ARGS, and instead default to log into two locations

1. stdout using the txt format
2. a file named after the text binary

**Rationale:** one more attempt to reduce the CI pain


Notes:
- Not all cmake versions in CI support all output formats, e.g. some runners lack junit support
- fooling around a bit with other test options to help CI
- mingw test failures are some kind of exception (maybe missing dll) Exit code 0xc0000139