### PR TITLE
Fix Qt6 deprecation warnings

### DIFF
--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -473,7 +473,11 @@ void App::openNewWindow(const QVariantList& args) noexcept
 	QString server;
 	QString nvim{ "nvim" };
 	ConnectorInitArgs::Type type{ ConnectorInitArgs::Type::Default };
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
 	if (args.size() > 1 && args.at(1).type() == QVariant::Type::Map) {
+#else
+	if (args.size() > 1 && args.at(1).metaType().id() == QMetaType::QVariantMap) {
+#endif
 		const QVariantMap initMap{ args.at(1).toMap() };
 
 		if (initMap.contains("nvim")) {

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -454,7 +454,11 @@ void Shell::handleHighlightSet(const QVariantMap& attrs)
 /// Paint a character and advance the cursor
 void Shell::handlePut(const QVariantList& args)
 {
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
 	if (args.size() != 1 || (QMetaType::Type)args.at(0).type() != QMetaType::QByteArray) {
+#else
+	if (args.size() != 1 || args.at(0).metaType().id() != QMetaType::QByteArray) {
+#endif
 		qWarning() << "Unexpected arguments for redraw:put" << args;
 		return;
 	}
@@ -582,7 +586,11 @@ void Shell::handleRedraw(const QByteArray& name, const QVariantList& opargs)
 		// setNeovimCursor will cause typing lags
 		qApp->inputMethod()->update(Qt::ImCursorRectangle);
 	} else if (name == "highlight_set") {
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
 		if (opargs.size() < 1 && (QMetaType::Type)opargs.at(0).type() != QMetaType::QVariantMap) {
+#else
+		if (opargs.size() < 1 && opargs.at(0).metaType().id() != QMetaType::QVariantMap) {
+#endif
 			qWarning() << "Unexpected argument for redraw:" << name << opargs;
 			return;
 		}
@@ -652,7 +660,11 @@ void Shell::handlePopupMenuShow(const QVariantList& opargs)
 	// The 'popupmenu_show' API is not consistent across NeoVim versions!
 	// A 5th argument was introduced in neovim/neovim@16c3337
 	if (opargs.size() < 4
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
 		|| static_cast<QMetaType::Type>(opargs.at(0).type()) != QMetaType::QVariantList
+#else
+		|| opargs.at(0).metaType().id() != QMetaType::QVariantList
+#endif
 		|| !opargs.at(1).canConvert<int64_t>()
 		|| !opargs.at(2).canConvert<int64_t>()
 		|| !opargs.at(3).canConvert<int64_t>()) {
@@ -810,7 +822,12 @@ void Shell::handleModeInfoSet(const QVariantList& opargs)
 {
 	if (opargs.size() < 2
 		|| !opargs.at(0).canConvert<bool>()
-		|| static_cast<QMetaType::Type>(opargs.at(1).type()) != QMetaType::QVariantList) {
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
+		|| static_cast<QMetaType::Type>(opargs.at(1).type()) != QMetaType::QVariantList
+#else
+		|| opargs.at(1).metaType().id() != QMetaType::QVariantList
+#endif
+			) {
 		qWarning() << "Unexpected arguments for mode_info_set:" << opargs;
 		return;
 	}
@@ -1158,8 +1175,14 @@ void Shell::handleHighlightAttributeDefine(const QVariantList& opargs)
 {
 	if (opargs.size() < 4
 		|| !opargs.at(0).canConvert<qint64>()
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
 		|| static_cast<QMetaType::Type>(opargs.at(1).type()) != QMetaType::QVariantMap
-		|| static_cast<QMetaType::Type>(opargs.at(2).type()) != QMetaType::QVariantMap) {
+		|| static_cast<QMetaType::Type>(opargs.at(2).type()) != QMetaType::QVariantMap
+#else
+		|| opargs.at(1).metaType().id() != QMetaType::QVariantMap
+		|| opargs.at(2).metaType().id() != QMetaType::QVariantMap
+#endif
+			) {
 		qWarning() << "Unexpected arguments for hl_attr_define:" << opargs;
 		return;
 	}
@@ -1177,7 +1200,11 @@ void Shell::handleHighlightAttributeDefine(const QVariantList& opargs)
 void Shell::handleHighlightGroupSet(const QVariantList& opargs) noexcept
 {
 	if (opargs.size() < 2
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
 		|| opargs.at(0).type() != QVariant::Type::ByteArray
+#else
+		|| opargs.at(0).metaType().id() != QMetaType::QByteArray
+#endif
 		|| !opargs.at(1).canConvert<uint64_t>()) {
 		qWarning() << "Unexpected arguments for hl_group_set:" << opargs;
 		return;
@@ -1195,7 +1222,12 @@ void Shell::handleGridLine(const QVariantList& opargs)
 		|| !opargs.at(0).canConvert<qint64>()
 		|| !opargs.at(1).canConvert<qint64>()
 		|| !opargs.at(2).canConvert<qint64>()
-		|| static_cast<QMetaType::Type>(opargs.at(3).type()) != QMetaType::QVariantList) {
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
+		|| static_cast<QMetaType::Type>(opargs.at(3).type()) != QMetaType::QVariantList
+#else
+		|| opargs.at(3).metaType().id() != QMetaType::QVariantList
+#endif
+			) {
 		qWarning() << "Unexpected arguments for grid_line:" << opargs;
 		return;
 	}
@@ -1411,8 +1443,14 @@ void Shell::neovimMouseEvent(QMouseEvent *ev)
 		return;
 	}
 
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
 	QPoint pos(ev->x()/cellSize().width(),
 			ev->y()/cellSize().height());
+#else
+	QPointF eventPos = ev->position();
+	QPoint pos(eventPos.x()/cellSize().width(),
+			eventPos.y()/cellSize().height());
+#endif
 	QString inp;
 	if (ev->type() == QEvent::MouseMove) {
 		Qt::MouseButton bt;
@@ -1476,8 +1514,14 @@ void Shell::mouseMoveEvent(QMouseEvent *ev)
 {
 	setCursorFromBusyState();
 
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
 	QPoint pos(ev->x()/cellSize().width(),
 			ev->y()/cellSize().height());
+#else
+	QPointF eventPos = ev->position();
+	QPoint pos(eventPos.x()/cellSize().width(),
+			eventPos.y()/cellSize().height());
+#endif
 	if (pos != m_mouse_pos) {
 		m_mouse_pos = pos;
 		mouseClickReset();

--- a/src/gui/shellwidget/helpers.cpp
+++ b/src/gui/shellwidget/helpers.cpp
@@ -54,7 +54,11 @@ bool saveShellContents(const ShellContents& s, const QString& filename)
 			if (cell.GetBackgroundColor().isValid()) {
 				p.fillRect(r, cell.GetBackgroundColor());
 			}
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
 			const uint character{ cell.GetCharacter() };
+#else
+			const char32_t character{ static_cast<char32_t>(cell.GetCharacter()) };
+#endif
 			p.drawText(r, QString::fromUcs4(&character, 1));
 		}
 	}

--- a/src/gui/shellwidget/shellwidget.cpp
+++ b/src/gui/shellwidget/shellwidget.cpp
@@ -432,7 +432,11 @@ void ShellWidget::paintForegroundCellText(
 	// Draw chars at the baseline
 	const int cellTextOffset{ m_ascent + (m_lineSpace / 2) };
 	const QPoint pos{ cellRect.left(), cellRect.top() + cellTextOffset};
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
 	const uint character{ cell.GetCharacter() };
+#else
+	const char32_t character{ static_cast<char32_t>(cell.GetCharacter()) };
+#endif
 	const QString text{ QString::fromUcs4(&character, 1) };
 
 	p.drawText(pos, text);
@@ -712,7 +716,11 @@ void ShellWidget::paintRectLigatures(QPainter& p, const QRect rect) noexcept
 					blockCursorPos = blockText.size();
 				}
 
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
 				const uint cellCharacter{ checkCell.GetCharacter() };
+#else
+				const char32_t cellCharacter{ static_cast<char32_t>(checkCell.GetCharacter()) };
+#endif
 				blockText += QString::fromUcs4(&cellCharacter, 1);
 
 				if (checkCell.IsDoubleWidth()) {
@@ -1035,7 +1043,11 @@ QVariant ShellWidget::TryGetQFontFromDescription(const QString& fdesc) const noe
 	qreal pointSizeF = curFont.pointSizeF();
 	int weight = -1;
 	bool italic = false;
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
 	for (const auto& attr : qAsConst(attrs)) {
+#else
+	for (const auto& attr : std::as_const(attrs)) {
+#endif
 		if (attr.size() >= 2 && attr[0] == 'h') {
 			bool ok{ false };
 			qreal height = midString(attr, 1).toFloat(&ok);
@@ -1071,7 +1083,11 @@ QVariant ShellWidget::TryGetQFontFromDescription(const QString& fdesc) const noe
 
 /*static*/ bool ShellWidget::IsValidFont(const QVariant& variant) noexcept
 {
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
 	return static_cast<QMetaType::Type>(variant.type()) == QMetaType::QFont;
+#else
+	return variant.metaType().id() == QMetaType::QFont;
+#endif
 }
 
 /*static*/ bool ShellWidget::isBadMonospace(const QFont& f) noexcept

--- a/src/gui/tabline.cpp
+++ b/src/gui/tabline.cpp
@@ -163,7 +163,11 @@ static std::vector<Tab> ParseTablineVariant(const QVariantList tabs) noexcept
 	std::vector<Tab> tabList;
 
 	for (const auto& varTab : tabs) {
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
 		if (static_cast<QMetaType::Type>(varTab.type()) != QMetaType::QVariantMap) {
+#else
+		if (varTab.metaType().id() != QMetaType::QVariantMap) {
+#endif
 			qWarning() << "Unexpected varTab value in tabline_update:" << varTab;
 			continue;
 		}
@@ -187,7 +191,12 @@ static std::vector<Tab> ParseTablineVariant(const QVariantList tabs) noexcept
 void Tabline::handleTablineUpdate(const QVariantList& args) noexcept
 {
 	if (args.size() < 2 || !args.at(0).canConvert<uint64_t>()
-		|| static_cast<QMetaType::Type>(args.at(1).type()) != QMetaType::QVariantList) {
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
+		|| static_cast<QMetaType::Type>(args.at(1).type()) != QMetaType::QVariantList
+#else
+		|| args.at(1).metaType().id() != QMetaType::QVariantList
+#endif
+			) {
 		qWarning() << "Unexpected argument for tabline_update:" << args;
 		return;
 	}
@@ -203,7 +212,12 @@ void Tabline::handleTablineUpdate(const QVariantList& args) noexcept
 	}
 
 	if (!args.at(2).canConvert<uint64_t>()
-		|| static_cast<QMetaType::Type>(args.at(3).type()) != QMetaType::QVariantList) {
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
+		|| static_cast<QMetaType::Type>(args.at(3).type()) != QMetaType::QVariantList
+#else
+		|| args.at(3).metaType().id() != QMetaType::QVariantList
+#endif
+			) {
 		qWarning() << "Unexpected argument for tabline_update:" << args;
 		return;
 	}
@@ -468,7 +482,11 @@ static QString GetSanitizedErrorString(const QVariant& err) noexcept
 		"No write since last change!\nPlease save and try again."
 	};
 
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
 	if (err.type() != QVariant::Type::List) {
+#else
+	if (err.metaType().id() != QMetaType::QVariantList) {
+#endif
 		return s_errorUnknown;
 	}
 

--- a/src/msgpackiodevice.cpp
+++ b/src/msgpackiodevice.cpp
@@ -401,8 +401,13 @@ void MsgpackIODevice::dispatchNotification(msgpack_object& nt)
 	}
 
 	QVariant val; 
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
 	if (decodeMsgpack(nt.via.array.ptr[2], val) ||
 			(QMetaType::Type)val.type() != QMetaType::QVariantList  ) {
+#else
+	if (decodeMsgpack(nt.via.array.ptr[2], val) ||
+			val.metaType().id() != QMetaType::QVariantList  ) {
+#endif
 		qDebug() << "Unable to unpack notification parameters" << nt;
 		return;
 	}
@@ -731,11 +736,19 @@ void MsgpackIODevice::send(const QVariant& var)
 {
 	if (!checkVariant(var)) {
 		msgpack_pack_nil(&m_pk);
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
 		qWarning() << "Trying to pack unsupported variant type" << var.type() << "packing Nil instead";
+#else
+		qWarning() << "Trying to pack unsupported variant type" << var.metaType().id() << "packing Nil instead";
+#endif
 		return;
 	}
 
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
 	switch((QMetaType::Type)var.type()) {
+#else
+	switch(var.metaType().id()) {
+#endif
 	case QMetaType::Void:
 	case QMetaType::UnknownType:
 		msgpack_pack_nil(&m_pk);
@@ -805,7 +818,11 @@ void MsgpackIODevice::send(const QVariant& var)
 		break;
 	default:
 		msgpack_pack_nil(&m_pk);
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
 		qWarning() << "There is a BUG in the QVariant serializer" << var.type();
+#else
+		qWarning() << "There is a BUG in the QVariant serializer" << var.metaType().id();
+#endif
 	}
 }
 
@@ -843,7 +860,11 @@ fail:
  */
 bool MsgpackIODevice::checkVariant(const QVariant& var)
 {
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
 	switch((QMetaType::Type)var.type()) {
+#else
+	switch(var.metaType().id()) {
+#endif
 	case QMetaType::UnknownType:
 		break;
 	case QMetaType::Bool:

--- a/src/util.h
+++ b/src/util.h
@@ -17,8 +17,13 @@ template <class T>
 bool decode(const QVariant& in, QList<T>& out)
 {
 	out.clear();
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
 	if ((QMetaType::Type)in.type() != QMetaType::QVariantList) {
 		qWarning() << "Attempting to decode as QList<...> when type is" << in.type() << in;
+#else
+	if (in.metaType().id() != QMetaType::QVariantList) {
+		qWarning() << "Attempting to decode as QList<...> when type is" << in.metaType().id() << in;
+#endif
 		return true;
 	}
 	foreach(const QVariant val, in.toList()) {


### PR DESCRIPTION
These changes fix the deprecation warnings generated during a build against Qt6. Most of these are due to the deprecation of QVariant::type(), but I also addressed the deprecation of QString::fromUcs4(uint*,) and qAsConst().

This is my first pull request for this project, please let me know if any changes need to be made.