### PR TITLE
Require nvim api version 2 in GUI

### DIFF
--- a/src/gui/contextmenu.cpp
+++ b/src/gui/contextmenu.cpp
@@ -34,22 +34,22 @@ ContextMenu::ContextMenu(NeovimConnector* nvim, QWidget* parent) noexcept
 
 void ContextMenu::neovimSendCut() noexcept
 {
-	m_nvim->api0()->vim_command_output(R"(normal! "+x)");
+	m_nvim->api2()->vim_command_output(R"(normal! "+x)");
 }
 
 void ContextMenu::neovimSendCopy() noexcept
 {
-	m_nvim->api0()->vim_command(R"(normal! "+y)");
+	m_nvim->api2()->vim_command(R"(normal! "+y)");
 }
 
 void ContextMenu::neovimSendPaste() noexcept
 {
-	m_nvim->api0()->vim_command(R"(normal! "+gP)");
+	m_nvim->api2()->vim_command(R"(normal! "+gP)");
 }
 
 void ContextMenu::neovimSendSelectAll() noexcept
 {
-	m_nvim->api0()->vim_command("normal! ggVG");
+	m_nvim->api2()->vim_command("normal! ggVG");
 }
 
 void ContextMenu::showContextMenu() noexcept

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -175,12 +175,20 @@ void MainWindow::neovimError(NeovimConnector::NeovimError err)
 	m_errorWidget->showReconnect(m_nvim->canReconnect());
 	m_stack.setCurrentIndex(0);
 }
-void MainWindow::neovimIsUnsupported()
+void MainWindow::neovimIsUnsupported(bool error, quint64 required)
 {
-	m_errorWidget->setText(
-		QStringLiteral("Cannot connect to this Neovim, required API version 1, found [%1-%2]")
-			.arg(m_nvim->apiCompatibility())
-			.arg(m_nvim->apiLevel()));
+	if (error) {
+		m_errorWidget->setText(
+			QStringLiteral("Cannot connect to this Neovim, failed to check API version [%1-%2]")
+				.arg(m_nvim->apiCompatibility())
+				.arg(m_nvim->apiLevel()));
+	} else {
+		m_errorWidget->setText(
+			QStringLiteral("Cannot connect to this Neovim, required API%1, found [%1-%2]")
+				.arg(required)
+				.arg(m_nvim->apiCompatibility())
+				.arg(m_nvim->apiLevel()));
+	}
 	m_errorWidget->showReconnect(m_nvim->canReconnect());
 	m_stack.setCurrentIndex(0);
 }
@@ -229,7 +237,7 @@ void MainWindow::neovimFrameless(bool isFrameless)
 	// Details: https://doc.qt.io/qt-5/qwidget.html#windowFlags-prop
 	show();
 
-	m_nvim->api0()->vim_set_var("GuiWindowFrameless", isFrameless ? 1 : 0);
+	m_nvim->api2()->vim_set_var("GuiWindowFrameless", isFrameless ? 1 : 0);
 
 }
 
@@ -391,7 +399,7 @@ void MainWindow::showGuiAdaptiveStyleList()
 {
 	const QString styleKeys{ QStyleFactory::keys().join("\n") };
 	QString echoCommand{ R"(echo "%1")" };
-	m_nvim->api0()->vim_command(echoCommand.arg(styleKeys).toLatin1());
+	m_nvim->api2()->vim_command(echoCommand.arg(styleKeys).toLatin1());
 }
 
 void MainWindow::updateAdaptiveFont() noexcept

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -53,7 +53,7 @@ private slots:
 	void neovimError(NeovimConnector::NeovimError);
 	void reconnectNeovim();
 	void handleNeovimAttachment(bool);
-	void neovimIsUnsupported();
+	void neovimIsUnsupported(bool error, quint64 required);
 	void saveWindowGeometry();
 	void handleClosing();
 

--- a/src/gui/scrollbar.cpp
+++ b/src/gui/scrollbar.cpp
@@ -15,7 +15,6 @@ ScrollBar::ScrollBar(NeovimConnector* nvim, QWidget* parent) noexcept
 	}
 
 	connect(m_nvim, &NeovimConnector::ready, this, &ScrollBar::neovimConnectorReady);
