### PR TITLE
Fix appveyor tests

### DIFF
--- a/contrib/appveyor.yml
+++ b/contrib/appveyor.yml
@@ -19,7 +19,7 @@ configuration:
 matrix:
   fast_finish: false
 install:
-- ps: appveyor DownloadFile -FileName Neovim.zip "https://github.com/neovim/neovim/releases/download/nightly/nvim-win64.zip"
+- ps: appveyor DownloadFile -FileName Neovim.zip "https://github.com/neovim/neovim/releases/download/stable/nvim-win64.zip"
 - 7z x Neovim.zip
 - set PATH=%PATH%;%CD%\nvim-win64\bin;
 - nvim --version


### PR DESCRIPTION
For a while now the appveyor builds have been blocking during the test phase. This meant that all jobs would run for 60min and fail due to timeout. The output revealed no information.

An earlier change (already merged) added a timeout to ctest (2min per test). This allowed the job to complete and reveal which jobs were stuck:

- tst_neovimconnector.tst_neovimconnector
- tst_qsettings.tst_qsettings
- tst_shell.tst_shell

e.g. https://ci.appveyor.com/project/equalsraf/neovim-qt/builds/46609511/job/4yq41mkl2xxc5f5y the output is not very helpful other than pointing out the timeout.

There were some suspicious log lines that suggest nvim either crashed or hang, but since I could not reproduce this I decided to take a lucky shot and change the nvim version to 0.8 instead of nightly. The tests did run ok, still waiting waiting on a second execution before I do the victory dance here.

**Note**: we also saw some things earlier that might suggest some raciness in the tests, but I'm assuming this is unrelated to the stuck tests.


