### PR TITLE
QProcess cleanup

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -49,30 +49,6 @@ jobs:
             cc: clang
             cxx: clang++
             publish: true
-
-          # Qt 5.15 only supports MinGW 8.11. The `windows-latest` and `windows-2022`
-          # images bundle only 11.2. For now, we must use the older image `windows-2019`.
-          - name: Windows_MingGW
-            flavor: Debug
-            runner: windows-2022
-            generator: MinGW Makefiles
-            qtver: 5.15.2
-            qtdir: mingw81_64
-            qtstr: windows desktop win64_mingw81
-            cc: gcc
-            cxx: g++
-            ctest_exe_args: -tap
-
-          - name: Windows_Release
-            flavor: Release
-            runner: windows-2022
-            generator: Visual Studio 17 2022
-            qtver: 5.15.2
-            qtdir: msvc2019_64
-            qtstr: windows desktop win64_msvc2019_64
-            ctest_exe_args: -tap
-            publish: true
-
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v2
@@ -95,33 +71,6 @@ jobs:
           brew ls --formula | grep -wq qt5 || brew install qt5
           brew ls --formula | grep -wq msgpack || brew install msgpack
           brew link qt5 --force
-
-      - name: Windows - Setup
-        if: ${{ startsWith(matrix.runner, 'windows') }}
-        env:
-          QT_DIR: ${{ github.workspace }}\${{ matrix.qtver }}\${{ matrix.qtdir }}
-        run: |
-          New-Item -Path .\build -Name "build" -ItemType "directory"
-          Invoke-WebRequest https://github.com/neovim/neovim/releases/download/stable/nvim-win64.zip -OutFile nvim-win64.zip
-          Expand-Archive -Path nvim-win64.zip -DestinationPath .\build\
-          Add-Content -Path $env:GITHUB_PATH -Value ${{ github.workspace }}\build\nvim-win64\bin\
-          Add-Content -Path $env:GITHUB_ENV -Value "CMAKE_PREFIX_PATH=$env:QT_DIR;$env:QT_DIR\lib\cmake"
-          Add-Content -Path $env:GITHUB_PATH -Value "${{ env.qt_dir }}"
-          Add-Content -Path $env:GITHUB_PATH -Value "${{ env.qt_dir }}\bin"
-
-      - name: Qt Cache Restore
-        if: ${{ matrix.qtver }}
-        id: cache-qt
-        uses: actions/cache@v2
-        with:
-          path: ${{ matrix.qtver }}\${{ matrix.qtdir }}
-          key: qt-${{ runner.os }}-${{ matrix.qtver }}-${{ matrix.qtdir }}
-
-      - name: Qt Cache Install
-        if: ${{ matrix.qtver && steps.cache-qt.outputs.cache-hit != 'true' }}
-        run: |
-          pip install aqtinstall
-          python -m aqt install ${{ matrix.qtver }} ${{ matrix.qtstr }}
 
       #
       # Build and Test
@@ -168,16 +117,6 @@ jobs:
         run: |
           macdeployqt ./build/bin/nvim-qt.app -dmg
           mv ./build/bin/nvim-qt.dmg neovim-qt.dmg
-
-      - name: Windows - Publish
-        if: ${{ matrix.publish && startsWith(matrix.runner, 'windows') }}
-        run: |
-          cmake --build ./build --target install
-          Push-Location ${{ github.workspace }}/build
-          cpack --verbose -G WIX
-          Pop-Location
-          Compress-Archive -Path ./install -DestinationPath neovim-qt.zip
-          Move-Item -Path ./build/neovim-qt-installer.msi -Destination neovim-qt-installer.msi
 
       - name: Upload Artifacts
         if: ${{ matrix.publish }}

--- a/contrib/appveyor.yml
+++ b/contrib/appveyor.yml
@@ -10,16 +10,19 @@ environment:
     GENERATOR: MinGW Makefiles
     RELEASE_ARTIFACT: true
     CMAKE_PATH_PREFIX: C:\Qt\5.15\mingw81_64\lib\cmake
+    CMAKE_BUILD_TYPE: Release
   - PlatformToolset: VisualStudio2019
     QTPATH: C:\Qt\5.15\msvc2019_64
     GENERATOR: Visual Studio 16
     CMAKE_PATH_PREFIX: C:\Qt\5.15\msvc2019_64\lib\cmake
+    CMAKE_BUILD_TYPE: Debug
   - PlatformToolset: MinGW-Win64-Qt6
     QTPATH: C:\Qt\6.2.4\mingw_64
     GENERATOR: MinGW Makefiles
     RELEASE_ARTIFACT: false
     CMAKE_PATH_PREFIX: C:\Qt\6.2.4\mingw_64\lib\cmake
     EXTRA_CMAKE_ARGS: -DWITH_QT=Qt6
+    CMAKE_BUILD_TYPE: Release
 configuration:
 - RelWithDebInfo
 matrix:
@@ -42,7 +45,7 @@ build_script:
 - echo %PATH%
 - mkdir build
 - cd build