-	connect(this, &QScrollBar::valueChanged, this, &ScrollBar::handleValueChanged);
 
 	QSettings settings;
 	setVisible(settings.value("Gui/ScrollBar", false).toBool());
@@ -25,10 +24,16 @@ ScrollBar::ScrollBar(NeovimConnector* nvim, QWidget* parent) noexcept
 
 void ScrollBar::neovimConnectorReady() noexcept
 {
-	connect(m_nvim->api0(), &NeovimApi0::neovimNotification,
-		this, &ScrollBar::handleNeovimNotification);
+	if (!m_nvim->api2()) {
+		qWarning() << "Scrollbar NeovimConnector api version 2 is not available";
+		return;
+	}
 
-	m_nvim->api0()->vim_subscribe("Gui");
+	connect(m_nvim->api2(), &NeovimApi2::neovimNotification,
+		this, &ScrollBar::handleNeovimNotification);
+	connect(this, &QScrollBar::valueChanged, this, &ScrollBar::handleValueChanged);
+
+	m_nvim->api2()->vim_subscribe("Gui");
 }
 
 bool ScrollBar::IsWinViewportSupported() const noexcept
@@ -217,14 +222,14 @@ void ScrollBar::handleValueChanged(int value)
 	// Scroll Up: normal! {Control + Y}
 	// MSVC cannot parse the un-escaped sequence below `^Y`.
 	if (delta > 0) {
-		m_nvim->api0()->vim_command(
+		m_nvim->api2()->vim_command(
 			QStringLiteral("normal! %1\031").arg(delta).toLatin1());
 	}
 
 	// Scroll Down normal! {Control + E}
 	// MSVC cannot parse the un-escaped sequence below `^E`.
 	if (delta < 0) {
-		m_nvim->api0()->vim_command(
+		m_nvim->api2()->vim_command(
 			QStringLiteral("normal! %1\005").arg(delta).toLatin1());
 	}
 }

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -117,7 +117,7 @@ void Shell::ensureVisible() noexcept
 void Shell::handleFontError(const QString& msg)
 {
 	if (m_attached) {
-		m_nvim->api0()->vim_report_error(m_nvim->encode(msg));
+		m_nvim->api2()->vim_report_error(m_nvim->encode(msg));
 	}
 }
 
@@ -282,13 +282,13 @@ bool Shell::setGuiFontWide(const QString& fdesc) noexcept
 
 void Shell::updateGuiFontRegisters() noexcept
 {
-	if (!m_attached || !m_nvim || !m_nvim->api0()) {
+	if (!m_attached || !m_nvim || !m_nvim->api2()) {
 		return;
 	}
 
 	qDebug() << __func__ << fontDesc();
 	// Update `set guifont=`, but only if value changes
-	MsgpackRequest* getOption{ m_nvim->api0()->vim_get_option("guifont") };
+	MsgpackRequest* getOption{ m_nvim->api2()->vim_get_option("guifont") };
 
 	auto timestamp = this->m_font_timestamp;
 	connect(getOption,
@@ -308,11 +308,11 @@ void Shell::updateGuiFontRegisters() noexcept
 				return;
 			}
 
-			m_nvim->api0()->vim_set_option("guifont", newFont);
+			m_nvim->api2()->vim_set_option("guifont", newFont);
 		});
 
 	// Update `:GuiFont`, but only if value changes
-	MsgpackRequest* getVariable{ m_nvim->api0()->vim_get_var("GuiFont") };
+	MsgpackRequest* getVariable{ m_nvim->api2()->vim_get_var("GuiFont") };
 	connect(getVariable, &MsgpackRequest::finished, this, &Shell::handleGuiFontVariable);
 }
 
@@ -331,13 +331,13 @@ void Shell::handleGuiFontVariable(quint32 msgid, quint64 fun, const QVariant& va
 		return;
 	}
 
-	m_nvim->api0()->vim_set_var("GuiFont", newFont);
+	m_nvim->api2()->vim_set_var("GuiFont", newFont);
 }
 
 Shell::~Shell()
 {
 	if (m_nvim && m_attached) {
-		m_nvim->api0()->ui_detach();
+		m_nvim->api2()->ui_detach();
 	}
 }
 
