### PR TITLE
Release v0.2.18

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ endif (POLICY CMP0069)
 
 # Neovim-Qt Version, used by --version update before release
 # 9999 = Development Pre-Release
-project(neovim-qt VERSION 0.2.18.9999)
+project(neovim-qt VERSION 0.2.18.0)
 
 if(NOT EXISTS ${NEOVIM_EXEC})
 	set(NEOVIM_EXEC nvim)


### PR DESCRIPTION
Barring any problems this will be release v0.2.18

Here are the highlights:

- e8f3a51 HyperKey should be ignored
- 1640d9d Ability to disable GuiTabline buffers
- eeec0c3 Only set tooltip and icon if buffer has path
- cf83a00 Assume utf8 for nvim strings, remove QTextCodec
- 2b4cb87 Add error connection description to error message
- c6ae970 Fix finding msgpack 6+
- 81a3ca1 Support Qt6 builds
- 187d5ba Wait for neovim to terminate after close event
- e16ce98 Add missing setParent in neovimconnector/shell
- ecb3679 Disconnect old QScreen on show event
- 1538a1c Adjust font on DPI changes
- 77504d3 Add option to disable rendering of bold/italic

There is a staging build happening now for the staging tag. Following that we can merge and tag the release (ref https://github.com/equalsraf/neovim-qt/wiki/Release-Process).

