### PR TITLE
Issue 999: Replace Issue 728 with key remap

### DIFF
--- a/src/gui/input.cpp
+++ b/src/gui/input.cpp
@@ -191,13 +191,6 @@ QString convertKey(const QKeyEvent& ev) noexcept
 	const QMap<int, QString>& specialKeys { GetSpecialKeysMap() };
 
 	if (specialKeys.contains(key)) {
-		// Issue#728: Shift + Space inserts ;2u in `:terminal`. Incorrectly sent as <S-Space>.
-		// Issue#259: Shift + BackSpace inserts 7;2u in `:terminal`. Incorrectly sent as <S-BS>.
-		if (key == Qt::Key_Space
-			|| key == Qt::Key_Backspace) {
-			mod &= ~Qt::ShiftModifier;
-		}
-
 		return ToKeyString(GetModifierPrefix(mod), specialKeys.value(key));
 	}
 

--- a/src/gui/runtime/plugin/nvim_gui_shim.vim
+++ b/src/gui/runtime/plugin/nvim_gui_shim.vim
@@ -283,3 +283,16 @@ function! s:GuiWindowOpacityCommand(value) abort
   call rpcnotify(0, 'Gui', 'WindowOpacity', a:value)
 endfunction
 command! -nargs=1 GuiWindowOpacity call s:GuiWindowOpacityCommand("<args>")
+
+" Issue 728: Terminal reports ';2u' for key sequences such as <S-Space>
+" Force-mapping keys is a less-than ideal workaround, but it is the only
+" option that appeases everyone. Neovim does not report terminal mode.
+"
+" See issues:
+"  - https://github.com/neovim/neovim/issues/20325
+"  - https://github.com/neovim/neovim/issues/19265
+"  - https://github.com/equalsraf/neovim-qt/issues/999
+tnoremap <S-Space> <Space>
+tnoremap <C-Space> <Space>
+tnoremap <S-Backspace> <BackSpace>
+tnoremap <C-Backspace> <Backspace>

--- a/test/tst_input_common.cpp
+++ b/test/tst_input_common.cpp
@@ -15,8 +15,6 @@ private slots:
 	void CapsLockIgnored() noexcept;
 	void AltGrAloneIgnored() noexcept;
 	void AltGrKeyEventWellFormed() noexcept;
-	void ShiftSpaceWellFormed() noexcept;
-	void ShiftBackSpaceWellFormed() noexcept;
 	void IgnoreHyperKey() noexcept;
 
 	// Mouse Input
@@ -136,16 +134,6 @@ void TestInputCommon::CapsLockIgnored() noexcept
 
 	QKeyEvent evMetaCapsLock{ QEvent::KeyPress, Qt::Key_CapsLock, Qt::MetaModifier};
 	QCOMPARE(NeovimQt::Input::convertKey(evMetaCapsLock), QString{ "" });
-}
-
-void TestInputCommon::ShiftBackSpaceWellFormed() noexcept
-{
-	// Issue#259: Shift + BackSpace inserts 7;2u in `:terminal`, mode sent as <S-BS>.
-	QKeyEvent evShift{ QEvent::KeyPress, Qt::Key_Shift, Qt::ShiftModifier, "" };
-	QCOMPARE(NeovimQt::Input::convertKey(evShift), QString{ "" });
-
-	QKeyEvent evShiftBackSpace{ QEvent::KeyPress, Qt::Key_Backspace, Qt::ShiftModifier, "\b" };
-	QCOMPARE(NeovimQt::Input::convertKey(evShiftBackSpace), QString{ "<BS>" });
 }
 
 void TestInputCommon::IgnoreHyperKey() noexcept

--- a/test/tst_input_common.cpp
+++ b/test/tst_input_common.cpp
@@ -138,16 +138,6 @@ void TestInputCommon::CapsLockIgnored() noexcept
 	QCOMPARE(NeovimQt::Input::convertKey(evMetaCapsLock), QString{ "" });
 }
 
-void TestInputCommon::ShiftSpaceWellFormed() noexcept
-{
-	// Issue#728: Shift + Space inserts ;2u in `:terminal`, mode sent as <S-Space>.
-	QKeyEvent evShift{ QEvent::KeyPress, Qt::Key_Shift, Qt::ShiftModifier, "" };
-	QCOMPARE(NeovimQt::Input::convertKey(evShift), QString{ "" });
-
-	QKeyEvent evShiftSpace{ QEvent::KeyPress, Qt::Key_Space, Qt::ShiftModifier, " " };
-	QCOMPARE(NeovimQt::Input::convertKey(evShiftSpace), QString{ "<Space>" });
-}
-
 void TestInputCommon::ShiftBackSpaceWellFormed() noexcept
 {
 	// Issue#259: Shift + BackSpace inserts 7;2u in `:terminal`, mode sent as <S-BS>.


### PR DESCRIPTION
Many users find the shift-space and shift-backspace behavior in terminal frustrating. However, some users still want to map these sequences.

Applying the runtime re-map workaround, since Neovim is unable to fix this issue upstream. Neovim still does not report `:terminal` mode.

Related: #728 #999 