@@ -358,7 +358,7 @@ void Shell::setAttached(bool attached)
 	if (attached) {
 		updateWindowId();
 
-		m_nvim->api0()->vim_set_var("GuiFont", fontDesc());
+		m_nvim->api2()->vim_set_var("GuiFont", fontDesc());
 
 		if (isWindow()) {
 			updateGuiWindowState(windowState());
@@ -372,14 +372,14 @@ void Shell::setAttached(bool attached)
 			auto runtimeDir = App::getRuntimePath();
 			if (!runtimeDir.isEmpty()) {
 				const QString rtpCmd{ QString{ "let &rtp.=',%1'" }.arg(runtimeDir) };
-				m_nvim->api0()->vim_command(rtpCmd.toUtf8());
+				m_nvim->api2()->vim_command(rtpCmd.toUtf8());
 			}
 		}
 
-		MsgpackRequest* req_shim{ m_nvim->api0()->vim_command("runtime plugin/nvim_gui_shim.vim") };
+		MsgpackRequest* req_shim{ m_nvim->api2()->vim_command("runtime plugin/nvim_gui_shim.vim") };
 		connect(req_shim, &MsgpackRequest::error, this, &Shell::handleShimError);
 
-		MsgpackRequest* req_ginit{ m_nvim->api0()->vim_command(GetGVimInitCommand()) };
+		MsgpackRequest* req_ginit{ m_nvim->api2()->vim_command(GetGVimInitCommand()) };
 		connect(req_ginit, &MsgpackRequest::error, this, &Shell::handleGinitError);
 
 		// Neovim was not able to open urls till now. Check if we have any to open.
@@ -408,8 +408,11 @@ void Shell::init()
 	m_init_called = true;
 
 	// Make sure the connector provides us with an api object
-	if (!m_nvim || !m_nvim->api0()) {
-		emit neovimIsUnsupported();
+	if (!m_nvim) {
+		emit neovimIsUnsupported(true, 0);
+	}
+	if (!m_nvim->api2()) {
+		emit neovimIsUnsupported(false, 2);
 		return;
 	}
 
@@ -418,8 +421,8 @@ void Shell::init()
 		setVisible(false);
 	}
 	connect(
-		m_nvim->api0(), &NeovimApi0::neovimNotification, this, &Shell::handleNeovimNotification);
-	connect(m_nvim->api0(), &NeovimApi0::on_ui_try_resize, this, &Shell::neovimResizeFinished);
+		m_nvim->api2(), &NeovimApi2::neovimNotification, this, &Shell::handleNeovimNotification);
+	connect(m_nvim->api2(), &NeovimApi2::on_ui_try_resize, this, &Shell::neovimResizeFinished);
 
 	QRect screenRect{};
 	if (this->screen()) {
@@ -444,7 +447,7 @@ void Shell::init()
 		req = m_nvim->api2()->nvim_ui_attach(shellWidth, shellHeight, options);
 	}
 	else {
-		req = m_nvim->api0()->ui_attach(shellWidth, shellHeight, true);
+		req = m_nvim->api2()->ui_attach(shellWidth, shellHeight, true);
 	}
 
 	connect(req, &MsgpackRequest::timeout, m_nvim, &NeovimConnector::fatalTimeout);
@@ -454,10 +457,10 @@ void Shell::init()
 	connect(req, &MsgpackRequest::finished, this, &Shell::setAttached);
 
 	// Subscribe to GUI events
-	m_nvim->api0()->vim_subscribe("Gui");
+	m_nvim->api2()->vim_subscribe("Gui");
 
 	// Set initial value
