### PR TITLE
mainwindow: add an option to avoid restoring window geometry

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -312,7 +312,7 @@ Shell* MainWindow::shell()
 void MainWindow::saveWindowGeometry()
 {
 	QSettings settings("nvim-qt", "window-geometry");
-	bool restore_window_geometry = settings.value("restore_window_geometry", true).toBool();
+	const bool restore_window_geometry{ settings.value("restore_window_geometry", true).toBool() };
 	if (!restore_window_geometry) {
 		return;
 	}

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -312,6 +312,11 @@ Shell* MainWindow::shell()
 void MainWindow::saveWindowGeometry()
 {
 	QSettings settings("nvim-qt", "window-geometry");
+	bool restore_window_geometry = settings.value("restore_window_geometry", true).toBool();
+	if (!restore_window_geometry) {
+		return;
+	}
+	settings.setValue("restore_window_geometry", restore_window_geometry);
 	settings.setValue("window_geometry", saveGeometry());
 	settings.setValue("window_state", saveState());
 }
@@ -325,6 +330,9 @@ void MainWindow::restoreWindowGeometry()
 #endif
 
 	QSettings settings("nvim-qt", "window-geometry");
+	if (!settings.value("restore_window_geometry", true).toBool()) {
+		return;
+	}
 	restoreGeometry(settings.value("window_geometry").toByteArray());
 	restoreState(settings.value("window_state").toByteArray());
 }


### PR DESCRIPTION
Avoid restoring window geometry when `restore_window_geometry=false` in `~/.config/nvim-qt/window-geometry.conf`. Defaults to `true`.

Suggested-by: @damanis on github
Related-to: #997
Related-to: #1094