-- cmake -G "%GENERATOR%" -DCMAKE_PREFIX_PATH="%CMAKE_PATH_PREFIX%" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../INSTALL -DENABLE_TESTS=ON %EXTRA_CMAKE_ARGS% ..
+- cmake -G "%GENERATOR%" -DCMAKE_PREFIX_PATH="%CMAKE_PATH_PREFIX%" -DCMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE% -DCMAKE_INSTALL_PREFIX=../INSTALL -DENABLE_TESTS=ON %EXTRA_CMAKE_ARGS% ..
 - cmake --build . --config Release --target install
 - cpack --verbose -G WIX
 test_script:

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -43,11 +43,11 @@ void MainWindow::init(NeovimConnector *c)
 	}
 
 	m_shell = new Shell(c);
+	m_shell->setParent(this);
 
 	addToolBar(&m_tabline);
 
 	m_nvim = c;
-	m_nvim->setParent(this);
 
 	// GuiShowContextMenu - right click context menu and actions.
 	m_contextMenu = new ContextMenu(c, this);

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1,6 +1,7 @@
 #include "mainwindow.h"
 
 #include <QCloseEvent>
+#include <QEventLoop>
 #include <QLayout>
 #include <QSettings>
 #include <QStyleFactory>
@@ -235,6 +236,18 @@ void MainWindow::neovimGuiCloseRequest(int status)
 {
 	m_neovim_requested_close = true;
 	m_exitStatus = status;
+
+	// Try to wait for neovim to quit
+	QTimer timer;
+	timer.setSingleShot(true);
+	QEventLoop loop;
+	connect(m_nvim, &NeovimConnector::processExited, &loop, &QEventLoop::quit);
+	connect(m_nvim, &NeovimConnector::aboutToClose, &loop, &QEventLoop::quit);
+	timer.start(500);
+	loop.exec();
+	bool timed_out = !timer.isActive();
+	qDebug() << "Waited for neovim close, timed out:" << timed_out;
+
 	QMainWindow::close();
 	m_neovim_requested_close = false;
 }

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -92,6 +92,8 @@ Shell::Shell(NeovimConnector *nvim, QWidget *parent)
 		return;
 	}
 
+	m_nvim->setParent(this);
+
 	connect(m_nvim, &NeovimConnector::error,
 			this, &Shell::neovimError);
 	connect(m_nvim, &NeovimConnector::processExited,

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -70,6 +70,7 @@ public:
 	static void DispatchRedrawNotifications(
 		T* pThis, const QVariantList& args) noexcept;
 
+	NeovimConnector* nvim() { return m_nvim; }
 signals:
 	void neovimTitleChanged(const QString &title);
 	void neovimBusyChanged(bool);

--- a/src/msgpackiodevice.cpp
+++ b/src/msgpackiodevice.cpp
@@ -60,6 +60,7 @@ MsgpackIODevice::MsgpackIODevice(QIODevice* dev, QObject* parent)
 		m_dev->setParent(this);
 		connect(m_dev, &QAbstractSocket::readyRead,
 				this, &MsgpackIODevice::dataAvailable);
+		connect(m_dev, &QIODevice::aboutToClose, this, &MsgpackIODevice::aboutToClose);
 
 		if ( !m_dev->isSequential() ) {
 			setError(InvalidDevice, tr("IO device needs to be sequential"));

--- a/src/msgpackiodevice.h
+++ b/src/msgpackiodevice.h
@@ -71,6 +71,7 @@ signals:
 	/** A notification with the given name and arguments was received */
 	void notification(const QByteArray &name, const QVariantList& args);
 	void encodingChanged(const QByteArray& encoding);
+	void aboutToClose();
 
 protected:
 	void sendError(const msgpack_object& req, const QString& msg);

--- a/src/neovimconnector.cpp
+++ b/src/neovimconnector.cpp
@@ -37,6 +37,7 @@ NeovimConnector::NeovimConnector(MsgpackIODevice *dev)
 
 	connect(m_dev, &MsgpackIODevice::error,
 			this, &NeovimConnector::msgpackError);
+	connect(m_dev, &MsgpackIODevice::aboutToClose, this, &NeovimConnector::aboutToClose);
 
 	m_dev->setParent(this);
 

--- a/src/neovimconnector.cpp
+++ b/src/neovimconnector.cpp
@@ -38,6 +38,8 @@ NeovimConnector::NeovimConnector(MsgpackIODevice *dev)
 	connect(m_dev, &MsgpackIODevice::error,
 			this, &NeovimConnector::msgpackError);
 
+	m_dev->setParent(this);
+
 	if ( !m_dev->isOpen() ) {
 		return;
 	}

--- a/src/neovimconnector.h
+++ b/src/neovimconnector.h
@@ -106,6 +106,7 @@ signals:
 	void ready();
 	void error(NeovimQt::NeovimConnector::NeovimError);
 	void processExited(int exitCode);
+	void aboutToClose();
 
 public slots:
 	void fatalTimeout();

--- a/test/common_gui.cpp
+++ b/test/common_gui.cpp
@@ -35,7 +35,7 @@ template<class T> static void ValidateNeovimConnection(T* obj) noexcept
 	Q_ASSERT(obj->isNeovimAttached());
 }
 
-Shell* CreateShellWidget() noexcept
+QSharedPointer<Shell> CreateShellWidget() noexcept
 {
 	DisableLocalGInitVim();
 	NeovimConnector* c{ NeovimConnector::spawn(cs_argsNone) };
@@ -45,10 +45,10 @@ Shell* CreateShellWidget() noexcept
 
 	ValidateNeovimConnection(s);
 
-	return s;
+	return QSharedPointer<Shell>(s);
 }
 
-MainWindow* CreateMainWindow() noexcept
+QSharedPointer<MainWindow> CreateMainWindow() noexcept
 {
 	NeovimConnector* c{ NeovimConnector::spawn(cs_argsNone) };
 	MainWindow* w{ new MainWindow{ c } };
@@ -57,10 +57,10 @@ MainWindow* CreateMainWindow() noexcept
 
 	ValidateNeovimConnection(w);
 
-	return w;
+	return QSharedPointer<MainWindow>(w);
 }
 
-MainWindow* CreateMainWindowWithRuntime() noexcept
+QSharedPointer<MainWindow> CreateMainWindowWithRuntime() noexcept
 {
 	static const QStringList cs_argsNoneRuntime{
 		"-u", "NONE", "--cmd", "set rtp+=" + GetRuntimeAbsolutePath()
@@ -74,7 +74,7 @@ MainWindow* CreateMainWindowWithRuntime() noexcept
 
 	ValidateNeovimConnection(w);
 
-	return w;
+	return QSharedPointer<MainWindow>(w);
 }
 
 } // namespace NeovimQt

--- a/test/common_gui.cpp
+++ b/test/common_gui.cpp
@@ -35,7 +35,7 @@ template<class T> static void ValidateNeovimConnection(T* obj) noexcept
 	Q_ASSERT(obj->isNeovimAttached());
 }
 