-	m_nvim->api0()->vim_set_var(
+	m_nvim->api2()->vim_set_var(
 		"GuiWindowFrameless", (windowFlags() & Qt::FramelessWindowHint) ? 1 : 0);
 
 	// Make the shell visible even when default_colors_set is not received,
@@ -963,7 +966,7 @@ void Shell::handleNeovimNotification(const QByteArray &name, const QVariantList&
 		} else if (guiEvName == "Mousehide" && args.size() == 2) {
 			m_mouseHide = variant_not_zero(args.at(1));
 			int val = m_mouseHide ? 1 : 0;
-			m_nvim->api0()->vim_set_var("GuiMousehide", val);
+			m_nvim->api2()->vim_set_var("GuiMousehide", val);
 		} else if (guiEvName == "Close") {
 			handleCloseEvent(args);
 		} else if (guiEvName == "NewWindow") {
@@ -977,7 +980,7 @@ void Shell::handleNeovimNotification(const QByteArray &name, const QVariantList&
 			QString reg_name = args.at(3).toString();
 
 			if (reg_name != "*" && reg_name != "+") {
-				m_nvim->api0()->vim_report_error(m_nvim->encode("Cannot set register via GUI"));
+				m_nvim->api2()->vim_report_error(m_nvim->encode("Cannot set register via GUI"));
 				return;
 			}
 
@@ -1132,7 +1135,7 @@ void Shell::handleLineSpace(const QVariant& value) noexcept
 	}
 
 	setLineSpace(linespace);
-	m_nvim->api0()->vim_set_var("GuiLinespace", linespace);
+	m_nvim->api2()->vim_set_var("GuiLinespace", linespace);
 	resizeNeovim(size());
 }
 
@@ -1144,7 +1147,7 @@ void Shell::handleWindowFrameless(const QVariant& value) noexcept {
 		// https://doc.qt.io/qt-5/qwidget.html#windowFlags-prop
 		show();
 		// DD: It seems there is no event representing the change of flags
-		m_nvim->api0()->vim_set_var("GuiWindowFrameless", isWindowFrameOn ? 1 : 0);
+		m_nvim->api2()->vim_set_var("GuiWindowFrameless", isWindowFrameOn ? 1 : 0);
 	} else {
 		emit neovimFrameless(variant_not_zero(value));
 	}
@@ -1169,12 +1172,6 @@ void Shell::handleCloseEvent(const QVariantList& args) noexcept
 
 void Shell::handleGuiPopupmenu(const QVariant& value) noexcept
 {
-	if (!m_nvim->api1())
-	{
-		qDebug() << "GuiPopupmenu not supported by Neovim API!";
-		return;
-	}
-
 	if (!value.canConvert<bool>())
 	{
 		qDebug() << "GuiPopupmenu value not recognized!";
@@ -1182,7 +1179,7 @@ void Shell::handleGuiPopupmenu(const QVariant& value) noexcept
 	}
 
 	const bool isEnabled{ value.toBool() };
-	m_nvim->api1()->nvim_ui_set_option("ext_popupmenu", isEnabled);
+	m_nvim->api2()->nvim_ui_set_option("ext_popupmenu", isEnabled);
 
 	QSettings settings;
 	settings.setValue("ext_popupmenu", isEnabled);
@@ -1228,7 +1225,7 @@ void Shell::handleDefaultColorsSet(const QVariantList& opargs)
 	const uint32_t rgb_sp{ opargs.at(2).toUInt() };
 
 	MsgpackRequest* getBackgroundMode{
-		m_nvim->api0()->vim_get_option(QString{ "background" }.toLatin1()) };
+		m_nvim->api2()->vim_get_option(QString{ "background" }.toLatin1()) };
 
 	connect(getBackgroundMode, &MsgpackRequest::finished, this, &Shell::handleGetBackgroundOption);
 
@@ -1454,14 +1451,14 @@ void Shell::handleMacOptionIsMeta(const QVariant& value) noexcept
 		metaMode = Input::MacOptionMetaMode::Both;
 	}
 	else {
-		m_nvim->api0()->vim_report_error(m_nvim->encode(
+		m_nvim->api2()->vim_report_error(m_nvim->encode(
 			QString{ "Unknown GuiMacOptionIsMeta value: '%1'. Expected: none, left, right, both" }
 				.arg(mode)));
 		return;
 	}
 
 	Input::SetMacOptionIsMeta(metaMode);
-	m_nvim->api0()->vim_set_var("GuiMacOptionIsMeta", mode);
+	m_nvim->api2()->vim_set_var("GuiMacOptionIsMeta", mode);
 }
 
 void Shell::showEvent(QShowEvent* ev)
@@ -1524,7 +1521,7 @@ void Shell::keyPressEvent(QKeyEvent *ev)
 		return;
 	}
 
