### PR TITLE
Discard resize if already resizing for same size

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -37,10 +37,10 @@ jobs:
 
           - name: MacOS_GCC
             flavor: Debug
-            runner: macos-11
+            runner: macos-12
             generator: Ninja
-            cc: gcc-10
-            cxx: g++-10
+            cc: gcc-11
+            cxx: g++-11
 
           - name: MacOS_Release
             flavor: Release

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -221,7 +221,7 @@ private:
 	/// Neovim mode descriptions from "mode_change", used by guicursor
 	QVariantList m_modeInfo;
 
-	bool m_resizing{ false };
+	QSize m_resizing;
 	QSize m_resize_neovim_pending;
 	QLabel* m_tooltip{ nullptr };
 	QPoint m_mouse_pos;


### PR DESCRIPTION
When resizeNeovim() is called we can defer the call for later, but we should never defer a resize if the target size is the same. Otherwise we can end up in a loop with Neovim issuing resize events.

ref #1090