-std::pair<NeovimConnector*, Shell*> CreateShellWidget() noexcept
+Shell* CreateShellWidget() noexcept
 {
 	DisableLocalGInitVim();
 	NeovimConnector* c{ NeovimConnector::spawn(cs_argsNone) };
@@ -45,7 +45,7 @@ std::pair<NeovimConnector*, Shell*> CreateShellWidget() noexcept
 
 	ValidateNeovimConnection(s);
 
-	return { c, s };
+	return s;
 }
 
 std::pair<NeovimConnector*, MainWindow*> CreateMainWindow() noexcept

--- a/test/common_gui.cpp
+++ b/test/common_gui.cpp
@@ -48,7 +48,7 @@ Shell* CreateShellWidget() noexcept
 	return s;
 }
 
-std::pair<NeovimConnector*, MainWindow*> CreateMainWindow() noexcept
+MainWindow* CreateMainWindow() noexcept
 {
 	NeovimConnector* c{ NeovimConnector::spawn(cs_argsNone) };
 	MainWindow* w{ new MainWindow{ c } };
@@ -57,7 +57,7 @@ std::pair<NeovimConnector*, MainWindow*> CreateMainWindow() noexcept
 
 	ValidateNeovimConnection(w);
 
-	return { c, w };
+	return w;
 }
 
 std::pair<NeovimConnector*, MainWindow*> CreateMainWindowWithRuntime() noexcept

--- a/test/common_gui.cpp
+++ b/test/common_gui.cpp
@@ -60,7 +60,7 @@ MainWindow* CreateMainWindow() noexcept
 	return w;
 }
 
-std::pair<NeovimConnector*, MainWindow*> CreateMainWindowWithRuntime() noexcept
+MainWindow* CreateMainWindowWithRuntime() noexcept
 {
 	static const QStringList cs_argsNoneRuntime{
 		"-u", "NONE", "--cmd", "set rtp+=" + GetRuntimeAbsolutePath()
@@ -74,7 +74,7 @@ std::pair<NeovimConnector*, MainWindow*> CreateMainWindowWithRuntime() noexcept
 
 	ValidateNeovimConnection(w);
 
-	return { c, w };
+	return w;
 }
 
 } // namespace NeovimQt