-	m_nvim->api0()->vim_input(m_nvim->encode(inp));
+	m_nvim->api2()->vim_input(m_nvim->encode(inp));
 	// FIXME: bytes might not be written, and need to be buffered
 }
 
@@ -1561,7 +1558,7 @@ void Shell::neovimMouseEvent(QMouseEvent* ev)
 	if (inp.isEmpty()) {
 		return;
 	}
-	m_nvim->api0()->vim_input(inp.toLatin1());
+	m_nvim->api2()->vim_input(inp.toLatin1());
 }
 
 void Shell::mousePressEvent(QMouseEvent *ev)
@@ -1641,7 +1638,7 @@ void Shell::wheelEvent(QWheelEvent *ev)
 		return;
 	}
 
-	m_nvim->api0()->vim_input(evString.toLatin1());
+	m_nvim->api2()->vim_input(evString.toLatin1());
 }
 
 /*static*/ QString Shell::GetWheelEventStringAndSetScrollRemainder(
@@ -1692,8 +1689,8 @@ void Shell::updateWindowId()
 	if (m_attached &&
 		m_nvim->connectionType() == NeovimConnector::SpawnedConnection) {
 		WId window_id = effectiveWinId();
-		m_nvim->api0()->vim_set_var("GuiWindowId", QVariant(window_id));
-		m_nvim->api0()->vim_command(
+		m_nvim->api2()->vim_set_var("GuiWindowId", QVariant(window_id));
+		m_nvim->api2()->vim_command(
 			QStringLiteral("let v:windowid = %1").arg(window_id).toLatin1());
 		updateClientInfo();
 	}
@@ -1768,7 +1765,7 @@ void Shell::resizeNeovim(int n_cols, int n_rows)
 		m_resize_neovim_pending = newsize;
 	}
 	else {
-		m_nvim->api0()->ui_try_resize(n_cols, n_rows);
+		m_nvim->api2()->ui_try_resize(n_cols, n_rows);
 		m_resizing = newsize;
 	}
 }
@@ -1814,14 +1811,14 @@ void Shell::updateGuiWindowState(Qt::WindowStates state)
 		return;
 	}
 	if (state & Qt::WindowMaximized) {
-		m_nvim->api0()->vim_set_var("GuiWindowMaximized", 1);
+		m_nvim->api2()->vim_set_var("GuiWindowMaximized", 1);
 	} else {
-		m_nvim->api0()->vim_set_var("GuiWindowMaximized", 0);
+		m_nvim->api2()->vim_set_var("GuiWindowMaximized", 0);
 	}
 	if (state & Qt::WindowFullScreen) {
-		m_nvim->api0()->vim_set_var("GuiWindowFullScreen", 1);
+		m_nvim->api2()->vim_set_var("GuiWindowFullScreen", 1);
 	} else {
-		m_nvim->api0()->vim_set_var("GuiWindowFullScreen", 0);
+		m_nvim->api2()->vim_set_var("GuiWindowFullScreen", 0);
 	}
 }
 
@@ -1838,9 +1835,9 @@ void Shell::closeEvent(QCloseEvent *ev)
 		connect(m_nvim, &NeovimConnector::processExited, &loop, &QEventLoop::quit);
 		connect(this,   &Shell::forceQuit,               &loop, [this] {
 			bailoutIfinputBlocking();
-			m_nvim->api0()->vim_command("q!");
+			m_nvim->api2()->vim_command("q!");
 		});
