### PR TITLE
Disconnect old QSCreen on show event

### DIFF
--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -1333,9 +1333,15 @@ void Shell::showEvent(QShowEvent* ev)
 
 	screenChanged();
 
+	if (m_window_handle) {
+		disconnect(m_window_handle, &QWindow::screenChanged, this, &Shell::screenChanged);
+		m_window_handle = nullptr;
+	}
+
 	auto win = this->window();
 	if (win) {
-		connect(win->windowHandle(), &QWindow::screenChanged, this, &Shell::screenChanged);
+		m_window_handle = win->windowHandle();
+		connect(m_window_handle, &QWindow::screenChanged, this, &Shell::screenChanged);
 	}
 }
 

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -237,6 +237,8 @@ private:
 	ShellOptions m_options;
 	PopupMenu m_pum{ this };
 	bool m_mouseEnabled{ true };
+
+	QWindow *m_window_handle{ nullptr };
 };
 
 class ShellRequestHandler: public QObject, public MsgpackRequestHandler


### PR DESCRIPTION
One additional fix to the earlier merge on the DPI issue.

I wont be able to test this for a few days, so if anyone can find a windows machine and confirm that this did not change the intended behaviour that would be great/