--- a/test/common_gui.h
+++ b/test/common_gui.h
@@ -7,7 +7,7 @@
 
 namespace NeovimQt {
 
-std::pair<NeovimConnector*, Shell*> CreateShellWidget() noexcept;
+Shell* CreateShellWidget() noexcept;
 
 std::pair<NeovimConnector*, MainWindow*> CreateMainWindow() noexcept;
 

--- a/test/common_gui.h
+++ b/test/common_gui.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QSharedPointer>
 #include <gui/mainwindow.h>
 #include <gui/shell.h>
 #include <neovimconnector.h>
@@ -7,10 +8,10 @@
 
 namespace NeovimQt {
 
-Shell* CreateShellWidget() noexcept;
+QSharedPointer<Shell> CreateShellWidget() noexcept;
 
-MainWindow* CreateMainWindow() noexcept;
+QSharedPointer<MainWindow> CreateMainWindow() noexcept;
 
-MainWindow* CreateMainWindowWithRuntime() noexcept;
+QSharedPointer<MainWindow> CreateMainWindowWithRuntime() noexcept;
 
 } // namespace NeovimQt

--- a/test/common_gui.h
+++ b/test/common_gui.h
@@ -9,7 +9,7 @@ namespace NeovimQt {
 
 Shell* CreateShellWidget() noexcept;
 
-std::pair<NeovimConnector*, MainWindow*> CreateMainWindow() noexcept;
+MainWindow* CreateMainWindow() noexcept;
 
 std::pair<NeovimConnector*, MainWindow*> CreateMainWindowWithRuntime() noexcept;
 

--- a/test/common_gui.h
+++ b/test/common_gui.h
@@ -11,6 +11,6 @@ Shell* CreateShellWidget() noexcept;
 
 MainWindow* CreateMainWindow() noexcept;
 
-std::pair<NeovimConnector*, MainWindow*> CreateMainWindowWithRuntime() noexcept;
+MainWindow* CreateMainWindowWithRuntime() noexcept;
 
 } // namespace NeovimQt

--- a/test/tst_neovimconnector.cpp
+++ b/test/tst_neovimconnector.cpp
@@ -20,6 +20,7 @@ private slots:
 		QCOMPARE(c.canReconnect(), false);
 
 		NeovimConnector *spawned = NeovimConnector::spawn({"-u", "NONE"});
+		spawned->setParent(this);
 		QCOMPARE(spawned->connectionType(), NeovimConnector::SpawnedConnection);
 		QCOMPARE(spawned->canReconnect(), true);
 
@@ -29,6 +30,7 @@ private slots:
 	void isReady() {
 
 		NeovimConnector *c = NeovimConnector::spawn({"-u", "NONE"});
+		c->setParent(this);
 		QSignalSpy onReady(c, SIGNAL(ready()));
 		QVERIFY(onReady.isValid());
 
@@ -38,7 +40,7 @@ private slots:
 
 	void encodeDecode() {
 		NeovimConnector *c = NeovimConnector::spawn({"-u", "NONE"});
-
+		c->setParent(this);
 		// This will print a warning, but should succeed
 		QString s = "ç日本語";
 		QByteArray bytes = c->encode(s);
@@ -55,6 +57,7 @@ private slots:
 
 	void connectToNeovimTCP() {
 		NeovimConnector *c = NeovimConnector::connectToNeovim("127.0.0.1:64999");
+		c->setParent(this);
 		QCOMPARE(c->connectionType(), NeovimConnector::HostConnection);
 		QSignalSpy onError(c, SIGNAL(error(NeovimError)));
 		QVERIFY(onError.isValid());
@@ -68,6 +71,7 @@ private slots:
 
 	void connectToNeovimSocket() {
 		NeovimConnector *c = NeovimConnector::connectToNeovim("NoSuchFile");
+		c->setParent(this);
 		QCOMPARE(c->connectionType(), NeovimConnector::SocketConnection);
 		QSignalSpy onError(c, SIGNAL(error(NeovimError)));
 		QVERIFY(onError.isValid());
@@ -82,6 +86,7 @@ private slots:
 	void connectToNeovimEnvEmpty() {
 		// This is the same as ::spawn()
 		NeovimConnector *c = NeovimConnector::connectToNeovim("");
+		c->setParent(this);
 		QSignalSpy onReady(c, SIGNAL(ready()));
 		QVERIFY(onReady.isValid());
 		QVERIFY(SPYWAIT(onReady));

--- a/test/tst_qsettings.cpp
+++ b/test/tst_qsettings.cpp
@@ -59,15 +59,13 @@ void TestQSettings::OptionLineGrid() noexcept
 	QSettings settings;
 
 	settings.setValue("ext_linegrid", true);
-	auto csWithLineGrid{ CreateShellWidget() };
-	Shell* sWithLineGrid{ csWithLineGrid.second };
+	auto sWithLineGrid = CreateShellWidget();
 	ShellOptions shellOptionsWithLineGrid{ sWithLineGrid->GetShellOptions() };
 
 	QCOMPARE(shellOptionsWithLineGrid.IsLineGridEnabled(), true);
 
 	settings.setValue("ext_linegrid", false);
-	auto csLegacy{ CreateShellWidget() };
-	Shell* sLegacy{ csLegacy.second };
+	auto sLegacy = CreateShellWidget();
 	ShellOptions shellOptionsLegacy{ sLegacy->GetShellOptions() };
 
 	QCOMPARE(shellOptionsLegacy.IsLineGridEnabled(), false);

--- a/test/tst_qsettings.cpp
+++ b/test/tst_qsettings.cpp
@@ -25,9 +25,9 @@ private slots:
 	void GuiTreeView() noexcept;
 };
 
-static void SendNeovimCommand(NeovimConnector& connector, const QString& command) noexcept
+static void SendNeovimCommand(NeovimConnector* connector, const QString& command) noexcept
 {
-	QSignalSpy spyCommand{ connector.api0()->vim_command_output(connector.encode(command)),
+	QSignalSpy spyCommand{ connector->api0()->vim_command_output(connector->encode(command)),
 		&MsgpackRequest::finished };
 
 	QVERIFY(spyCommand.isValid());
@@ -73,11 +73,11 @@ void TestQSettings::OptionLineGrid() noexcept
 
 void TestQSettings::OptionPopupMenu() noexcept
 {
-	auto cw{ CreateMainWindowWithRuntime() };
-	NeovimConnector& connector{ *cw.first };
+	auto w = CreateMainWindowWithRuntime();
+	NeovimConnector *connector = w->shell()->nvim();
 
 	QSettings settings;
-	QSignalSpy spy_fontchange(cw.second->shell(), &ShellWidget::shellFontChanged);
+	QSignalSpy spy_fontchange(w->shell(), &ShellWidget::shellFontChanged);
 
 	SendNeovimCommand(connector, "GuiPopupmenu 1");
 	SPYWAIT(spy_fontchange, 2500 /*msec*/);
@@ -87,13 +87,13 @@ void TestQSettings::OptionPopupMenu() noexcept
 	SPYWAIT(spy_fontchange, 2500 /*msec*/);
 	QCOMPARE(settings.value("ext_popupmenu").toBool(), false);
 
-	cw.second->deleteLater();
+	w->deleteLater();
 }
 
 void TestQSettings::OptionTabline() noexcept
 {
-	auto cw{ CreateMainWindowWithRuntime() };
-	NeovimConnector& connector{ *cw.first };
+	auto w = CreateMainWindowWithRuntime();
+	NeovimConnector* connector = w->shell()->nvim();
 
 	QSettings settings;
 
@@ -103,14 +103,13 @@ void TestQSettings::OptionTabline() noexcept
 	SendNeovimCommand(connector, "GuiTabline 0");
 	QCOMPARE(settings.value("ext_tabline").toBool(), false);
 
-	cw.second->deleteLater();
+	w->deleteLater();
 }
 
 void TestQSettings::GuiFont() noexcept
 {
-	auto cw{ CreateMainWindowWithRuntime() };
-	NeovimConnector& connector{ *cw.first };
-	MainWindow& window{ *cw.second };
+	auto w = CreateMainWindowWithRuntime();
+	NeovimConnector* connector = w->shell()->nvim();
 
 	QSettings settings;
 
@@ -118,16 +117,16 @@ void TestQSettings::GuiFont() noexcept
 	const QString fontCommand{ QStringLiteral("GuiFont! %1").arg(fontDesc) };
 
 	SendNeovimCommand(connector, fontCommand);
-	QCOMPARE(window.shell()->fontDesc(), fontDesc);
+	QCOMPARE(w->shell()->fontDesc(), fontDesc);
 	QCOMPARE(settings.value("Gui/Font").toString(), fontDesc);
 
-	cw.second->deleteLater();
+	w->deleteLater();
 }
 
 void TestQSettings::GuiScrollBar() noexcept
 {
-	auto cw{ CreateMainWindowWithRuntime() };
-	NeovimConnector& connector{ *cw.first };
+	auto w = CreateMainWindowWithRuntime();
+	NeovimConnector* connector = w->shell()->nvim();
 
 	QSettings settings;
 
@@ -137,12 +136,12 @@ void TestQSettings::GuiScrollBar() noexcept
 	SendNeovimCommand(connector, "GuiScrollBar 0");
 	QCOMPARE(settings.value("Gui/ScrollBar").toBool(), false);
 
-	cw.second->deleteLater();
+	w->deleteLater();
 }
 void TestQSettings::GuiTreeView() noexcept
 {
-	auto cw{ CreateMainWindowWithRuntime() };
-	NeovimConnector& connector{ *cw.first };
+	auto w = CreateMainWindowWithRuntime();
+	NeovimConnector* connector = w->shell()->nvim();
 
 	QSettings settings;
 
@@ -152,7 +151,7 @@ void TestQSettings::GuiTreeView() noexcept
 	SendNeovimCommand(connector, "GuiTreeviewHide");
 	QCOMPARE(settings.value("Gui/TreeView").toBool(), false);
 
-	cw.second->deleteLater();
+	w->deleteLater();
 }
 
 } // Namespace NeovimQt

--- a/test/tst_qsettings.cpp
+++ b/test/tst_qsettings.cpp
@@ -74,7 +74,7 @@ void TestQSettings::OptionLineGrid() noexcept
 void TestQSettings::OptionPopupMenu() noexcept
 {
 	auto w = CreateMainWindowWithRuntime();
-	NeovimConnector *connector = w->shell()->nvim();
+	NeovimConnector* connector = w->shell()->nvim();
 
 	QSettings settings;
 	QSignalSpy spy_fontchange(w->shell(), &ShellWidget::shellFontChanged);
@@ -86,8 +86,6 @@ void TestQSettings::OptionPopupMenu() noexcept
 	SendNeovimCommand(connector, "GuiPopupmenu 0");
 	SPYWAIT(spy_fontchange, 2500 /*msec*/);
 	QCOMPARE(settings.value("ext_popupmenu").toBool(), false);
-
-	w->deleteLater();
 }
 
 void TestQSettings::OptionTabline() noexcept
@@ -102,8 +100,6 @@ void TestQSettings::OptionTabline() noexcept
 
 	SendNeovimCommand(connector, "GuiTabline 0");
 	QCOMPARE(settings.value("ext_tabline").toBool(), false);
-
-	w->deleteLater();
 }
 
 void TestQSettings::GuiFont() noexcept
@@ -119,8 +115,6 @@ void TestQSettings::GuiFont() noexcept
 	SendNeovimCommand(connector, fontCommand);
 	QCOMPARE(w->shell()->fontDesc(), fontDesc);
 	QCOMPARE(settings.value("Gui/Font").toString(), fontDesc);
-
-	w->deleteLater();
 }
 
 void TestQSettings::GuiScrollBar() noexcept
@@ -135,8 +129,6 @@ void TestQSettings::GuiScrollBar() noexcept
 
 	SendNeovimCommand(connector, "GuiScrollBar 0");
 	QCOMPARE(settings.value("Gui/ScrollBar").toBool(), false);
-
-	w->deleteLater();
 }
 void TestQSettings::GuiTreeView() noexcept
 {
@@ -150,8 +142,6 @@ void TestQSettings::GuiTreeView() noexcept
 
 	SendNeovimCommand(connector, "GuiTreeviewHide");
 	QCOMPARE(settings.value("Gui/TreeView").toBool(), false);
-
-	w->deleteLater();
 }
 
 } // Namespace NeovimQt

--- a/test/tst_qsettings.cpp
+++ b/test/tst_qsettings.cpp
@@ -79,12 +79,17 @@ void TestQSettings::OptionPopupMenu() noexcept
 	NeovimConnector& connector{ *cw.first };
 
 	QSettings settings;
+	QSignalSpy spy_fontchange(cw.second->shell(), &ShellWidget::shellFontChanged);
 
 	SendNeovimCommand(connector, "GuiPopupmenu 1");
+	SPYWAIT(spy_fontchange, 2500 /*msec*/);
 	QCOMPARE(settings.value("ext_popupmenu").toBool(), true);
 
 	SendNeovimCommand(connector, "GuiPopupmenu 0");
+	SPYWAIT(spy_fontchange, 2500 /*msec*/);
 	QCOMPARE(settings.value("ext_popupmenu").toBool(), false);
+
+	cw.second->deleteLater();
 }
 
 void TestQSettings::OptionTabline() noexcept
@@ -99,6 +104,8 @@ void TestQSettings::OptionTabline() noexcept
 
 	SendNeovimCommand(connector, "GuiTabline 0");
 	QCOMPARE(settings.value("ext_tabline").toBool(), false);
+
+	cw.second->deleteLater();
 }
 
 void TestQSettings::GuiFont() noexcept
