### PR TITLE
Add option to disable rendering of bold/italic

### DIFF
--- a/src/gui/runtime/doc/nvim_gui_shim.txt
+++ b/src/gui/runtime/doc/nvim_gui_shim.txt
@@ -69,6 +69,10 @@ GuiLinespace	When called with no arguments this command displays the
 		linespace, the number of extra pixels each line will have.
                 A single argument is accepted as the new linespace height.
 
+								*GuiRenderFontAttr*
+GuiRenderFontAttr	Enable or disable Rendering of GUI font attributes. Turning
+			this off disables rendering of italic or bold text.
+
 								*GuiScrollBar*
 GuiScrollBar	Enable or disable the external GUI scrollbar
 

--- a/src/gui/runtime/plugin/nvim_gui_shim.vim
+++ b/src/gui/runtime/plugin/nvim_gui_shim.vim
@@ -278,6 +278,12 @@ function! s:GuiRenderLigatures(enable) abort
 endfunction
 command! -nargs=1 GuiRenderLigatures call s:GuiRenderLigatures(<args>)
 
+" Enable/Disable the rendering of bold/italics
+function! s:GuiRenderFontAttr(enable) abort
+	call rpcnotify(0, 'Gui', 'Option', 'RenderFontAttr', a:enable)
+endfunction
+command! -nargs=1 GuiRenderFontAttr call s:GuiRenderFontAttr(<args>)
+
 " Set window transparency, forwards to Qt setWindowOpacity
 function! s:GuiWindowOpacityCommand(value) abort
   call rpcnotify(0, 'Gui', 'WindowOpacity', a:value)

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -928,7 +928,11 @@ void Shell::handleExtGuiOption(const QString& name, const QVariant& value)
 		handleGuiPopupmenu(value);
 	} else if (name == "RenderLigatures"){
 		setLigatureMode(value.toBool());
-	} else {
+	}
+	else if (name == "RenderFontAttr") {
+		setRenderFontAttr(value.toBool());
+	}
+	else {
 		// Uncomment for writing new event handling code.
 		// qDebug() << "Unknown GUI Option" << name << value;
 	}

--- a/src/gui/shellwidget/shellwidget.cpp
+++ b/src/gui/shellwidget/shellwidget.cpp
@@ -118,6 +118,20 @@ QSize ShellWidget::cellSize() const
 	return m_cellSize;
 }
 
+bool ShellWidget::renderFontAttr() const
+{
+	return m_renderFontAttr;
+}
+
+void ShellWidget::setRenderFontAttr(bool value)
+{
+	if (value != m_renderFontAttr) {
+		m_renderFontAttr = value;
+		update();
+		emit renderFontAttrChanged(m_renderFontAttr);
+	}
+}
+
 QRect ShellWidget::getNeovimCursorRect(QRect cellRect) noexcept
 {
 	QRect cursorRect{ cellRect };
@@ -342,11 +356,11 @@ QFont ShellWidget::GetCellFont(const Cell& cell) const noexcept
 		}
 	}
 
-	if (cell.IsBold()) {
+	if (cell.IsBold() && renderFontAttr()) {
 		cellFont.setBold(cell.IsBold());
 	}
 
-	if (cell.IsItalic()) {
+	if (cell.IsItalic() && renderFontAttr()) {
 		cellFont.setItalic(cell.IsItalic());
 	}
 

--- a/src/gui/shellwidget/shellwidget.h
+++ b/src/gui/shellwidget/shellwidget.h
@@ -14,6 +14,7 @@ class ShellWidget: public QWidget
 	Q_PROPERTY(int columns READ columns NOTIFY columnsChanged)
 	Q_PROPERTY(QSize cellSize READ cellSize NOTIFY cellSizeChanged)
 	Q_PROPERTY(bool ligatureMode MEMBER m_isLigatureModeEnabled READ isLigatureModeEnabled WRITE setLigatureMode NOTIFY ligatureModeChanged)
+	Q_PROPERTY(bool renderFontAttr READ renderFontAttr WRITE setRenderFontAttr NOTIFY renderFontAttrChanged)
 
 public:
 	ShellWidget(QWidget *parent=0);
@@ -80,6 +81,8 @@ public:
 	{
 		return m_isLigatureModeEnabled;
 	}
+	bool renderFontAttr() const;
+	void setRenderFontAttr(bool);
 
 signals:
 	void shellFontChanged();
@@ -90,6 +93,7 @@ signals:
 	void columnsChanged(int cols);
 	void cellSizeChanged(QSize size);
 	void ligatureModeChanged(bool isEnabled);
+	void renderFontAttrChanged(bool isEnabled);
 
 public slots:
 	void resizeShell(int rows, int columns);
@@ -198,6 +202,7 @@ private:
 	QColor m_spColor;
 	int m_lineSpace{ 0 };
 	bool m_isLigatureModeEnabled{ false };
+	bool m_renderFontAttr{ true };
 
 	Background m_background{ Background::Dark };
 };

--- a/test/tst_shell.cpp
+++ b/test/tst_shell.cpp
@@ -146,6 +146,32 @@ void TestShell::guiShimCommands() noexcept
 	SPYWAIT(spy_fontchange2, 5000 /*msec*/);
 
 	QCOMPARE(w->shell()->fontDesc(), expectedFontBoldRemoved);
+
+	// GuiRenderFontAttr
+	QCOMPARE(w->shell()->renderFontAttr(), true);
+
+	QSignalSpy spy_fontattr_change(w->shell(), &ShellWidget::renderFontAttrChanged);
+	QVERIFY(spy_fontattr_change.isValid());
+	QSignalSpy cmd_fontattr(
+		c->neovimObject()->vim_command_output(c->encode("GuiRenderFontAttr 0")),
+		&MsgpackRequest::finished);
+	QVERIFY(cmd_fontattr.isValid());
+
+	QVERIFY2(SPYWAIT(cmd_fontattr), "Waiting for GuiRenderFontAttr cmd");
+	QVERIFY2(SPYWAIT(spy_fontattr_change), "Waiting for renderFontAttrChanged");
+	QCOMPARE(w->shell()->renderFontAttr(), false);
+
+	QSignalSpy spy_fontattr_change2(w->shell(), &ShellWidget::renderFontAttrChanged);
+	QVERIFY(spy_fontattr_change2.isValid());
+	QSignalSpy cmd_fontattr2(
+		c->neovimObject()->vim_command_output(c->encode("GuiRenderFontAttr 1")),
+		&MsgpackRequest::finished);
+	QVERIFY(cmd_fontattr2.isValid());
+
+	QVERIFY2(SPYWAIT(cmd_fontattr2), "Waiting for GuiRenderFontAttr cmd");
+	QVERIFY2(SPYWAIT(spy_fontattr_change2), "Waiting for renderFontAttrChanged");
+	QCOMPARE(w->shell()->renderFontAttr(), true);
+
 }
 
 void TestShell::CloseEvent_data() noexcept


### PR DESCRIPTION
In some cases the user may want to disable bold/italic fonts entirely. But this can only be achieved by rewriting the color theme as well as syntax files, which is not practical.

Instead we can ignore the bold/italic attribute when rendering to the screen.

- the default behaviour is unchanged
- a new command GuiRenderBoldItalic can be used to toggle this option

TODO:

- [x] add tests (default value and enable/disable)
- [x] rename option to renderfontattr