### PR TITLE
settings: store window geometry in ~/.config/nvim-qt/window_geometry.conf

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -311,7 +311,7 @@ Shell* MainWindow::shell()
 
 void MainWindow::saveWindowGeometry()
 {
-	QSettings settings{ "window-geometry" };
+	QSettings settings("nvim-qt", "window-geometry");
 	settings.setValue("window_geometry", saveGeometry());
 	settings.setValue("window_state", saveState());
 }
@@ -324,7 +324,7 @@ void MainWindow::restoreWindowGeometry()
 	qRegisterMetaTypeStreamOperators<QList<int>>("QList<int>");
 #endif
 
-	QSettings settings{ "window-geometry" };
+	QSettings settings("nvim-qt", "window-geometry");
 	restoreGeometry(settings.value("window_geometry").toByteArray());
 	restoreState(settings.value("window_state").toByteArray());
 }


### PR DESCRIPTION
The single-argument QSettings constructor sets the organization name. nvim-qt is passing "window-geometry" as the organization name, which results in QSettings using `~/.config/window-geometry.conf`. This is undesirable because the file is written to the root of `~/.config` without any indication about which application created or uses the file.

Set the organization name to "nvim-qt" when writing window geometry so that `~/.config/nvim-qt/window-geometry.conf` is used instead.