### PR TITLE
Issue 1063: change default guicursor behavior

### DIFF
--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -588,6 +588,8 @@ void Shell::handleRedraw(const QByteArray& name, const QVariantList& opargs)
 	} else if (name == "popupmenu_hide") {
 		m_pum.hide();
 	} else if (name == "mode_info_set") {
+		qDebug() << "mode_info_set";
+		qDebug() << "  " << opargs;
 		handleModeInfoSet(opargs);
 	} else if (name == "flush") {
 		// Do Nothing, a notification that nvim is done redrawing.
@@ -688,25 +690,13 @@ void Shell::handleModeChange(const QVariantList& opargs)
 		return;
 	}
 
-	const QString mode{ m_nvim->decode(opargs.at(0).toByteArray()) };
+	//const QString mode{ m_nvim->decode(opargs.at(0).toByteArray()) };
 	const uint64_t modeIndex{ opargs.at(1).toULongLong() };
 
 	if (!m_cursor.IsStyleEnabled()) {
-		if (mode == "insert") {
-			m_cursor.SetColor({});
-			m_cursor.SetStyle(Cursor::Shape::Vertical, 25);
-			m_cursor.SetTimer(0, 0, 0);
-		}
-		else if (mode == "replace") {
-			m_cursor.SetColor({});
-			m_cursor.SetStyle(Cursor::Shape::Horizontal, 20);
-			m_cursor.SetTimer(0, 0, 0);
-		}
-		else {
-			m_cursor.SetColor({});
-			m_cursor.SetStyle(Cursor::Shape::Block, 100);
-			m_cursor.SetTimer(0, 0, 0);
-		}
+		m_cursor.SetColor({});
+		m_cursor.SetStyle(Cursor::Shape::Block, 100);
+		m_cursor.SetTimer(0, 0, 0);
 
 		update(neovimCursorRect());
 		return;
@@ -785,6 +775,8 @@ void Shell::handleModeInfoSet(const QVariantList& opargs)
 
 	const bool cursor_style_enabled{ opargs.at(0).toBool() };
 	const QVariantList mode_info = opargs.at(1).toList();
+
+	qDebug() << "  cursor_style_enabled:" << cursor_style_enabled;
 
 	m_cursor.SetIsStyleEnabled(cursor_style_enabled);
 	m_modeInfo = mode_info;


### PR DESCRIPTION
**Issue #1063:** can't disable cursor styling

Currently, when no guicursor value is provided (styling is disabled), we use some default values: block, ver25, or hor25 based on mode.

The TUI does not behave the same way, it uses block mode for all cases when guicursor is empty.

This change removes the cursor defaults, and applies block mode to all cases where guicursor is empty.