### PR TITLE
Fix finding msgpack 6+

### DIFF
--- a/cmake/FindMsgpack.cmake
+++ b/cmake/FindMsgpack.cmake
@@ -5,7 +5,7 @@ find_path(MSGPACK_INCLUDE_DIR
 )
 
 find_library(MSGPACK_LIBRARY
-    NAMES msgpack msgpackc libmsgpack.a libmsgpackc.a
+    NAMES msgpack-c msgpack msgpackc libmsgpack.a libmsgpackc.a
 )
 
 mark_as_advanced(MSGPACK_INCLUDE_DIR MSGPACK_LIBRARY)


### PR DESCRIPTION
`libmsgpackc` was renamed to `libmsgpack-c` in 6.0.0. See msgpack/msgpack-c#1053.