### PR TITLE
Update GitHub Actions upload-artifact to v4

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -120,7 +120,7 @@ jobs:
 
       - name: Upload Artifacts
         if: ${{ matrix.publish }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.name }}
           if-no-files-found: ignore

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Upload Artifacts
         if: fromJSON(env.changes_detected)
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ClangFormat Patch
           path: clang_format.patch

--- a/.github/workflows/neovim-api.yml
+++ b/.github/workflows/neovim-api.yml
@@ -70,7 +70,7 @@ jobs:
           python ${{ env.GEN_CMD }} ${{ env.NVIM_EXE }} ${{ env.OUTPUT }}
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Neovim API ${{ matrix.version}} Bindings
           path: |
@@ -119,7 +119,7 @@ jobs:
           Expand-Archive -Path nvim-win64.zip -DestinationPath ${{ github.workspace }}\build\
 
       - name: Install Dependencies
-        run:
+        run: |
           pip install jinja2 msgpack
           choco install dos2unix
 
@@ -135,7 +135,7 @@ jobs:
           dos2unix src/auto/neovimapi${{ matrix.version }}.h
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Neovim API ${{ matrix.version}} Bindings
           path: |


### PR DESCRIPTION
The version of upload-artifact we're currently using is deprecated: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/

We should bump to the latest version.