### PR TITLE
Support font lists in guifont options

### DIFF
--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -119,6 +119,52 @@ void Shell::handleFontError(const QString& msg)
 	}
 }
 
+QStringList Shell::splitFontList(const QString& value) noexcept
+{
+	QStringList fonts;
+	QString font;
+	bool escaped{ false };
+	bool skipSpaces{ false };
+
+	for (const QChar character : value) {
+		if (skipSpaces && character == ' ') {
+			continue;
+		}
+		skipSpaces = false;
+
+		if (escaped) {
+			if (character != ',' && character != '\\') {
+				font.append('\\');
+			}
+			font.append(character);
+			escaped = false;
+		}
+		else if (character == '\\') {
+			escaped = true;
+		}
+		else if (character == ',') {
+			fonts.append(font);
+			font.clear();
+			skipSpaces = true;
+		}
+		else {
+			font.append(character);
+		}
+	}
+
+	if (escaped) {
+		font.append('\\');
+	}
+	fonts.append(font);
+
+	return fonts;
+}
+
+QString Shell::escapeFontListEntry(QString value) noexcept
+{
+	return value.replace('\\', QStringLiteral("\\\\")).replace(',', QStringLiteral("\\,"));
+}
+
 /// Set the GUI font, or display the current font
 ///
 /// @param fdesc Neovim font description string, "Fira Code:h11".
