### PR TITLE
Avoid a flashing window blink during startup

### DIFF
--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -190,10 +190,12 @@ protected:
 
 private slots:
 	void setAttached(bool attached);
+	void ensureVisible() noexcept;
 
 private:
 	bool m_init_called{ false };
 	bool m_attached{ false };
+	bool m_shown{ false };
 	NeovimConnector* m_nvim{ nullptr };
 
 	QList<QUrl> m_deferredOpen;
@@ -231,6 +233,8 @@ private:
 	Qt::MouseButton m_mouseclick_pending;
 	// Accumulates remainder of steppy scroll
 	QPoint m_scrollDeltaRemainder;
+	// Ensures that the Shell widget is made visible
+	QTimer m_visibility_timer;
 
 	// Properties
 	bool m_neovimBusy{ false };


### PR DESCRIPTION
The very first paint events cause a bright flash of unstyled shell
content to appear before the configured colors are applied.

Defer displaying the shell widget until nvim sends us colors.

Instead of seeing the shell with its constructor-provided colors
we will instead see Qt's default window background color, which
follows the user's desktop theme and dark mode settings.
    
The shell becomes visible once nvim sends a color message
and the colors are applied.