### PR TITLE
Issue 1022: Add GuiTreeview custom filters

### DIFF
--- a/src/gui/treeview.cpp
+++ b/src/gui/treeview.cpp
@@ -9,6 +9,32 @@
 
 namespace NeovimQt {
 
+static QDir::Filters getTreeviewFilters(const QSettings& settings) noexcept
+{
+	QDir::Filters filters{ QDir::Filter::NoDotAndDotDot };
+
+	if (settings.value("Treeview/ShowDirs", true).toBool()) {
+		filters |= QDir::Filter::Dirs;
+		filters |= QDir::Filter::AllDirs;
+	}
+	if (settings.value("Treeview/ShowFiles", true).toBool()) {
+		filters |= QDir::Filter::Files;
+	}
+	if (settings.value("Treeview/ShowDrives", true).toBool()) {
+		filters |= QDir::Filter::Drives;
+	}
+	if (settings.value("Treeview/NoSymLinks", false).toBool()) {
+		filters |= QDir::Filter::NoSymLinks;
+	}
+	if (settings.value("Treeview/ShowHiddenFiles", false).toBool()) {
+		filters |= QDir::Filter::Hidden;
+	}
+	if (settings.value("Treeview/ShowSystemFiles", false).toBool()) {
+		filters |= QDir::Filter::System;
+	}
+
+	return filters;
+}
 TreeView::TreeView(NeovimConnector* nvim, QWidget* parent) noexcept
 	: QTreeView(parent)
 	, m_model{ parent }
@@ -18,7 +44,10 @@ TreeView::TreeView(NeovimConnector* nvim, QWidget* parent) noexcept
 		qFatal("Fatal Error: TreeView must have a valid NeovimConnector!");
 	}
 
+	QSettings settings;
+
 	setModel(&m_model);
+	m_model.setFilter(getTreeviewFilters(settings));
 
 	header()->hide();
 
@@ -27,7 +56,6 @@ TreeView::TreeView(NeovimConnector* nvim, QWidget* parent) noexcept
 		hideColumn(i);
 	}
 
-	QSettings settings;
 	setVisible(settings.value("Gui/TreeView", false).toBool());
 
 	connect(m_nvim, &NeovimConnector::ready, this, &TreeView::neovimConnectorReady);

--- a/src/gui/treeview.h
+++ b/src/gui/treeview.h
@@ -25,6 +25,7 @@ public slots:
 
 private:
 	void updateVisibility(bool isVisible) noexcept;
+	void updateFilters() noexcept;
 
 	QFileSystemModel m_model;
 	NeovimConnector* m_nvim;


### PR DESCRIPTION
**Issue #1022: ** Support Treeview filtering

Adds support for custom filtering of the content displayed by GuiTreeView.

Uses QSettings to add the following `~/.config/nvim-qt/nvim-qt.conf` options:
```
[Treeview]
ShowDirs=true
ShowDrives=true
NoSymLinks=true
ShowHiddenFiles=false
ShowSystemFiles=false
```

Default values shown. Defaults line up with the current implicit GuiTreeview filter values.


**TODO:**
 - Add documentation in the Wiki
 - Add a mechanism to set the options from the shim. Windows uses Registry, difficult to set.
 - Unit Tests
