### PR TITLE
Fix scrollbar command for negative delta

### DIFF
--- a/src/gui/scrollbar.cpp
+++ b/src/gui/scrollbar.cpp
@@ -205,6 +205,23 @@ void ScrollBar::handleSetScrollBarVisible(const QVariantList& args) noexcept
 	settings.setValue("Gui/ScrollBar", isVisible);
 }
 
+QByteArray ScrollBar::scrollCommand(int delta)
+{
+	if (delta > 0) {
+		// Scroll Up: normal! {Control + Y}
+		// MSVC cannot parse the un-escaped sequence below `^Y`.
+		return QStringLiteral("normal! %1\031").arg(delta).toLatin1();
+	}
+	else if (delta < 0) {
+		// Scroll Down normal! {Control + E}
+		// MSVC cannot parse the un-escaped sequence below `^E`.
+		return QStringLiteral("normal! %1\005").arg(-delta).toLatin1();
+	}
+	else {
+		return QByteArray();
+	}
+}
+
 void ScrollBar::handleValueChanged(int value)
 {
 	const int delta{ m_lastKnownPosition - value};
@@ -214,18 +231,9 @@ void ScrollBar::handleValueChanged(int value)
 
 	m_lineScrollLockout += delta;
 
-	// Scroll Up: normal! {Control + Y}
-	// MSVC cannot parse the un-escaped sequence below `^Y`.
-	if (delta > 0) {
-		m_nvim->api0()->vim_command(
-			QStringLiteral("normal! %1\031").arg(delta).toLatin1());
-	}
-
-	// Scroll Down normal! {Control + E}
-	// MSVC cannot parse the un-escaped sequence below `^E`.
-	if (delta < 0) {
-		m_nvim->api0()->vim_command(
-			QStringLiteral("normal! %1\005").arg(delta).toLatin1());
+	auto cmd = scrollCommand(delta);
+	if (!cmd.isEmpty()) {
+		m_nvim->api0()->vim_command(cmd);
 	}
 }
 

--- a/src/gui/scrollbar.h
+++ b/src/gui/scrollbar.h
@@ -41,6 +41,8 @@ private:
 
 	NeovimConnector *m_nvim{ nullptr };
 
+	QByteArray scrollCommand(int value);
+
 	/// Locks out GUI triggered scrolling for a number of lines. Prevent double registration.
 	int m_lineScrollLockout{ 0 };
 


### PR DESCRIPTION
Negative deltas were being passed to neovim as e.g.

	normal! -5<C-e>

instead of

	normal! 5<C-e>

ref https://github.com/equalsraf/neovim-qt/issues/984