-		MsgpackRequest * request = m_nvim->api0()->vim_command("confirm qa");
+		MsgpackRequest * request = m_nvim->api2()->vim_command("confirm qa");
 		connect(request, &MsgpackRequest::finished, &loop, [&loop, ev](){
 			//This will fire if we cancel the closing
 			ev->ignore();
@@ -1855,7 +1852,7 @@ void Shell::focusInEvent(QFocusEvent *ev)
 {
 	if (m_attached) {
 		// Issue #329: The <FocusGained> key no longer exists, use autocmd instead.
-		m_nvim->api0()->vim_command("if exists('#FocusGained') | doautocmd <nomodeline> FocusGained | endif");
+		m_nvim->api2()->vim_command("if exists('#FocusGained') | doautocmd <nomodeline> FocusGained | endif");
 	}
 	QWidget::focusInEvent(ev);
 }
@@ -1864,7 +1861,7 @@ void Shell::focusOutEvent(QFocusEvent *ev)
 {
 	if (m_attached) {
 		// Issue #591: Option <nomodeline> prevents unwanted interaction, consistent with nvim.
-		m_nvim->api0()->vim_command("if exists('#FocusLost') | doautocmd <nomodeline> FocusLost | endif");
+		m_nvim->api2()->vim_command("if exists('#FocusLost') | doautocmd <nomodeline> FocusLost | endif");
 	}
 	QWidget::focusOutEvent(ev);
 }
@@ -1905,7 +1902,7 @@ void Shell::inputMethodEvent(QInputMethodEvent *ev)
 	}
 	if ( !ev->commitString().isEmpty() ) {
 		QByteArray s = m_nvim->encode(ev->commitString());
-		m_nvim->api0()->vim_input(s);
+		m_nvim->api2()->vim_input(s);
 		tooltip("");
 	} else {
 		tooltip(ev->preeditString());
@@ -1964,7 +1961,7 @@ void Shell::openFiles(QList<QUrl> urls)
 				args.append(u.toString());
 			}
 		}
-		m_nvim->api0()->vim_call_function("GuiDrop", args);
+		m_nvim->api2()->vim_call_function("GuiDrop", args);
 	} else {
 		// Neovim cannot open urls now. Store them to open later.
 		m_deferredOpen.append(urls);
@@ -2076,7 +2073,7 @@ void Shell::handleGinitError(quint32 msgid, quint64 fun, const QVariant& err)
 {
 	qDebug() << "ginit.vim error " << err;
 	auto msg = neovimErrorToString(err);
-	m_nvim->api0()->vim_report_error("ginit.vim error: " + msg.toUtf8());
+	m_nvim->api2()->vim_report_error("ginit.vim error: " + msg.toUtf8());
 }
 
 void Shell::handleShimError(quint32 msgid, quint64 fun, const QVariant& err)

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -95,7 +95,7 @@ signals:
 	void neovimFrameless(bool);
 	void neovimGuiCloseRequest(int status = 0);
 	/// This signal is emmited if the running neovim version is unsupported by the GUI
-	void neovimIsUnsupported();
+	void neovimIsUnsupported(bool error, quint64 required);
 	void neovimShowContextMenu();
 	void colorsChanged();
 

--- a/src/gui/tabline.cpp
+++ b/src/gui/tabline.cpp
@@ -66,8 +66,8 @@ Tabline::Tabline(NeovimConnector& nvim, QWidget* parent) noexcept
 void Tabline::neovimConnectorReady() noexcept
 {
 	connect(
-		m_nvim.api0(), &NeovimApi0::neovimNotification, this, &Tabline::handleNeovimNotification);
-	m_nvim.api0()->vim_subscribe("Gui");
+		m_nvim.api2(), &NeovimApi2::neovimNotification, this, &Tabline::handleNeovimNotification);
+	m_nvim.api2()->vim_subscribe("Gui");
 }
 
 void Tabline::handleNeovimNotification(const QByteArray& name, const QVariantList& args) noexcept
@@ -133,8 +133,8 @@ void Tabline::handleGuiTabline(const QVariantList& args) noexcept
 	QSettings settings;
 	settings.setValue(cs_showTablineOptionName, isEnabled);
 