@@ -115,6 +122,8 @@ void TestQSettings::GuiFont() noexcept
 	SendNeovimCommand(connector, fontCommand);
 	QCOMPARE(window.shell()->fontDesc(), fontDesc);
 	QCOMPARE(settings.value("Gui/Font").toString(), fontDesc);
+
+	cw.second->deleteLater();
 }
 
 void TestQSettings::GuiScrollBar() noexcept
@@ -129,6 +138,8 @@ void TestQSettings::GuiScrollBar() noexcept
 
 	SendNeovimCommand(connector, "GuiScrollBar 0");
 	QCOMPARE(settings.value("Gui/ScrollBar").toBool(), false);
+
+	cw.second->deleteLater();
 }
 void TestQSettings::GuiTreeView() noexcept
 {
@@ -142,6 +153,8 @@ void TestQSettings::GuiTreeView() noexcept
 
 	SendNeovimCommand(connector, "GuiTreeviewHide");
 	QCOMPARE(settings.value("Gui/TreeView").toBool(), false);
+
+	cw.second->deleteLater();
 }
 
 } // Namespace NeovimQt

--- a/test/tst_shell.cpp
+++ b/test/tst_shell.cpp
@@ -64,9 +64,9 @@ void TestShell::benchStart() noexcept
 {
 	QBENCHMARK
 	{
-		Shell* s = CreateShellWidget();
+		auto s = CreateShellWidget();
 
-		QSignalSpy onResize(s, &Shell::neovimResized);
+		QSignalSpy onResize(s.get(), &Shell::neovimResized);
 		QVERIFY(onResize.isValid());
 		QVERIFY(SPYWAIT(onResize));
 	}
@@ -77,8 +77,6 @@ void TestShell::startVarsShellWidget() noexcept
 	auto s = CreateShellWidget();
 
 	checkStartVars(s->nvim());
-
-	s->deleteLater();
 }
 
 void TestShell::startVarsMainWindow() noexcept
