### PR TITLE
Add support for X1Mouse X2Mouse buttons

### DIFF
--- a/src/gui/input.cpp
+++ b/src/gui/input.cpp
@@ -79,6 +79,12 @@ static QVariant GetButtonName(
 		case Qt::NoButton:
 			return QLatin1String{""};
 
+    case Qt::XButton1:
+			return QStringLiteral("X1");
+
+    case Qt::XButton2:
+			return QStringLiteral("X2");
+
 		default:
 			return {}; // Invalid
 	}


### PR DESCRIPTION
These buttons are usually mapped to Back and Forward. 
The help docs has this [example](https://neovim.io/doc/user/term.html#_using-the-mouse:~:text=%3Amap%20%3CX1Mouse%3E%20%3CC%2DO%3E%0A%3Amap%20%3CX2Mouse%3E%20%3CC%2DI%3E):
```vim
:map <X1Mouse> <C-O>
:map <X2Mouse> <C-I>
```
