### PR TITLE
WIP 1185: Load shim at attachment

### DIFF
--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -417,15 +417,39 @@ void App::checkArgumentsMayTerminate(QCommandLineParser& parser) noexcept
 	return {};
 }
 
-/*static*/ QStringList App::getNeovimArgs() noexcept
+/*static*/ QString App::getRuntimeShim() noexcept
 {
-	QString runtimePath{ getRuntimePath() };
-	if (runtimePath.isEmpty()) {
-		return { "--cmd","set termguicolors" };
+	QString rtp{ QString::fromLocal8Bit(qgetenv("NVIM_QT_RUNTIME_PATH")) };
+	const auto filepath = "plugin/nvim_gui_shim.vim";
+
+	if (QFileInfo(rtp).isDir()) {
+		const QFileInfo fi{ QDir{ rtp }.filePath(filepath) };
+		if (fi.isFile()) {
+			qDebug() << __func__ << fi;
+			return fi.absoluteFilePath();
+		}
 	}
 
-	return { "--cmd", QString{ "let &rtp.=',%1'" }.arg(runtimePath),
-		"--cmd","set termguicolors" };
+	// Look for the runtime relative to the nvim-qt binary.
+	// Probe both known layouts: macOS bundle and standard install.
+	const QString appDir{ applicationDirPath() };
+	for (const char* relPath : { "../Resources/runtime", "../share/nvim-qt/runtime" }) {
+		const QDir d{ QDir{ appDir }.filePath(relPath) };
+		if (d.exists()) {
+			const QFileInfo fi{ d.filePath(filepath) };
+			if (fi.isFile()) {
+				qDebug() << __func__ << fi;
+				return fi.absoluteFilePath();
+			}
+		}
+	}
+
+	return {};
+}
+
+/*static*/ QStringList App::getNeovimArgs() noexcept
+{
+	return { "--cmd","set termguicolors" };
 }
 
 static QString GetNeovimVersionInfo(const QString& nvim) noexcept

--- a/src/gui/app.h
+++ b/src/gui/app.h
@@ -25,6 +25,7 @@ public:
 	static void processCommandlineOptions(QCommandLineParser&, QStringList) noexcept;
 	static void openNewWindow(const QVariantList& args) noexcept;
 	static QString getRuntimePath() noexcept;
+	static QString getRuntimeShim() noexcept;
 
 private:
 	static QStringList getNeovimArgs() noexcept;

--- a/src/gui/runtime/plugin/nvim_gui_shim.vim
+++ b/src/gui/runtime/plugin/nvim_gui_shim.vim
@@ -1,8 +1,7 @@
 " A Neovim plugin that implements GUI helper commands
-if !has('nvim') || exists('g:GuiLoaded')
+if !has('nvim')
   finish
 endif
-let g:GuiLoaded = 1
 
 " Get the channel to the last UI in the uis_list
 function! s:get_last_ui_chan()

--- a/src/gui/shell.cpp
+++ b/src/gui/shell.cpp
@@ -366,18 +366,18 @@ void Shell::setAttached(bool attached)
 
 		updateClientInfo();
 
-		if (m_nvim->connectionType() == NeovimConnector::SpawnedConnection) {
-			// Re-add runtime to rtp: plugin managers (e.g. lazy.nvim) may have reset it.
-			// but only if nvim is spawned
-			auto runtimeDir = App::getRuntimePath();
-			if (!runtimeDir.isEmpty()) {
-				const QString rtpCmd{ QString{ "let &rtp.=',%1'" }.arg(runtimeDir) };
-				m_nvim->api0()->vim_command(rtpCmd.toUtf8());
-			}
-		}
+		//if (m_nvim->connectionType() == NeovimConnector::SpawnedConnection) {
+		//	// Re-add runtime to rtp: plugin managers (e.g. lazy.nvim) may have reset it.
+		//	// but only if nvim is spawned
+		//	auto runtimeDir = App::getRuntimePath();
+		//	if (!runtimeDir.isEmpty()) {
+		//		const QString rtpCmd{ QString{ "let &rtp.=',%1'" }.arg(runtimeDir) };
+		//		m_nvim->api0()->vim_command(rtpCmd.toUtf8());
+		//	}
+		//}
 
-		MsgpackRequest* req_shim{ m_nvim->api0()->vim_command("runtime plugin/nvim_gui_shim.vim") };
-		connect(req_shim, &MsgpackRequest::error, this, &Shell::handleShimError);
+		//MsgpackRequest* req_shim{ m_nvim->api0()->vim_command("runtime plugin/nvim_gui_shim.vim") };
+		//connect(req_shim, &MsgpackRequest::error, this, &Shell::handleShimError);
 
 		MsgpackRequest* req_ginit{ m_nvim->api0()->vim_command(GetGVimInitCommand()) };
 		connect(req_ginit, &MsgpackRequest::error, this, &Shell::handleGinitError);
@@ -397,6 +397,26 @@ void Shell::setAttached(bool attached)
 	updateGuiFontRegisters();
 
 	update();
+}
+
+/// Take data (vimscript) and evaluate it in neovim via the vim.cmd.
+/// It is up to the caller to check if api3() is available.
+///
+/// Note: lua string assumes shim script does not have === string inside.
+void Shell::loadShimApi3(QString data)
+{
+	auto api = m_nvim->api3();
+	if (!api) {
+		m_nvim->api0()->vim_report_error("neovim-qt tried to luad script via vim.cmd but nvim does not support api3");
+		return;
+	}
+
+	auto wrapper = QStringLiteral("vim.cmd([===[%1]===])")
+		.arg(data)
+		.toLatin1();
+
+	MsgpackRequest* req_shim{ api->nvim_execute_lua(wrapper, QVariantList()) };
+	connect(req_shim, &MsgpackRequest::error, this, &Shell::handleShimError);
 }
 
 void Shell::init()