@@ -155,8 +201,9 @@ bool Shell::setGuiFont(
 		QVariant varFont{ TryGetQFontFromDescription(fdesc) };
 
 		if (!ShellWidget::IsValidFont(varFont)) {
-			m_nvim->api0()->vim_report_error(
-				m_nvim->encode(varFont.toString()));
+			if (!opts.testFlag(FontOption::Quiet)) {
+				emit fontError(varFont.toString());
+			}
 			return false;
 		}
 
@@ -167,7 +214,7 @@ bool Shell::setGuiFont(
 
 	// Only update the ShellWidget when font changes.
 	if (!m_attached) {
-		return false;
+		return true;
 	}
 
 	// The font has changed (track a logical timestamp):
@@ -177,7 +224,7 @@ bool Shell::setGuiFont(
 	//  3) Update font variables (as necessary).
 	resizeNeovim(size());
 	writeGuiFontQSettings();
-	updateGuiFontRegisters();
+	updateGuiFontRegisters(isGuiDialogRequest ? FontChangeSource::Internal : src);
 
 
 	return true;
@@ -201,24 +248,29 @@ bool Shell::setGuiFontWide(const QString& fdesc) noexcept
 		return true;
 	}
 
-	const QStringList fdescList{ fdesc.split(",") };
+	const QStringList fdescList{ splitFontList(fdesc) };
 	if (fdescList.size() < 1) {
 		return false;
 	}
 
 	std::vector<QFont> fontList;
 	fontList.reserve(fdescList.size());
+	QString lastError;
 
 	for (const auto& strFont : fdescList) {
 		QVariant varFont{ TryGetQFontFromDescription(strFont) };
 
 		if (!ShellWidget::IsValidFont(varFont)) {
-			m_nvim->api0()->vim_report_error(
-				m_nvim->encode(varFont.toString()));
-			return false;
+			lastError = varFont.toString();
+			continue;
 		}
 
 		fontList.push_back(qvariant_cast<QFont>(varFont));
+	}
+
+	if (fontList.empty()) {
+		emit fontError(lastError);
+		return false;
 	}
 
 	m_guifontwidelist = std::move(fontList);
@@ -226,7 +278,7 @@ bool Shell::setGuiFontWide(const QString& fdesc) noexcept
 	return true;
 }
 
-void Shell::updateGuiFontRegisters() noexcept
+void Shell::updateGuiFontRegisters(FontChangeSource src) noexcept
 {
 	if (!m_attached || !m_nvim || !m_nvim->api0()) {
 		return;
@@ -240,8 +292,12 @@ void Shell::updateGuiFontRegisters() noexcept
 	connect(getOption,
 		&MsgpackRequest::finished,
 		this,
-		[this, timestamp](quint32 msg, quint64 _f, const QVariant& val) noexcept
+		[this, timestamp, src](quint32 msg, quint64 _f, const QVariant& val) noexcept
 		{
+			if (src == FontChangeSource::NvimOption) {
+				return;
+			}
+
 			if (timestamp != this->m_font_timestamp) {
 				// The font changed since the call
 				qDebug() << "Ignoring guifont option update - timestamp changed";
@@ -249,7 +305,7 @@ void Shell::updateGuiFontRegisters() noexcept
 			}
 
 			const QString oldFont{ val.toString() };
-			const QString newFont{ fontDesc() };
+			const QString newFont{ escapeFontListEntry(fontDesc()) };
 			if (newFont.compare(oldFont, Qt::CaseInsensitive) == 0) {
 				return;
 			}
@@ -992,11 +1048,16 @@ void Shell::handleSetOption(const QVariantList& opargs)
 	const QVariant& value{ opargs.at(1) };
 
 	if (name == "guifont") {
-		// TODO value needs to be parsed properly according to 'guifont' option
-		// here just split non escaped commas to get the last entry.
-		static const QRegularExpression s_fontSplit = QRegularExpression(R"(,(?<!\\))");
-		auto values = value.toString().split(s_fontSplit);
-		setGuiFont(values.last(), FontOption::Force, FontChangeSource::NvimOption, false /*reset*/);
+		const QStringList values{ splitFontList(value.toString()) };
+		for (qsizetype i = 0; i < values.size(); i++) {
+			auto opts = FontOptions{ FontOption::Force };
+			opts.setFlag(FontOption::Quiet, i + 1 < values.size());
+
+			if (values.at(i).compare(fontDesc(), Qt::CaseInsensitive) == 0
+				|| setGuiFont(values.at(i), opts, FontChangeSource::NvimOption, false)) {
+				break;
+			}
+		}
 	} else if (name == "guifontwide") {
 		handleGuiFontWide(value);
 	} else if (name == "linespace") {

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -214,7 +214,7 @@ bool Shell::setGuiFont(
 
 	// Only update the ShellWidget when font changes.
 	if (!m_attached) {
-		return true;
+		return false;
 	}
 
 	// The font has changed (track a logical timestamp):
@@ -224,7 +224,7 @@ bool Shell::setGuiFont(
 	//  3) Update font variables (as necessary).
 	resizeNeovim(size());
 	writeGuiFontQSettings();
-	updateGuiFontRegisters(isGuiDialogRequest ? FontChangeSource::Internal : src);
+	updateGuiFontRegisters();
 
 
 	return true;
@@ -278,7 +278,7 @@ bool Shell::setGuiFontWide(const QString& fdesc) noexcept
 	return true;
 }
 
-void Shell::updateGuiFontRegisters(FontChangeSource src) noexcept
+void Shell::updateGuiFontRegisters() noexcept
 {
 	if (!m_attached || !m_nvim || !m_nvim->api0()) {
 		return;
@@ -292,12 +292,8 @@ void Shell::updateGuiFontRegisters(FontChangeSource src) noexcept
 	connect(getOption,
 		&MsgpackRequest::finished,
 		this,
-		[this, timestamp, src](quint32 msg, quint64 _f, const QVariant& val) noexcept
+		[this, timestamp](quint32 msg, quint64 _f, const QVariant& val) noexcept
 		{
-			if (src == FontChangeSource::NvimOption) {
-				return;
-			}
-
 			if (timestamp != this->m_font_timestamp) {
 				// The font changed since the call
 				qDebug() << "Ignoring guifont option update - timestamp changed";
@@ -1053,8 +1049,12 @@ void Shell::handleSetOption(const QVariantList& opargs)
 			auto opts = FontOptions{ FontOption::Force };
 			opts.setFlag(FontOption::Quiet, i + 1 < values.size());
 
-			if (values.at(i).compare(fontDesc(), Qt::CaseInsensitive) == 0
-				|| setGuiFont(values.at(i), opts, FontChangeSource::NvimOption, false)) {
+			if (values.at(i).compare(fontDesc(), Qt::CaseInsensitive) == 0) {
+				break;
+			}
+
+			if (setGuiFont(values.at(i), opts, FontChangeSource::NvimOption, false)
+				|| values.at(i).compare(fontDesc(), Qt::CaseInsensitive) == 0) {
 				break;
 			}
 		}

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -199,7 +199,7 @@ protected:
 	void setCursorFromBusyState() noexcept;
 
 	// GuiFont
-	void updateGuiFontRegisters(FontChangeSource src = FontChangeSource::Internal) noexcept;
+	void updateGuiFontRegisters() noexcept;
 	void writeGuiFontQSettings() noexcept;
 	void handleGuiFontOption(quint32 msgid, quint64 fun, const QVariant& val) noexcept;
 	void handleGuiFontVariable(quint32 msgid, quint64 fun, const QVariant& val) noexcept;

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -5,6 +5,7 @@
 #include <QList>
 #include <QMap>
 #include <QMenu>
+#include <QStringList>
 #include <QTimer>
 #include <QUrl>
 #include <QVariantList>
@@ -172,6 +173,8 @@ protected:
 	virtual void handleWindowFrameless(const QVariant& value) noexcept;
 	virtual void handleCloseEvent(const QVariantList &args) noexcept;
 	virtual void handleGuiPopupmenu(const QVariant& value) noexcept;
+	static QStringList splitFontList(const QString& value) noexcept;
+	static QString escapeFontListEntry(QString value) noexcept;
 
 	// Modern 'ext_linegrid' Grid UI Events
 	virtual void handleGridResize(const QVariantList& opargs);
@@ -196,7 +199,7 @@ protected:
 	void setCursorFromBusyState() noexcept;
 
 	// GuiFont
-	void updateGuiFontRegisters() noexcept;
+	void updateGuiFontRegisters(FontChangeSource src = FontChangeSource::Internal) noexcept;
 	void writeGuiFontQSettings() noexcept;
 	void handleGuiFontOption(quint32 msgid, quint64 fun, const QVariant& val) noexcept;
 	void handleGuiFontVariable(quint32 msgid, quint64 fun, const QVariant& val) noexcept;

--- a/src/gui/shellwidget/shellwidget.cpp
+++ b/src/gui/shellwidget/shellwidget.cpp
@@ -65,14 +65,18 @@ bool ShellWidget::setShellFont(const QFont& font, FontOptions opts) noexcept
 
 	QFontInfo fi(font);
 	if (fi.family().compare(font.family(), Qt::CaseInsensitive) != 0
-		&& font.family().compare("Monospace", Qt::CaseInsensitive) != 0 && !quiet) {
-		emit fontError(QStringLiteral("Unknown font: %1").arg(font.family()));
+		&& font.family().compare("Monospace", Qt::CaseInsensitive) != 0) {
+		if (!quiet) {
+			emit fontError(QStringLiteral("Unknown font: %1").arg(font.family()));
+		}
 		return false;
 	}
 
 	if (!force) {
-		if (!fi.fixedPitch() && !quiet) {
-			emit fontError(QStringLiteral("%1 is not a fixed pitch font").arg(font.family()));
+		if (!fi.fixedPitch()) {
+			if (!quiet) {
+				emit fontError(QStringLiteral("%1 is not a fixed pitch font").arg(font.family()));
+			}
 			return false;
 		}
 
@@ -1056,6 +1060,7 @@ QVariant ShellWidget::TryGetQFontFromDescription(const QString& fdesc) const noe
 	}
 
 	QFont font{ attrs.at(0), -1 /*pointSize*/, weight, italic };
+	font.setFamilies({ attrs.at(0) });
 
 	font.setPointSizeF(pointSizeF);
 	font.setStyleHint(

--- a/src/gui/shellwidget/shellwidget.h
+++ b/src/gui/shellwidget/shellwidget.h
@@ -30,9 +30,9 @@ public:
 	enum FontOption
 	{
 		/// Override monospace font check
-		Force,
+		Force = 0x1,
 		/// Do not emit errors for errorss
-		Quiet,
+		Quiet = 0x2,
 	};
 	Q_ENUM(FontOption);
 	Q_DECLARE_FLAGS(FontOptions, FontOption)

--- a/src/gui/shellwidget/test/test_shellwidget.cpp
+++ b/src/gui/shellwidget/test/test_shellwidget.cpp
@@ -14,6 +14,7 @@ private slots:
 	void clearRegion();
 	void fontDescriptionFromQFont();
 	void fontDescriptionToQFont();
+	void quietFontErrors();
 };
 
 
@@ -79,6 +80,13 @@ void Test::fontDescriptionToQFont()
 	QVERIFY(ValidateQFont(
 		ShellWidget::TryGetQFontFromDescription(QString{ "%1:h11" }.arg(fontFamily), defaultFont),
 		fontFamily, 11, QFont::Weight::Normal, false /*italic*/));
+	QVERIFY(ValidateQFont(
+		ShellWidget::TryGetQFontFromDescription(QString{ "Font, Name:h12" }, defaultFont),
+		"Font, Name",
+		12,
+		QFont::Weight::Normal,
+		false));
+
 
 	QVERIFY(ValidateQFont(
 		ShellWidget::TryGetQFontFromDescription(QString{ "%1:h12:l" }.arg(fontFamily), defaultFont),
@@ -124,6 +132,19 @@ void Test::fontDescriptionToQFont()
 
 	QVERIFY(!ShellWidget::IsValidFont(varInvalidNegativeHeight));
 	QCOMPARE(varInvalidHeight, QVariant{ QString{ "Invalid font height" } });
+}
+
+void Test::quietFontErrors()
+{
+	ShellWidget widget;
+	QSignalSpy fontError{ &widget, &ShellWidget::fontError };
+	QSignalSpy fontChanged{ &widget, &ShellWidget::shellFontChanged };
+	QFont missingFont{ QStringLiteral("Neovim Qt Missing Font") };
+
+	QVERIFY(!widget.setShellFont(
+		missingFont, ShellWidget::FontOption::Force | ShellWidget::FontOption::Quiet));
+	QCOMPARE(fontError.count(), 0);
+	QCOMPARE(fontChanged.count(), 0);
 }
 
 QTEST_MAIN(Test)

--- a/test/tst_shell.cpp
+++ b/test/tst_shell.cpp
@@ -18,6 +18,24 @@ Q_IMPORT_PLUGIN (QWindowsIntegrationPlugin);
 
 namespace NeovimQt {
 
+class FontListTestShell : public Shell
+{
+public:
+	QStringList wideFontFamilies() const
+	{
+		QStringList families;
+		for (const auto& font : m_guifontwidelist) {
+			families.append(font.family());
+		}
+		return families;
+	}
+
+	using Shell::escapeFontListEntry;
+	using Shell::handleSetOption;
+	using Shell::Shell;
+	using Shell::splitFontList;
+};
+
 class TestShell : public QObject
 {
 	Q_OBJECT
@@ -29,6 +47,7 @@ private slots:
 	void startVarsMainWindow() noexcept;
 	void gviminit() noexcept;
 	void guiShimCommands() noexcept;
+	void fontDescriptionList() noexcept;
 	void CloseEvent_data() noexcept;
 	void CloseEvent() noexcept;
 	void GetClipboard_data() noexcept;
@@ -175,6 +194,50 @@ void TestShell::guiShimCommands() noexcept
 	QVERIFY2(SPYWAIT(spy_fontattr_change2), "Waiting for renderFontAttrChanged");
 	QCOMPARE(w->shell()->renderFontAttr(), true);
 
+}
+
+void TestShell::fontDescriptionList() noexcept
+{
+	const QString defaultFonts{ QStringLiteral(
+		"Source Code Pro,DejaVu Sans Mono,Courier New,monospace") };
+	QCOMPARE(FontListTestShell::splitFontList(defaultFonts),
+		QStringList({ "Source Code Pro", "DejaVu Sans Mono", "Courier New", "monospace" }));
+	QCOMPARE(FontListTestShell::splitFontList(QStringLiteral("Font One,  Font Two")),
+		QStringList({ "Font One", "Font Two" }));
+	QCOMPARE(FontListTestShell::splitFontList(QStringLiteral(R"(Font\, Name,monospace)")),
+		QStringList({ "Font, Name", "monospace" }));
+	QCOMPARE(FontListTestShell::splitFontList(QStringLiteral(R"(Font\\,monospace)")),
+		QStringList({ R"(Font\)", "monospace" }));
+	QCOMPARE(FontListTestShell::splitFontList(QStringLiteral(R"(Font\ Name,monospace)")),
+		QStringList({ R"(Font\ Name)", "monospace" }));
+	const QString escapedFamily{ QStringLiteral(R"(Font\ Name, Alternate)") };
+	QCOMPARE(
+		FontListTestShell::splitFontList(FontListTestShell::escapeFontListEntry(escapedFamily)),
+		QStringList{ escapedFamily });
+
+	auto socket = new QLocalSocket;
+	auto connector = new NeovimConnector{ socket };
+	socket->setParent(connector);
+	FontListTestShell shell{ connector };
+	QSignalSpy fontError{ &shell, &ShellWidget::fontError };
+
+	QVERIFY(shell.setGuiFontWide(QStringLiteral(R"(Font\, Name, monospace)")));
+	QCOMPARE(shell.wideFontFamilies(), QStringList({ "Font, Name", "monospace" }));
+	QVERIFY(shell.setGuiFontWide(QStringLiteral(R"(Missing:ha, Font\, Name)")));
+	QCOMPARE(shell.wideFontFamilies(), QStringList({ "Font, Name" }));
+	QCOMPARE(fontError.count(), 0);
+	QVERIFY(!shell.setGuiFontWide(QStringLiteral("Missing:ha, Also Missing:hb")));
+	QCOMPARE(fontError.count(), 1);
+
+	fontError.clear();
+	shell.handleSetOption({ QStringLiteral("guifont"),
+		QStringLiteral("Neovim Qt Missing Font,DejaVu Sans Mono:h13,monospace:h14") });
+	QCOMPARE(shell.fontDesc(), QStringLiteral("DejaVu Sans Mono:h13"));
+	QCOMPARE(fontError.count(), 0);
+
+	shell.handleSetOption({ QStringLiteral("guifont"),
+		QStringLiteral("Neovim Qt Missing One,Neovim Qt Missing Two") });
+	QCOMPARE(fontError.count(), 1);
 }
 
 void TestShell::CloseEvent_data() noexcept


### PR DESCRIPTION
Parse `guifont` and `guifontwide` as font lists instead of a single description. This tries each entry in order, handles escaped commas, and only reports an error if none work.

When a fallback is selected, the option is updated to the font that was actually applied.

Tests:
- `test_shellwidget`
- `tst_shell fontDescriptionList`

Closes #1168