@@ -98,8 +96,6 @@ void TestShell::gviminit() noexcept
 	QVERIFY(cmd.isValid());
 	QVERIFY(SPYWAIT(cmd));
 	QCOMPARE(cmd.at(0).at(2).toByteArray(), QByteArray("1"));
-
-	s->deleteLater();
 }
 
 void TestShell::guiShimCommands() noexcept
@@ -150,8 +146,6 @@ void TestShell::guiShimCommands() noexcept
 	SPYWAIT(spy_fontchange2, 5000 /*msec*/);
 
 	QCOMPARE(w->shell()->fontDesc(), expectedFontBoldRemoved);
-
-	w->deleteLater();
 }
 
 void TestShell::CloseEvent_data() noexcept
@@ -186,7 +180,7 @@ void TestShell::CloseEvent() noexcept
 	QSignalSpy onClose(w->shell(), &Shell::neovimGuiCloseRequest);
 	QVERIFY(onClose.isValid());
 
-	QSignalSpy onWindowClosing(w, &MainWindow::closing);
+	QSignalSpy onWindowClosing(w.get(), &MainWindow::closing);
 	QVERIFY(onWindowClosing.isValid());
 
 	c->api0()->vim_command(c->encode(command));
@@ -210,8 +204,6 @@ void TestShell::CloseEvent() noexcept
 	int actual_exit_status{ p.exitCode() };
 
 	QCOMPARE(actual_exit_status, exit_status);