@@ -438,6 +458,32 @@ void Shell::init()
 		options.insert("ext_linegrid", true);
 	}
 	options.insert("rgb", true);
+
+	// FIXME - load shim, try different approaches depending on version - last resort is
+	// to blindly assume plugin is in rtp
+	auto shim = App::getRuntimeShim();
+	if (shim.isEmpty()) {
+		auto msg = QStringLiteral("Failed to find neovim-qt gui shim file")
+			.toLatin1();
+		m_nvim->api0()->vim_report_error(msg);
+		qDebug() << __func__ << msg;
+	} else {
+		auto f = QFile(shim);
+		if (f.open(QFile::ReadOnly | QFile::Text)) {
+			auto shimData = QTextStream(&f).readAll();
+
+			// FIXME check api3 and fallback
+			loadShimApi3(shimData);
+			qDebug() << __func__ << "shin loading" << shim;
+		} else {
+			auto msg = QStringLiteral("Failed to open GUI shim file: %1 - %2")
+				.arg(shim)
+				.arg(f.errorString())
+				.toLatin1();
+			m_nvim->api0()->vim_report_error(msg);
+			qDebug() << __func__ << msg << f.errorString();
+		}
+	}
 
 	MsgpackRequest* req{ nullptr };
 	if (m_nvim->api2()) {
@@ -2081,6 +2127,10 @@ void Shell::handleGinitError(quint32 msgid, quint64 fun, const QVariant& err)
 
 void Shell::handleShimError(quint32 msgid, quint64 fun, const QVariant& err)
 {
+	// FIXME
+	auto msg = QStringLiteral("Error loading neovim-qt shim")
+		.toLatin1();
+	m_nvim->api0()->vim_report_error(msg);
 	qDebug() << "GUI shim error " << err;
 }
 

--- a/src/gui/shell.h
+++ b/src/gui/shell.h
@@ -230,6 +230,8 @@ private:
 	bool m_mouseHide{ true };
 	quint64 m_font_timestamp{ 0 };
 
+	void loadShimApi3(QString data);
+
 	// highlight fg/bg - from redraw:highlightset - by default we
 	// use the values from above
 	QColor m_hg_foreground{ Qt::black };


### PR DESCRIPTION

- [ ] currently only has one method for api3
- [ ] check if vim.cmd is backwards compatible with this e.g. up to 0.2.1

ref #1185 see also helptags in the comments