-	if (m_nvim.api1()) {
-		m_nvim.api1()->nvim_ui_set_option(cs_showTablineOptionName, isEnabled);
+	if (m_nvim.api2()) {
+		m_nvim.api2()->nvim_ui_set_option(cs_showTablineOptionName, isEnabled);
 	}
 
 	updateTablineVisibility();
@@ -323,14 +323,14 @@ void Tabline::drawTablineUpdates(
 	const std::vector<Tab>& bufferList,
 	uint64_t curbuf) noexcept
 {
-	updateTabControl(m_tabline, m_nvim.api0(), tabList, curtab, false /*drawTabIcons*/);
-	updateTabControl(m_bufferline, m_nvim.api0(), bufferList, curbuf, true /*drawTabIcons*/);
+	updateTabControl(m_tabline, m_nvim.api2(), tabList, curtab, false /*drawTabIcons*/);
+	updateTabControl(m_bufferline, m_nvim.api2(), bufferList, curbuf, true /*drawTabIcons*/);
 	updateTablineVisibility();
 }
 
 void Tabline::updateTabControl(
 	QTabBar& tabControl,
-	NeovimApi0* nvimApi0,
+	NeovimApi2* nvimApi2,
 	const std::vector<Tab> tabList,
 	uint64_t curtab,
 	bool drawTabIcons) noexcept
@@ -365,8 +365,8 @@ void Tabline::updateTabControl(
 		}
 
 		// Optional: Add filetype icons
-		if (drawTabIcons && nvimApi0) {
-			auto reqBufferPath{ nvimApi0->vim_eval(
+		if (drawTabIcons && nvimApi2) {
+			auto reqBufferPath{ nvimApi2->vim_eval(
 				QStringLiteral("expand('#%1:p')").arg(tab.GetHandle()).toLatin1()) };
 
 			QPointer<QTabBar> spTabControl{ &tabControl };
@@ -430,33 +430,33 @@ void Tabline::updateTablineVisibility() noexcept
 
 void Tabline::currentChangedTabline(int index) noexcept
 {
-	if (!m_nvim.api0()) {
+	if (!m_nvim.api2()) {
 		return;
 	}
 
 	const uint64_t handle{ m_tabline.tabData(index).toULongLong() };
 
-	m_nvim.api0()->vim_set_current_tabpage(handle);
+	m_nvim.api2()->vim_set_current_tabpage(handle);
 }
 
 void Tabline::closeRequestedTabline(int index) noexcept
 {
-	if (!m_nvim.api0()) {
+	if (!m_nvim.api2()) {
 		return;
 	}
 
 	const uint64_t handle{ m_bufferline.tabData(index).toULongLong() };
-	m_nvim.api0()->vim_command(QStringLiteral("tabclose %1").arg(handle).toLatin1());
+	m_nvim.api2()->vim_command(QStringLiteral("tabclose %1").arg(handle).toLatin1());
 }
 
 void Tabline::currentChangedBufline(int index) noexcept
 {
-	if (!m_nvim.api0()) {
+	if (!m_nvim.api2()) {
 		return;
 	}
 
 	const uint64_t handle{ m_bufferline.tabData(index).toULongLong() };
-	m_nvim.api0()->vim_command(QStringLiteral("buffer! %1").arg(handle).toLatin1());
+	m_nvim.api2()->vim_command(QStringLiteral("buffer! %1").arg(handle).toLatin1());
 }
 
 static QString GetSanitizedErrorString(const QVariant& err) noexcept
@@ -499,13 +499,13 @@ void Tabline::handleCloseBufferError(quint32 msgid, quint64 fun, const QVariant&
 
 void Tabline::closeRequestedBufline(int index) noexcept
 {
-	if (!m_nvim.api0()) {
+	if (!m_nvim.api2()) {
 		return;
 	}
 
 	const uint64_t handle{ m_bufferline.tabData(index).toULongLong() };
 
-	auto reqCloseBuffer{ m_nvim.api0()->vim_command(
+	auto reqCloseBuffer{ m_nvim.api2()->vim_command(
 		QStringLiteral("bdel %1").arg(handle).toLatin1()) };
 	connect(reqCloseBuffer, &MsgpackRequest::error, this, &Tabline::handleCloseBufferError);
 }

--- a/src/gui/tabline.h
+++ b/src/gui/tabline.h
@@ -44,7 +44,7 @@ private:
 
 	void updateTabControl(
 		QTabBar& tabControl,
-		NeovimApi0* nvimApi0,
+		NeovimApi2* nvimApi2,
 		const std::vector<Tab> tabList,
 		uint64_t curtab,
 		bool drawTabIcons) noexcept;

--- a/src/gui/treeview.cpp
+++ b/src/gui/treeview.cpp
@@ -38,17 +38,17 @@ void TreeView::neovimConnectorReady() noexcept
 	connect(this, &TreeView::doubleClicked, this, &TreeView::open);
 
 	connect(
-		m_nvim->api0(), &NeovimApi0::neovimNotification, this, &TreeView::handleNeovimNotification);
+		m_nvim->api2(), &NeovimApi2::neovimNotification, this, &TreeView::handleNeovimNotification);
 
-	m_nvim->api0()->vim_subscribe("Dir");
-	m_nvim->api0()->vim_subscribe("Gui");
+	m_nvim->api2()->vim_subscribe("Dir");
+	m_nvim->api2()->vim_subscribe("Gui");
 }
 
 void TreeView::open(const QModelIndex& index) noexcept
 {
 	const QFileInfo fileInfo{ m_model.fileInfo(index) };
 	if (fileInfo.isFile() && fileInfo.isReadable()) {
-		m_nvim->api0()->vim_call_function("GuiDrop", { fileInfo.filePath() });
+		m_nvim->api2()->vim_call_function("GuiDrop", { fileInfo.filePath() });
 	}
 	focusNextChild();
 }

--- a/test/tst_qsettings.cpp
+++ b/test/tst_qsettings.cpp
@@ -27,7 +27,7 @@ private slots:
 
 static void SendNeovimCommand(NeovimConnector* connector, const QString& command) noexcept
 {
-	QSignalSpy spyCommand{ connector->api0()->vim_command_output(connector->encode(command)),
+	QSignalSpy spyCommand{ connector->api2()->vim_command_output(connector->encode(command)),
 		&MsgpackRequest::finished };
 
 	QVERIFY(spyCommand.isValid());

--- a/test/tst_shell.cpp
+++ b/test/tst_shell.cpp
@@ -110,7 +110,7 @@ void TestShell::gviminit() noexcept
 	auto s = CreateShellWidget();
 	NeovimConnector* c = s->nvim();
 
-	MsgpackRequest* req{ c->api0()->vim_command_output(c->encode("echo g:test_gviminit")) };
+	MsgpackRequest* req{ c->api2()->vim_command_output(c->encode("echo g:test_gviminit")) };
 	QSignalSpy cmd{ req, &MsgpackRequest::finished };
 	QVERIFY(cmd.isValid());
 	QVERIFY(SPYWAIT(cmd));
@@ -275,7 +275,7 @@ void TestShell::CloseEvent() noexcept
 	QSignalSpy onWindowClosing(w.get(), &MainWindow::closing);
 	QVERIFY(onWindowClosing.isValid());
 
-	c->api0()->vim_command(c->encode(command));
+	c->api2()->vim_command(c->encode(command));
 
 	QVERIFY(SPYWAIT(onClose));
 	QCOMPARE(onClose.takeFirst().at(0).toInt(), msgpack_status);
@@ -329,7 +329,7 @@ void TestShell::GetClipboard() noexcept
 	QObject::connect(c->neovimObject(), &NeovimApi1::err_vim_command_output, SignalPrintError);
 
 	// provided by the GUI shim
-	c->api0()->vim_command(c->encode("call GuiClipboard()"));
+	c->api2()->vim_command(c->encode("call GuiClipboard()"));
 
 	QGuiApplication::clipboard()->setText(register_data, GetClipboardMode(reg));
 
@@ -367,7 +367,7 @@ void TestShell::SetClipboard() noexcept
 	QObject::connect(c->neovimObject(), &NeovimApi1::err_vim_command_output, SignalPrintError);
 
 	// provided by the GUI shim
-	c->api0()->vim_command(c->encode("call GuiClipboard()"));
+	c->api2()->vim_command(c->encode("call GuiClipboard()"));
 
 	QString setreg_cmd =
 		QStringLiteral("setreg('%1', '%2')\n").arg(reg).arg(QString::fromUtf8(register_data));


### PR DESCRIPTION
This replaces all uses of api0() with api2() in the GUI and changes the ::init check in the shell to require v2.

There was an issue with the scrollbar that failed to correctly check the api - partially due to a signal being set too early - that could end up in a segfault.

The connector was not changed and it still supports api0/1.

Notes
- https://github.com/equalsraf/neovim-qt/issues/1156
- I probably won't be able to work on this anytime soon
- afaik nvim api 2 is API level 2 - 52727d98d76983f73e214369fe98ef541031395c