### PR TITLE
bindings generator fixes

### DIFF
--- a/bindings/generate_bindings.py
+++ b/bindings/generate_bindings.py
@@ -46,7 +46,7 @@ def generate_file(name, outfile, **kw):
     with open(outfile, 'w') as fp:
         fp.write(template.render(kw))
 
-ARRAY_OF = re.compile('ArrayOf\(\s*(\w+)\s*\)')
+ARRAY_OF = re.compile(r'ArrayOf\(\s*(\w+)\s*\)')
 class UnsupportedType(Exception): pass
 class NeovimTypeVal:
     """
@@ -71,7 +71,7 @@ class NeovimTypeVal:
         }
     PAIRTYPE = 'ArrayOf(Integer, 2)'
     # Unbound Array types
-    UNBOUND_ARRAY = re.compile('ArrayOf\(\s*(\w+)\s*\)')
+    UNBOUND_ARRAY = re.compile(r'ArrayOf\(\s*(\w+)\s*\)')
 
     def __init__(self, typename, name=''):
         self.name = name

--- a/bindings/generate_bindings.py
+++ b/bindings/generate_bindings.py
@@ -33,6 +33,12 @@ def get_api_info(nvim):
     info = subprocess.check_output(args)
     return decutf8(msgpack.unpackb(info))
 
+def read_api_info(path):
+    with open(path, 'rb') as f:
+        info = f.read()
+        return decutf8(msgpack.unpackb(info))
+
+
 def generate_file(name, outfile, **kw):
     from jinja2 import Environment, FileSystemLoader
     env=Environment(loader=FileSystemLoader('bindings'), trim_blocks=True)
@@ -210,8 +216,15 @@ if __name__ == '__main__':
 
     nvim = sys.argv[1]
     outpath = None if len(sys.argv) < 3 else sys.argv[2]
+
+    is_mpack = nvim.endswith('.mpack')
+
     try:
-        api = get_api_info(sys.argv[1])
+        if is_mpack:
+            print('Treating input as .mpack file')
+            api = read_api_info(sys.argv[1])
+        else:
+            api = get_api_info(sys.argv[1])
     except subprocess.CalledProcessError as ex:
         print(ex)
         sys.exit(-1)


### PR DESCRIPTION
- allow generating api from mpack files (from neovim repo)
- fix syntax warning in python bindings scripts

I did not generate bindings for API7 - it appears to work but missing a couple of functions, I need to figure out the msgpack encoding for LuaRef