-
-	w->deleteLater();
 }
 
 void TestShell::GetClipboard_data() noexcept
@@ -250,8 +242,6 @@ void TestShell::GetClipboard() noexcept
 	QVERIFY(cmd_clip.isValid());
 	QVERIFY(SPYWAIT(cmd_clip));
 	QCOMPARE(cmd_clip.takeFirst().at(2), QVariant(register_data));
-
-	w->deleteLater();
 }
 
 void TestShell::SetClipboard_data() noexcept
@@ -292,8 +282,6 @@ void TestShell::SetClipboard() noexcept
 	QVERIFY(SPYWAIT(spy_sync));
 
 	QGuiApplication::clipboard()->setText(register_data, GetClipboardMode(reg));
-
-	w->deleteLater();
 }
 
 void TestShell::checkStartVars(NeovimQt::NeovimConnector* conn) noexcept

--- a/test/tst_shell.cpp
+++ b/test/tst_shell.cpp
@@ -79,6 +79,8 @@ void TestShell::startVarsShellWidget() noexcept
 	NeovimConnector* c{ cs.first };
 
 	checkStartVars(c);
+
+	cs.second->deleteLater();
 }
 
 void TestShell::startVarsMainWindow() noexcept
@@ -92,13 +94,16 @@ void TestShell::startVarsMainWindow() noexcept
 void TestShell::gviminit() noexcept
 {
 	qputenv("GVIMINIT", "let g:test_gviminit = 1");
-	NeovimConnector* c{ CreateShellWidget().first };
+	auto cs{ CreateShellWidget() };
+	NeovimConnector* c = cs.first;
 
 	MsgpackRequest* req{ c->api0()->vim_command_output(c->encode("echo g:test_gviminit")) };
 	QSignalSpy cmd{ req, &MsgpackRequest::finished };
 	QVERIFY(cmd.isValid());
 	QVERIFY(SPYWAIT(cmd));
 	QCOMPARE(cmd.at(0).at(2).toByteArray(), QByteArray("1"));
+
+	cs.second->deleteLater();
 }
 
 void TestShell::guiShimCommands() noexcept
@@ -150,6 +155,8 @@ void TestShell::guiShimCommands() noexcept
 	SPYWAIT(spy_fontchange2, 5000 /*msec*/);
 
 	QCOMPARE(w->shell()->fontDesc(), expectedFontBoldRemoved);
+
+	w->deleteLater();
 }
 
 void TestShell::CloseEvent_data() noexcept
@@ -209,6 +216,8 @@ void TestShell::CloseEvent() noexcept
 	int actual_exit_status{ p.exitCode() };
 
 	QCOMPARE(actual_exit_status, exit_status);
+
+	w->deleteLater();
 }
 
 void TestShell::GetClipboard_data() noexcept
@@ -247,6 +256,8 @@ void TestShell::GetClipboard() noexcept
 	QVERIFY(cmd_clip.isValid());
 	QVERIFY(SPYWAIT(cmd_clip));
 	QCOMPARE(cmd_clip.takeFirst().at(2), QVariant(register_data));
+
+	cw.second->deleteLater();
 }
 
 void TestShell::SetClipboard_data() noexcept
@@ -287,6 +298,8 @@ void TestShell::SetClipboard() noexcept
 	QVERIFY(SPYWAIT(spy_sync));
 
 	QGuiApplication::clipboard()->setText(register_data, GetClipboardMode(reg));
+
+	cw.second->deleteLater();
 }
 
 void TestShell::checkStartVars(NeovimQt::NeovimConnector* conn) noexcept

