### PR TITLE
cmake: set the minimum version to 3.9.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
-if (POLICY CMP0048)
-  cmake_policy(SET CMP0048 NEW)
-endif (POLICY CMP0048)
-if (POLICY CMP0069)
-  cmake_policy(SET CMP0069 NEW)
-endif (POLICY CMP0069)
-
+cmake_minimum_required(VERSION 3.9.0)
 # Neovim-Qt Version, used by --version update before release
 # 9999 = Development Pre-Release
 project(neovim-qt VERSION 0.2.18.0)

--- a/src/gui/shellwidget/CMakeLists.txt
+++ b/src/gui/shellwidget/CMakeLists.txt
@@ -1,7 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
-if (POLICY CMP0048)
-  cmake_policy(SET CMP0048 NEW)
-endif (POLICY CMP0048)
+cmake_minimum_required(VERSION 3.9.0)
 project(qshellwidget)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -1,9 +1,6 @@
 # This is a minimal CMake project to fetch and build third party
 # dependencies
-cmake_minimum_required(VERSION 2.8.12)
-if (POLICY CMP0048)
-  cmake_policy(SET CMP0048 NEW)
-endif (POLICY CMP0048)
+cmake_minimum_required(VERSION 3.9.0)
 project(neovim-qt-deps)
 
 #


### PR DESCRIPTION
Newer versions of cmake warn that support for cmake < 3.5 will be removed.

cmake 3.9.0 was released in 2017 and most distros have much newer versions available at this point.

Bump the minimum required version to 3.9.0 to silence deprecation warnings.