### PR TITLE
Test flakyness

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -29,7 +29,7 @@ jobs:
 
           - name: Linux_Release
             flavor: Release
-            runner: ubuntu-18.04
+            runner: ubuntu-20.04
             generator: Ninja
             cc: gcc
             cxx: g++

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -102,7 +102,7 @@ jobs:
           QT_DIR: ${{ github.workspace }}\${{ matrix.qtver }}\${{ matrix.qtdir }}
         run: |
           New-Item -Path .\build -Name "build" -ItemType "directory"
-          Invoke-WebRequest https://github.com/neovim/neovim/releases/download/nightly/nvim-win64.zip -OutFile nvim-win64.zip
+          Invoke-WebRequest https://github.com/neovim/neovim/releases/download/stable/nvim-win64.zip -OutFile nvim-win64.zip
           Expand-Archive -Path nvim-win64.zip -DestinationPath .\build\
           Add-Content -Path $env:GITHUB_PATH -Value ${{ github.workspace }}\build\nvim-win64\bin\
           Add-Content -Path $env:GITHUB_ENV -Value "CMAKE_PREFIX_PATH=$env:QT_DIR;$env:QT_DIR\lib\cmake"

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -148,7 +148,7 @@ jobs:
         uses: GabrielBB/xvfb-action@v1 # Required by Linux, no X11 $DISPLAY
         with:
           working-directory: ${{ github.workspace }}/build
-          run: ctest --timeout 120 --output-on-failure -C ${{ matrix.flavor }}
+          run: ctest -VV --timeout 120 --output-on-failure -C ${{ matrix.flavor }}
 
       #
       # Deploy Release Binaries

--- a/contrib/azure-pipelines.yml
+++ b/contrib/azure-pipelines.yml
@@ -20,9 +20,9 @@ jobs:
       displayName: CMake Build
 
 
-  - job: UbuntuBionic
+  - job: UbuntuFocal
     pool:
-      vmImage: 'ubuntu-18.04'
+      vmImage: 'ubuntu-20.04'
     steps:
     - script: |
         sudo add-apt-repository -y ppa:neovim-ppa/stable

--- a/contrib/azure-pipelines.yml
+++ b/contrib/azure-pipelines.yml
@@ -78,6 +78,8 @@ jobs:
 
 
   - job: Windows_qt5
+    variables:
+      VCINSTALLDIR: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC
     pool:
       vmImage: 'windows-2019'
     steps:
@@ -98,7 +100,7 @@ jobs:
     - task: CMake@1
       inputs:
         workingDirectory: $(Build.BinariesDirectory)
-        cmakeArgs: -G "Visual Studio 16 2019" -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=$(Build.BinariesDirectory)\5.15.0\msvc2019_64\lib\cmake;$(Build.BinariesDirectory)\5.15.0\msvc2019_64\bin $(Build.SourcesDirectory)
+        cmakeArgs: -G "Visual Studio 16 2019" -DCMAKE_BUILD_TYPE=Debug -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_PREFIX_PATH=$(Build.BinariesDirectory)\5.15.0\msvc2019_64\lib\cmake;$(Build.BinariesDirectory)\5.15.0\msvc2019_64\bin $(Build.SourcesDirectory)
       displayName: CMake Configure
     - task: CMake@1
       inputs:

--- a/contrib/azure-pipelines.yml
+++ b/contrib/azure-pipelines.yml
@@ -89,7 +89,7 @@ jobs:
         architecture: 'x64'
       displayName: Setup Python
     - script: |
-        cinst --no-progress -y 7zip neovim
+        choco install --no-progress -y 7zip neovim
         pip install aqtinstall
         cd $(Build.BinariesDirectory)
         python -m aqt install 5.15.0 windows desktop win64_msvc2019_64
@@ -118,7 +118,7 @@ jobs:
         architecture: 'x64'
       displayName: Setup Python
     - script: |
-        cinst --no-progress -y 7zip neovim
+        choco install --no-progress -y 7zip neovim
         pip install aqtinstall
         cd $(Build.BinariesDirectory)
         python -m aqt install 6.0.0 windows desktop win64_msvc2019_64

--- a/test/tst_qsettings.cpp
+++ b/test/tst_qsettings.cpp
@@ -32,6 +32,16 @@ static void SendNeovimCommand(NeovimConnector& connector, const QString& command
 
 	QVERIFY(spyCommand.isValid());
 	QVERIFY(SPYWAIT(spyCommand));
+
+
+	// Hypothesis: sometimes we do not wait long enough for the effects of
+	// a command to manifest because it requires
+	// 1. msg from gui to nvim
+	// 2. msg from nvim to gui
+	// The later are usually asynchronous notifications
+	//
+	// Attempt to ensure the previous command had the inteded effect
+	QTest::qSleep(1000);
 }
 
 void TestQSettings::initTestCase() noexcept


### PR DESCRIPTION
There is some flakiness in the tests - mostly seen in the windows runners.

1. For the qsettings tests, I don't think send command waits long enough because for the command to have an effect it must also callback the gui (gui -> nvim -> gui) but the signal spy only waits for the completion of the first one
2. a number of other small issues mixed in