--- a/test/tst_shell.cpp
+++ b/test/tst_shell.cpp
@@ -64,8 +64,7 @@ void TestShell::benchStart() noexcept
 {
 	QBENCHMARK
 	{
-		auto cs{ CreateShellWidget() };
-		Shell* s{ cs.second };
+		Shell* s = CreateShellWidget();
 
 		QSignalSpy onResize(s, &Shell::neovimResized);
 		QVERIFY(onResize.isValid());
@@ -75,12 +74,11 @@ void TestShell::benchStart() noexcept
 
 void TestShell::startVarsShellWidget() noexcept
 {
-	auto cs{ CreateShellWidget() };
-	NeovimConnector* c{ cs.first };
+	auto s = CreateShellWidget();
 
-	checkStartVars(c);
+	checkStartVars(s->nvim());
 
-	cs.second->deleteLater();
+	s->deleteLater();
 }
 
 void TestShell::startVarsMainWindow() noexcept
@@ -94,8 +92,8 @@ void TestShell::startVarsMainWindow() noexcept
 void TestShell::gviminit() noexcept
 {
 	qputenv("GVIMINIT", "let g:test_gviminit = 1");
-	auto cs{ CreateShellWidget() };
-	NeovimConnector* c = cs.first;
+	auto s = CreateShellWidget();
+	NeovimConnector* c = s->nvim();
 
 	MsgpackRequest* req{ c->api0()->vim_command_output(c->encode("echo g:test_gviminit")) };
 	QSignalSpy cmd{ req, &MsgpackRequest::finished };
@@ -103,7 +101,7 @@ void TestShell::gviminit() noexcept
 	QVERIFY(SPYWAIT(cmd));
 	QCOMPARE(cmd.at(0).at(2).toByteArray(), QByteArray("1"));
 
-	cs.second->deleteLater();
+	s->deleteLater();
 }
 
 void TestShell::guiShimCommands() noexcept

--- a/test/tst_shell.cpp
+++ b/test/tst_shell.cpp
@@ -83,10 +83,8 @@ void TestShell::startVarsShellWidget() noexcept
 
 void TestShell::startVarsMainWindow() noexcept
 {
-	auto cw{ CreateMainWindow() };
-	NeovimConnector* c{ cw.first };
-
-	checkStartVars(c);
+	auto w = CreateMainWindow();
+	checkStartVars(w->shell()->nvim());
 }
 
 void TestShell::gviminit() noexcept

--- a/test/tst_shell.cpp
+++ b/test/tst_shell.cpp
@@ -104,9 +104,8 @@ void TestShell::gviminit() noexcept
 
 void TestShell::guiShimCommands() noexcept
 {
-	auto cw{ CreateMainWindowWithRuntime() };
-	NeovimConnector* c{ cw.first };
-	MainWindow* w{ cw.second };
+	auto w = CreateMainWindowWithRuntime();
+	auto c = w->shell()->nvim();
 
 	QObject::connect(c->neovimObject(), &NeovimApi1::err_vim_command_output, SignalPrintError);
 
@@ -176,9 +175,8 @@ void TestShell::CloseEvent_data() noexcept
 
 void TestShell::CloseEvent() noexcept
 {
-	auto cw{ CreateMainWindowWithRuntime() };
-	NeovimConnector* c{ cw.first };
-	MainWindow* w{ cw.second };
+	auto w = CreateMainWindowWithRuntime();
+	auto c = w->shell()->nvim();
 
 	QFETCH(int, msgpack_status);
 	QFETCH(int, exit_status);
@@ -234,8 +232,8 @@ void TestShell::GetClipboard_data() noexcept
 
 void TestShell::GetClipboard() noexcept
 {
-	auto cw{ CreateMainWindowWithRuntime() };
-	NeovimConnector* c{ cw.first };
+	auto w = CreateMainWindowWithRuntime();
+	NeovimConnector* c = w->shell()->nvim();
 
 	QFETCH(char, reg);
 	QFETCH(QByteArray, register_data);
@@ -253,7 +251,7 @@ void TestShell::GetClipboard() noexcept
 	QVERIFY(SPYWAIT(cmd_clip));
 	QCOMPARE(cmd_clip.takeFirst().at(2), QVariant(register_data));
 
-	cw.second->deleteLater();
+	w->deleteLater();
 }
 
 void TestShell::SetClipboard_data() noexcept
@@ -274,8 +272,8 @@ void TestShell::SetClipboard_data() noexcept
 
 void TestShell::SetClipboard() noexcept
 {
-	auto cw{ CreateMainWindowWithRuntime() };
-	NeovimConnector* c{ cw.first };
+	auto w = CreateMainWindowWithRuntime();
+	NeovimConnector* c = w->shell()->nvim();
 
 	QFETCH(char, reg);
 	QFETCH(QByteArray, register_data);
@@ -295,7 +293,7 @@ void TestShell::SetClipboard() noexcept
 
 	QGuiApplication::clipboard()->setText(register_data, GetClipboardMode(reg));
 
-	cw.second->deleteLater();
+	w->deleteLater();
 }
 
 void TestShell::checkStartVars(NeovimQt::NeovimConnector* conn) noexcept


### PR DESCRIPTION
Try to softly shutdown QProcess instances before allowing the QProcess destructor to SIGKILL.

- The major change are the calls to setparent that result in the underlying qprocess being removed by the destructor (killing the nvim process).
- For the GUI close event we first try to wait 500ms for the process to terminate (this may have to be tuned).
- Tests were adjusted to make this a bit easier to manage with a QSharedPointer, the main reason for this was the issues we see in windows with leftover process breaking CI.

There is still some flakyness in the tests, with occasional failures, but at least tests succeed more often now. No doubt that the root cause for races in tests is still present.

Given the issues we saw with CI, I have removed all github CI windows. Troubleshooting them was always hard and some tests systematically failed.
