### PR TITLE
Fix building the tests with clang

### DIFF
--- a/test/common_gui.cpp
+++ b/test/common_gui.cpp
@@ -29,7 +29,7 @@ template<class T> static void ValidateNeovimConnection(T* obj) noexcept
 	const bool signalEmitted{ onAttached.wait() };
 	Q_ASSERT(signalEmitted);
 
-	const int signalCount{ onAttached.count() };
+	const qsizetype signalCount{ onAttached.count() };
 	Q_ASSERT(signalCount == 1);
 
 	Q_ASSERT(obj->isNeovimAttached());


### PR DESCRIPTION
Clang (I only tested with versions >= 18) complains about narrowing from long long int (qsizetype) to int on my platform. gcc accepts it, but issues a warning. So just use qsizetype instead of int as type of the variable as well.